### PR TITLE
fix(inference): restore chat — stream_response never accepted turn_agent_id

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -61,6 +61,7 @@ class StreamCoordinator:
         main_agent_wrapper: Any = None,
         citations: Optional[List] = None,
         original_message: Optional[str] = None,
+        turn_agent_id: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Stream agent responses with proper lifecycle management
@@ -77,6 +78,11 @@ class StreamCoordinator:
             main_agent_wrapper: MainAgent wrapper instance (has model_config, enabled_tools, etc.)
             citations: Optional list of citation dicts from RAG retrieval to persist with metadata
             original_message: Original user message before RAG augmentation (for clean UI display)
+            turn_agent_id: Which Agent ran this turn (#756), recorded on each cost row so a
+                deliberate `@`-mention prefix swap is distinguishable from the
+                nondeterministic-ordering regression the fingerprints exist to catch.
+                Passed per turn rather than read off the agent: the agent instance is cached
+                and shared across turns, so per-turn state must never live on it (#741/#751).
 
         Yields:
             str: SSE formatted events

--- a/backend/tests/agents/main_agent/streaming/test_stream_response_signature.py
+++ b/backend/tests/agents/main_agent/streaming/test_stream_response_signature.py
@@ -1,0 +1,116 @@
+"""The `ChatAgent.stream_async` → `StreamCoordinator.stream_response` seam.
+
+`turn_agent_id` (#756) was threaded through `_store_message_metadata`, `ChatAgent`,
+`base_agent` and `voice_agent`, and forwarded from inside `stream_response`'s own body —
+but never added to `stream_response`'s **signature**. Every invocation raised
+``TypeError: StreamCoordinator.stream_response() got an unexpected keyword argument
+'turn_agent_id'`` before the model was reached, so 100% of chat turns 500'd and AgentCore
+surfaced 424. It reproduced with and without an Agent attached.
+
+⚠️ **The stub below binds against the real signature on purpose.** The existing coordinator
+stubs take bare ``**kwargs``, which silently accepts arguments the real coordinator rejects
+— a stub shaped like the *caller* rather than the *callee* cannot fail on caller/callee
+drift, which is precisely how this shipped CI-green. Binding is what makes these tests able
+to fail; do not "simplify" it back to ``**kwargs``.
+"""
+
+import inspect
+
+import pytest
+
+from agents.main_agent.chat_agent import ChatAgent
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+
+class _SignatureFaithfulCoordinator:
+    """Records forwarded kwargs, after checking the real coordinator would accept them."""
+
+    _real_signature = inspect.signature(StreamCoordinator.stream_response)
+
+    def __init__(self):
+        self.captured = {}
+
+    async def stream_response(self, **kwargs):
+        # Raises TypeError on any drift between what ChatAgent sends and what
+        # StreamCoordinator declares — the production failure, in-process.
+        self._real_signature.bind(self, **kwargs)
+        self.captured = kwargs
+        if False:  # pragma: no cover - make this an async generator
+            yield ""
+
+
+class _PassthroughMultimodalBuilder:
+    def build_prompt(self, message, files):
+        return message
+
+
+def _bare_chat_agent(coordinator):
+    """A ChatAgent with the real forwarding code but no Strands agent construction."""
+    agent = object.__new__(ChatAgent)
+    agent.agent = object()  # truthy so _create_agent() is skipped
+    agent.stream_coordinator = coordinator
+    agent.multimodal_builder = _PassthroughMultimodalBuilder()
+    agent.session_manager = object()
+    agent.session_id = "sess-1"
+    agent.user_id = "user-1"
+    return agent
+
+
+def test_stream_response_accepts_turn_agent_id():
+    """The signature itself — the one line whose absence took chat down."""
+    params = inspect.signature(StreamCoordinator.stream_response).parameters
+
+    assert "turn_agent_id" in params, (
+        "stream_response() must accept turn_agent_id: ChatAgent.stream_async forwards it "
+        "and stream_response's own body passes it to _store_message_metadata."
+    )
+    assert params["turn_agent_id"].default is None, (
+        "turn_agent_id must default to None — voice and non-mention turns omit it."
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_async_forwards_turn_agent_id_the_coordinator_accepts():
+    """The seam end-to-end: a mention turn binds cleanly against the real signature."""
+    coordinator = _SignatureFaithfulCoordinator()
+    agent = _bare_chat_agent(coordinator)
+
+    async for _ in agent.stream_async("summarize this", turn_agent_id="ast-canvas"):
+        pass
+
+    assert coordinator.captured.get("turn_agent_id") == "ast-canvas"
+
+
+@pytest.mark.asyncio
+async def test_plain_turn_binds_and_carries_no_agent_id():
+    """A turn with no `@`-mention must still bind, and must not invent an agent id."""
+    coordinator = _SignatureFaithfulCoordinator()
+    agent = _bare_chat_agent(coordinator)
+
+    async for _ in agent.stream_async("hello"):
+        pass
+
+    assert coordinator.captured.get("turn_agent_id") is None
+
+
+@pytest.mark.asyncio
+async def test_every_kwarg_chat_agent_forwards_is_accepted():
+    """Generalises past this one parameter: no kwarg ChatAgent sends may be unknown.
+
+    This is the assertion that would have caught #756's break on the day it landed, and
+    catches the next one without anybody remembering to add a case for it.
+    """
+    coordinator = _SignatureFaithfulCoordinator()
+    agent = _bare_chat_agent(coordinator)
+
+    async for _ in agent.stream_async(
+        "a message",
+        session_id="sess-9",
+        citations=[{"source": "doc-1"}],
+        original_message="a message",
+        turn_agent_id="ast-canvas",
+    ):
+        pass
+
+    accepted = set(inspect.signature(StreamCoordinator.stream_response).parameters)
+    assert set(coordinator.captured) <= accepted


### PR DESCRIPTION
## The outage

Every chat turn on dev returns AgentCore **424**. The runtime container is 500ing before the model is reached:

```
TypeError: StreamCoordinator.stream_response() got an unexpected keyword argument 'turn_agent_id'
INFO: 127.0.0.1:36696 - "POST /invocations HTTP/1.1" 500 Internal Server Error
```

Found while smoke-testing the Agent epic on dev; the epic's own surfaces are fine, this is the cost-observability change that shipped alongside them.

## Cause

`d64d4208` (#756 / PR #765) threaded `turn_agent_id` through `_store_message_metadata`, `ChatAgent.stream_async`, `base_agent` and `voice_agent`, and added the forwarding call inside `stream_response`'s own body at `stream_coordinator.py:946` — but never added the parameter to `stream_response`'s **signature** at `stream_coordinator.py:54`.

`ChatAgent.stream_async` passes the kwarg on **every** turn, not just mention turns:

```python
async for event in self.stream_coordinator.stream_response(
    ...
    turn_agent_id=turn_agent_id,   # chat_agent.py:143
):
```

So this is a total chat outage, not a mention-path bug. Verified on dev both with an Agent attached and with **zero tools and no Agent** — identical TypeError.

One line to fix; the body already referenced the name.

> Note: a second, unrelated error is visible in the same logs — the `canvas_faculty` external MCP tool is registered with `http://localhost:8026/mcp`, unreachable from the runtime container. It logs `failed to start MCP client` each turn but does **not** block the turn. Filing separately; out of scope here.

## Why CI was green

The existing coordinator stubs take a bare `**kwargs`:

```python
async def stream_response(self, **kwargs):   # accepts anything, including what the real one rejects
```

A stub shaped like the *caller* can never fail on caller/callee drift. `grep turn_agent_id backend/tests/` returned two hits before this PR, both asserting on the cost-row **model** — nothing exercised the seam that actually broke.

The new tests bind against `inspect.signature(StreamCoordinator.stream_response)`, reproducing the production TypeError in-process. **All four fail against the unfixed coordinator** (verified by reverting the fix and re-running):

```
E   TypeError: got an unexpected keyword argument 'turn_agent_id'
FAILED test_stream_response_accepts_turn_agent_id
FAILED test_stream_async_forwards_turn_agent_id_the_coordinator_accepts
FAILED test_plain_turn_binds_and_carries_no_agent_id
FAILED test_every_kwarg_chat_agent_forwards_is_accepted
```

That third failure is the one that pins the blast radius: a turn with no `@`-mention breaks too.

The last test asserts that *no* kwarg `ChatAgent` forwards is unknown to the coordinator — so the next parameter added to this seam is covered without anyone remembering to write a case for it.

## Verification

- 4 new tests: red against the unfixed coordinator, green with the fix
- `tests/agents/main_agent/` — 981 passed
- Full backend suite — **5254 passed, 3 skipped**

## Deploy

`backend.yml` only — no CDK, no index, env var or IAM change. Ships the inference-api image to the AgentCore Runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)