### PR TITLE
feat(marketplace): make locked seeds cost something to an admin, not to a cap

### DIFF
--- a/backend/src/apis/app_api/admin/roles/agent_pins.py
+++ b/backend/src/apis/app_api/admin/roles/agent_pins.py
@@ -18,6 +18,14 @@ for any role that carries no ``jwtRoleMappings`` at all.
 **Removing a role pin unpins for everyone who had not pinned it themselves (D9.1).** Pins
 resolve live; there is no fan-out and no "new members only". The console's removal dialog
 has to say that plainly.
+
+**Locking is bounded by friction, not by a cap (#748).** A locked seed cannot be dismissed
+by the member who receives it, and an admin weighing "seed" against "seed locked" otherwise
+has no reason not to lock. ``lockedElsewhere`` on the response tells the console how many
+locked seeds other roles already hold, because a user's shelf is the *union* across every
+role they match and a lock from any one of them wins. That union cannot be capped: role
+membership resolves per user from Entra claims, so it is not knowable at write time, and
+enforcing it at read time would silently drop an admin's lock for some users.
 """
 
 import logging
@@ -30,7 +38,11 @@ from apis.shared.assistants.models import (
     RoleAgentPinsResponse,
     RoleAgentPinsUpdateRequest,
 )
-from apis.shared.assistants.role_pins import list_role_pins, put_role_pins
+from apis.shared.assistants.role_pins import (
+    count_locked_outside,
+    list_role_pins,
+    put_role_pins,
+)
 from apis.shared.auth import User
 from apis.shared.rbac.admin_service import get_app_role_admin_service
 
@@ -51,6 +63,9 @@ async def _load_role(role_id: str):
 async def _respond(role, admin: User) -> RoleAgentPinsResponse:
     pins = await list_role_pins(role.role_id)
     rows, unavailable = await resolve_role_pins(role, pins, admin)
+    # #748 — what other roles lock. Advisory context, not a limit; see
+    # ``count_locked_outside`` for why the union cannot be capped.
+    locked_elsewhere, locked_elsewhere_roles = await count_locked_outside(role.role_id)
     return RoleAgentPinsResponse(
         role_id=role.role_id,
         role_label=role.display_name or role.role_id,
@@ -58,6 +73,8 @@ async def _respond(role, admin: User) -> RoleAgentPinsResponse:
         # travels with the data to any other surface that renders it.
         fallback_only=role.role_id == "default",
         unmapped=not role.jwt_role_mappings,
+        locked_elsewhere=locked_elsewhere,
+        locked_elsewhere_roles=locked_elsewhere_roles,
         pins=rows,
         unavailable=unavailable,
     )

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -1039,6 +1039,22 @@ class RoleAgentPinsResponse(BaseModel):
         False,
         description="The role carries no jwtRoleMappings, so no user matches it at all",
     )
+    locked_elsewhere: int = Field(
+        0,
+        alias="lockedElsewhere",
+        description=(
+            "Locked seeds held by OTHER roles (D9 open question, #748). Pins merge as a "
+            "union across every role a user holds and a lock from any one of them wins, so "
+            "the shelf an individual actually gets is this plus whatever this role locks. "
+            "Reported rather than capped: role membership resolves per user from Entra "
+            "claims, so the union is not knowable at write time."
+        ),
+    )
+    locked_elsewhere_roles: int = Field(
+        0,
+        alias="lockedElsewhereRoles",
+        description="How many other roles lock at least one seed — the spread behind lockedElsewhere",
+    )
     pins: List[RoleAgentPinRow] = Field(default_factory=list, description="Seeded agents, in order")
     unavailable: List[str] = Field(
         default_factory=list,

--- a/backend/src/apis/shared/assistants/role_pins.py
+++ b/backend/src/apis/shared/assistants/role_pins.py
@@ -34,7 +34,7 @@ records when an Agent was *seeded*, not when the list was last dragged around.
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Tuple
 
 from boto3.dynamodb.conditions import Key
 
@@ -105,6 +105,50 @@ async def list_pins_for_roles(role_ids: Sequence[str]) -> Dict[str, List[RoleAge
             logger.warning(f"Failed to read default pins for role {role_id}", exc_info=True)
             result[role_id] = []
     return result
+
+
+async def count_locked_outside(role_id: str) -> Tuple[int, int]:
+    """``(locked seeds held by other roles, how many other roles lock at least one)``.
+
+    Feeds the admin console's locked-pin friction (D9 open question, #748). A locked seed
+    cannot be dismissed by the member who receives it, and an admin choosing between "seed"
+    and "seed locked" otherwise has no reason not to lock: locking guarantees the rollout
+    lands and the cost falls on someone else's sidebar.
+
+    ⚠️ **This is reported, never enforced, and that is not a shortcut.** Pins merge as a
+    union across every role a user holds and a lock from *any* of them wins
+    (``pin_service._role_seeds``), so a per-role cap would not bound what any individual
+    sees — the case the open question flags. Nor can the union be capped at write time:
+    role membership resolves per user from Entra claims, so which roles co-occur on one
+    person is not knowable here. Capping at *read* time would be worse still, silently
+    dropping an admin's lock for some users. What is knowable on this surface is the
+    institution-wide total, so that is what the console shows.
+
+    Costs one query per role. The admin console is low-traffic and an institution has a
+    handful of roles, which is the same trade ``list_pins_for_roles`` already makes.
+    """
+    from apis.shared.rbac.admin_service import get_app_role_admin_service
+
+    try:
+        roles = await get_app_role_admin_service().list_roles()
+    except Exception:
+        # Friction copy is advisory; failing to compute it must never fail the page.
+        logger.warning("Failed to list roles for the locked-pin count", exc_info=True)
+        return 0, 0
+
+    other_ids = [r.role_id for r in roles if r.role_id != role_id]
+    if not other_ids:
+        return 0, 0
+
+    by_role = await list_pins_for_roles(other_ids)
+    total = 0
+    roles_locking = 0
+    for pins in by_role.values():
+        locked = sum(1 for pin in pins if pin.locked)
+        if locked:
+            total += locked
+            roles_locking += 1
+    return total, roles_locking
 
 
 async def put_role_pins(

--- a/backend/tests/shared/test_role_agent_pins.py
+++ b/backend/tests/shared/test_role_agent_pins.py
@@ -195,3 +195,89 @@ async def test_delete_role_pins_clears_the_list(table):
     await delete_role_pins("faculty")
 
     assert await list_role_pins("faculty") == []
+
+
+# ── #748 — locked-seed friction, not a cap ───────────────────────────────────────────
+class TestCountLockedOutside:
+    """What the admin console cannot work out for itself: what *other* roles lock.
+
+    Deliberately a count and not a limit. Pins merge as a union across every role a user
+    matches and a lock from any one of them wins, so a per-role cap would not bound what
+    an individual sees — and the union itself is uncappable, because role membership
+    resolves per user from Entra claims. Reporting is the honest thing this surface can do.
+    """
+
+    @staticmethod
+    def _roles(*role_ids):
+        """Patch the admin service's role listing to exactly these ids."""
+        from unittest.mock import AsyncMock, patch
+
+        from apis.shared.rbac.models import AppRole as _AppRole
+
+        service = AsyncMock()
+        service.list_roles = AsyncMock(
+            return_value=[
+                _AppRole(role_id=rid, display_name=rid, description="") for rid in role_ids
+            ]
+        )
+        return patch(
+            "apis.shared.rbac.admin_service.get_app_role_admin_service",
+            return_value=service,
+        )
+
+    @pytest.mark.asyncio
+    async def test_counts_locked_seeds_on_other_roles_only(self, table):
+        from apis.shared.assistants.role_pins import count_locked_outside
+
+        await put_role_pins("faculty", _inputs(("ast-1", True), ("ast-2", True)), ADMIN)
+        await put_role_pins("staff", _inputs(("ast-3", True), "ast-4"), ADMIN)
+
+        with self._roles("faculty", "staff"):
+            total, roles = await count_locked_outside("faculty")
+
+        # Only staff's single locked seed — faculty's own two are the caller's business.
+        assert (total, roles) == (1, 1)
+
+    @pytest.mark.asyncio
+    async def test_unlocked_seeds_elsewhere_do_not_count(self, table):
+        from apis.shared.assistants.role_pins import count_locked_outside
+
+        await put_role_pins("staff", _inputs("ast-3", "ast-4"), ADMIN)
+
+        with self._roles("faculty", "staff"):
+            assert await count_locked_outside("faculty") == (0, 0)
+
+    @pytest.mark.asyncio
+    async def test_reports_the_spread_across_roles(self, table):
+        """Two roles locking one each is a different shape from one locking two."""
+        from apis.shared.assistants.role_pins import count_locked_outside
+
+        await put_role_pins("staff", _inputs(("ast-1", True)), ADMIN)
+        await put_role_pins("student", _inputs(("ast-2", True), ("ast-3", True)), ADMIN)
+
+        with self._roles("faculty", "staff", "student"):
+            assert await count_locked_outside("faculty") == (3, 2)
+
+    @pytest.mark.asyncio
+    async def test_a_lone_role_has_nothing_outside_it(self, table):
+        from apis.shared.assistants.role_pins import count_locked_outside
+
+        await put_role_pins("faculty", _inputs(("ast-1", True)), ADMIN)
+
+        with self._roles("faculty"):
+            assert await count_locked_outside("faculty") == (0, 0)
+
+    @pytest.mark.asyncio
+    async def test_a_failure_to_list_roles_never_breaks_the_page(self, table):
+        """Friction copy is advisory — it must not take the pins surface down with it."""
+        from unittest.mock import AsyncMock, patch
+
+        from apis.shared.assistants.role_pins import count_locked_outside
+
+        service = AsyncMock()
+        service.list_roles = AsyncMock(side_effect=RuntimeError("dynamo is having a day"))
+        with patch(
+            "apis.shared.rbac.admin_service.get_app_role_admin_service",
+            return_value=service,
+        ):
+            assert await count_locked_outside("faculty") == (0, 0)

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -253,6 +253,30 @@ pins assigned to `default` therefore reach only users who match nothing else —
 nobody. The admin UI must label that chip *"fallback only — does not apply to users with any other
 role"* or admins will assume it means "everyone" and quietly seed no one.
 
+**7. Locking is bounded by friction, not a cap.** (Resolves the former "locked-pin ceiling" open
+question, #748.) It asked whether to cap locked pins per role, say at two. **No cap.** The admin
+console shows the cost instead: a running locked count on the seed header, a warning past a
+threshold, and — the part an admin cannot work out for themselves — how many locked seeds *every
+other role* already holds.
+
+The concern was real and phase 6 sharpened it. A locked seed genuinely cannot be dismissed
+(verified on dev: a lock beats a user's own tombstone, which is the specced behavior and is right —
+a lock a user could dismiss would be pointless). So an admin choosing between "seed" and "seed
+locked" has no reason not to lock: locking guarantees the rollout lands and the cost falls on
+someone else's sidebar.
+
+**A cap does not work here, and the reason is structural.** Pins merge as a *union* across every
+role a user matches, and a lock from any one of them wins (D9.2). So a per-role cap of two does not
+mean a member sees at most two locked Agents — someone in five roles sees ten. Capping the union
+instead is not implementable: role membership resolves per user from Entra claims at request time,
+so which roles co-occur on one person is unknowable when an admin saves a seed list. Enforcing it at
+read time would be worse than no cap, because it would silently drop an admin's lock for some users
+— a rollout that appears to have landed and did not.
+
+Friction has none of those failure modes, nothing to migrate for roles already over any line, and a
+threshold that can move without breaking a saved list. If evidence of over-locking shows up, revisit
+with the counts this change makes visible.
+
 ## D10 — Admin owns seven levers, in one console
 
 Every store behavior needs a surface, or it becomes a code deploy:
@@ -831,8 +855,6 @@ rather than restating the checks.
   The owner is settled; the commitment is not.
 - **`tagline` backfill.** New required-ish field on existing agents. Derive from the first clause of
   `description` at submit time and let the author edit, or require it outright?
-- **Locked-pin ceiling.** Should the system cap locked pins per role (say, two)? Without a limit,
-  "locked" becomes the default choice and the sidebar becomes someone else's toolbar.
 - **Quota attribution.** Confirm the invoker pays for a store-launched run, not the author. The
   existing per-user model implies yes, but a published Agent is the first case where a stranger's
   usage is attributable to someone else's configuration.

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -175,6 +175,24 @@ export interface AgentCategory {
 /** A role seeds at most this many agents — see `role_pins.MAX_ROLE_PINS`. */
 export const MAX_ROLE_PINS = 25;
 
+/**
+ * Warn past this many *locked* seeds on one role (#748).
+ *
+ * A threshold, not a limit, and the distinction is the whole decision. A locked seed
+ * cannot be dismissed by the member who receives it, so an admin choosing between "seed"
+ * and "seed locked" has no reason not to lock — locking guarantees the rollout lands and
+ * the cost falls on someone else's sidebar. Left unchecked the dominant strategy is to
+ * lock everything and Pinned stops being the user's shelf.
+ *
+ * A hard cap was considered and rejected: pins merge as a union across every role a user
+ * matches and a lock from any one wins, so a per-role cap would not bound what any
+ * individual sees, and the union itself is not cappable (membership resolves per user from
+ * Entra claims, so it is unknowable at write time; enforcing at read time would silently
+ * drop an admin's lock for some users). Friction has no such failure mode, and the number
+ * below can move without breaking anyone's saved list.
+ */
+export const LOCK_WARN_THRESHOLD = 3;
+
 /** One capability the role does not grant, named rather than counted (D9.5). */
 export interface MissingCapability {
   label: string;
@@ -223,6 +241,18 @@ export interface RoleAgentPinsResponse {
   fallbackOnly: boolean;
   /** The role has no JWT mappings, so no user matches it at all. */
   unmapped: boolean;
+  /**
+   * Locked seeds held by *other* roles (#748).
+   *
+   * A member's shelf is the union across every role they match, and a lock from any one
+   * of them wins — so this role's locked count is only part of what an individual gets.
+   * Reported, never enforced: role membership resolves per user from Entra claims, so the
+   * union is not knowable at write time, and capping it at read time would silently drop
+   * an admin's lock for some users.
+   */
+  lockedElsewhere: number;
+  /** How many other roles lock at least one seed — the spread behind `lockedElsewhere`. */
+  lockedElsewhereRoles: number;
   pins: RoleAgentPinRow[];
   /** Seeded ids whose agent no longer exists — reported, never pruned on read. */
   unavailable: string[];

--- a/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AppRolesService } from '../../roles/services/app-roles.service';
+import { MarketplaceDefaultPinsPage } from './default-pins.page';
+import { LOCK_WARN_THRESHOLD, RoleAgentPinsResponse } from '../models/marketplace.model';
+
+/**
+ * Locked-seed friction (#748).
+ *
+ * The decision was **friction, not a cap**, so what has to hold is that the cost of
+ * locking is visible — not that anything is refused. Two facts carry it: how many seeds
+ * this role locks, and how many every *other* role locks. The second is the one an admin
+ * cannot work out from this page, and it is the only honest way to show the union
+ * problem: a member's shelf is the union across the roles they match, and a lock from any
+ * one role wins, so no per-role number describes what an individual ends up with.
+ */
+describe('MarketplaceDefaultPinsPage — locked-seed friction', () => {
+  let mockService: any;
+  let mockRoles: any;
+
+  function response(overrides: Partial<RoleAgentPinsResponse> = {}): RoleAgentPinsResponse {
+    return {
+      roleId: 'faculty',
+      roleLabel: 'Faculty',
+      fallbackOnly: false,
+      unmapped: false,
+      lockedElsewhere: 0,
+      lockedElsewhereRoles: 0,
+      pins: [],
+      unavailable: [],
+      ...overrides,
+    };
+  }
+
+  function pin(agentId: string, locked: boolean) {
+    return {
+      agentId,
+      name: agentId,
+      category: 'Administration',
+      order: 0,
+      locked,
+      reachable: true,
+      visibility: 'PUBLIC',
+      state: 'ready' as const,
+      missing: [],
+      notes: [],
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: vi.fn().mockReturnValue(null),
+      loadListings: vi.fn().mockResolvedValue([]),
+      loadRolePins: vi.fn().mockResolvedValue(response()),
+      saveRolePins: vi.fn().mockResolvedValue(response()),
+    };
+    mockRoles = { fetchRoles: vi.fn().mockResolvedValue([{ roleId: 'faculty', displayName: 'Faculty' }]) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: AppRolesService, useValue: mockRoles },
+        { provide: Dialog, useValue: { open: vi.fn() } },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function render(
+    res: RoleAgentPinsResponse,
+  ): Promise<ComponentFixture<MarketplaceDefaultPinsPage>> {
+    mockService.loadRolePins.mockResolvedValue(res);
+    const fixture = TestBed.createComponent(MarketplaceDefaultPinsPage);
+    const page = fixture.componentInstance;
+    page.roleId.set('faculty');
+    await page.reloadPins();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function text(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('counts the locked seeds on this role', async () => {
+    const fixture = await render(
+      response({ pins: [pin('a', true), pin('b', false), pin('c', true)] }),
+    );
+    expect(fixture.componentInstance.lockedCount()).toBe(2);
+  });
+
+  it('stays quiet at or below the threshold', async () => {
+    const pins = Array.from({ length: LOCK_WARN_THRESHOLD }, (_, i) => pin(`a${i}`, true));
+    const fixture = await render(response({ pins }));
+
+    expect(fixture.componentInstance.lockWarning()).toBe(false);
+    expect(text(fixture)).not.toContain('Members cannot remove a locked agent');
+  });
+
+  it('warns once past the threshold', async () => {
+    const pins = Array.from({ length: LOCK_WARN_THRESHOLD + 1 }, (_, i) => pin(`a${i}`, true));
+    const fixture = await render(response({ pins }));
+
+    expect(fixture.componentInstance.lockWarning()).toBe(true);
+    expect(text(fixture)).toContain('Members cannot remove a locked agent');
+  });
+
+  it('never refuses a lock — this is friction, not a cap', async () => {
+    const pins = Array.from({ length: 12 }, (_, i) => pin(`a${i}`, true));
+    const fixture = await render(response({ pins }));
+
+    // Warned, but every seed is still staged and saveable.
+    expect(fixture.componentInstance.lockWarning()).toBe(true);
+    expect(fixture.componentInstance.lockedCount()).toBe(12);
+    expect(text(fixture)).not.toContain('cannot lock');
+  });
+
+  it('surfaces what other roles lock, even when this role locks nothing', async () => {
+    // The union case: this role looks innocent, the member's shelf is not.
+    const fixture = await render(
+      response({ pins: [pin('a', false)], lockedElsewhere: 4, lockedElsewhereRoles: 2 }),
+    );
+
+    expect(fixture.componentInstance.lockWarning()).toBe(false);
+    const body = text(fixture);
+    expect(body).toContain('2 other roles lock');
+    expect(body).toContain('4 more');
+    expect(body).toContain('union');
+  });
+
+  it('says "role locks" rather than "roles lock" for a single other role', async () => {
+    const fixture = await render(response({ lockedElsewhere: 1, lockedElsewhereRoles: 1 }));
+    expect(text(fixture)).toContain('1 other role locks');
+  });
+
+  it('shows nothing when no role locks anything', async () => {
+    const fixture = await render(response({ pins: [pin('a', false)] }));
+    const body = text(fixture);
+
+    expect(body).not.toContain('other roles lock');
+    expect(body).not.toContain('Members cannot remove a locked agent');
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
@@ -23,6 +23,7 @@ import { AppRole } from '../../roles/models/app-role.model';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import {
   AdminListingRow,
+  LOCK_WARN_THRESHOLD,
   MAX_ROLE_PINS,
   RoleAgentPinRow,
 } from '../models/marketplace.model';
@@ -146,6 +147,42 @@ interface StagedPin {
           </div>
         }
 
+        <!--
+          #748 — locking friction. Two separate facts, and the second is the one an admin
+          cannot work out for themselves: their own locked count, and what every other
+          role already locks. A member's shelf is the union across the roles they match.
+        -->
+        @if (lockWarning() || lockedElsewhere()) {
+          <div
+            role="status"
+            class="mb-4 rounded-2xl border px-4 py-3 text-sm/6"
+            [class]="
+              lockWarning()
+                ? 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200'
+                : 'border-gray-200 bg-gray-50 text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300'
+            "
+          >
+            @if (lockWarning()) {
+              <span class="font-semibold">
+                {{ lockedCount() }} of {{ staged().length }} seeds are locked.
+              </span>
+              Members cannot remove a locked agent — it is in their sidebar for good. Lock
+              the ones that genuinely must be there and leave the rest removable, or Pinned
+              stops being the user's own shelf.
+            }
+            @if (lockedElsewhere()) {
+              <span [class]="lockWarning() ? 'mt-2 block' : ''">
+                {{ lockedElsewhereRoles() }}
+                other {{ lockedElsewhereRoles() === 1 ? 'role locks' : 'roles lock' }}
+                {{ lockedElsewhere() }} more.
+                A member who matches several roles gets the union of all of them, and a
+                lock from any one role wins — so the shelf an individual ends up with can
+                be larger than any single role's list.
+              </span>
+            }
+          </div>
+        }
+
         @if (unavailable().length) {
           <div
             role="status"
@@ -172,6 +209,11 @@ interface StagedPin {
             <div class="mb-3 flex items-center justify-between gap-4">
               <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
                 Seeded for {{ roleLabel() }} ({{ staged().length }}/{{ maxPins }})
+                @if (lockedCount()) {
+                  <span class="ml-2 text-sm/6 font-normal text-gray-500 dark:text-gray-400">
+                    · {{ lockedCount() }} locked
+                  </span>
+                }
               </h2>
               <div class="flex items-center gap-2">
                 @if (dirty()) {
@@ -401,6 +443,7 @@ export class MarketplaceDefaultPinsPage implements OnInit {
   private dialog = inject(Dialog);
 
   readonly maxPins = MAX_ROLE_PINS;
+  readonly lockWarnThreshold = LOCK_WARN_THRESHOLD;
 
   readonly roles = signal<AppRole[]>([]);
   readonly roleId = signal('');
@@ -408,6 +451,8 @@ export class MarketplaceDefaultPinsPage implements OnInit {
   readonly fallbackOnly = signal(false);
   readonly unmapped = signal(false);
   readonly unavailable = signal<string[]>([]);
+  readonly lockedElsewhere = signal(0);
+  readonly lockedElsewhereRoles = signal(0);
   readonly staged = signal<StagedPin[]>([]);
   readonly listings = signal<AdminListingRow[]>([]);
   readonly loading = signal(true);
@@ -429,6 +474,17 @@ export class MarketplaceDefaultPinsPage implements OnInit {
   readonly dirty = computed(() => this.fingerprint() !== this.saved());
 
   readonly isFull = computed(() => this.staged().length >= MAX_ROLE_PINS);
+
+  /**
+   * Locked-seed friction (#748). There is deliberately **no cap** — see
+   * `count_locked_outside` in the backend for why the union across a user's roles cannot
+   * be bounded at write time. What the console can do is make the cost visible, because
+   * an admin weighing "seed" against "seed locked" otherwise has no reason not to lock:
+   * locking guarantees the rollout lands and the cost falls on someone else's sidebar.
+   */
+  readonly lockedCount = computed(() => this.staged().filter((pin) => pin.locked).length);
+
+  readonly lockWarning = computed(() => this.lockedCount() > LOCK_WARN_THRESHOLD);
 
   readonly candidates = computed(() => {
     const already = new Set(this.staged().map((pin) => pin.agentId));
@@ -474,6 +530,8 @@ export class MarketplaceDefaultPinsPage implements OnInit {
       this.fallbackOnly.set(response.fallbackOnly);
       this.unmapped.set(response.unmapped);
       this.unavailable.set(response.unavailable ?? []);
+      this.lockedElsewhere.set(response.lockedElsewhere ?? 0);
+      this.lockedElsewhereRoles.set(response.lockedElsewhereRoles ?? 0);
       this.savedPins.set(response.pins ?? []);
       this.staged.set(
         (response.pins ?? []).map((row) => ({


### PR DESCRIPTION
Fixes #748 — the D9 "locked-pin ceiling" open question. Resolved as **option 2 (soft friction)**.

## Why not a cap

Not because a cap is heavy-handed — because it doesn't work, structurally:

- **A per-role cap doesn't bound what anyone sees.** Pins merge as a *union* across every role a user matches, and a lock from any one wins (`pin_service._role_seeds`, D9.2). A cap of two means someone in five roles sees ten.
- **The union can't be capped at write time.** Role membership resolves per user from Entra claims at request time, so which roles co-occur on one person is unknowable when an admin saves a seed list. That is what makes option 3 unimplementable, not merely awkward.
- **At read time it would be worse than nothing** — silently dropping an admin's lock for some users, i.e. a rollout that looks like it landed and didn't.

The concern itself is real, and phase 6 sharpened it: a locked seed genuinely cannot be dismissed (a lock beats the user's own tombstone — correct, since a dismissable lock is pointless). So an admin weighing "seed" against "seed locked" has no reason not to lock, and the cost lands on someone else's sidebar.

## What the console does instead

| | |
|---|---|
| Seed header | `Seeded for Faculty (7/25) · 4 locked` |
| Past threshold (`LOCK_WARN_THRESHOLD = 3`) | "N of M seeds are locked. Members cannot remove a locked agent…" |
| **`lockedElsewhere`** | "2 other roles lock 4 more. A member who matches several roles gets the union…" |

The third row is the point. It's the one fact an admin cannot work out from their own page, and the only honest way to show the union — the institution-wide total *is* knowable here even though the per-user union isn't.

Advisory throughout: `count_locked_outside` swallows a failed role listing and returns `(0, 0)` rather than taking the pins page down for a piece of warning copy.

## Testing

- Backend: **5303 passed, 6 skipped** — 5 new tests covering other-roles-only counting, unlocked seeds not counting, the spread across roles, a lone role, and the swallowed failure.
- SPA: **140 files / 1579 tests** — 7 new. Verified they discriminate: with the banner removed, exactly the three template-dependent tests fail.
- One test asserts the decision itself — `never refuses a lock — this is friction, not a cap` stages 12 locked seeds and checks they all survive.

Spec: the open question is removed from Open Questions and resolved in place as **D9.7**, matching that section's existing bold-numbered convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)