### PR TITLE
docs(agents): settle the Agent specs, and make the tagline decision true

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -295,7 +295,13 @@ async def submit_listing(
         review_note=request.note or (previous.review_note if previous else None),
         admin_edits=previous.admin_edits if previous else [],
     )
-    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    # The tagline rides this write rather than a second one (same reason as the D13 patch
+    # path). ``None`` means "leave it alone" — an author resubmitting without touching the
+    # field must not have their existing subtitle blanked.
+    tagline = (request.tagline or "").strip() or None
+    await write_listing(
+        agent_id, listing, assistant.created_at, updated_at=now, tagline=tagline
+    )
     logger.info(f"📨 Agent {agent_id} submitted for review by {user.user_id}")
     return listing, exposed
 

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -523,6 +523,17 @@ class SubmitListingRequest(BaseModel):
         ),
     )
     note: Optional[str] = Field(None, max_length=2000, description="Optional note to the reviewer")
+    tagline: Optional[str] = Field(
+        None,
+        max_length=80,
+        description=(
+            "Shelf subtitle (D4). Submission is where an author sets this, because it is "
+            "the moment the shelf row comes into existence and the only point they are "
+            "looking at what the store will say. Omit to leave the existing tagline "
+            "untouched; the SPA prefills it from the description's first clause so a "
+            "legacy Agent is not asked for a field it has never had."
+        ),
+    )
 
 
 class SkillExposure(BaseModel):

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -222,6 +222,61 @@ class TestSubmit:
         assert listing["category"] == "Teaching"
         assert listing["reviewNote"] == "For the CTL team"
 
+    # ── #749 — the author sets the shelf subtitle at submission ──────────────────
+    def test_a_supplied_tagline_is_written_with_the_listing(
+        self, app, make_user, _no_writes
+    ):
+        """One write, not two — same reason the D13 patch path bundles presentation."""
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit",
+                json={"category": "Teaching", "tagline": "Cites policy, with sources"},
+            )
+
+        assert resp.status_code == 200
+        assert _no_writes.call_args.kwargs["tagline"] == "Cites policy, with sources"
+
+    def test_an_omitted_tagline_leaves_the_existing_one_alone(
+        self, app, make_user, _no_writes
+    ):
+        """A resubmission that never touches the field must not blank the subtitle.
+
+        ``write_listing`` treats ``None`` as "don't set", so the omission has to reach it
+        as ``None`` rather than as an empty string.
+        """
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Teaching"}
+            )
+
+        assert _no_writes.call_args.kwargs["tagline"] is None
+
+    def test_a_whitespace_only_tagline_is_treated_as_omitted(
+        self, app, make_user, _no_writes
+    ):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            TestClient(app).post(
+                "/agents/ast-001/listing/submit",
+                json={"category": "Teaching", "tagline": "   "},
+            )
+
+        assert _no_writes.call_args.kwargs["tagline"] is None
+
+    def test_a_tagline_past_the_shelf_limit_is_rejected(self, app, make_user, _no_writes):
+        """80 chars is a layout constraint, not a suggestion — the row is one line."""
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit",
+                json={"category": "Teaching", "tagline": "x" * 81},
+            )
+
+        assert resp.status_code == 422
+        _no_writes.assert_not_called()
+
     def test_unknown_category_is_rejected(self, app, make_user, _no_writes):
         mock_auth_user(app, make_user())
         with _owner(_make_assistant(bindings=[])):

--- a/docs/specs/agent-designer.md
+++ b/docs/specs/agent-designer.md
@@ -1,6 +1,9 @@
 # Agent Designer — a unified authoring surface for composed Agents
 
-**Status:** Draft / proposal (2026-07-07)
+**Status:** ✅ **Implemented** (phases 0–5; Phase 5, Assistant deprecation, closed 2026-07-26).
+Originally drafted 2026-07-07 as a proposal. There is one noun now, and it is Agent: `/assistants*`
+redirects to `/agents` and the old editor is gone. See the phasing table below for per-phase state.
+
 **Author:** (drafted with Claude)
 **Targets branch:** `develop`
 **Supersedes:** the "extend the Assistant editor to bind a Memory Space" assumption in

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -1,6 +1,11 @@
 # Agent Marketplace — a browsable store for published Agents
 
-**Status:** Draft / proposal (2026-07-24)
+**Status:** ✅ **Implemented** (phases 0–8 shipped 2026-07-24 → 2026-07-26). Originally drafted
+2026-07-24 as a proposal. Every decision below describes code that exists; where a decision was
+later revised, the revision is recorded in place rather than by editing history away — see D6
+(runnability, two states not three), D9.7 (locked-pin friction) and D14 (GA). The only deferred item
+is the ranking / full-corpus search note under D10, which belongs to the Registry epic.
+
 **Author:** Phil Merrell (drafted with Claude)
 **Targets branch:** `develop`
 **Supersedes:** [`agent-directory.md`](agent-directory.md) — carries forward D1, D2, D3, D6 and D8;
@@ -54,8 +59,21 @@ across three or more Agents.
 
 **This replaces `agent-directory.md` D7,** which argued that a review queue makes publication stop.
 That argument is real and the mitigation is an operational commitment, not a technical one: a
-**stated review SLA (two business days)** and a pending-count badge on the admin nav so the queue is
-visible rather than discovered.
+**stated review SLA** and a pending-count badge on the admin nav so the queue is visible rather than
+discovered.
+
+**The SLA, committed (was an open question):**
+
+| Queue | Turnaround |
+|---|---|
+| Submissions | **Two business days** |
+| Reports — `inappropriate` | **Same day** |
+| Reports — everything else | **Weekly sweep** |
+
+Phase 8 added reports as a second queue, and they are deliberately not on the same clock. A
+submission is a person waiting to publish; a report is mostly maintenance signal, and `inappropriate`
+is the one that should page a human rather than wait (D15). One number covering both would either
+over-promise on reports or under-promise on submissions.
 
 The lifecycle is a state machine on the listing:
 
@@ -848,13 +866,27 @@ rather than restating the checks.
 - **Publisher identity** — its own admin-managed `PublisherProfile`, proposed by the author and
   owned by the admin, with institution publishing supported so official Agents don't carry a staff
   member's personal name (D12). Display-only, never an access gate.
+- **Quota attribution** — **the invoker pays**, confirmed in code, not inferred.
+  `quota_checker.check_quota(user=current_user, …)`
+  ([`chat/routes.py:1319`](../../backend/src/apis/inference_api/chat/routes.py)) resolves against the
+  caller, and there is no author-side lookup anywhere on the invocation path. Cost rows land on the
+  same person: `PK = USER#{user_id}`
+  ([`sessions/services/metadata.py:157`](../../backend/src/apis/app_api/sessions/services/metadata.py)).
+  So spend and quota agree, and a published Agent does not bill its author for a stranger's run.
+- **Review SLA** — committed, and split by queue. See the table in D2: two business days for
+  submissions, same day for an `inappropriate` report, weekly for the rest.
+- **`tagline` backfill** — **derive and let the author edit**, at submission. Requiring it outright
+  adds a blocking field to every legacy Agent's first submission with no starting point offered,
+  which is friction exactly where publication should be easy.
+
+  ⚠️ Implementing this exposed a second problem the question did not mention: `tagline` was
+  *author-owned on the wire and unsettable in the UI*. The API accepted it and the model said the
+  author owns it, but no Designer control ever wrote one — the same dormant-field shape as the
+  `limits` state (#747). So submission is now where an author sets it, prefilled from the
+  description's first clause (`deriveTagline`). Prefilling is the point rather than the derivation
+  itself: it puts the shelf row in front of the author at the one moment they are looking at what
+  the store will say, so a bad line is one edit away instead of a surprise after publication.
 
 ## Open questions
 
-- **Review SLA.** D2's defense against `agent-directory.md` D7 is operational: a stated turnaround.
-  The owner is settled; the commitment is not.
-- **`tagline` backfill.** New required-ish field on existing agents. Derive from the first clause of
-  `description` at submit time and let the author edit, or require it outright?
-- **Quota attribution.** Confirm the invoker pays for a store-launched run, not the author. The
-  existing per-user model implies yes, but a published Agent is the first case where a stranger's
-  usage is attributable to someone else's configuration.
+*(None outstanding. Everything previously here is resolved above or tracked as its own issue.)*

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -242,6 +242,9 @@ export class AgentsPage implements OnInit {
         agentId: agent.agentId,
         agentName: agent.name,
         listing: agent.listing,
+        tagline: agent.tagline,
+        // Only read to prefill an absent tagline (#749).
+        description: agent.description,
       } satisfies SubmitListingDialogData,
     });
     // The dialog writes through `AgentListingService`, which patches the card itself;

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -7,6 +7,8 @@ import {
   AgentCategory,
   AgentListingBlock,
   SkillExposure,
+  TAGLINE_MAX,
+  deriveTagline,
 } from '../models/store.model';
 
 export interface SubmitListingDialogData {
@@ -14,6 +16,10 @@ export interface SubmitListingDialogData {
   agentName: string;
   /** Present on a resubmission; its category preselects the picker. */
   listing?: AgentListingBlock;
+  /** The current shelf subtitle, if the Agent already has one. */
+  tagline?: string;
+  /** Only used to prefill an absent tagline — see `deriveTagline` (#749). */
+  description?: string;
 }
 
 /** The listing after submission, or `undefined` if cancelled. */
@@ -119,6 +125,32 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
               }
             </div>
 
+            <!--
+              Tagline (D4). Prefilled from the description's first clause for the many
+              Agents that predate the field — the author edits rather than invents, and
+              sees what the shelf will say at the one moment they are looking at it.
+            -->
+            <div class="mt-5">
+              <label for="listing-tagline" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Tagline
+              </label>
+              <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                The one line under the name on the shelf. We started it from your
+                description — make it read like a subtitle.
+              </p>
+              <input
+                id="listing-tagline"
+                type="text"
+                [value]="tagline()"
+                (input)="onTaglineInput($event)"
+                [attr.maxlength]="taglineMax"
+                class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+              />
+              <p class="mt-1 text-right text-xs/5 text-gray-400 dark:text-gray-500">
+                {{ tagline().length }}/{{ taglineMax }}
+              </p>
+            </div>
+
             <div class="mt-5">
               <label for="listing-note" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
                 Note to the reviewer <span class="font-normal text-gray-500 dark:text-gray-400">(optional)</span>
@@ -206,6 +238,8 @@ export class SubmitListingDialogComponent implements OnInit {
 
   readonly category = signal('');
   readonly note = signal('');
+  readonly tagline = signal('');
+  readonly taglineMax = TAGLINE_MAX;
 
   readonly isResubmission = computed(() => !!this.data.listing);
 
@@ -223,6 +257,11 @@ export class SubmitListingDialogComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     // Preselect the category the listing already had, so a resubmission is one click.
     this.category.set(this.data.listing?.category ?? '');
+    // Keep an existing tagline; derive one only when the Agent has never had it, which
+    // is every Agent that predates the field (#749).
+    this.tagline.set(
+      (this.data.tagline ?? '').trim() || deriveTagline(this.data.description),
+    );
     try {
       const [categories, preflight] = await Promise.all([
         this.listings.loadCategories(),
@@ -250,6 +289,10 @@ export class SubmitListingDialogComponent implements OnInit {
     this.note.set((event.target as HTMLTextAreaElement).value);
   }
 
+  onTaglineInput(event: Event): void {
+    this.tagline.set((event.target as HTMLInputElement).value);
+  }
+
   async onSubmit(): Promise<void> {
     if (!this.canSubmit()) return;
     this.submitting.set(true);
@@ -258,6 +301,9 @@ export class SubmitListingDialogComponent implements OnInit {
       const response = await this.listings.submit(this.data.agentId, {
         category: this.category(),
         note: this.note().trim() || undefined,
+        // Omitted rather than blanked when empty — the backend reads `undefined` as
+        // "leave the existing tagline alone".
+        tagline: this.tagline().trim() || undefined,
       });
       this.dialogRef.close(response.listing);
     } catch (err) {

--- a/frontend/ai.client/src/app/agents/models/store.model.spec.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { deriveTagline, TAGLINE_MAX } from './store.model';
+
+/**
+ * Tagline derivation (D4 backfill, #749).
+ *
+ * `tagline` postdates every Agent built before the Marketplace, and it was author-owned
+ * but never author-settable — no Designer control wrote it. Submission prefills from the
+ * description so a legacy Agent is not asked to invent a field it never had, and so the
+ * author sees what the shelf will say at the moment they can still change it.
+ *
+ * The bar is "a sensible starting point the author will edit", not "correct prose". What
+ * these pin is that it never emits something *worse* than the truncated description the
+ * store falls back to today: no mid-word breaks, no trailing punctuation, never over the
+ * limit.
+ */
+describe('deriveTagline', () => {
+  it('returns nothing for an empty description', () => {
+    expect(deriveTagline(undefined)).toBe('');
+    expect(deriveTagline(null)).toBe('');
+    expect(deriveTagline('   ')).toBe('');
+  });
+
+  it('uses a short description whole', () => {
+    expect(deriveTagline('Finds and cites university policy')).toBe(
+      'Finds and cites university policy',
+    );
+  });
+
+  it('drops trailing punctuation', () => {
+    expect(deriveTagline('Finds and cites university policy.')).toBe(
+      'Finds and cites university policy',
+    );
+  });
+
+  it('collapses whitespace, including newlines', () => {
+    expect(deriveTagline('Finds  and\n  cites\tpolicy')).toBe('Finds and cites policy');
+  });
+
+  it('cuts at the first sentence when the description runs long', () => {
+    const text =
+      'Finds and cites university policy. It also drafts summaries for department chairs and '
+      + 'answers questions about the travel reimbursement process.';
+    expect(deriveTagline(text)).toBe('Finds and cites university policy');
+  });
+
+  it('cuts at a semicolon clause', () => {
+    const text =
+      'Answers questions about travel reimbursement; it reads the policy manual and the '
+      + 'current per-diem tables before replying to anyone.';
+    expect(deriveTagline(text)).toBe('Answers questions about travel reimbursement');
+  });
+
+  it('never exceeds the limit', () => {
+    const text = 'x'.repeat(500);
+    expect(deriveTagline(text).length).toBeLessThanOrEqual(TAGLINE_MAX);
+  });
+
+  it('breaks on a whole word when there is no clause boundary', () => {
+    // The fallback case — this is the one that would otherwise read as a truncation.
+    const text =
+      'A research assistant for graduate students working on federally funded grant '
+      + 'proposals across every college in the university';
+    const result = deriveTagline(text);
+
+    expect(result.length).toBeLessThanOrEqual(TAGLINE_MAX);
+    // Whatever it cut, it cut between words — the property that matters.
+    expect(text.startsWith(result)).toBe(true);
+    expect(text[result.length]).toBe(' ');
+  });
+
+  it('ignores a boundary too early to be a useful subtitle', () => {
+    // "Hi." is a clause, but a three-character tagline is not a subtitle.
+    const text = 'Hi. This agent helps students find and understand university policy quickly.';
+    expect(deriveTagline(text).length).toBeGreaterThan(20);
+  });
+});

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -84,6 +84,11 @@ export interface SubmitListingRequest {
   /** Omit to publish under the author's own individual profile (D12). */
   publisherId?: string;
   note?: string;
+  /**
+   * Shelf subtitle (D4). Omit to leave any existing tagline untouched — a resubmission
+   * that does not touch the field must not blank it.
+   */
+  tagline?: string;
 }
 
 /** One skill that publication would make readable (D7.1). */
@@ -224,4 +229,44 @@ export interface SubmitReportResponse {
    * one is now queued.
    */
   replacedExisting: boolean;
+}
+
+/** The shelf subtitle's hard limit — mirrors `SubmitListingRequest.tagline` (D4). */
+export const TAGLINE_MAX = 80;
+
+/**
+ * A starting tagline derived from an Agent's description (D4 backfill, #749).
+ *
+ * `tagline` postdates every Agent that existed before the Marketplace, and the field is
+ * author-owned but was never author-settable — no Designer control wrote it. So a legacy
+ * Agent arrives at submission with nothing for the shelf, and the store falls back to a
+ * truncated `description`, which is exactly the mid-clause row D4 added `tagline` to avoid.
+ *
+ * Rather than requiring the author to invent one, submission prefills from the first
+ * clause of the description and lets them edit it. Deriving is not the point — *showing*
+ * it at the one moment the author is looking at what the shelf will say is. A bad
+ * derivation is then one edit away instead of a surprise after publication.
+ *
+ * "First clause" is the first sentence or clause boundary, whichever comes first, trimmed
+ * of its punctuation. Falls back to a hard truncation only when the text has no boundary
+ * inside the limit — the case a human should be looking at anyway.
+ */
+export function deriveTagline(description: string | undefined | null): string {
+  const text = (description ?? '').replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  if (text.length <= TAGLINE_MAX) return text.replace(/[.;,\s]+$/, '');
+
+  // Prefer a real boundary inside the limit; `.` `;` and `—` all end a clause.
+  const window = text.slice(0, TAGLINE_MAX + 1);
+  const boundary = Math.max(
+    window.lastIndexOf('. '),
+    window.lastIndexOf('; '),
+    window.lastIndexOf(' — '),
+  );
+  if (boundary > 20) return window.slice(0, boundary).replace(/[.;,\s]+$/, '');
+
+  // No boundary worth using — break on the last whole word instead of mid-token.
+  const space = window.lastIndexOf(' ');
+  const cut = space > 20 ? window.slice(0, space) : text.slice(0, TAGLINE_MAX);
+  return cut.replace(/[.;,\s]+$/, '');
 }


### PR DESCRIPTION
Fixes #749. Four items — the last one turned out to need code.

## 1. Phasing table — already done

Fixed while shipping #746 (#758/#760). Verified, no change here.

## 2. Quota attribution — resolved in code, not by inference

**The invoker pays.** `quota_checker.check_quota(user=current_user, …)` at [`chat/routes.py:1319`](backend/src/apis/inference_api/chat/routes.py:1319), with no author-side lookup anywhere on the invocation path. Cost rows land on the same person — `PK = USER#{user_id}` at [`metadata.py:157`](backend/src/apis/app_api/sessions/services/metadata.py:157) — so spend and quota agree. Both file:lines are now in the spec so nobody re-derives it.

## 3. Review SLA — committed, split by queue

| Queue | Turnaround |
|---|---|
| Submissions | Two business days |
| Reports — `inappropriate` | Same day |
| Reports — everything else | Weekly sweep |

Phase 8 added reports as a second queue and they aren't on the same clock: a submission is a person waiting to publish, a report is mostly maintenance signal, and `inappropriate` is the one meant to page a human (D15).

Worth noting the spec was already contradicting itself — D2's body asserted "two business days" while Open Questions said the commitment was never made. That's now settled in one place.

## 4. `tagline` backfill — decided, **and implemented**

Decision: **derive and let the author edit**, at submission. Requiring it outright adds a blocking field to every legacy Agent's first submission with no starting point, which is friction exactly where publication should be easy.

⚠️ **Writing that down alone would have re-opened the gap this issue exists to close.** Implementing it surfaced a second problem the question never mentioned: `tagline` was **author-owned on the wire and unsettable in the UI**. `AssistantUpdateRequest` accepts it and the model comment says *"the author owns their own tagline"* — but no Designer control ever wrote one, and `SubmitListingRequest` didn't carry it. The same dormant-field shape as the `limits` state in #747.

So this PR adds the field where it belongs:

- `SubmitListingRequest.tagline` (≤80), persisted on the same write as the listing — no second round trip, same reasoning as the D13 patch path
- `deriveTagline()` — first sentence/clause boundary, falling back to a whole-word break; never mid-token, never over the limit
- A tagline input in the submit dialog, prefilled and character-counted

The derivation isn't the clever part. Putting the shelf row in front of the author at the one moment they're looking at what the store will say is — a bad line is one edit away instead of a surprise after publication. Omitted means "leave it alone", so a resubmission can't blank an existing subtitle.

## Also: the specs' own front pages

Both `agent-marketplace.md` and `agent-designer.md` still read **"Status: Draft / proposal"** while describing shipped code. That is precisely the `agent-directory.md` failure this issue cites — a document whose face doesn't say what it is — just on the header instead of the phasing table. Both now state what's implemented and point at the revisions recorded in place (D6, D9.7, D14).

**Open questions on the marketplace spec are now empty.**

## Testing

- Backend: **5307 passed, 6 skipped** — 4 new (tagline written, omitted-means-untouched, whitespace-only treated as omitted, over-limit rejected with no write)
- SPA: **141 files / 1588 tests** — 9 new on `deriveTagline`, including the property that matters: whatever it cuts, it cuts between words

🤖 Generated with [Claude Code](https://claude.com/claude-code)