### PR TITLE
feat(costs): tell a deliberate @-mention swap from a cache regression

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -121,7 +121,7 @@ Do not reintroduce a Bearer-only `Depends(...)` on any user-facing route. If you
 - **Tool not appearing:** Check `__init__.py` export, RBAC permissions, `enabled_tools`, ToolRegistry
 - **Session not persisting:** Check AgentCore Memory config, session_id, TurnBasedSessionManager flush
 - **SSE stream disconnecting:** Check 600s timeout, client connection, quota exceeded events
-- **Cost spike / cache miss:** Check `cacheStatus` + `toolConfigHash`/`systemPromptHash`/`historyHash` on the session's `C#` rows in sessions-metadata (or `GET /admin/costs/sessions/{id}/calls`) — the hash that changed between consecutive calls names the cache-buster
+- **Cost spike / cache miss:** Check `cacheStatus` + `toolConfigHash`/`systemPromptHash`/`historyHash` on the session's `C#` rows in sessions-metadata (or `GET /admin/costs/sessions/{id}/calls`) — the hash that changed between consecutive calls names the cache-buster. Rule out the explained case first: `agentSwitched` on the row means an `@`-mention ran that turn on a different Agent, which re-writes the prefix on purpose and looks identical to the regression (`agentSwitchMissCount`/`agentSwitchUsd` are a subset of the totals — subtract for unexplained waste)
 
 ## Coding Standards
 

--- a/backend/src/agents/main_agent/base_agent.py
+++ b/backend/src/agents/main_agent/base_agent.py
@@ -193,6 +193,7 @@ class BaseAgent(ABC):
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List[Dict[str, Any]]] = None,
         continue_truncated: bool = False,
+        turn_agent_id: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """Stream agent responses. Subclasses must implement.
 

--- a/backend/src/agents/main_agent/chat_agent.py
+++ b/backend/src/agents/main_agent/chat_agent.py
@@ -88,6 +88,7 @@ class ChatAgent(BaseAgent):
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List[Dict[str, Any]]] = None,
         continue_truncated: bool = False,
+        turn_agent_id: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Stream agent responses.
@@ -139,5 +140,6 @@ class ChatAgent(BaseAgent):
             main_agent_wrapper=self,
             citations=citations,
             original_message=original_message,
+            turn_agent_id=turn_agent_id,
         ):
             yield event

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -943,6 +943,7 @@ class StreamCoordinator:
                             agent=main_agent_wrapper,  # Use wrapper instead of internal agent
                             citations=citations_for_message,  # Pass citations for persistence
                             call_index=idx,  # Nth model call of this turn (prefix fingerprint lookup)
+                            turn_agent_id=turn_agent_id,  # Which Agent ran this turn (#756)
                         )
                     )
 
@@ -2087,6 +2088,7 @@ class StreamCoordinator:
         agent: Any = None,
         citations: Optional[List] = None,
         call_index: Optional[int] = None,
+        turn_agent_id: Optional[str] = None,
     ) -> None:
         """
         Store message-level metadata (token usage, latency, model info, citations)
@@ -2247,6 +2249,16 @@ class StreamCoordinator:
                     prefix_fingerprint = get_prefix_fingerprint(strands_agent, call_index)
                     if prefix_fingerprint:
                         metadata_kwargs["prefixFingerprints"] = prefix_fingerprint
+
+                # Which Agent ran this turn (#756), as another extra field. An
+                # `@`-mention swaps the Agent for one turn, which genuinely re-writes
+                # the cache prefix; recording the id is what lets the cost surfaces tell
+                # that deliberate swap apart from the nondeterministic-ordering
+                # regression the fingerprints exist to catch. Both show
+                # `toolConfigHash` and `systemPromptHash` flipping together, and nothing
+                # else on the row distinguishes them.
+                if turn_agent_id:
+                    metadata_kwargs["turnAgentId"] = turn_agent_id
 
                 message_metadata = MessageMetadata(**metadata_kwargs)
 

--- a/backend/src/agents/main_agent/voice_agent.py
+++ b/backend/src/agents/main_agent/voice_agent.py
@@ -342,6 +342,9 @@ class VoiceAgent(BaseAgent):
         citations: Optional[List] = None,
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List] = None,
+        # Accepted only to satisfy the base signature. Voice has no `@`-mention
+        # surface, so there is no turn-scoped Agent to record (#756).
+        turn_agent_id: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         BaseAgent interface compatibility — not used for voice mode.

--- a/backend/src/apis/app_api/admin/costs/models.py
+++ b/backend/src/apis/app_api/admin/costs/models.py
@@ -130,6 +130,17 @@ class SessionCallRow(BaseModel):
         None, alias="cachePrefixGapSeconds"
     )
     wasted_usd: float = Field(0.0, alias="wastedUsd")
+    # #756 — which Agent ran this call, and whether that changed from the call
+    # before it. An `@`-mention (Marketplace D11) hands one turn to a different
+    # Agent, which genuinely re-writes the prefix; without this a deliberate swap
+    # is indistinguishable from a nondeterministic-ordering regression, since both
+    # flip `toolConfigHash` and `systemPromptHash` together.
+    turn_agent_id: Optional[str] = Field(None, alias="turnAgentId")
+    agent_switched: bool = Field(
+        False,
+        alias="agentSwitched",
+        description="This call ran on a different Agent than the previous one — an explained prefix re-write",
+    )
     prefix_fingerprints: Optional[PrefixFingerprints] = Field(
         None, alias="prefixFingerprints"
     )
@@ -147,6 +158,13 @@ class SessionCostAnatomy(BaseModel):
     total_cache_write_tokens: int = Field(0, alias="totalCacheWriteTokens")
     avoidable_miss_count: int = Field(0, alias="avoidableMissCount")
     wasted_usd: float = Field(0.0, alias="wastedUsd")
+    # #756 — the subset of the two figures above that an Agent switch explains.
+    # Deliberately a *split*, not a deduction: the totals still carry every dollar
+    # spent, because hiding the cost of `@`-mentions would understate a feature we
+    # want to be able to measure on purpose. Subtract to get unexplained waste,
+    # which is the number a prefix-stability regression moves.
+    agent_switch_miss_count: int = Field(0, alias="agentSwitchMissCount")
+    agent_switch_usd: float = Field(0.0, alias="agentSwitchUsd")
     # cacheRead / (cacheRead + cacheWrite) over the session; None until
     # there has been any cache activity.
     cache_efficiency: Optional[float] = Field(None, alias="cacheEfficiency")

--- a/backend/src/apis/app_api/admin/costs/routes.py
+++ b/backend/src/apis/app_api/admin/costs/routes.py
@@ -129,6 +129,16 @@ async def get_session_cost_anatomy(
     re-writes: on a miss_avoidable row, diff its fingerprint hashes against
     the previous row's to see which prefix component changed.
 
+    ⚠️ **Check `agentSwitched` before treating a miss as a regression.** An
+    `@`-mention hands one turn to a different Agent, which genuinely re-writes
+    the prefix — it presents exactly like the nondeterministic-ordering bug the
+    fingerprints exist to catch (`toolConfigHash` and `systemPromptHash` flipping
+    together), so the row says which it was, and `turnAgentId` says which Agent
+    ran it. The session rollup splits the same way: `agentSwitchMissCount` /
+    `agentSwitchUsd` are a *subset* of `avoidableMissCount` / `wastedUsd`, never
+    deducted from them. Subtract to get unexplained waste — that difference is
+    what a prefix-stability regression moves.
+
     Args:
         session_id: Session identifier (any user's session — admin scope)
         admin_user: Authenticated admin user (injected)

--- a/backend/src/apis/app_api/admin/costs/service.py
+++ b/backend/src/apis/app_api/admin/costs/service.py
@@ -341,6 +341,8 @@ class AdminCostService:
         total_cache_write = 0
         avoidable_misses = 0
         wasted_usd = 0.0
+        agent_switch_misses = 0
+        agent_switch_usd = 0.0
 
         for record in records:
             token_usage = record.get("tokenUsage") or {}
@@ -361,12 +363,19 @@ class AdminCostService:
             cache_write = int(token_usage.get("cacheWriteInputTokens") or 0)
             cache_status = record.get("cacheStatus")
             row_wasted = float(record.get("wastedUsd") or 0.0)
+            # #756 — derived at write time, where the predecessor row was already
+            # in hand; read here as a plain projection.
+            agent_switched = bool(record.get("agentSwitched"))
 
             total_cost += cost
             total_cache_read += cache_read
             total_cache_write += cache_write
             if cache_status == "miss_avoidable":
                 avoidable_misses += 1
+                # A split of the totals, never a deduction from them.
+                if agent_switched:
+                    agent_switch_misses += 1
+                    agent_switch_usd += row_wasted
             wasted_usd += row_wasted
 
             gap_raw = record.get("cacheGapSeconds")
@@ -386,6 +395,8 @@ class AdminCostService:
                     int(prefix_gap_raw) if prefix_gap_raw is not None else None
                 ),
                 wasted_usd=row_wasted,
+                turn_agent_id=record.get("turnAgentId"),
+                agent_switched=agent_switched,
                 prefix_fingerprints=(
                     PrefixFingerprints(**fingerprints_raw)
                     if isinstance(fingerprints_raw, dict) else None
@@ -410,6 +421,8 @@ class AdminCostService:
             total_cache_write_tokens=total_cache_write,
             avoidable_miss_count=avoidable_misses,
             wasted_usd=round(wasted_usd, 6),
+            agent_switch_miss_count=agent_switch_misses,
+            agent_switch_usd=round(agent_switch_usd, 6),
             cache_efficiency=cache_efficiency,
         )
 

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -2152,6 +2152,13 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 original_message=input_data.message if message_will_be_modified else None,
                 interrupt_responses=interrupt_responses_payload,
                 continue_truncated=is_continuation,
+                # Which Agent ran this turn (#756). Recorded on the cost row so a
+                # deliberate `@`-mention prefix swap is distinguishable from the
+                # nondeterministic-ordering regression the fingerprints exist to catch.
+                # Passed per turn rather than read off the agent: the agent instance is
+                # cached and shared across turns, so per-turn state must never live on it
+                # (see #741/#751).
+                turn_agent_id=input_data.rag_assistant_id,
             ):
                 yield event
                 # Interleave the finished title between agent events (same

--- a/backend/src/apis/shared/observability/emf.py
+++ b/backend/src/apis/shared/observability/emf.py
@@ -42,6 +42,7 @@ def emit_prompt_cache_metrics(
     model_id: Optional[str] = None,
     session_id: Optional[str] = None,
     cache_status: Optional[str] = None,
+    agent_switched: bool = False,
 ) -> None:
     """Emit one EMF record for a completed model call.
 
@@ -53,6 +54,14 @@ def emit_prompt_cache_metrics(
     - ``AvoidableMiss``: count of calls classified ``miss_avoidable`` — the
       alarm target (a prefix-stability regression shows up as a step change).
     - ``WastedUsd``: dollars attributed to avoidable re-writes.
+    - ``AgentSwitchMiss``: the subset of ``AvoidableMiss`` explained by the turn
+      running on a different Agent than the one before it — an ``@``-mention
+      (Marketplace D11) genuinely re-writes the prefix. Emitted as its own metric
+      rather than as a dimension on ``AvoidableMiss`` so the alarm target stays a
+      single fleet-wide sum: subtract it to get unexplained waste, which is the
+      number that should never step-change. `turnAgentId` rides along as a
+      property, not a dimension, so per-Agent detail is queryable without
+      multiplying metric streams.
 
     Best-effort: never raises.
     """
@@ -68,6 +77,7 @@ def emit_prompt_cache_metrics(
                             {"Name": "CacheReadTokens", "Unit": "Count"},
                             {"Name": "CacheWriteTokens", "Unit": "Count"},
                             {"Name": "AvoidableMiss", "Unit": "Count"},
+                            {"Name": "AgentSwitchMiss", "Unit": "Count"},
                             {"Name": "WastedUsd", "Unit": "None"},
                         ],
                     }
@@ -76,6 +86,7 @@ def emit_prompt_cache_metrics(
             "CacheReadTokens": int(cache_read_tokens or 0),
             "CacheWriteTokens": int(cache_write_tokens or 0),
             "AvoidableMiss": 1 if avoidable_miss else 0,
+            "AgentSwitchMiss": 1 if (avoidable_miss and agent_switched) else 0,
             "WastedUsd": round(float(wasted_usd or 0.0), 6),
         }
         if model_id:

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -515,6 +515,27 @@ def _derive_cache_observability(
             "cacheStatus": status.value,
             "wastedUsd": round(wasted_usd, 6),
         }
+
+        # #756 — was this prefix re-write *explained*?
+        #
+        # An `@`-mention hands one turn to a different Agent (Marketplace D11), which
+        # swaps the system prompt and toolConfig and so genuinely re-writes the cache
+        # prefix. That spend is real and stays in `wastedUsd` — hiding it would understate
+        # the cost of the mention feature, which is a thing worth measuring on purpose.
+        # What it must not do is look like the nondeterministic-ordering regression the
+        # fingerprints exist to catch: both present as `toolConfigHash` and
+        # `systemPromptHash` flipping together, and until now nothing on the row told them
+        # apart, so expected traffic diluted the signal.
+        #
+        # Recorded here rather than derived on read because this is the only place that
+        # already holds the predecessor row. Compared against the *previous call*, not the
+        # same-prefix match above: the question is "did the Agent change from one turn to
+        # the next", and the same-prefix row is by construction one that did not.
+        own_agent = getattr(message_metadata, "turnAgentId", None)
+        prev_agent = (prev_row or {}).get("turnAgentId")
+        if prev_row is not None and own_agent != prev_agent:
+            result["agentSwitched"] = True
+
         # `cacheGapSeconds` keeps its original meaning — seconds since the
         # previous call — because the anatomy page and its consumers read it as
         # a plain chronology. When the call that actually determined the verdict
@@ -577,6 +598,7 @@ def _emit_cache_metrics(
             model_id=message_metadata.model_info.model_id if message_metadata.model_info else None,
             session_id=session_id,
             cache_status=status,
+            agent_switched=bool(cache_observability.get("agentSwitched")),
         )
     except Exception as e:  # noqa: BLE001 - metrics must never break the write path
         logger.debug("Cache EMF emission skipped: %s", e)

--- a/backend/tests/apis/app_api/test_cost_anatomy_agent_switch.py
+++ b/backend/tests/apis/app_api/test_cost_anatomy_agent_switch.py
@@ -1,0 +1,116 @@
+"""Session cost anatomy — the agent-switch split (#756).
+
+An `@`-mention hands one turn to a different Agent (Marketplace D11), which genuinely
+re-writes the prompt-cache prefix. The turn classifies as ``miss_avoidable`` and that is
+*correct* — the tokens really were spent at the write premium.
+
+What these pin is that the anatomy **splits** rather than **deducts**. The totals keep
+every dollar, because hiding the cost of mentions would understate a feature we want to
+measure on purpose; the split is what lets a reader subtract the explained part and see
+whether unexplained waste moved, which is the signal the fingerprints exist for.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from apis.app_api.admin.costs.service import AdminCostService
+
+
+def _row(*, status, wasted, agent_id=None, switched=False, ts="2026-07-26T00:00:00Z"):
+    return {
+        "timestamp": ts,
+        "cacheStatus": status,
+        "wastedUsd": wasted,
+        "turnAgentId": agent_id,
+        "agentSwitched": switched,
+        "tokenUsage": {"inputTokens": 10, "outputTokens": 5, "cacheWriteInputTokens": 5000},
+        "modelInfo": {"modelId": "claude-sonnet-5"},
+        "cost": {"total": 0.02},
+    }
+
+
+def _service(rows):
+    service = AdminCostService.__new__(AdminCostService)
+    service.storage = AsyncMock()
+    service.storage.get_session_cost_records = AsyncMock(return_value=rows)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_an_explained_miss_is_counted_in_both_the_total_and_the_split():
+    anatomy = await _service(
+        [_row(status="miss_avoidable", wasted=0.006, agent_id="ast-x", switched=True)]
+    ).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.avoidable_miss_count == 1
+    assert anatomy.wasted_usd == 0.006
+    assert anatomy.agent_switch_miss_count == 1
+    assert anatomy.agent_switch_usd == 0.006
+
+
+@pytest.mark.asyncio
+async def test_an_unexplained_miss_is_absent_from_the_split():
+    anatomy = await _service(
+        [_row(status="miss_avoidable", wasted=0.02, agent_id="ast-x", switched=False)]
+    ).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.avoidable_miss_count == 1
+    assert anatomy.wasted_usd == 0.02
+    assert anatomy.agent_switch_miss_count == 0
+    assert anatomy.agent_switch_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_unexplained_waste_is_the_total_minus_the_split():
+    """The number a prefix-stability regression actually moves."""
+    anatomy = await _service([
+        _row(status="miss_avoidable", wasted=0.006, agent_id="ast-x", switched=True),
+        _row(status="miss_avoidable", wasted=0.05, agent_id="ast-x", switched=False),
+        _row(status="hit", wasted=0.0, agent_id="ast-x"),
+    ]).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.avoidable_miss_count == 2
+    assert anatomy.agent_switch_miss_count == 1
+    assert round(anatomy.wasted_usd - anatomy.agent_switch_usd, 6) == 0.05
+
+
+@pytest.mark.asyncio
+async def test_a_switch_that_hit_the_cache_contributes_no_explained_waste():
+    """The flag describes the turn; only a miss can be waste."""
+    anatomy = await _service(
+        [_row(status="hit", wasted=0.0, agent_id="ast-x", switched=True)]
+    ).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.avoidable_miss_count == 0
+    assert anatomy.agent_switch_miss_count == 0
+    assert anatomy.agent_switch_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_the_row_carries_the_agent_so_a_reader_can_see_which_one():
+    anatomy = await _service(
+        [_row(status="miss_avoidable", wasted=0.006, agent_id="ast-canvas", switched=True)]
+    ).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.calls[0].turn_agent_id == "ast-canvas"
+    assert anatomy.calls[0].agent_switched is True
+
+
+@pytest.mark.asyncio
+async def test_rows_written_before_this_shipped_read_as_unswitched():
+    """No backfill — an older row simply has neither attribute."""
+    anatomy = await _service([
+        {
+            "timestamp": "2026-07-01T00:00:00Z",
+            "cacheStatus": "miss_avoidable",
+            "wastedUsd": 0.01,
+            "tokenUsage": {"inputTokens": 10, "outputTokens": 5},
+            "modelInfo": {"modelId": "claude-sonnet-5"},
+            "cost": {"total": 0.02},
+        }
+    ]).get_session_cost_anatomy("sess-1")
+
+    assert anatomy.calls[0].turn_agent_id is None
+    assert anatomy.calls[0].agent_switched is False
+    assert anatomy.agent_switch_miss_count == 0

--- a/backend/tests/shared/test_metadata_cache_derivation.py
+++ b/backend/tests/shared/test_metadata_cache_derivation.py
@@ -20,7 +20,7 @@ from apis.shared.sessions.models import (
 NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricing=True, prints=None):
+def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricing=True, prints=None, agent_id=None):
     pricing = None
     if with_pricing:
         pricing = PricingSnapshot(
@@ -36,6 +36,8 @@ def _metadata(input_t=100, output_t=50, cache_read=0, cache_write=0, with_pricin
             "toolConfigHash": prints[0],
             "systemPromptHash": prints[1],
         }
+    if agent_id is not None:
+        extra["turnAgentId"] = agent_id
     return MessageMetadata(
         **extra,
         token_usage=TokenUsage(
@@ -70,7 +72,7 @@ class _FakeTable:
         return {}
 
 
-def _prev_row(seconds_ago, cache_read=0, cache_write=0, prints=None):
+def _prev_row(seconds_ago, cache_read=0, cache_write=0, prints=None, agent_id=None):
     """A prior cost row. ``prints`` is (toolConfigHash, systemPromptHash)."""
     ts = (NOW - timedelta(seconds=seconds_ago)).isoformat()
     row = {
@@ -85,6 +87,8 @@ def _prev_row(seconds_ago, cache_read=0, cache_write=0, prints=None):
             "toolConfigHash": prints[0],
             "systemPromptHash": prints[1],
         }
+    if agent_id is not None:
+        row["turnAgentId"] = agent_id
     return row
 
 
@@ -338,3 +342,69 @@ class TestKillSwitch:
             cache_observability={"cacheStatus": "miss_avoidable", "wastedUsd": 0.01},
         )
         assert capsys.readouterr().out == ""
+
+
+class TestAgentSwitchDimension:
+    """#756 — whether a prefix re-write is *explained*.
+
+    An `@`-mention hands one turn to a different Agent (Marketplace D11), swapping the
+    system prompt and toolConfig and so genuinely re-writing the prefix. That is
+    indistinguishable on the row from the nondeterministic-ordering regression the
+    fingerprints exist to catch — both flip `toolConfigHash` and `systemPromptHash`
+    together. The flag is what tells them apart.
+
+    It never changes `cacheStatus` or `wastedUsd`: the tokens really were spent, and
+    hiding them would understate the cost of mentions, which is worth measuring.
+    """
+
+    def _derive(self, table, meta):
+        return md._derive_cache_observability(
+            session_id="sess-1", table=table, timestamp=NOW.isoformat(),
+            message_metadata=meta,
+        )
+
+    def test_a_mention_turn_is_flagged_as_switched(self):
+        table = _FakeTable([_prev_row(30, cache_read=4000, agent_id=None)])
+        result = self._derive(table, _metadata(cache_write=5000, agent_id="ast-mention"))
+
+        assert result["agentSwitched"] is True
+        # …and the spend is still reported in full.
+        assert result["cacheStatus"] == "miss_avoidable"
+        assert result["wastedUsd"] > 0
+
+    def test_returning_to_plain_chat_is_also_a_switch(self):
+        """The turn *after* a mention pays a re-write too, and for the same reason."""
+        table = _FakeTable([_prev_row(30, cache_read=4000, agent_id="ast-mention")])
+        result = self._derive(table, _metadata(cache_write=5000, agent_id=None))
+
+        assert result["agentSwitched"] is True
+
+    def test_the_same_agent_twice_is_not_a_switch(self):
+        """A bound conversation: every turn runs the same Agent, so a miss is unexplained
+        and should stay that way — this is the case the metric exists to surface."""
+        table = _FakeTable([_prev_row(30, cache_read=4000, agent_id="ast-bound")])
+        result = self._derive(table, _metadata(cache_write=5000, agent_id="ast-bound"))
+
+        assert "agentSwitched" not in result
+
+    def test_plain_chat_throughout_is_not_a_switch(self):
+        table = _FakeTable([_prev_row(30, cache_read=4000)])
+        result = self._derive(table, _metadata(cache_write=5000))
+
+        assert "agentSwitched" not in result
+
+    def test_the_first_call_of_a_session_is_never_a_switch(self):
+        """Nothing to have switched *from*."""
+        result = self._derive(_FakeTable(), _metadata(cache_write=5000, agent_id="ast-1"))
+
+        assert "agentSwitched" not in result
+
+    def test_a_switch_that_still_hit_the_cache_is_flagged_but_costs_nothing(self):
+        """The flag describes the turn, not the verdict — the rollup only counts it
+        against a miss, so a hit contributes no explained waste."""
+        table = _FakeTable([_prev_row(30, cache_read=4000, agent_id="ast-a")])
+        result = self._derive(table, _metadata(cache_read=4000, agent_id="ast-b"))
+
+        assert result["agentSwitched"] is True
+        assert result["cacheStatus"] == "hit"
+        assert result["wastedUsd"] == 0.0

--- a/backend/tests/shared/test_prompt_cache_observability.py
+++ b/backend/tests/shared/test_prompt_cache_observability.py
@@ -216,6 +216,7 @@ class TestEmfEmission:
             "CacheReadTokens",
             "CacheWriteTokens",
             "AvoidableMiss",
+            "AgentSwitchMiss",
             "WastedUsd",
         }
         assert record["CacheReadTokens"] == 1000
@@ -224,6 +225,49 @@ class TestEmfEmission:
         assert record["WastedUsd"] == 0.012346  # rounded to 6 places
         assert record["modelId"].startswith("us.anthropic")
         assert record["cacheStatus"] == "miss_avoidable"
+
+    def test_an_unexplained_avoidable_miss_emits_no_agent_switch(self):
+        """The default. `AvoidableMiss` minus `AgentSwitchMiss` is unexplained waste."""
+        record = json.loads(
+            self._capture(
+                cache_read_tokens=0, cache_write_tokens=5000, avoidable_miss=True
+            )
+        )
+        assert record["AvoidableMiss"] == 1
+        assert record["AgentSwitchMiss"] == 0
+
+    def test_an_agent_switch_miss_is_counted_in_both(self):
+        """A subset, not a reclassification (#756).
+
+        The turn really did pay for a prefix re-write, so it stays in `AvoidableMiss`
+        and `WastedUsd`; `AgentSwitchMiss` is what lets a dashboard subtract the part an
+        `@`-mention explains rather than pretend it did not happen.
+        """
+        record = json.loads(
+            self._capture(
+                cache_read_tokens=0,
+                cache_write_tokens=5000,
+                avoidable_miss=True,
+                wasted_usd=0.01,
+                agent_switched=True,
+            )
+        )
+        assert record["AvoidableMiss"] == 1
+        assert record["AgentSwitchMiss"] == 1
+        assert record["WastedUsd"] == 0.01
+
+    def test_an_agent_switch_without_a_miss_counts_nothing(self):
+        """A switch that still hit the cache is not waste and must not read as any."""
+        record = json.loads(
+            self._capture(
+                cache_read_tokens=5000,
+                cache_write_tokens=0,
+                avoidable_miss=False,
+                agent_switched=True,
+            )
+        )
+        assert record["AvoidableMiss"] == 0
+        assert record["AgentSwitchMiss"] == 0
 
     def test_no_miss_and_defaults(self):
         line = self._capture(

--- a/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
+++ b/frontend/ai.client/src/app/admin/costs/models/admin-cost.models.ts
@@ -135,6 +135,16 @@ export interface SessionCallRow {
    */
   cachePrefixGapSeconds?: number | null;
   wastedUsd: number;
+  /**
+   * Which Agent ran this call, and whether that changed from the call before it (#756).
+   *
+   * An `@`-mention hands one turn to a different Agent, which genuinely re-writes the
+   * prefix. On the row that is indistinguishable from the nondeterministic-ordering
+   * regression the fingerprints exist to catch — both flip `toolConfigHash` and
+   * `systemPromptHash` together — so this is what tells them apart.
+   */
+  turnAgentId?: string | null;
+  agentSwitched?: boolean;
   prefixFingerprints?: PrefixFingerprints | null;
 }
 
@@ -148,6 +158,15 @@ export interface SessionCostAnatomy {
   totalCacheWriteTokens: number;
   avoidableMissCount: number;
   wastedUsd: number;
+  /**
+   * The subset of the two figures above that an Agent switch explains (#756).
+   *
+   * A *split*, never a deduction — the totals still carry every dollar spent, because
+   * hiding what `@`-mentions cost would understate a feature worth measuring. Subtract
+   * for unexplained waste, which is the number a prefix-stability regression moves.
+   */
+  agentSwitchMissCount: number;
+  agentSwitchUsd: number;
   /** cacheRead / (cacheRead + cacheWrite); null until any cache activity. */
   cacheEfficiency: number | null;
 }

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.spec.ts
@@ -14,6 +14,8 @@ const MOCK_ANATOMY: SessionCostAnatomy = {
   totalCacheWriteTokens: 5_000,
   avoidableMissCount: 1,
   wastedUsd: 0.03,
+  agentSwitchMissCount: 0,
+  agentSwitchUsd: 0,
   cacheEfficiency: 0.8,
   calls: [
     {
@@ -156,5 +158,46 @@ describe('SessionCostAnatomyPage', () => {
     expect(page.getStatusClass('miss_ttl_expired')).toContain('bg-yellow-100');
     expect(page.getStatusClass('miss_avoidable')).toContain('bg-red-100');
     expect(page.getStatusClass('uncached')).toContain('bg-gray-100');
+  });
+
+  // ── #756 — explained vs unexplained avoidable misses ──────────────────────────
+  describe('agent-switch split', () => {
+    async function loadWith(overrides: Partial<SessionCostAnatomy>) {
+      const fixture = setup(
+        vi.fn().mockReturnValue(of({ ...MOCK_ANATOMY, ...overrides })),
+      );
+      const page = fixture.componentInstance;
+      await vi.waitFor(() => expect(page.anatomyResource.hasValue()).toBe(true));
+      return page;
+    }
+
+    it('counts every avoidable miss as unexplained when none is a switch', async () => {
+      const page = await loadWith({ avoidableMissCount: 3, agentSwitchMissCount: 0 });
+      expect(page.unexplainedMisses()).toBe(3);
+    });
+
+    it('subtracts the explained subset', async () => {
+      // The point of the split: the total stays whole because the money was really
+      // spent, and the remainder is what a regression would actually move.
+      const page = await loadWith({ avoidableMissCount: 3, agentSwitchMissCount: 2 });
+      expect(page.unexplainedMisses()).toBe(1);
+    });
+
+    it('reports zero when every miss is a switch', async () => {
+      const page = await loadWith({ avoidableMissCount: 2, agentSwitchMissCount: 2 });
+      expect(page.unexplainedMisses()).toBe(0);
+    });
+
+    it('never reports a negative remainder', async () => {
+      // Defensive: the two figures come from separate passes over the same rows, and
+      // a nonsense pair must not render as "-4 unexplained".
+      const page = await loadWith({ avoidableMissCount: 1, agentSwitchMissCount: 5 });
+      expect(page.unexplainedMisses()).toBe(0);
+    });
+
+    it('is zero before the resource resolves', async () => {
+      const page = setup(vi.fn().mockReturnValue(of(MOCK_ANATOMY))).componentInstance;
+      expect(page.unexplainedMisses()).toBe(0);
+    });
   });
 });

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
@@ -117,13 +117,25 @@ import {
             <p
               class="mt-1 text-lg/7 font-semibold"
               [class]="
-                anatomyResource.value().avoidableMissCount > 0
+                unexplainedMisses() > 0
                   ? 'text-red-600 dark:text-red-400'
                   : 'text-gray-900 dark:text-white'
               "
             >
               {{ anatomyResource.value().avoidableMissCount }}
             </p>
+            <!--
+              #756 — an @-mention re-writes the prefix on purpose and looks exactly
+              like the regression this page exists to find. The count stays whole (the
+              spend was real); the explained part is named underneath so the red number
+              above only means "unexplained".
+            -->
+            @if (anatomyResource.value().agentSwitchMissCount > 0) {
+              <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                {{ anatomyResource.value().agentSwitchMissCount }} from an agent switch ·
+                <span class="font-medium">{{ unexplainedMisses() }} unexplained</span>
+              </p>
+            }
           </div>
           <div class="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
             <p class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
@@ -364,6 +376,19 @@ export class SessionCostAnatomyPage {
 
   /** True when the backend returned 404 — the session has no cost rows. */
   readonly notFound = computed(() => this.errorStatus(this.anatomyResource.error()) === 404);
+
+  /**
+   * Avoidable misses with no explanation — the number that should never move (#756).
+   *
+   * `avoidableMissCount` includes deliberate `@`-mention prefix swaps, which cost real
+   * money but are not a regression. The backend reports the explained subset rather than
+   * deducting it, so the page does the subtraction where a reader can see both halves.
+   */
+  readonly unexplainedMisses = computed(() => {
+    const anatomy = this.anatomyResource.value();
+    if (!anatomy) return 0;
+    return Math.max(0, anatomy.avoidableMissCount - anatomy.agentSwitchMissCount);
+  });
 
   private expandedRows = signal<ReadonlySet<number>>(new Set());
 


### PR DESCRIPTION
Fixes #756 — the last item on the Agent epic.

## The problem

An `@`-mention hands one turn to a different Agent (D11), swapping the system prompt and toolConfig and so genuinely re-writing the prompt cache. It classifies as `miss_avoidable`, **correctly** — the tokens were spent at the write premium.

What was missing is that nothing on the `C#` row said the turn *was* a mention. A deliberate swap and the nondeterministic-ordering regression the fingerprints exist to catch are identical on the row: both flip `toolConfigHash` and `systemPromptHash` together. Expected traffic was diluting the one signal that should never move.

## A dimension, not a reclassification

| | |
|---|---|
| `turnAgentId` | which Agent ran the call |
| `agentSwitched` | it differs from the previous call's |
| `agentSwitchMissCount` / `agentSwitchUsd` | a **subset** of `avoidableMissCount` / `wastedUsd` |

`cacheStatus` and `wastedUsd` are untouched. The rollup splits rather than deducts: hiding what mentions cost would understate a feature worth measuring on purpose. Subtract for unexplained waste — the number a regression moves.

## Three decisions worth review

**The agent id is threaded per turn from the route, not read off the agent.** The agent object is cached and shared across turns, so per-turn state must never live on it — that is precisely what forked history in #741 and compaction state in #751. Costs a parameter through `stream_async` (chat, voice, base) and the coordinator; voice accepts and ignores it, having no mention surface.

**`agentSwitched` is derived at write time**, in `_derive_cache_observability` — the only place already holding the predecessor row, so it costs no extra read. It compares against the **previous call**, deliberately not the same-prefix match the TTL clock uses (#754): the question is whether the Agent changed turn-to-turn, and a same-prefix row is by construction one where it didn't.

**EMF gains `AgentSwitchMiss` as its own metric, not a dimension on `AvoidableMiss`.** The namespace has no dimensions on purpose — fleet-wide sums are the alarm target — so a dimension would multiply metric streams per Agent. `turnAgentId` rides as a property, queryable without that cost.

## Admin page

The red "Avoidable Misses" count stays whole; the explained part is named underneath (`2 from an agent switch · 1 unexplained`), so the alarming number only ever means unexplained. `unexplainedMisses()` clamps at zero.

## Compatibility

Rows written before this carry neither attribute and read as unswitched. No backfill, and none is needed — the dimension only has to be right going forward.

## Testing

- Backend: **5322 passed, 6 skipped** — 15 new across the derivation (mention out, mention back, same agent, plain chat, first call, switch-that-hit), the EMF record, and the rollup split
- SPA: **141 files / 1593 tests** — 5 new on the subtraction, including the negative-remainder guard
- One existing EMF test asserted the exact metric-name set and correctly failed on the new metric; updated rather than loosened

🤖 Generated with [Claude Code](https://claude.com/claude-code)