### PR TITLE
feat(rbac): add delegated admin scopes as an AppRole grant axis

### DIFF
--- a/backend/src/apis/shared/rbac/admin_scopes.py
+++ b/backend/src/apis/shared/rbac/admin_scopes.py
@@ -1,0 +1,206 @@
+"""The closed registry of delegated admin scopes.
+
+An admin scope names one admin *feature area* — one router package under
+``apis/app_api/admin/`` — that a system admin may delegate to another role via
+``AppRole.granted_admin_scopes``.
+
+Two properties of this module matter more than its contents:
+
+**It is closed.** Scopes are defined here in code, never derived from a catalog
+and never free text. The roles admin UI builds its ``grantedTools`` control from
+the *tool catalog* with no free-text entry, so a capability id that is not a
+catalog tool cannot be granted from the UI at all — only by hand-writing
+DynamoDB items. That is precisely what made the short-lived ``skills`` and
+``scheduled-runs`` capability gates inoperable (see the docstring on
+``AppRoleService.resolve_user_permissions`` and the comment block at
+``sidenav.html``). Admin scopes therefore get their own grant axis fed by this
+registry, and PR-3 serves it to the SPA so the role form can render real
+checkboxes.
+
+**Some scopes are permanently non-delegable.** ``admin.roles`` is self-evident:
+whoever can edit a role can grant themselves anything. ``admin.auth_providers``
+is the non-obvious one — role resolution starts from JWT claims, so whoever
+controls IdP attribute mapping controls which groups arrive and therefore which
+AppRoles resolve. It is role administration by another route. Both stay
+``system_admin``-only forever, enforced at the service layer by
+``role_constraints.validate_admin_scopes`` so the rule holds for the REST API,
+seed scripts, and future automation alike.
+
+There is deliberately **no wildcard**. ``"*"`` is the idiom for the tool, model,
+and skill axes; on this axis it is the shorthand that would quietly turn a role
+into a superuser. Full admin is spelled ``system_admin``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class AdminScope:
+    """One delegable (or explicitly non-delegable) admin feature area."""
+
+    id: str
+    label: str
+    group: str
+    description: str
+    delegable: bool = True
+
+
+# Scope groups mirror the SPA's admin nav groups (``admin.layout.ts``) so the
+# role form can render the picker in the same shape an admin already navigates.
+GROUP_USAGE = "Usage & Spend"
+GROUP_AI_CONFIG = "AI Configuration"
+GROUP_MARKETPLACE = "Agent Marketplace"
+GROUP_IDENTITY = "Identity & Access"
+GROUP_CUSTOMIZATION = "Customization"
+
+
+ADMIN_SCOPES: tuple[AdminScope, ...] = (
+    AdminScope(
+        id="admin.costs",
+        label="Cost Analytics",
+        group=GROUP_USAGE,
+        description="View spend dashboards, per-session call anatomy, and cost exports.",
+    ),
+    AdminScope(
+        id="admin.quota",
+        label="Quotas",
+        group=GROUP_USAGE,
+        description="Manage quota tiers, assignments, overrides, and quota events.",
+    ),
+    AdminScope(
+        id="admin.fine_tuning",
+        label="Fine-Tuning",
+        group=GROUP_USAGE,
+        description="Manage fine-tuning access, jobs, and fine-tuning costs.",
+    ),
+    AdminScope(
+        id="admin.models",
+        label="Models",
+        group=GROUP_AI_CONFIG,
+        description="Manage the managed-model catalog and provider model listings.",
+    ),
+    AdminScope(
+        id="admin.tools",
+        label="Tools",
+        group=GROUP_AI_CONFIG,
+        description="Manage the tool catalog, discovery, and which roles may use each tool.",
+    ),
+    AdminScope(
+        id="admin.skills",
+        label="Skills",
+        group=GROUP_AI_CONFIG,
+        description="Manage skill bundles, their reference files, and skill role grants.",
+    ),
+    AdminScope(
+        id="admin.connectors",
+        label="Connectors",
+        group=GROUP_AI_CONFIG,
+        description="Manage OAuth providers used by external MCP tools.",
+    ),
+    AdminScope(
+        id="admin.file_sources",
+        label="File Sources",
+        group=GROUP_AI_CONFIG,
+        description="View the registered file-source adapters.",
+    ),
+    AdminScope(
+        id="admin.export_targets",
+        label="Export Targets",
+        group=GROUP_AI_CONFIG,
+        description="View the registered conversation export-target adapters.",
+    ),
+    AdminScope(
+        id="admin.marketplace",
+        label="Agent Marketplace",
+        group=GROUP_MARKETPLACE,
+        description=(
+            "Review agent submissions, handle reports and takedowns, and curate the "
+            "storefront, categories, and default pins."
+        ),
+    ),
+    AdminScope(
+        id="admin.users",
+        label="Users",
+        group=GROUP_IDENTITY,
+        description="Browse and search the user directory.",
+    ),
+    AdminScope(
+        id="admin.system_prompts",
+        label="System Prompts",
+        group=GROUP_CUSTOMIZATION,
+        description="Manage the admin-authored system prompts offered to users.",
+    ),
+    AdminScope(
+        id="admin.user_menu_links",
+        label="User Menu Links",
+        group=GROUP_CUSTOMIZATION,
+        description="Manage the custom links shown in the user menu.",
+    ),
+    # ── Non-delegable ────────────────────────────────────────────────────────
+    # Present in the registry so they are named, documented, and covered by the
+    # route-coverage test — but rejected by validation if anyone tries to grant
+    # them. See the module docstring for why auth_providers belongs here.
+    AdminScope(
+        id="admin.roles",
+        label="Roles",
+        group=GROUP_IDENTITY,
+        description=(
+            "Manage AppRoles and their grants. Never delegable — editing a role is "
+            "how admin power is handed out."
+        ),
+        delegable=False,
+    ),
+    AdminScope(
+        id="admin.auth_providers",
+        label="Auth Providers",
+        group=GROUP_IDENTITY,
+        description=(
+            "Manage identity providers and claim mapping. Never delegable — "
+            "controlling which claims arrive controls which roles resolve."
+        ),
+        delegable=False,
+    ),
+)
+
+
+ADMIN_SCOPES_BY_ID: dict[str, AdminScope] = {s.id: s for s in ADMIN_SCOPES}
+
+ALL_SCOPE_IDS: frozenset[str] = frozenset(ADMIN_SCOPES_BY_ID)
+
+NON_DELEGABLE_SCOPES: frozenset[str] = frozenset(
+    s.id for s in ADMIN_SCOPES if not s.delegable
+)
+
+DELEGABLE_SCOPES: frozenset[str] = ALL_SCOPE_IDS - NON_DELEGABLE_SCOPES
+
+
+def get_scope(scope_id: str) -> Optional[AdminScope]:
+    """Return the registry entry for ``scope_id``, or None if unknown."""
+    return ADMIN_SCOPES_BY_ID.get(scope_id)
+
+
+def is_known_scope(scope_id: str) -> bool:
+    """Return True if ``scope_id`` exists in the registry."""
+    return scope_id in ALL_SCOPE_IDS
+
+
+def is_delegable(scope_id: str) -> bool:
+    """Return True if ``scope_id`` may appear in a role's ``granted_admin_scopes``."""
+    return scope_id in DELEGABLE_SCOPES
+
+
+def normalize_scopes(scopes: Optional[Iterable[str]]) -> list[str]:
+    """De-duplicate and sort a scope list.
+
+    Sorted because these lists are merged into ``UserEffectivePermissions``
+    alongside tools/models/skills, which are sorted deliberately — set iteration
+    order varies with hash randomization, and an order flip between turns
+    rewrites a cached prompt prefix. Keeping the whole struct deterministic is
+    cheaper than reasoning about which fields escape into the prompt.
+    """
+    if not scopes:
+        return []
+    return sorted(set(scopes))

--- a/backend/src/apis/shared/rbac/admin_service.py
+++ b/backend/src/apis/shared/rbac/admin_service.py
@@ -8,7 +8,8 @@ from apis.shared.auth.models import User
 from .models import AppRole, EffectivePermissions, AppRoleCreate, AppRoleUpdate
 from .repository import AppRoleRepository
 from .cache import AppRoleCache, get_app_role_cache
-from .role_constraints import validate_jwt_role_mappings
+from .admin_scopes import normalize_scopes
+from .role_constraints import validate_admin_scopes, validate_jwt_role_mappings
 from .version import bump_roles_version
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,9 @@ class AppRoleAdminService:
         # malformed entries, regardless of role.
         validate_jwt_role_mappings(role_data.role_id, role_data.jwt_role_mappings)
 
+        # Reject unknown or non-delegable admin scopes.
+        validate_admin_scopes(role_data.granted_admin_scopes)
+
         # Build the AppRole object
         role = AppRole(
             role_id=role_data.role_id,
@@ -76,6 +80,7 @@ class AppRoleAdminService:
             granted_tools=role_data.granted_tools,
             granted_models=role_data.granted_models,
             granted_skills=role_data.granted_skills,
+            granted_admin_scopes=normalize_scopes(role_data.granted_admin_scopes),
             priority=role_data.priority,
             enabled=role_data.enabled,
             is_system_role=False,
@@ -150,11 +155,23 @@ class AppRoleAdminService:
         if updates.jwt_role_mappings is not None:
             validate_jwt_role_mappings(role_id, updates.jwt_role_mappings)
 
+        # Reject unknown or non-delegable admin scopes. Note that for
+        # `system_admin` this never fires: the field is not in `allowed_fields`
+        # above, so it has already been stripped — which is correct, since
+        # system_admin holds every scope implicitly.
+        if updates.granted_admin_scopes is not None:
+            validate_admin_scopes(updates.granted_admin_scopes)
+
         # Apply updates
         update_dict = updates.model_dump(exclude_unset=True, by_alias=False)
         for field, value in update_dict.items():
             if hasattr(existing, field):
                 setattr(existing, field, value)
+
+        if updates.granted_admin_scopes is not None:
+            existing.granted_admin_scopes = normalize_scopes(
+                existing.granted_admin_scopes
+            )
 
         # Validate inheritance if changed
         if updates.inherits_from is not None:
@@ -280,6 +297,14 @@ class AppRoleAdminService:
         Compute effective permissions for a role, including inheritance.
 
         This resolves single-level inheritance and merges permissions.
+
+        **Admin scopes deliberately do not inherit.** Tools, models, and skills
+        absorb a parent's grants because that is the convenience `inheritsFrom`
+        exists to provide. Administrative power is different: a role acquiring
+        the ability to manage the tool catalog as a side effect of someone
+        setting `inheritsFrom` is exactly the surprise delegated admin exists to
+        prevent. `effective_permissions.admin_scopes` is always the role's own
+        `granted_admin_scopes`, verbatim.
         """
         all_tools: Set[str] = set(role.granted_tools)
         all_models: Set[str] = set(role.granted_models)
@@ -292,12 +317,14 @@ class AppRoleAdminService:
                 all_tools.update(parent.granted_tools)
                 all_models.update(parent.granted_models)
                 all_skills.update(parent.granted_skills)
+                # NOT parent.granted_admin_scopes — see docstring.
 
         return EffectivePermissions(
             tools=list(all_tools),
             models=list(all_models),
             skills=list(all_skills),
             quota_tier=None,  # Quota tier comes from direct configuration
+            admin_scopes=normalize_scopes(role.granted_admin_scopes),
         )
 
     async def _validate_inheritance(self, inherits_from: List[str]):

--- a/backend/src/apis/shared/rbac/models.py
+++ b/backend/src/apis/shared/rbac/models.py
@@ -13,6 +13,9 @@ class EffectivePermissions:
     models: List[str] = field(default_factory=list)
     skills: List[str] = field(default_factory=list)
     quota_tier: Optional[str] = None
+    # Delegated admin feature areas. Unlike the three axes above, this one does
+    # NOT absorb grants from `inherits_from` — see `_compute_effective_permissions`.
+    admin_scopes: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for DynamoDB storage."""
@@ -21,21 +24,23 @@ class EffectivePermissions:
             "models": self.models,
             "skills": self.skills,
             "quotaTier": self.quota_tier,
+            "adminScopes": self.admin_scopes,
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "EffectivePermissions":
         """Create from dictionary (DynamoDB item).
 
-        `skills` defaults to [] for roles persisted before skills existed —
-        they pick up skill grants on their next save/sync (mirror of how a new
-        permission type rolls out for tools/models).
+        `skills` and `admin_scopes` default to [] for roles persisted before
+        those axes existed — they pick the new axis up on their next save/sync
+        (mirror of how a new permission type rolls out for tools/models).
         """
         return cls(
             tools=data.get("tools", []),
             models=data.get("models", []),
             skills=data.get("skills", []),
             quota_tier=data.get("quotaTier"),
+            admin_scopes=data.get("adminScopes", []),
         )
 
 
@@ -67,6 +72,11 @@ class AppRole:
     granted_tools: List[str] = field(default_factory=list)
     granted_models: List[str] = field(default_factory=list)
     granted_skills: List[str] = field(default_factory=list)
+    # Delegated admin feature areas (see `rbac/admin_scopes.py`). Stored as a
+    # plain attribute on the DEFINITION item rather than as `*_GRANT#` items
+    # with a GSI, because nothing needs the reverse lookup and every extra
+    # mapping prefix is another thing `_delete_mapping_items` must know about.
+    granted_admin_scopes: List[str] = field(default_factory=list)
 
     # Metadata
     priority: int = 0
@@ -90,6 +100,7 @@ class AppRole:
             "grantedTools": self.granted_tools,
             "grantedModels": self.granted_models,
             "grantedSkills": self.granted_skills,
+            "grantedAdminScopes": self.granted_admin_scopes,
             "priority": self.priority,
             "isSystemRole": self.is_system_role,
             "enabled": self.enabled,
@@ -112,6 +123,7 @@ class AppRole:
             granted_tools=data.get("grantedTools", []),
             granted_models=data.get("grantedModels", []),
             granted_skills=data.get("grantedSkills", []),
+            granted_admin_scopes=data.get("grantedAdminScopes", []),
             priority=data.get("priority", 0),
             is_system_role=data.get("isSystemRole", False),
             enabled=data.get("enabled", True),
@@ -135,9 +147,10 @@ class UserEffectivePermissions:
     models: List[str]
     quota_tier: Optional[str]
     resolved_at: str
-    # Trailing default so existing positional/kwargs construction sites that
-    # predate skills keep working (they resolve to no skills).
+    # Trailing defaults so existing positional/kwargs construction sites that
+    # predate these axes keep working (they resolve to none of them).
     skills: List[str] = field(default_factory=list)
+    admin_scopes: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -147,6 +160,7 @@ class UserEffectivePermissions:
             "tools": self.tools,
             "models": self.models,
             "skills": self.skills,
+            "adminScopes": self.admin_scopes,
             "quotaTier": self.quota_tier,
             "resolvedAt": self.resolved_at,
         }
@@ -170,6 +184,9 @@ class AppRoleCreate(BaseModel):
     granted_tools: List[str] = Field(default_factory=list, alias="grantedTools")
     granted_models: List[str] = Field(default_factory=list, alias="grantedModels")
     granted_skills: List[str] = Field(default_factory=list, alias="grantedSkills")
+    granted_admin_scopes: List[str] = Field(
+        default_factory=list, alias="grantedAdminScopes"
+    )
     priority: int = Field(0, ge=0, le=999)
     enabled: bool = True
 
@@ -188,6 +205,9 @@ class AppRoleUpdate(BaseModel):
     granted_tools: Optional[List[str]] = Field(None, alias="grantedTools")
     granted_models: Optional[List[str]] = Field(None, alias="grantedModels")
     granted_skills: Optional[List[str]] = Field(None, alias="grantedSkills")
+    granted_admin_scopes: Optional[List[str]] = Field(
+        None, alias="grantedAdminScopes"
+    )
     priority: Optional[int] = Field(None, ge=0, le=999)
     enabled: Optional[bool] = None
 
@@ -200,6 +220,7 @@ class EffectivePermissionsResponse(BaseModel):
     tools: List[str]
     models: List[str]
     skills: List[str] = Field(default_factory=list)
+    admin_scopes: List[str] = Field(default_factory=list, alias="adminScopes")
     quota_tier: Optional[str] = Field(None, alias="quotaTier")
 
     model_config = {"populate_by_name": True}
@@ -216,6 +237,9 @@ class AppRoleResponse(BaseModel):
     granted_tools: List[str] = Field(..., alias="grantedTools")
     granted_models: List[str] = Field(..., alias="grantedModels")
     granted_skills: List[str] = Field(default_factory=list, alias="grantedSkills")
+    granted_admin_scopes: List[str] = Field(
+        default_factory=list, alias="grantedAdminScopes"
+    )
     effective_permissions: EffectivePermissionsResponse = Field(
         ..., alias="effectivePermissions"
     )
@@ -240,10 +264,12 @@ class AppRoleResponse(BaseModel):
             granted_tools=role.granted_tools,
             granted_models=role.granted_models,
             granted_skills=role.granted_skills,
+            granted_admin_scopes=role.granted_admin_scopes,
             effective_permissions=EffectivePermissionsResponse(
                 tools=role.effective_permissions.tools,
                 models=role.effective_permissions.models,
                 skills=role.effective_permissions.skills,
+                admin_scopes=role.effective_permissions.admin_scopes,
                 quota_tier=role.effective_permissions.quota_tier,
             ),
             priority=role.priority,

--- a/backend/src/apis/shared/rbac/role_constraints.py
+++ b/backend/src/apis/shared/rbac/role_constraints.py
@@ -12,12 +12,16 @@ mistake:
    a real group identifier (whitespace, HTML, control characters, etc.) —
    typically indicates a mis-typed or attacker-shaped payload rather than
    a legitimate IdP claim value.
+3. Granting an admin scope that must never be delegated, or one that does
+   not exist — see :func:`validate_admin_scopes`.
 """
 
 from __future__ import annotations
 
 import re
 from typing import Iterable
+
+from .admin_scopes import is_delegable, is_known_scope
 
 # Roles that must never have their JWT mappings broadened. Adding to this
 # set is the recommended way to protect new role names introduced later.
@@ -49,6 +53,12 @@ _FORBIDDEN_PROTECTED_MAPPINGS: frozenset[str] = frozenset(
 # Cognito groups, custom claims) all conform to this shape; values that
 # don't are almost certainly malformed.
 _JWT_MAPPING_PATTERN = re.compile(r"^[A-Za-z0-9_-]{2,64}$")
+
+# Shape of an admin scope id (``admin.tools``). Deliberately length-bounded:
+# this pattern is the gate that decides whether a rejected value is safe to
+# echo back in an error message and a log line, so it must not admit an
+# arbitrarily long string.
+_ADMIN_SCOPE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}(\.[a-z][a-z0-9_]{0,31}){1,3}$")
 
 
 class RoleConstraintError(ValueError):
@@ -87,3 +97,48 @@ def validate_jwt_role_mappings(role_id: str, mappings: Iterable[str]) -> None:
 def is_protected_role(role_id: str) -> bool:
     """Return True if ``role_id`` is in the protected set."""
     return role_id in PROTECTED_ROLE_IDS
+
+
+def validate_admin_scopes(scopes: Iterable[str] | None) -> None:
+    """Validate a role's proposed ``granted_admin_scopes``.
+
+    Rejects two things:
+
+    * **Unknown scopes.** The registry is closed, so an id that isn't in it is
+      either a typo or a stale grant left behind by a deleted feature area.
+      Either way it would sit in the role record looking like a permission
+      while granting nothing — the silent-no-op failure mode this axis exists
+      to avoid.
+    * **Non-delegable scopes** (``admin.roles``, ``admin.auth_providers``).
+      These are the escalation paths back to full admin: editing a role grants
+      arbitrary permissions, and editing IdP claim mapping decides which roles
+      resolve at all. Enforced here, at the service layer, so the rule applies
+      to the REST API, seed scripts, and any future automation equally.
+
+    Unlike :func:`validate_jwt_role_mappings`, the errors here name the
+    offending value. Only a ``system_admin`` can reach this code path (writing
+    admin scopes requires the roles admin, which is itself non-delegable), so
+    there is no untrusted caller to withhold detail from, and a silent
+    "Invalid role configuration." on a 15-checkbox form is hostile to the one
+    person allowed to use it.
+
+    Raises:
+        RoleConstraintError: on an unknown or non-delegable scope.
+    """
+    if not scopes:
+        return
+
+    for scope in scopes:
+        if not isinstance(scope, str) or not _ADMIN_SCOPE_PATTERN.fullmatch(scope):
+            # Echo only after the value has passed a conservative charset/length
+            # check, so a malformed payload can't ride into the error message.
+            raise RoleConstraintError("Invalid admin scope.")
+
+        if not is_known_scope(scope):
+            raise RoleConstraintError(f"Unknown admin scope: '{scope}'.")
+
+        if not is_delegable(scope):
+            raise RoleConstraintError(
+                f"Admin scope '{scope}' cannot be delegated. "
+                "Managing roles and auth providers requires the system_admin role."
+            )

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -153,6 +153,8 @@ class AppRoleService:
         Merge rules:
         - Tools: Union (user gets access to all tools from all roles)
         - Models: Union (user gets access to all models from all roles)
+        - Admin scopes: Union (but no ``"*"`` — there is no wildcard on this
+          axis; full admin is the ``system_admin`` role, not a scope)
         - Quota Tier: Highest priority role's tier wins
         """
         if not roles:
@@ -162,6 +164,7 @@ class AppRoleService:
                 tools=[],
                 models=[],
                 skills=[],
+                admin_scopes=[],
                 quota_tier=None,
                 resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
             )
@@ -170,6 +173,7 @@ class AppRoleService:
         all_tools: Set[str] = set()
         all_models: Set[str] = set()
         all_skills: Set[str] = set()
+        all_admin_scopes: Set[str] = set()
 
         for role in roles:
             if role.effective_permissions:
@@ -188,6 +192,11 @@ class AppRoleService:
                     all_skills.add("*")
                 else:
                     all_skills.update(role.effective_permissions.skills)
+
+                # No wildcard handling: `"*"` is not a valid admin scope, so a
+                # stray one is carried through as an unknown scope that matches
+                # nothing rather than silently granting every admin surface.
+                all_admin_scopes.update(role.effective_permissions.admin_scopes)
 
         # Determine quota tier (highest priority wins)
         sorted_roles = sorted(roles, key=lambda r: r.priority, reverse=True)
@@ -210,6 +219,7 @@ class AppRoleService:
             tools=sorted(all_tools),
             models=sorted(all_models),
             skills=sorted(all_skills),
+            admin_scopes=sorted(all_admin_scopes),
             quota_tier=quota_tier,
             resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
         )

--- a/backend/tests/agents/main_agent/test_prompt_cache_determinism.py
+++ b/backend/tests/agents/main_agent/test_prompt_cache_determinism.py
@@ -24,6 +24,8 @@ import pytest
 from strands import Agent, tool
 from strands.hooks import BeforeInvocationEvent
 
+from apis.shared.rbac.models import EffectivePermissions
+
 from agents.main_agent.session.hooks.prefix_fingerprint import (
     PrefixFingerprintHook,
     get_prefix_fingerprint,
@@ -80,10 +82,13 @@ TOOLS_BY_ID = {"alpha_tool": alpha_tool, "beta_tool": beta_tool, "gamma_tool": g
 
 
 def _role(role_id: str, tools: list, skills: list, priority: int = 10) -> SimpleNamespace:
+    # `effective_permissions` uses the real dataclass rather than a namespace:
+    # a hand-rolled stand-in silently loses any field added to the real type,
+    # and the merge under test reads every axis off it.
     return SimpleNamespace(
         role_id=role_id,
         priority=priority,
-        effective_permissions=SimpleNamespace(
+        effective_permissions=EffectivePermissions(
             tools=tools, models=[], skills=skills, quota_tier=None
         ),
     )

--- a/backend/tests/rbac/conftest.py
+++ b/backend/tests/rbac/conftest.py
@@ -32,9 +32,11 @@ def make_app_role():
         granted_tools: Optional[List[str]] = None,
         granted_models: Optional[List[str]] = None,
         granted_skills: Optional[List[str]] = None,
+        granted_admin_scopes: Optional[List[str]] = None,
         tools: Optional[List[str]] = None,
         models: Optional[List[str]] = None,
         skills: Optional[List[str]] = None,
+        admin_scopes: Optional[List[str]] = None,
         quota_tier: Optional[str] = None,
         priority: int = 0,
         is_system_role: bool = False,
@@ -44,6 +46,9 @@ def make_app_role():
         effective_tools = tools if tools is not None else (granted_tools or [])
         effective_models = models if models is not None else (granted_models or [])
         effective_skills = skills if skills is not None else (granted_skills or [])
+        effective_admin_scopes = (
+            admin_scopes if admin_scopes is not None else (granted_admin_scopes or [])
+        )
 
         return AppRole(
             role_id=role_id,
@@ -55,11 +60,15 @@ def make_app_role():
                 tools=effective_tools,
                 models=effective_models,
                 skills=effective_skills,
+                admin_scopes=effective_admin_scopes,
                 quota_tier=quota_tier,
             ),
             granted_tools=granted_tools if granted_tools is not None else [],
             granted_models=granted_models if granted_models is not None else [],
             granted_skills=granted_skills if granted_skills is not None else [],
+            granted_admin_scopes=(
+                granted_admin_scopes if granted_admin_scopes is not None else []
+            ),
             priority=priority,
             is_system_role=is_system_role,
             enabled=enabled,

--- a/backend/tests/rbac/test_admin_scopes.py
+++ b/backend/tests/rbac/test_admin_scopes.py
@@ -1,0 +1,429 @@
+"""Delegated admin scopes — registry integrity, grant validation, and resolution.
+
+PR-1 of the granular-admin-permissions epic (``docs/specs/granular-admin-permissions.md``).
+Nothing *authorizes* on admin scopes yet; these tests cover the data path —
+that a scope can be granted, survives a round trip, merges the way the spec
+says, and cannot be used to climb back to full admin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apis.shared.auth.models import User
+from apis.shared.rbac.admin_scopes import (
+    ADMIN_SCOPES,
+    ADMIN_SCOPES_BY_ID,
+    DELEGABLE_SCOPES,
+    NON_DELEGABLE_SCOPES,
+    is_delegable,
+    is_known_scope,
+    normalize_scopes,
+)
+from apis.shared.rbac.admin_service import AppRoleAdminService
+from apis.shared.rbac.models import (
+    AppRole,
+    AppRoleCreate,
+    AppRoleResponse,
+    AppRoleUpdate,
+    EffectivePermissions,
+)
+from apis.shared.rbac.role_constraints import RoleConstraintError, validate_admin_scopes
+from apis.shared.rbac.service import AppRoleService
+
+
+@pytest.fixture
+def admin() -> User:
+    return User(
+        email="admin@example.com",
+        user_id="admin-1",
+        name="Admin User",
+        roles=["Admin"],
+    )
+
+
+@pytest.fixture
+def service(mock_app_role_repo, mock_app_role_cache) -> AppRoleAdminService:
+    return AppRoleAdminService(repository=mock_app_role_repo, cache=mock_app_role_cache)
+
+
+# ---------------------------------------------------------------------------
+# Registry integrity
+# ---------------------------------------------------------------------------
+
+
+def test_scope_ids_are_unique() -> None:
+    ids = [s.id for s in ADMIN_SCOPES]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_scope_id_is_namespaced_and_lowercase() -> None:
+    for scope in ADMIN_SCOPES:
+        assert scope.id.startswith("admin."), scope.id
+        assert scope.id == scope.id.lower(), scope.id
+
+
+def test_every_scope_has_label_group_and_description() -> None:
+    for scope in ADMIN_SCOPES:
+        assert scope.label.strip(), scope.id
+        assert scope.group.strip(), scope.id
+        assert scope.description.strip(), scope.id
+
+
+def test_roles_and_auth_providers_are_non_delegable() -> None:
+    """I1 — the two escalation paths back to full admin.
+
+    ``admin.roles`` is obvious. ``admin.auth_providers`` is the one that gets
+    argued about: role resolution starts from JWT claims, so controlling IdP
+    attribute mapping controls which AppRoles resolve at all.
+    """
+    assert NON_DELEGABLE_SCOPES == {"admin.roles", "admin.auth_providers"}
+
+
+def test_delegable_and_non_delegable_partition_the_registry() -> None:
+    assert DELEGABLE_SCOPES.isdisjoint(NON_DELEGABLE_SCOPES)
+    assert DELEGABLE_SCOPES | NON_DELEGABLE_SCOPES == set(ADMIN_SCOPES_BY_ID)
+
+
+def test_wildcard_is_not_a_scope() -> None:
+    """There is deliberately no `"*"` on this axis — full admin is a role."""
+    assert not is_known_scope("*")
+    assert not is_delegable("*")
+
+
+def test_normalize_scopes_dedupes_and_sorts() -> None:
+    assert normalize_scopes(["admin.tools", "admin.costs", "admin.tools"]) == [
+        "admin.costs",
+        "admin.tools",
+    ]
+    assert normalize_scopes(None) == []
+    assert normalize_scopes([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Grant validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scope", sorted(DELEGABLE_SCOPES))
+def test_validate_accepts_every_delegable_scope(scope: str) -> None:
+    validate_admin_scopes([scope])
+
+
+@pytest.mark.parametrize("scope", sorted(NON_DELEGABLE_SCOPES))
+def test_validate_rejects_non_delegable_scope(scope: str) -> None:
+    with pytest.raises(RoleConstraintError, match="cannot be delegated"):
+        validate_admin_scopes([scope])
+
+
+@pytest.mark.parametrize(
+    "scope", ["admin.nonexistent", "admin.role", "tools", "admin.tools.write"]
+)
+def test_validate_rejects_unknown_scope(scope: str) -> None:
+    with pytest.raises(RoleConstraintError):
+        validate_admin_scopes([scope])
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "*",
+        "",
+        "admin tools",
+        "<script>",
+        "ADMIN.TOOLS",
+        "admin.",
+        ".tools",
+        "admin." + "x" * 64,  # length-bounded so it can't reach the error message
+        "a.b.c.d.e.f",
+    ],
+)
+def test_validate_rejects_malformed_scope(scope: str) -> None:
+    with pytest.raises(RoleConstraintError, match="Invalid admin scope"):
+        validate_admin_scopes([scope])
+
+
+def test_malformed_scope_is_not_echoed_into_the_error(caplog) -> None:
+    """The generic message is the point — a rejected payload must not travel."""
+    payload = "<img src=x onerror=alert(1)>"
+
+    with pytest.raises(RoleConstraintError) as exc:
+        validate_admin_scopes([payload])
+
+    assert payload not in str(exc.value)
+
+
+@pytest.mark.parametrize("value", [None, 42, ["nested"], {"a": 1}])
+def test_validate_rejects_non_string_entries(value) -> None:
+    with pytest.raises(RoleConstraintError, match="Invalid admin scope"):
+        validate_admin_scopes([value])
+
+
+def test_validate_allows_empty() -> None:
+    validate_admin_scopes(None)
+    validate_admin_scopes([])
+
+
+# ---------------------------------------------------------------------------
+# Grants through the admin service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_role_persists_normalized_admin_scopes(
+    service, mock_app_role_repo, admin
+) -> None:
+    mock_app_role_repo.create_role.side_effect = lambda role: role
+
+    created = await service.create_role(
+        AppRoleCreate(
+            role_id="content_admin",
+            display_name="Content Admin",
+            granted_admin_scopes=["admin.skills", "admin.costs", "admin.skills"],
+        ),
+        admin,
+    )
+
+    assert created.granted_admin_scopes == ["admin.costs", "admin.skills"]
+    assert created.effective_permissions.admin_scopes == ["admin.costs", "admin.skills"]
+
+
+@pytest.mark.asyncio
+async def test_create_role_rejects_non_delegable_scope(service, admin) -> None:
+    with pytest.raises(RoleConstraintError):
+        await service.create_role(
+            AppRoleCreate(
+                role_id="sneaky",
+                display_name="Sneaky",
+                granted_admin_scopes=["admin.roles"],
+            ),
+            admin,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_role_rejects_non_delegable_scope(
+    service, mock_app_role_repo, make_app_role, admin
+) -> None:
+    role = make_app_role(role_id="content_admin", granted_admin_scopes=["admin.skills"])
+    mock_app_role_repo.get_role.return_value = role
+
+    with pytest.raises(RoleConstraintError):
+        await service.update_role(
+            "content_admin",
+            AppRoleUpdate(granted_admin_scopes=["admin.skills", "admin.auth_providers"]),
+            admin,
+        )
+
+
+@pytest.mark.asyncio
+async def test_system_admin_update_strips_admin_scopes(
+    service, mock_app_role_repo, make_app_role, admin
+) -> None:
+    """system_admin holds every scope implicitly; the field is not writable on it.
+
+    The existing protected-field stripping in ``update_role`` already covers
+    this — granted_admin_scopes is simply not in ``allowed_fields``. Asserted
+    here so a future widening of that set has to consciously break this test.
+    """
+    role = make_app_role(
+        role_id="system_admin",
+        is_system_role=True,
+        jwt_role_mappings=["system_admin"],
+    )
+    mock_app_role_repo.get_role.return_value = role
+    mock_app_role_repo.update_role.side_effect = lambda r: r
+
+    updated = await service.update_role(
+        "system_admin",
+        AppRoleUpdate(display_name="Sys Admin", granted_admin_scopes=["admin.tools"]),
+        admin,
+    )
+
+    assert updated.granted_admin_scopes == []
+
+
+# ---------------------------------------------------------------------------
+# I4 — admin scopes do not inherit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_scopes_are_not_inherited_from_parent(
+    service, mock_app_role_repo, make_app_role, admin
+) -> None:
+    """Tools inherit; admin power does not.
+
+    A child role that inherits from a scope-bearing parent picks up the
+    parent's *tools* but none of its admin scopes.
+    """
+    parent = make_app_role(
+        role_id="content_admin",
+        granted_tools=["tool_a"],
+        granted_admin_scopes=["admin.skills"],
+    )
+    mock_app_role_repo.get_role.return_value = parent
+    mock_app_role_repo.create_role.side_effect = lambda role: role
+
+    child = await service.create_role(
+        AppRoleCreate(
+            role_id="child_role",
+            display_name="Child",
+            inherits_from=["content_admin"],
+            granted_tools=["tool_b"],
+        ),
+        admin,
+    )
+
+    assert set(child.effective_permissions.tools) == {"tool_a", "tool_b"}
+    assert child.effective_permissions.admin_scopes == []
+
+
+# ---------------------------------------------------------------------------
+# Runtime resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user() -> User:
+    return User(
+        email="test@example.com",
+        user_id="user-1",
+        name="Test User",
+        roles=["Editor", "Viewer"],
+    )
+
+
+@pytest.fixture
+def runtime_service(mock_app_role_repo, mock_app_role_cache) -> AppRoleService:
+    return AppRoleService(repository=mock_app_role_repo, cache=mock_app_role_cache)
+
+
+def _wire(mock_app_role_repo, roles: dict[str, AppRole]) -> None:
+    """Map the `user` fixture's two JWT roles onto the given AppRoles."""
+    jwt_to_role = dict(zip(["Editor", "Viewer"], roles))
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: (
+        [jwt_to_role[r]] if r in jwt_to_role else []
+    )
+    mock_app_role_repo.get_role.side_effect = lambda rid: roles.get(rid)
+
+
+@pytest.mark.asyncio
+async def test_merge_unions_admin_scopes_across_roles(
+    runtime_service, mock_app_role_repo, make_app_role, user
+) -> None:
+    _wire(
+        mock_app_role_repo,
+        {
+            "editor": make_app_role(role_id="editor", admin_scopes=["admin.tools"]),
+            "viewer": make_app_role(
+                role_id="viewer", admin_scopes=["admin.skills", "admin.tools"]
+            ),
+        },
+    )
+
+    perms = await runtime_service.resolve_user_permissions(user)
+
+    assert perms.admin_scopes == ["admin.skills", "admin.tools"]
+
+
+@pytest.mark.asyncio
+async def test_merge_is_sorted_and_deterministic(
+    runtime_service, mock_app_role_repo, make_app_role, user
+) -> None:
+    _wire(
+        mock_app_role_repo,
+        {
+            "editor": make_app_role(
+                role_id="editor",
+                admin_scopes=["admin.tools", "admin.costs", "admin.skills"],
+            )
+        },
+    )
+
+    perms = await runtime_service.resolve_user_permissions(user)
+
+    assert perms.admin_scopes == ["admin.costs", "admin.skills", "admin.tools"]
+
+
+@pytest.mark.asyncio
+async def test_merge_does_not_expand_a_stray_wildcard(
+    runtime_service, mock_app_role_repo, make_app_role, user
+) -> None:
+    """A `"*"` that somehow reached the stored list grants nothing.
+
+    Unlike tools/models/skills, this axis has no wildcard collapse, so a stray
+    value is carried through as an unknown scope that matches no route rather
+    than silently granting every admin surface.
+    """
+    _wire(
+        mock_app_role_repo,
+        {"editor": make_app_role(role_id="editor", admin_scopes=["*"])},
+    )
+
+    perms = await runtime_service.resolve_user_permissions(user)
+
+    assert perms.admin_scopes == ["*"]
+    assert not any(is_known_scope(s) for s in perms.admin_scopes)
+
+
+@pytest.mark.asyncio
+async def test_user_matching_no_roles_gets_no_scopes(
+    runtime_service, mock_app_role_repo, make_app_role, user
+) -> None:
+    """The `default` fallback role carries no admin scopes."""
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda r: []
+    mock_app_role_repo.get_role.side_effect = lambda rid: (
+        make_app_role(role_id="default") if rid == "default" else None
+    )
+
+    perms = await runtime_service.resolve_user_permissions(user)
+
+    assert perms.admin_scopes == []
+
+
+# ---------------------------------------------------------------------------
+# Round trips
+# ---------------------------------------------------------------------------
+
+
+def test_app_role_dict_round_trip_preserves_admin_scopes() -> None:
+    role = AppRole(
+        role_id="content_admin",
+        display_name="Content Admin",
+        description="",
+        granted_admin_scopes=["admin.skills"],
+        effective_permissions=EffectivePermissions(admin_scopes=["admin.skills"]),
+    )
+
+    restored = AppRole.from_dict(role.to_dict())
+
+    assert restored.granted_admin_scopes == ["admin.skills"]
+    assert restored.effective_permissions.admin_scopes == ["admin.skills"]
+
+
+def test_role_persisted_before_this_axis_defaults_to_empty() -> None:
+    """A DEFINITION item written before admin scopes existed must still load."""
+    legacy = {
+        "roleId": "faculty",
+        "displayName": "Faculty",
+        "description": "",
+        "grantedTools": ["tool_a"],
+        "effectivePermissions": {"tools": ["tool_a"], "models": [], "skills": []},
+    }
+
+    role = AppRole.from_dict(legacy)
+
+    assert role.granted_admin_scopes == []
+    assert role.effective_permissions.admin_scopes == []
+
+
+def test_response_model_carries_admin_scopes(make_app_role) -> None:
+    """Guards the `skills`-omission bug: written on create, dropped on read."""
+    role = make_app_role(role_id="content_admin", granted_admin_scopes=["admin.skills"])
+
+    response = AppRoleResponse.from_app_role(role)
+
+    assert response.granted_admin_scopes == ["admin.skills"]
+    assert response.effective_permissions.admin_scopes == ["admin.skills"]
+    assert response.model_dump(by_alias=True)["grantedAdminScopes"] == ["admin.skills"]


### PR DESCRIPTION
**PR-1** of [`docs/specs/granular-admin-permissions.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/granular-admin-permissions.md) (spec: #768, decisions: #769).

Data path only — **no authorization check reads admin scopes yet**, so behavior is unchanged. Full backend suite green: 5332 passed, 3 skipped.

## What this adds

`granted_admin_scopes` on `AppRole`, alongside the existing tools/models/skills axes, resolved through `EffectivePermissions` → `UserEffectivePermissions` → the per-user merge, and onto the create/update/response bodies so the axis round-trips end to end.

The registry in `rbac/admin_scopes.py` is **closed and code-defined**, not catalog-derived. The roles admin UI builds its grant controls from resource catalogs with no free-text entry, so a capability id that isn't a catalog entry can't be granted from the UI at all — that's what made the earlier `skills` and `scheduled-runs` capability gates inoperable. 13 delegable scopes, 1:1 with the admin router packages.

## Escalation guards

- **`admin.roles` and `admin.auth_providers` are non-delegable.** Editing a role grants arbitrary permissions; editing IdP claim mapping decides which roles resolve at all. `validate_admin_scopes` rejects both at the service layer, so the rule holds for the REST API and seed scripts alike.
- **No wildcard on this axis.** Full admin stays spelled `system_admin`, and a stray `"*"` resolves to an unknown scope matching nothing rather than silently granting every surface.
- **Scopes don't inherit.** A child role picks up a parent's tools but none of its admin power — inheriting resource grants is convenience, inheriting admin power is the surprise this feature exists to prevent.
- **`system_admin` can't carry scopes.** This came free: `update_role`'s existing protected-field stripping already excludes anything outside `display_name`/`description`/`jwt_role_mappings`. Asserted in a test so a future widening of `allowed_fields` has to consciously break it.

## Notes for review

**Persistence needed no repository change.** `_build_role_items` spreads `role.to_dict()` into the DEFINITION item, so the attribute persists automatically — confirming the spec's call to make this a plain attribute rather than `*_GRANT#` mapping items with a GSI. Nothing needs the reverse lookup, and every extra prefix is another case `_delete_mapping_items` has to know about.

**One pre-existing test broke, and it's worth knowing about.** `test_prompt_cache_determinism.py` stubbed `effective_permissions` with a `SimpleNamespace` listing four fields by hand; adding a fifth to the dataclass broke it with an `AttributeError`. Swapped for the real `EffectivePermissions` dataclass — a hand-rolled stand-in for one of our own types silently drifts from it.

**Scope-id regex is length-bounded** (`{0,31}` per segment, ≤4 segments). That pattern is the gate deciding whether a rejected value is safe to echo into an error message and logs, so it must not admit an arbitrarily long string.

53 new tests in `tests/rbac/test_admin_scopes.py` covering registry integrity, grant validation, non-inheritance, merge/sort determinism, and legacy-item round trips.

## Merge ordering

PR-1 and PR-2 (enforcement) **must land in the same release**. PR-1 alone stores a grant that nothing enforces, which is worse than not having it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
