### PR TITLE
fix(timestamps): stop emitting `+00:00Z`, which no browser can parse

### DIFF
--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -35,6 +35,7 @@ from agents.main_agent.integrations.oauth_auth import (
     CompositeAuth,
     create_oauth_bearer_auth,
 )
+from apis.shared.timestamps import to_iso
 
 logger = logging.getLogger(__name__)
 
@@ -372,7 +373,7 @@ class ExternalMCPIntegration:
                 if allowed_tool_names is not None:
                     cache_key += "|allow:" + ",".join(sorted(allowed_tool_names))
                 tool_version = (
-                    tool.updated_at.isoformat() + "Z" if tool.updated_at else ""
+                    to_iso(tool.updated_at) if tool.updated_at else ""
                 )
 
                 if (

--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -13,7 +13,6 @@ truth for a seed.
 
 import logging
 import uuid
-from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -78,6 +77,7 @@ from apis.shared.assistants.publishers import (
 )
 from apis.shared.auth import User, require_admin
 from apis.shared.feature_flags import agent_marketplace_enabled
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ router = APIRouter(prefix="/agents", tags=["admin-agent-marketplace"])
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 async def require_marketplace_admin(admin: User = Depends(require_admin)) -> User:

--- a/backend/src/apis/app_api/admin/oauth/routes.py
+++ b/backend/src/apis/app_api/admin/oauth/routes.py
@@ -9,7 +9,6 @@ the callback URL that the admin must register with the vendor.
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Optional
 
@@ -39,6 +38,7 @@ from apis.shared.oauth.provider_repository import (
     OAuthProviderRepository,
     get_provider_repository,
 )
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -338,7 +338,7 @@ async def update_provider(
     if credential_info is not None:
         provider.credential_provider_arn = credential_info.credential_provider_arn
         provider.callback_url = credential_info.callback_url
-        provider.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+        provider.updated_at = utc_now_iso()
         await provider_repo.put_provider(provider)
 
     return OAuthProviderResponse.from_provider(provider)
@@ -434,7 +434,7 @@ def _validate_export_target_adapter(
 def _build_provider_from_create(
     data: OAuthProviderCreate, credential_info: CredentialProviderInfo
 ) -> OAuthProvider:
-    now = datetime.now(timezone.utc).isoformat() + "Z"
+    now = utc_now_iso()
     return OAuthProvider(
         provider_id=data.provider_id,
         display_name=data.display_name,

--- a/backend/src/apis/app_api/admin/services/tests/test_model_access.py
+++ b/backend/src/apis/app_api/admin/services/tests/test_model_access.py
@@ -13,6 +13,7 @@ from apis.app_api.admin.services.model_access import ModelAccessService
 from apis.shared.models.models import ManagedModel
 from apis.shared.auth.models import User
 from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.timestamps import utc_now_iso
 
 
 def create_test_user(
@@ -100,7 +101,7 @@ class TestModelAccessService:
                 tools=[],
                 models=["*"],  # Wildcard access
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -126,7 +127,7 @@ class TestModelAccessService:
                 tools=[],
                 models=["claude-opus", "claude-sonnet"],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -151,7 +152,7 @@ class TestModelAccessService:
                 tools=[],
                 models=["claude-sonnet"],  # Does not include gpt-4o
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -177,7 +178,7 @@ class TestModelAccessService:
                 tools=[],
                 models=[],  # No model access via AppRole
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -204,7 +205,7 @@ class TestModelAccessService:
                 tools=[],
                 models=[],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -230,7 +231,7 @@ class TestModelAccessService:
                 tools=[],
                 models=["claude-opus"],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -257,7 +258,7 @@ class TestModelAccessService:
                 tools=[],
                 models=[],  # Admin doesn't have model access configured
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -297,7 +298,7 @@ class TestModelAccessServiceFilterModels:
                 tools=["*"],
                 models=["*"],  # Wildcard
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -336,7 +337,7 @@ class TestModelAccessServiceFilterModels:
                 tools=[],
                 models=["model-1"],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -360,7 +361,7 @@ class TestModelAccessServiceFilterModels:
                 tools=["*"],
                 models=["*"],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 
@@ -421,7 +422,7 @@ class TestModelAccessIgnoresAllowedAppRoles:
                 tools=[],
                 models=models,
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
         )
 

--- a/backend/src/apis/app_api/agent_designer/services/icon_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/icon_service.py
@@ -19,7 +19,6 @@ Two authorization rules, and they are deliberately different from each other:
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Tuple
 
 from apis.shared.assistants.icons import (
@@ -38,6 +37,7 @@ from apis.shared.assistants.service import (
     resolve_assistant_permission,
 )
 from apis.shared.auth.models import User
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class AgentIconError(Exception):
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 async def _load_for_write(agent_id: str, user: User) -> Assistant:

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -27,7 +27,6 @@ the rest. Publisher is a name on a shelf.
 import hashlib
 import logging
 import os
-from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 from apis.shared.assistants.compat import effective_bindings
@@ -59,6 +58,7 @@ from apis.shared.auth.models import User
 from apis.shared.feature_flags import skills_enabled
 from apis.shared.memory.service import MemorySpaceService
 from apis.shared.skills.repository import get_skill_catalog_repository
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ _EDIT_FIELD_LABELS = {
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _current_state(assistant: Assistant) -> Optional[str]:

--- a/backend/src/apis/app_api/documents/ingestion/status.py
+++ b/backend/src/apis/app_api/documents/ingestion/status.py
@@ -6,8 +6,8 @@ Centralized status update logic with error message formatting.
 import logging
 import os
 import traceback
-from datetime import datetime, timezone
 from typing import Optional, Tuple, Literal
+from apis.shared.timestamps import utc_now_iso
 
 # Type alias for document processing status (duplicated from models.py for standalone use)
 DocumentStatus = Literal['uploading', 'chunking', 'embedding', 'complete', 'failed']
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def _get_current_timestamp() -> str:
     """Get current timestamp in ISO 8601 format"""
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 async def update_document_status(
     assistant_id: str,

--- a/backend/src/apis/app_api/files/service.py
+++ b/backend/src/apis/app_api/files/service.py
@@ -16,6 +16,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from apis.shared.security.log_sanitize import scrub_log
+from apis.shared.timestamps import to_iso
 
 from apis.shared.files.models import (
     FileMetadata,
@@ -255,7 +256,7 @@ class FileUploadService:
             logger.error(f"Failed to generate pre-signed URL: {e}")
             raise
 
-        expires_at = (datetime.now(timezone.utc) + timedelta(seconds=self.presign_expiration)).isoformat() + "Z"
+        expires_at = to_iso(datetime.now(timezone.utc) + timedelta(seconds=self.presign_expiration))
 
         logger.info(f"Generated pre-signed URL for upload {upload_id} by user {user_id}")
 
@@ -381,9 +382,9 @@ class FileUploadService:
             logger.error(f"Failed to generate preview URL: {e}")
             raise
 
-        expires_at = (
+        expires_at = to_iso(
             datetime.now(timezone.utc) + timedelta(seconds=self.preview_url_expiration)
-        ).isoformat() + "Z"
+        )
 
         return PreviewUrlResponse(
             upload_id=upload_id,
@@ -546,9 +547,9 @@ class FileUploadService:
             logger.error(f"Failed to generate thumbnail presigned URL: {e}")
             raise
 
-        expires_at = (
+        expires_at = to_iso(
             datetime.now(timezone.utc) + timedelta(seconds=self.preview_url_expiration)
-        ).isoformat() + "Z"
+        )
 
         return ThumbnailResponse(
             upload_id=upload_id,

--- a/backend/src/apis/app_api/kb_sync/dispatcher.py
+++ b/backend/src/apis/app_api/kb_sync/dispatcher.py
@@ -33,6 +33,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from apis.shared.sync_policies.models import SyncPolicy
+from apis.shared.timestamps import from_iso
 from apis.shared.sync_policies.service import (
     INTERVAL_DELTAS,
     delete_sync_policy,
@@ -69,7 +70,7 @@ def _parse_timestamp(value: str) -> Optional[datetime]:
     'Z' and the legacy '+00:00Z' (offset AND Z). Always returns a UTC-aware
     datetime so comparisons with :func:`_now` never mix naive and aware."""
     try:
-        dt = datetime.fromisoformat(value.rstrip("Z"))
+        dt = from_iso(value)
     except (ValueError, AttributeError):
         return None
     if dt.tzinfo is None:

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -6,7 +6,6 @@ Provides endpoints for managing session metadata.
 from fastapi import APIRouter, HTTPException, Depends, Query, Response, BackgroundTasks, status
 from typing import Optional
 import logging
-from datetime import datetime, timezone
 from apis.shared.sessions.models import (
     UpdateSessionMetadataRequest,
     SessionInterruptRequest,
@@ -37,6 +36,7 @@ from apis.shared.auth.models import User
 from apis.shared.system_prompts.service import get_system_prompts_service
 
 from apis.shared.security.log_sanitize import scrub_log
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +272,7 @@ async def update_session_metadata_endpoint(
                 )
 
             # Create new session metadata with defaults
-            now = datetime.now(timezone.utc).isoformat() + "Z"
+            now = utc_now_iso()
 
             # Build preferences if any preference fields are provided
             preferences = None

--- a/backend/src/apis/app_api/users/routes.py
+++ b/backend/src/apis/app_api/users/routes.py
@@ -9,6 +9,7 @@ from apis.shared.rbac.service import get_app_role_service
 from apis.shared.users.repository import UserRepository
 from apis.shared.users.models import UserProfile, UserStatus
 from .models import UserSearchResult, UserSearchResponse, UserPermissionsResponse, UserProfileSyncRequest
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -91,9 +92,8 @@ async def sync_my_profile(
         )
 
     email_domain = email.split("@")[1] if "@" in email else ""
-    from datetime import datetime, timezone
 
-    now = datetime.now(timezone.utc).isoformat() + "Z"
+    now = utc_now_iso()
 
     profile = UserProfile(
         user_id=current_user.user_id,

--- a/backend/src/apis/app_api/web_sources/crawl_repository.py
+++ b/backend/src/apis/app_api/web_sources/crawl_repository.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from typing import Any, List, Optional
 
 from apis.app_api.web_sources.models import CrawlJob, CrawlJobStatus, CrawlSettings
+from apis.shared.timestamps import from_iso
 
 logger = logging.getLogger(__name__)
 
@@ -187,8 +188,7 @@ def is_crawl_stale(job: CrawlJob) -> bool:
     removable or a zombie web source could never be cleared from the UI.
     """
     try:
-        started_str = job.started_at.rstrip("Z")
-        started = datetime.fromisoformat(started_str).replace(tzinfo=timezone.utc)
+        started = from_iso(job.started_at)
         elapsed = (datetime.now(timezone.utc) - started).total_seconds()
         return elapsed > _STALE_RUNNING_SECONDS
     except (ValueError, AttributeError) as e:

--- a/backend/src/apis/shared/assistants/categories.py
+++ b/backend/src/apis/shared/assistants/categories.py
@@ -20,11 +20,11 @@ and the browse header while its listings keep their partition intact.
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from .listing import DEFAULT_CATEGORIES
 from .models import AgentCategory
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ _PARTITION = "AGENT_CATEGORIES"
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/assistants/pins.py
+++ b/backend/src/apis/shared/assistants/pins.py
@@ -33,9 +33,9 @@ sorts and renders by.
 
 import logging
 import os
-from datetime import datetime, timezone
 
 from .models import PinnedAgentRef, UserPinState
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ MAX_PINS = 100
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/assistants/publishers.py
+++ b/backend/src/apis/shared/assistants/publishers.py
@@ -22,10 +22,10 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from .models import PublisherProfile
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ _PARTITION = "AGENT_PUBLISHERS"
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/assistants/reports.py
+++ b/backend/src/apis/shared/assistants/reports.py
@@ -47,10 +47,10 @@ for a request-changes or takedown, and that act is separately recorded on the li
 import hashlib
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from .models import AgentReport, ReportReason
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ _NAMES = {"#st": "state", "#reason": "reason", "#note": "note"}
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/assistants/role_pins.py
+++ b/backend/src/apis/shared/assistants/role_pins.py
@@ -33,12 +33,12 @@ records when an Agent was *seeded*, not when the list was last dragged around.
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Dict, List, Sequence, Tuple
 
 from boto3.dynamodb.conditions import Key
 
 from .models import RoleAgentPin, RoleAgentPinInput
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ MAX_ROLE_PINS = 25
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Tuple
 
 from .models import AgentBinding, AgentModelConfig, Assistant
 from .serialization import from_ddb, to_ddb_safe
+from apis.shared.timestamps import to_iso, utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def _generate_assistant_id() -> str:
 
 def _get_current_timestamp() -> str:
     """Get current timestamp in ISO 8601 format"""
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 async def create_assistant_draft(owner_id: str, owner_name: str, name: Optional[str] = None) -> Assistant:
@@ -321,12 +322,12 @@ async def bump_last_used_at(assistant_id: str, throttle_hours: int = 24) -> bool
         from botocore.exceptions import ClientError
 
         now_dt = datetime.now(timezone.utc)
-        floor = (now_dt - timedelta(hours=throttle_hours)).isoformat() + "Z"
+        floor = to_iso(now_dt - timedelta(hours=throttle_hours))
         table = boto3.resource("dynamodb").Table(assistants_table)
         table.update_item(
             Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"},
             UpdateExpression="SET lastUsedAt = :now",
-            ExpressionAttributeValues={":now": now_dt.isoformat() + "Z", ":floor": floor},
+            ExpressionAttributeValues={":now": to_iso(now_dt), ":floor": floor},
             ConditionExpression=(
                 "attribute_exists(PK) AND (attribute_not_exists(lastUsedAt) OR lastUsedAt < :floor)"
             ),

--- a/backend/src/apis/shared/assistants/storefront.py
+++ b/backend/src/apis/shared/assistants/storefront.py
@@ -21,8 +21,8 @@ is later reversed would have silently cost the Agent its slot.
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import List
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ MAX_FEATURED = 10
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _table():

--- a/backend/src/apis/shared/auth_providers/models.py
+++ b/backend/src/apis/shared/auth_providers/models.py
@@ -2,10 +2,10 @@
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +47,8 @@ class AuthProvider:
     logo_url: Optional[str] = None
     button_color: Optional[str] = None
     # Metadata
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
-    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
+    created_at: str = field(default_factory=lambda: utc_now_iso())
+    updated_at: str = field(default_factory=lambda: utc_now_iso())
     created_by: Optional[str] = None
     # Cognito federated identity provider name
     cognito_provider_name: Optional[str] = None
@@ -173,8 +173,8 @@ class AuthProvider:
             allowed_audiences=item.get("allowedAudiences"),
             logo_url=item.get("logoUrl"),
             button_color=item.get("buttonColor"),
-            created_at=item.get("createdAt", datetime.now(timezone.utc).isoformat() + "Z"),
-            updated_at=item.get("updatedAt", datetime.now(timezone.utc).isoformat() + "Z"),
+            created_at=item.get("createdAt", utc_now_iso()),
+            updated_at=item.get("updatedAt", utc_now_iso()),
             created_by=item.get("createdBy"),
             cognito_provider_name=item.get("cognitoProviderName"),
             agentcore_runtime_arn=item.get("agentcoreRuntimeArn"),

--- a/backend/src/apis/shared/auth_providers/repository.py
+++ b/backend/src/apis/shared/auth_providers/repository.py
@@ -3,13 +3,13 @@
 import json
 import logging
 import os
-from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from .models import AuthProvider, AuthProviderCreate, AuthProviderUpdate
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ class AuthProviderRepository:
             raise ValueError(f"Auth provider '{data.provider_id}' already exists")
 
         try:
-            now = datetime.now(timezone.utc).isoformat() + "Z"
+            now = utc_now_iso()
 
             provider = AuthProvider(
                 provider_id=data.provider_id,
@@ -213,7 +213,7 @@ class AuthProviderRepository:
                 if hasattr(existing, field_name):
                     setattr(existing, field_name, value)
 
-            existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+            existing.updated_at = utc_now_iso()
 
             # Store updated provider
             self._table.put_item(Item=existing.to_dynamo_item())

--- a/backend/src/apis/shared/files/models.py
+++ b/backend/src/apis/shared/files/models.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
+from apis.shared.timestamps import from_iso, to_iso
 
 
 class FileStatus(str, Enum):
@@ -202,8 +203,8 @@ class FileMetadata(BaseModel):
             "s3Uri": self.s3_uri,
             "source": self.source,
             "status": self.status if isinstance(self.status, str) else self.status.value,
-            "createdAt": self.created_at.isoformat() + "Z",
-            "updatedAt": self.updated_at.isoformat() + "Z",
+            "createdAt": to_iso(self.created_at),
+            "updatedAt": to_iso(self.updated_at),
             "ttl": ttl_value,
         }
 
@@ -224,8 +225,8 @@ class FileMetadata(BaseModel):
             s3_bucket=item.get("s3Bucket", ""),
             status=item.get("status", FileStatus.PENDING),
             source=item.get("source", "upload"),
-            created_at=datetime.fromisoformat(created_at.rstrip("Z")) if created_at else datetime.now(timezone.utc),
-            updated_at=datetime.fromisoformat(updated_at.rstrip("Z")) if updated_at else datetime.now(timezone.utc),
+            created_at=from_iso(created_at) if created_at else datetime.now(timezone.utc),
+            updated_at=from_iso(updated_at) if updated_at else datetime.now(timezone.utc),
             ttl=item.get("ttl"),
         )
 
@@ -252,7 +253,7 @@ class UserFileQuota(BaseModel):
             "userId": self.user_id,
             "totalBytes": self.total_bytes,
             "fileCount": self.file_count,
-            "updatedAt": self.updated_at.isoformat() + "Z",
+            "updatedAt": to_iso(self.updated_at),
         }
 
     @classmethod
@@ -263,7 +264,7 @@ class UserFileQuota(BaseModel):
             user_id=item.get("userId", ""),
             total_bytes=int(item.get("totalBytes", 0)),
             file_count=int(item.get("fileCount", 0)),
-            updated_at=datetime.fromisoformat(updated_at.rstrip("Z")) if updated_at else datetime.now(timezone.utc),
+            updated_at=from_iso(updated_at) if updated_at else datetime.now(timezone.utc),
         )
 
 
@@ -377,7 +378,7 @@ class FileResponse(BaseModel):
             session_id=meta.session_id,
             s3_uri=meta.s3_uri,
             status=meta.status if isinstance(meta.status, str) else meta.status.value,
-            created_at=meta.created_at.isoformat() + "Z",
+            created_at=to_iso(meta.created_at),
         )
 
 

--- a/backend/src/apis/shared/files/repository.py
+++ b/backend/src/apis/shared/files/repository.py
@@ -6,7 +6,6 @@ DynamoDB operations for file metadata and user quota tracking.
 
 import os
 import logging
-from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
@@ -14,6 +13,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from .models import FileMetadata, UserFileQuota, FileStatus
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ class FileUploadRepository:
                 ExpressionAttributeNames={"#status": "status"},
                 ExpressionAttributeValues={
                     ":status": status.value if isinstance(status, FileStatus) else status,
-                    ":now": datetime.now(timezone.utc).isoformat() + "Z",
+                    ":now": utc_now_iso(),
                 },
                 ConditionExpression="attribute_exists(PK)",
                 ReturnValues="ALL_NEW",
@@ -333,7 +333,7 @@ class FileUploadRepository:
                 ),
                 ExpressionAttributeValues={
                     ":userId": user_id,
-                    ":now": datetime.now(timezone.utc).isoformat() + "Z",
+                    ":now": utc_now_iso(),
                     ":size": size_bytes,
                     ":one": 1,
                 },
@@ -364,7 +364,7 @@ class FileUploadRepository:
                 ),
                 ExpressionAttributeValues={
                     ":userId": user_id,
-                    ":now": datetime.now(timezone.utc).isoformat() + "Z",
+                    ":now": utc_now_iso(),
                     ":negSize": -size_bytes,
                     ":negOne": -1,
                 },

--- a/backend/src/apis/shared/oauth/disconnect_repository.py
+++ b/backend/src/apis/shared/oauth/disconnect_repository.py
@@ -17,11 +17,11 @@ which may land on a different replica.
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class OAuthDisconnectRepository:
             return
         item = {
             **self._key(user_id, provider_id),
-            "disconnected_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "disconnected_at": utc_now_iso(),
         }
         try:
             self._table.put_item(Item=item)

--- a/backend/src/apis/shared/oauth/models.py
+++ b/backend/src/apis/shared/oauth/models.py
@@ -11,11 +11,11 @@ import hashlib
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -137,8 +137,8 @@ class OAuthProvider:
     # and an export target (e.g. a combined-scope Drive connector). Validated
     # in the admin route for the same reason as above.
     export_target_adapter_id: Optional[str] = None
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
-    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat() + "Z")
+    created_at: str = field(default_factory=lambda: utc_now_iso())
+    updated_at: str = field(default_factory=lambda: utc_now_iso())
 
     @property
     def scopes_hash(self) -> str:
@@ -188,8 +188,8 @@ class OAuthProvider:
             custom_parameters=item.get("customParameters"),
             file_source_adapter_id=item.get("fileSourceAdapterId"),
             export_target_adapter_id=item.get("exportTargetAdapterId"),
-            created_at=item.get("createdAt", datetime.now(timezone.utc).isoformat() + "Z"),
-            updated_at=item.get("updatedAt", datetime.now(timezone.utc).isoformat() + "Z"),
+            created_at=item.get("createdAt", utc_now_iso()),
+            updated_at=item.get("updatedAt", utc_now_iso()),
         )
 
 

--- a/backend/src/apis/shared/oauth/provider_repository.py
+++ b/backend/src/apis/shared/oauth/provider_repository.py
@@ -7,13 +7,13 @@ registered directly with AgentCore Identity by the admin route.
 
 import logging
 import os
-from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from .models import OAuthProvider, OAuthProviderUpdate
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class OAuthProviderRepository:
             # adapter key sets it. `None` leaves the existing value alone.
             existing.export_target_adapter_id = updates.export_target_adapter_id or None
 
-        existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+        existing.updated_at = utc_now_iso()
         self._table.put_item(Item=existing.to_dynamo_item())
         logger.info("Updated OAuth provider metadata: %s", provider_id)
         return existing

--- a/backend/src/apis/shared/rbac/repository.py
+++ b/backend/src/apis/shared/rbac/repository.py
@@ -3,12 +3,12 @@
 import os
 import logging
 from typing import List, Optional, Dict, Any
-from datetime import datetime, timezone
 
 import boto3
 from botocore.exceptions import ClientError
 
 from .models import AppRole
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ class AppRoleRepository:
                 raise ValueError(f"Role '{role.role_id}' already exists")
 
             # Set timestamps
-            now = datetime.now(timezone.utc).isoformat() + "Z"
+            now = utc_now_iso()
             role.created_at = now
             role.updated_at = now
 
@@ -152,7 +152,7 @@ class AppRoleRepository:
                 raise ValueError(f"Role '{role.role_id}' not found")
 
             # Update timestamp
-            role.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+            role.updated_at = utc_now_iso()
             role.created_at = existing.created_at  # Preserve original
 
             # Delete old mapping items and create new ones

--- a/backend/src/apis/shared/rbac/seeder.py
+++ b/backend/src/apis/shared/rbac/seeder.py
@@ -1,10 +1,10 @@
 """Seed default system roles on startup."""
 
 import logging
-from datetime import datetime, timezone
 
 from .models import AppRole, EffectivePermissions
 from .repository import AppRoleRepository
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ async def seed_system_roles(repository: AppRoleRepository = None):
         repository = AppRoleRepository()
 
     roles_to_seed = [SYSTEM_ADMIN_ROLE, DEFAULT_ROLE]
-    now = datetime.now(timezone.utc).isoformat() + "Z"
+    now = utc_now_iso()
 
     for role in roles_to_seed:
         try:

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import List, Set, Optional
-from datetime import datetime, timezone
 
 from apis.shared.auth.models import User
 from apis.shared.tools.scoped_ids import base_tool_id
@@ -10,6 +9,7 @@ from apis.shared.tools.scoped_ids import base_tool_id
 from .models import AppRole, UserEffectivePermissions
 from .repository import AppRoleRepository
 from .cache import AppRoleCache, get_app_role_cache
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class AppRoleService:
                 models=[],
                 skills=[],
                 quota_tier=None,
-                resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+                resolved_at=utc_now_iso(),
             )
 
         # Collect all tools, models and skills (union)
@@ -211,7 +211,7 @@ class AppRoleService:
             models=sorted(all_models),
             skills=sorted(all_skills),
             quota_tier=quota_tier,
-            resolved_at=datetime.now(timezone.utc).isoformat() + "Z",
+            resolved_at=utc_now_iso(),
         )
 
     async def can_access_tool(self, user: User, tool_id: str) -> bool:

--- a/backend/src/apis/shared/skills/freshness.py
+++ b/backend/src/apis/shared/skills/freshness.py
@@ -28,6 +28,7 @@ import hashlib
 import logging
 import time
 from typing import Dict, FrozenSet, List, Optional, Tuple
+from apis.shared.timestamps import to_iso
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ async def _fetch_updated_at(skill_id: str) -> Optional[str]:
     skill = await repo.get_skill(skill_id)
     if skill is None or skill.updated_at is None:
         return None
-    return skill.updated_at.isoformat() + "Z"
+    return to_iso(skill.updated_at)
 
 
 async def get_skill_updated_at(skill_id: str) -> Optional[str]:

--- a/backend/src/apis/shared/skills/models.py
+++ b/backend/src/apis/shared/skills/models.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
+from apis.shared.timestamps import from_iso, to_iso
 
 
 # Regex for a skill_id — identical shape to tool_id (see ToolCreateRequest).
@@ -231,8 +232,8 @@ class SkillDefinition(BaseModel):
             "visibility": self.visibility
             if isinstance(self.visibility, str)
             else self.visibility.value,
-            "createdAt": self.created_at.isoformat() + "Z" if self.created_at else None,
-            "updatedAt": self.updated_at.isoformat() + "Z" if self.updated_at else None,
+            "createdAt": to_iso(self.created_at) if self.created_at else None,
+            "updatedAt": to_iso(self.updated_at) if self.updated_at else None,
             "createdBy": self.created_by,
             "updatedBy": self.updated_by,
         }
@@ -267,10 +268,10 @@ class SkillDefinition(BaseModel):
             category=item.get("category"),
             owner_id=item.get("ownerId", "system"),
             visibility=item.get("visibility", SkillVisibility.ADMIN),
-            created_at=datetime.fromisoformat(created_at.rstrip("Z"))
+            created_at=from_iso(created_at)
             if created_at
             else datetime.now(timezone.utc),
-            updated_at=datetime.fromisoformat(updated_at.rstrip("Z"))
+            updated_at=from_iso(updated_at)
             if updated_at
             else datetime.now(timezone.utc),
             created_by=item.get("createdBy"),
@@ -400,8 +401,8 @@ class AdminSkillResponse(BaseModel):
             owner_id=skill.owner_id,
             visibility=skill.visibility,
             allowed_app_roles=allowed_roles or skill.allowed_app_roles,
-            created_at=skill.created_at.isoformat() + "Z" if skill.created_at else "",
-            updated_at=skill.updated_at.isoformat() + "Z" if skill.updated_at else "",
+            created_at=to_iso(skill.created_at) if skill.created_at else "",
+            updated_at=to_iso(skill.updated_at) if skill.updated_at else "",
             created_by=skill.created_by,
             updated_by=skill.updated_by,
         )
@@ -462,7 +463,7 @@ class UserSkillPreference(BaseModel):
             user_id=item.get("userId", ""),
             skill_preferences=dict(item.get("skillPreferences", {})),
             updated_at=(
-                datetime.fromisoformat(updated_at.rstrip("Z"))
+                from_iso(updated_at)
                 if updated_at
                 else datetime.now(timezone.utc)
             ),

--- a/backend/src/apis/shared/sync_policies/service.py
+++ b/backend/src/apis/shared/sync_policies/service.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from .models import DUE_INDEX_PK, SyncInterval, SyncPolicy, SyncPolicyState, SyncRunResult, SyncSourceType
+from apis.shared.timestamps import to_iso
 
 logger = logging.getLogger(__name__)
 
@@ -37,16 +38,9 @@ class DuplicateSyncPolicy(Exception):
     """Raised when the source already has a sync policy on this assistant."""
 
 
-def _iso(dt: datetime) -> str:
-    """Serialize a UTC datetime as strict ISO 8601 with a ``Z`` suffix.
-
-    ``datetime.isoformat()`` renders the offset as ``+00:00``; we normalize that
-    to ``Z`` so the result is valid ISO 8601 that JavaScript's ``Date`` parses.
-    A previous ``isoformat() + "Z"`` produced ``…+00:00Z`` — both an offset and a
-    Z — which is invalid and yields ``Invalid Date`` in strict engines (Safari),
-    leaving the sync status blank in the UI.
-    """
-    return dt.isoformat().replace("+00:00", "Z")
+# The shared implementation; kept under the module-local name so call sites and the
+# reason this exists (see apis.shared.timestamps) stay one import apart.
+_iso = to_iso
 
 
 def _get_current_timestamp() -> str:

--- a/backend/src/apis/shared/system_prompts/models.py
+++ b/backend/src/apis/shared/system_prompts/models.py
@@ -13,10 +13,10 @@ convention. The frontend admin page consumes the response shape directly.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
+from apis.shared.timestamps import utc_now_iso
 
 MAX_PROMPT_TEXT_LENGTH = 8_000
 
@@ -24,7 +24,7 @@ PromptStatus = Literal["enabled", "disabled"]
 
 
 def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 @dataclass

--- a/backend/src/apis/shared/system_prompts/repository.py
+++ b/backend/src/apis/shared/system_prompts/repository.py
@@ -3,13 +3,13 @@
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from .models import SystemPrompt, SystemPromptCreate, SystemPromptUpdate
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class SystemPromptsRepository:
         if not self._enabled:
             raise RuntimeError("System prompts repository is not enabled")
 
-        now = datetime.now(timezone.utc).isoformat() + "Z"
+        now = utc_now_iso()
         prompt = SystemPrompt(
             prompt_id=str(uuid.uuid4()),
             name=data.name,
@@ -141,7 +141,7 @@ class SystemPromptsRepository:
         update_fields = updates.model_dump(exclude_none=True)
         for field_name, value in update_fields.items():
             setattr(existing, field_name, value)
-        existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+        existing.updated_at = utc_now_iso()
 
         try:
             self._table.put_item(

--- a/backend/src/apis/shared/timestamps.py
+++ b/backend/src/apis/shared/timestamps.py
@@ -1,0 +1,88 @@
+"""UTC timestamp serialization — one spelling, because the obvious one is wrong.
+
+``datetime.now(timezone.utc)`` is timezone-**aware**, so ``.isoformat()`` already renders
+the offset as ``+00:00``. Appending ``"Z"`` to that produces ``2026-07-27T05:09:55.853557
++00:00Z`` — an offset *and* a Z — which is not valid ISO 8601. ``new Date()`` returns
+``Invalid Date`` for it in every browser, so any UI that formats the value silently shows
+a placeholder instead of a date.
+
+That is exactly what happened: the agent detail page rendered "Last updated —" on an agent
+edited minutes earlier, and the admin Reports queue rendered "recently" for every report
+ever filed, because both SPA helpers fall back defensively on an unparseable date. Nothing
+errored, nothing logged, and the values looked plausible in DynamoDB. The idiom had spread
+to 50+ call sites by the time anyone read one of the rendered dates.
+
+``sync_policies.service._iso`` had already discovered and fixed this locally; this module
+is that fix, promoted so there is one implementation to import rather than a convention to
+remember.
+
+**Use** :func:`utc_now_iso` for "now", and :func:`to_iso` for a datetime you already hold::
+
+    from apis.shared.timestamps import utc_now_iso
+
+    item["createdAt"] = utc_now_iso()
+
+⚠️ **Do not write ``datetime.now(timezone.utc).isoformat() + "Z"``.** A regression test
+(`tests/shared/test_timestamps.py`) greps the tree for it, so a reintroduction fails CI
+rather than waiting for someone to notice a blank date.
+
+**On the stored data.** Rows written before this landed still hold the ``+00:00Z`` form.
+They are deliberately **not** backfilled: the SPA normalizes both spellings on read
+(`normalizeIsoTimestamp` in `frontend/.../utils/date.ts`), which fixes the historical rows
+without rewriting items whose values are embedded in GSI sort keys (``GSI5_SK =
+CREATED#{created_at}`` and friends). Mixed formats are safe to compare as strings: the
+suffix only differs *after* the full date-time-microseconds, so two distinct instants
+still order correctly, and only an exact microsecond tie could compare unequal.
+"""
+
+from datetime import datetime, timezone
+
+__all__ = ["utc_now_iso", "to_iso", "from_iso"]
+
+
+def to_iso(dt: datetime) -> str:
+    """Serialize a datetime as strict ISO 8601 UTC with a ``Z`` suffix.
+
+    Accepts aware or naive datetimes. A naive value is *assumed* to be UTC — that is the
+    convention everywhere in this codebase, and treating it as local time would silently
+    shift timestamps by the host's offset in a container that is not on UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    # `.isoformat()` renders UTC as "+00:00"; normalize that single spelling to "Z" so the
+    # result is valid ISO 8601 rather than carrying both an offset and a Z.
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def utc_now_iso() -> str:
+    """The current time as strict ISO 8601 UTC (``…Z``)."""
+    return to_iso(datetime.now(timezone.utc))
+
+
+def from_iso(value: str) -> datetime:
+    """Parse a stored timestamp, tolerating the legacy ``…+00:00Z`` spelling.
+
+    Always returns an **aware** UTC datetime.
+
+    ⚠️ **This exists because the obvious parser silently depended on the writer's bug.**
+    Call sites used ``datetime.fromisoformat(value.rstrip("Z"))``, which happened to work
+    only while the writer emitted the broken form: stripping the ``Z`` off
+    ``…+00:00Z`` leaves ``…+00:00`` (aware), but stripping it off a *correct* ``…Z``
+    leaves a bare ``…`` (naive). Fixing the writers alone would therefore have flipped
+    every round-tripped timestamp from aware to naive — comparisons against
+    ``datetime.now(timezone.utc)`` would start raising
+    ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+
+    `tests/shared/test_skills_models.py::test_round_trip_preserves_fields` is what caught
+    it. Do not reintroduce ``rstrip("Z")``.
+    """
+    normalized = value.replace("+00:00Z", "Z")
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        # A stored value with no offset at all: same UTC assumption as `to_iso`.
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/backend/src/apis/shared/tools/freshness.py
+++ b/backend/src/apis/shared/tools/freshness.py
@@ -29,6 +29,7 @@ import hashlib
 import logging
 import time
 from typing import Dict, FrozenSet, List, Optional, Tuple
+from apis.shared.timestamps import to_iso
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ async def _fetch_updated_at(tool_id: str) -> Optional[str]:
     tool = await repo.get_tool(tool_id)
     if tool is None or tool.updated_at is None:
         return None
-    return tool.updated_at.isoformat() + "Z"
+    return to_iso(tool.updated_at)
 
 
 async def get_tool_updated_at(tool_id: str) -> Optional[str]:

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set
 
 from pydantic import BaseModel, Field, model_validator
+from apis.shared.timestamps import from_iso, to_iso
 
 
 class ToolCategory(str, Enum):
@@ -723,8 +724,8 @@ class ToolDefinition(BaseModel):
             "forwardAuthToken": self.forward_auth_token,
             "isPublic": self.is_public,
             "enabledByDefault": self.enabled_by_default,
-            "createdAt": self.created_at.isoformat() + "Z" if self.created_at else None,
-            "updatedAt": self.updated_at.isoformat() + "Z" if self.updated_at else None,
+            "createdAt": to_iso(self.created_at) if self.created_at else None,
+            "updatedAt": to_iso(self.updated_at) if self.updated_at else None,
             "createdBy": self.created_by,
             "updatedBy": self.updated_by,
         }
@@ -789,8 +790,8 @@ class ToolDefinition(BaseModel):
             mcp_config=mcp_config,
             a2a_config=a2a_config,
             mcp_gateway_config=mcp_gateway_config,
-            created_at=datetime.fromisoformat(created_at.rstrip("Z")) if created_at else datetime.now(timezone.utc),
-            updated_at=datetime.fromisoformat(updated_at.rstrip("Z")) if updated_at else datetime.now(timezone.utc),
+            created_at=from_iso(created_at) if created_at else datetime.now(timezone.utc),
+            updated_at=from_iso(updated_at) if updated_at else datetime.now(timezone.utc),
             created_by=item.get("createdBy"),
             updated_by=item.get("updatedBy"),
         )
@@ -816,7 +817,7 @@ class UserToolPreference(BaseModel):
             "SK": "TOOL_PREFERENCES",
             "userId": self.user_id,
             "toolPreferences": self.tool_preferences,
-            "updatedAt": self.updated_at.isoformat() + "Z" if self.updated_at else None,
+            "updatedAt": to_iso(self.updated_at) if self.updated_at else None,
         }
 
     @classmethod
@@ -826,7 +827,7 @@ class UserToolPreference(BaseModel):
         return cls(
             user_id=item.get("userId", ""),
             tool_preferences=item.get("toolPreferences", {}),
-            updated_at=datetime.fromisoformat(updated_at.rstrip("Z")) if updated_at else datetime.now(timezone.utc),
+            updated_at=from_iso(updated_at) if updated_at else datetime.now(timezone.utc),
         )
 
 
@@ -1333,8 +1334,8 @@ class AdminToolResponse(BaseModel):
             is_public=tool.is_public,
             allowed_app_roles=allowed_roles or tool.allowed_app_roles,
             enabled_by_default=tool.enabled_by_default,
-            created_at=tool.created_at.isoformat() + "Z" if tool.created_at else "",
-            updated_at=tool.updated_at.isoformat() + "Z" if tool.updated_at else "",
+            created_at=to_iso(tool.created_at) if tool.created_at else "",
+            updated_at=to_iso(tool.updated_at) if tool.updated_at else "",
             created_by=tool.created_by,
             updated_by=tool.updated_by,
             mcp_config=mcp_config_response,

--- a/backend/src/apis/shared/user_menu_links/models.py
+++ b/backend/src/apis/shared/user_menu_links/models.py
@@ -10,16 +10,16 @@ PK becomes ``USER_MENU_LINKS#<org_id>`` without touching the SK shape.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from apis.shared.timestamps import utc_now_iso
 
 LinkKind = Literal["external", "modal"]
 
 
 def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat() + "Z"
+    return utc_now_iso()
 
 
 def _validate_http_url(value: Optional[str]) -> Optional[str]:

--- a/backend/src/apis/shared/user_menu_links/repository.py
+++ b/backend/src/apis/shared/user_menu_links/repository.py
@@ -3,13 +3,13 @@
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from .models import UserMenuLink, UserMenuLinkCreate, UserMenuLinkUpdate
+from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ class UserMenuLinksRepository:
         if not self._enabled:
             raise RuntimeError("User-menu links repository is not enabled")
 
-        now = datetime.now(timezone.utc).isoformat() + "Z"
+        now = utc_now_iso()
         link = UserMenuLink(
             link_id=str(uuid.uuid4()),
             label=data.label,
@@ -133,7 +133,7 @@ class UserMenuLinksRepository:
         update_fields = updates.model_dump(exclude_none=True)
         for field_name, value in update_fields.items():
             setattr(existing, field_name, value)
-        existing.updated_at = datetime.now(timezone.utc).isoformat() + "Z"
+        existing.updated_at = utc_now_iso()
 
         # Re-validate the merged kind/url/body_markdown invariant before persist.
         if existing.kind == "external" and not existing.url:

--- a/backend/src/apis/shared/users/sync.py
+++ b/backend/src/apis/shared/users/sync.py
@@ -6,20 +6,14 @@ from typing import Tuple, Optional
 
 from .models import UserProfile, UserStatus
 from .repository import UserRepository
+from apis.shared.timestamps import to_iso
 
 logger = logging.getLogger(__name__)
 
 
-def _iso(dt: datetime) -> str:
-    """Serialize a UTC datetime as strict ISO 8601 with a ``Z`` suffix.
-
-    ``datetime.isoformat()`` renders the offset as ``+00:00``; we normalize that
-    to ``Z`` so the result is valid ISO 8601 that JavaScript's ``Date`` parses.
-    A previous ``isoformat() + "Z"`` produced ``…+00:00Z`` — both an offset and a
-    Z — which is invalid and yields ``Invalid Date`` in strict engines (Safari),
-    leaving the admin user list / detail dates blank ("Never").
-    """
-    return dt.isoformat().replace("+00:00", "Z")
+# The shared implementation; kept under the module-local name so call sites and the
+# reason this exists (see apis.shared.timestamps) stay one import apart.
+_iso = to_iso
 
 
 class UserSyncService:

--- a/backend/tests/shared/test_timestamps.py
+++ b/backend/tests/shared/test_timestamps.py
@@ -1,0 +1,147 @@
+"""UTC timestamp serialization, and a guard against the idiom that broke it.
+
+`datetime.now(timezone.utc)` is tz-aware, so `.isoformat()` already emits `+00:00`.
+Appending `"Z"` yields `…+00:00Z` — an offset *and* a Z — which is not valid ISO 8601 and
+parses to `Invalid Date` in JavaScript. It spread to 52 call sites before anyone read one
+of the rendered dates, because every SPA formatter falls back silently on an unparseable
+value ("Last updated —", "recently").
+"""
+
+import pathlib
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from apis.shared.timestamps import from_iso, to_iso, utc_now_iso
+
+# The exact expression that caused the outage. Kept as one regex so the guard test below
+# and this docstring cannot drift apart.
+BROKEN_IDIOM = re.compile(r'now\(timezone\.utc\)\.isoformat\(\)\s*\+\s*"Z"')
+
+SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
+
+
+def _js_parseable(value: str) -> bool:
+    """Mirror the subset of ISO 8601 that `new Date()` accepts.
+
+    Deliberately *not* `datetime.fromisoformat` — Python 3.11+ happily parses the broken
+    `+00:00Z` form that browsers reject, so validating with it would pass the very string
+    this module exists to prevent.
+    """
+    return bool(
+        re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})", value)
+    )
+
+
+def test_broken_form_is_actually_rejected_by_the_matcher():
+    """Guard the guard: the old output must fail `_js_parseable`, or these tests prove nothing."""
+    assert not _js_parseable("2026-07-27T05:09:55.853557+00:00Z")
+
+
+def test_utc_now_iso_is_js_parseable():
+    assert _js_parseable(utc_now_iso())
+
+
+def test_utc_now_iso_ends_in_z_with_no_offset():
+    value = utc_now_iso()
+    assert value.endswith("Z")
+    assert "+00:00" not in value
+
+
+def test_to_iso_normalizes_an_aware_utc_datetime():
+    dt = datetime(2026, 7, 27, 5, 9, 55, 853557, tzinfo=timezone.utc)
+    assert to_iso(dt) == "2026-07-27T05:09:55.853557Z"
+
+
+def test_to_iso_treats_naive_as_utc_rather_than_local():
+    """A naive value must not be shifted by the host's offset."""
+    naive = datetime(2026, 7, 27, 5, 9, 55, 853557)
+    aware = naive.replace(tzinfo=timezone.utc)
+    assert to_iso(naive) == to_iso(aware)
+
+
+def test_to_iso_converts_a_non_utc_offset_to_utc():
+    dt = datetime(2026, 7, 27, 0, 9, 55, tzinfo=timezone(timedelta(hours=-5)))
+    assert to_iso(dt) == "2026-07-27T05:09:55Z"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-07-27T05:09:55.853557Z",
+        "2026-07-27T05:09:55Z",
+    ],
+)
+def test_known_good_shapes_are_js_parseable(value):
+    assert _js_parseable(value)
+
+
+def test_from_iso_reads_the_legacy_form():
+    """Rows written before the fix keep `…+00:00Z` forever; they must still parse."""
+    assert from_iso("2026-07-27T05:09:55.853557+00:00Z") == datetime(
+        2026, 7, 27, 5, 9, 55, 853557, tzinfo=timezone.utc
+    )
+
+
+def test_from_iso_reads_the_current_form():
+    assert from_iso("2026-07-27T05:09:55.853557Z") == datetime(
+        2026, 7, 27, 5, 9, 55, 853557, tzinfo=timezone.utc
+    )
+
+
+def test_from_iso_always_returns_an_aware_datetime():
+    """The trap that `rstrip("Z")` fell into.
+
+    `datetime.fromisoformat(value.rstrip("Z"))` returns an *aware* datetime for the broken
+    `…+00:00Z` form and a *naive* one for a correct `…Z` — so fixing the writers alone
+    silently flipped round-tripped values to naive, and any comparison against
+    `datetime.now(timezone.utc)` would then raise TypeError.
+    """
+    for value in (
+        "2026-07-27T05:09:55.853557+00:00Z",
+        "2026-07-27T05:09:55.853557Z",
+        "2026-07-27T05:09:55.853557",  # no offset at all
+    ):
+        assert from_iso(value).tzinfo is not None, value
+
+
+def test_round_trip_through_to_iso_and_back_is_lossless():
+    dt = datetime(2026, 7, 27, 5, 9, 55, 853557, tzinfo=timezone.utc)
+    assert from_iso(to_iso(dt)) == dt
+
+
+def test_no_compensating_rstrip_parser_remains():
+    """`rstrip("Z")` before `fromisoformat` encodes the writer's bug into the reader.
+
+    ⚠️ Use `from_iso` instead. A reader shaped around a broken writer is how this survived
+    for as long as it did.
+    """
+    offenders = [
+        f"{path.relative_to(SRC)}:{i}"
+        for path in SRC.rglob("*.py")
+        if path.name != "timestamps.py"
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if 'rstrip("Z")' in line
+    ]
+    assert offenders == [], f"Use apis.shared.timestamps.from_iso. Offenders: {offenders}"
+
+
+def test_the_broken_idiom_is_gone_from_the_tree():
+    """A reintroduction fails CI instead of waiting for someone to notice a blank date.
+
+    ⚠️ If this fails on a line you just wrote: use `utc_now_iso()` / `to_iso(dt)` from
+    `apis.shared.timestamps`. Do not "fix" it by editing this test.
+    """
+    offenders = [
+        f"{path.relative_to(SRC)}:{i}"
+        for path in SRC.rglob("*.py")
+        if path.name != "timestamps.py"
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if BROKEN_IDIOM.search(line)
+    ]
+    assert offenders == [], (
+        "datetime.now(timezone.utc).isoformat() + \"Z\" emits an invalid `+00:00Z` "
+        "timestamp that JavaScript cannot parse. Use apis.shared.timestamps instead. "
+        f"Offenders: {offenders}"
+    )

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.ts
@@ -12,6 +12,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 import { FineTuningAdminStateService } from './services/fine-tuning-admin-state.service';
+import { parseIso } from '../../utils/date';
 
 @Component({
   selector: 'app-fine-tuning-access-page',
@@ -89,7 +90,7 @@ export class FineTuningAccessPage implements OnInit {
   }
 
   formatDate(iso: string): string {
-    const d = new Date(iso);
+    const d = parseIso(iso);
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
@@ -18,6 +18,7 @@ import {
   ResolveReportDialogData,
   ResolveReportDialogResult,
 } from '../components/resolve-report-dialog.component';
+import { parseIso } from '../../../utils/date';
 
 /**
  * The Reports queue — user-submitted problem reports (D10, D15).
@@ -288,7 +289,7 @@ export class ReportsPage implements OnInit {
   /** Matches the Review queue's subtitle wording, so the two streams read alike. */
   relativeTime(iso?: string): string {
     if (!iso) return 'recently';
-    const then = new Date(iso).getTime();
+    const then = parseIso(iso).getTime();
     if (Number.isNaN(then)) return 'recently';
 
     const days = Math.floor((Date.now() - then) / 86_400_000);

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -17,6 +17,7 @@ import {
   RequestChangesDialogData,
   RequestChangesDialogResult,
 } from '../components/request-changes-dialog.component';
+import { parseIso } from '../../../utils/date';
 
 /**
  * The Review queue — every submission awaiting a decision (D2).
@@ -189,7 +190,7 @@ export class ReviewQueuePage implements OnInit {
   /** "yesterday" / "3 days ago", matching the mockup's queue subtitle. */
   relativeTime(iso?: string): string {
     if (!iso) return 'recently';
-    const then = new Date(iso).getTime();
+    const then = parseIso(iso).getTime();
     if (Number.isNaN(then)) return 'recently';
 
     const days = Math.floor((Date.now() - then) / 86_400_000);

--- a/frontend/ai.client/src/app/admin/quota-tiers/pages/override-detail/override-detail.component.ts
+++ b/frontend/ai.client/src/app/admin/quota-tiers/pages/override-detail/override-detail.component.ts
@@ -3,6 +3,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { FormBuilder, FormGroup, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { QuotaStateService } from '../../services/quota-state.service';
 import { QuotaOverrideCreate, OverrideType } from '../../models/quota.models';
+import { parseIso } from '../../../../utils/date';
 
 interface OverrideFormGroup {
   userId: FormControl<string>;
@@ -63,7 +64,7 @@ export class OverrideDetailComponent implements OnInit {
     } else {
       // Set default dates (now to 30 days from now)
       const now = new Date();
-      const future = new Date(now);
+      const future = parseIso(now);
       future.setDate(future.getDate() + 30);
 
       // Check for userId query parameter
@@ -118,7 +119,7 @@ export class OverrideDetailComponent implements OnInit {
    * Convert datetime-local input to ISO string
    */
   private dateInputToISO(dateInput: string): string {
-    return new Date(dateInput).toISOString();
+    return parseIso(dateInput).toISOString();
   }
 
   /**
@@ -136,8 +137,8 @@ export class OverrideDetailComponent implements OnInit {
       }
 
       // Convert ISO dates to datetime-local format
-      const validFrom = this.formatDateForInput(new Date(override.validFrom));
-      const validUntil = this.formatDateForInput(new Date(override.validUntil));
+      const validFrom = this.formatDateForInput(parseIso(override.validFrom));
+      const validUntil = this.formatDateForInput(parseIso(override.validUntil));
 
       // Populate form
       this.overrideForm.patchValue({

--- a/frontend/ai.client/src/app/admin/users/pages/user-detail/user-detail.page.ts
+++ b/frontend/ai.client/src/app/admin/users/pages/user-detail/user-detail.page.ts
@@ -18,6 +18,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { UserStateService } from '../../services/user-state.service';
 import { QuotaEventSummary } from '../../models';
+import { parseIso } from '../../../../utils/date';
 
 @Component({
   selector: 'app-user-detail',
@@ -343,7 +344,7 @@ export class UserDetailPage implements OnInit {
     if (!isoString) {
       return 'Never';
     }
-    const date = new Date(isoString);
+    const date = parseIso(isoString);
     if (isNaN(date.getTime())) {
       return 'Never';
     }

--- a/frontend/ai.client/src/app/admin/users/pages/user-list/user-list.page.ts
+++ b/frontend/ai.client/src/app/admin/users/pages/user-list/user-list.page.ts
@@ -16,6 +16,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { UserStateService } from '../../services/user-state.service';
 import { UserListItem, UserStatus } from '../../models';
+import { parseIso } from '../../../../utils/date';
 
 @Component({
   selector: 'app-user-list',
@@ -221,7 +222,7 @@ export class UserListPage implements OnInit {
     if (!isoString) {
       return 'Never';
     }
-    const date = new Date(isoString);
+    const date = parseIso(isoString);
     if (isNaN(date.getTime())) {
       return 'Never';
     }

--- a/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
+++ b/frontend/ai.client/src/app/agents/detail/agent-detail.page.ts
@@ -34,6 +34,7 @@ import {
   ReportAgentDialogResult,
 } from '../components/report-agent-dialog.component';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+import { parseIso } from '../../utils/date';
 
 /**
  * Agent detail — the page a shelf row taps through to (Marketplace Phase 3).
@@ -577,7 +578,7 @@ export class AgentDetailPage implements OnInit {
   }
 
   private formatDate(iso: string): string {
-    const parsed = new Date(iso);
+    const parsed = parseIso(iso);
     if (Number.isNaN(parsed.getTime())) return '—';
     return parsed.toLocaleDateString(undefined, {
       year: 'numeric',

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -9,6 +9,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowPath, heroChevronDown } from '@ng-icons/heroicons/outline';
 
 import { SyncInterval, SyncPolicy } from '../models/sync-policy.model';
+import { parseIso } from '../../utils/date';
 
 /** The select's "no policy / turn sync off" sentinel. */
 export type SyncIntervalSelection = SyncInterval | 'manual';

--- a/frontend/ai.client/src/app/assistants/services/document.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/document.service.ts
@@ -10,6 +10,7 @@ import {
   DownloadUrlResponse,
   STALE_DOCUMENT_THRESHOLD_MS,
 } from '../models/document.model';
+import { parseIso } from '../../utils/date';
 
 /**
  * Error class for document upload operations
@@ -329,7 +330,7 @@ export class DocumentService {
         // should already be marked 'failed'. If for some reason it isn't
         // (clock skew, etc.), bail out and return what we have.
         try {
-          const updatedAt = new Date(document.updatedAt).getTime();
+          const updatedAt = parseIso(document.updatedAt).getTime();
           if (Date.now() - updatedAt > STALE_THRESHOLD_MS) {
             return document;
           }

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -16,6 +16,7 @@ import { SessionMetadata } from '../../../../session/services/models/session-met
 import { SidenavService } from '../../../../services/sidenav/sidenav.service';
 import { ToastService } from '../../../../services/toast/toast.service';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '../../../confirmation-dialog';
+import { parseIso } from '../../../../utils/date';
 
 @Component({
   selector: 'app-session-list',
@@ -224,7 +225,7 @@ export class SessionList {
    * @returns Formatted time string
    */
   protected formatTime(timestamp: string): string {
-    const date = new Date(timestamp);
+    const date = parseIso(timestamp);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);

--- a/frontend/ai.client/src/app/files/file-browser.page.ts
+++ b/frontend/ai.client/src/app/files/file-browser.page.ts
@@ -33,6 +33,7 @@ import {
   ConfirmationDialogData
 } from '../components/confirmation-dialog/confirmation-dialog.component';
 import { TooltipDirective } from '../components/tooltip';
+import { parseIso } from '../utils/date';
 
 /** Maximum number of files that can be selected for bulk delete */
 const MAX_SELECTION = 20;
@@ -622,7 +623,7 @@ export class FileBrowserPage implements OnInit {
     if (!dateString) return '';
 
     try {
-      const date = new Date(dateString);
+      const date = parseIso(dateString);
       const now = new Date();
       const diffMs = now.getTime() - date.getTime();
       const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));

--- a/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.ts
@@ -18,6 +18,7 @@ import { FineTuningStateService } from '../../services/fine-tuning-state.service
 import { StatusBadgeComponent } from '../../components/status-badge.component';
 import { QuotaCardComponent } from '../../components/quota-card.component';
 import type { JobResponse, InferenceJobResponse } from '../../models/fine-tuning.models';
+import { parseIso } from '../../../utils/date';
 
 @Component({
   selector: 'app-fine-tuning-dashboard',
@@ -181,7 +182,7 @@ export class FineTuningDashboardPage implements OnInit {
   /** Calculate elapsed time from a start timestamp to now. */
   private getElapsed(startTime: string | null, fallback: string): string {
     const start = startTime ?? fallback;
-    const ms = this.now() - new Date(start).getTime();
+    const ms = this.now() - parseIso(start).getTime();
     const totalSeconds = Math.max(0, Math.floor(ms / 1000));
     return this.formatDuration(totalSeconds);
   }
@@ -211,7 +212,7 @@ export class FineTuningDashboardPage implements OnInit {
 
   /** Get days remaining before S3 artifacts expire for a job. */
   getRetentionDaysRemaining(createdAt: string): number {
-    const created = new Date(createdAt).getTime();
+    const created = parseIso(createdAt).getTime();
     const expiresAt = created + this.RETENTION_DAYS * 24 * 60 * 60 * 1000;
     return Math.max(0, Math.ceil((expiresAt - Date.now()) / (24 * 60 * 60 * 1000)));
   }

--- a/frontend/ai.client/src/app/fine-tuning/pages/inference-job-detail/inference-job-detail.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/inference-job-detail/inference-job-detail.page.ts
@@ -13,6 +13,7 @@ import { heroStopSolid } from '@ng-icons/heroicons/solid';
 import { FineTuningStateService } from '../../services/fine-tuning-state.service';
 import { StatusBadgeComponent } from '../../components/status-badge.component';
 import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { parseIso } from '../../../utils/date';
 
 @Component({
   selector: 'app-inference-job-detail',
@@ -57,7 +58,7 @@ export class InferenceJobDetailPage implements OnInit {
     const job = this.state.currentInferenceJob();
     if (!job || !this.canStop(job.status)) return null;
     const start = job.transform_start_time ?? job.created_at;
-    const ms = this.now() - new Date(start).getTime();
+    const ms = this.now() - parseIso(start).getTime();
     const totalSeconds = Math.max(0, Math.floor(ms / 1000));
     return this.formatDuration(totalSeconds);
   });

--- a/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.ts
@@ -13,6 +13,7 @@ import { heroStopSolid } from '@ng-icons/heroicons/solid';
 import { FineTuningStateService } from '../../services/fine-tuning-state.service';
 import { StatusBadgeComponent } from '../../components/status-badge.component';
 import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { parseIso } from '../../../utils/date';
 
 @Component({
   selector: 'app-training-job-detail',
@@ -57,7 +58,7 @@ export class TrainingJobDetailPage implements OnInit {
     const job = this.state.currentTrainingJob();
     if (!job || !this.canStop(job.status)) return null;
     const start = job.training_start_time ?? job.created_at;
-    const ms = this.now() - new Date(start).getTime();
+    const ms = this.now() - parseIso(start).getTime();
     const totalSeconds = Math.max(0, Math.floor(ms / 1000));
     return this.formatDuration(totalSeconds);
   });

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.ts
@@ -11,6 +11,7 @@ import {
   CreateInferenceJobRequest,
   DownloadResponse,
 } from '../models/fine-tuning.models';
+import { parseIso } from '../../utils/date';
 
 /**
  * State service for the user-facing fine-tuning feature.
@@ -341,6 +342,6 @@ export class FineTuningStateService {
 
   /** Sort jobs by created_at descending (newest first). */
   private sortByCreatedDesc<T extends { created_at: string }>(jobs: T[]): T[] {
-    return [...jobs].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    return [...jobs].sort((a, b) => parseIso(b.created_at).getTime() - parseIso(a.created_at).getTime());
   }
 }

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
@@ -50,6 +50,7 @@ import {
 import { UserConnectorsService } from '../settings/connectors/services/user-connectors.service';
 import { OAuthConsentService } from '../services/oauth-consent/oauth-consent.service';
 import { ToastService } from '../services/toast/toast.service';
+import { parseIso } from '../utils/date';
 
 /**
  * The reusable "Knowledge base" authoring section — device upload, web-crawl
@@ -685,7 +686,7 @@ export class KnowledgeBaseSectionComponent implements OnDestroy {
    */
   private isDocumentStale(doc: Document): boolean {
     try {
-      const updatedAt = new Date(doc.updatedAt).getTime();
+      const updatedAt = parseIso(doc.updatedAt).getTime();
       return Date.now() - updatedAt > STALE_DOCUMENT_THRESHOLD_MS;
     } catch {
       return true; // Can't parse timestamp — treat as stale

--- a/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
+++ b/frontend/ai.client/src/app/manage-sessions/manage-sessions.page.ts
@@ -33,6 +33,7 @@ import {
   ManageSharesDialogComponent,
   ManageSharesDialogData,
 } from './manage-shares-dialog/manage-shares-dialog.component';
+import { parseIso } from '../utils/date';
 
 /** Maximum number of sessions that can be selected for bulk delete */
 const MAX_SELECTION = 20;
@@ -533,7 +534,7 @@ export class ManageSessionsPage implements OnInit {
   formatDate(dateString: string): string {
     if (!dateString) return '';
     try {
-      const date = new Date(dateString);
+      const date = parseIso(dateString);
       const now = new Date();
       const diffMs = now.getTime() - date.getTime();
       const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));

--- a/frontend/ai.client/src/app/manage-sessions/manage-shares-dialog/manage-shares-dialog.component.ts
+++ b/frontend/ai.client/src/app/manage-sessions/manage-shares-dialog/manage-shares-dialog.component.ts
@@ -18,6 +18,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { ShareService, ShareResponse } from '../../session/services/share/share.service';
 import { ToastService } from '../../services/toast/toast.service';
+import { parseIso } from '../../utils/date';
 
 export interface ManageSharesDialogData {
   sessionId: string;
@@ -284,7 +285,7 @@ export class ManageSharesDialogComponent implements OnInit {
   protected formatDate(dateString: string): string {
     if (!dateString) return '';
     try {
-      const date = new Date(dateString);
+      const date = parseIso(dateString);
       return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
     } catch {
       return '';

--- a/frontend/ai.client/src/app/memory/memory-dashboard.page.ts
+++ b/frontend/ai.client/src/app/memory/memory-dashboard.page.ts
@@ -12,6 +12,7 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { MemoryService } from './services/memory.service';
 import { MemoriesResponse } from './models/memory.model';
+import { parseIso } from '../utils/date';
 
 /**
  * Represents a parsed preference with structured display
@@ -685,7 +686,7 @@ export class MemoryDashboardPage {
     if (!dateString) return '';
 
     try {
-      const date = new Date(dateString);
+      const date = parseIso(dateString);
       const now = new Date();
       const diffMs = now.getTime() - date.getTime();
       const diffSecs = Math.floor(diffMs / 1000);

--- a/frontend/ai.client/src/app/schedules/schedules.page.ts
+++ b/frontend/ai.client/src/app/schedules/schedules.page.ts
@@ -12,6 +12,7 @@ import {
   ConfirmationDialogData,
 } from '../components/confirmation-dialog/confirmation-dialog.component';
 import { ToastService } from '../services/toast/toast.service';
+import { parseIso } from '../utils/date';
 
 const WEEKDAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -197,7 +198,7 @@ export class SchedulesPage implements OnInit {
   }
 
   private formatRelativeFuture(iso: string): string {
-    const then = new Date(iso).getTime();
+    const then = parseIso(iso).getTime();
     if (Number.isNaN(then)) return '—';
     const diffMins = Math.round((then - Date.now()) / 60_000);
     if (diffMins <= 0) return 'due now';
@@ -253,7 +254,7 @@ export class SchedulesPage implements OnInit {
   }
 
   private formatRelativePast(iso: string): string {
-    const then = new Date(iso).getTime();
+    const then = parseIso(iso).getTime();
     if (Number.isNaN(then)) return '';
     const diffMins = Math.floor((Date.now() - then) / 60_000);
     if (diffMins < 1) return 'just now';

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -16,6 +16,7 @@ import {
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
+import { parseIso } from '../../../../../utils/date';
 
 /** Visual treatment derived from an artifact's content type. */
 interface ArtifactKind {
@@ -479,7 +480,7 @@ function relativeTime(iso: string): string {
   const day = Math.floor(hr / 24);
   if (day < 7) return `${day}d ago`;
 
-  return new Date(then).toLocaleDateString(undefined, {
+  return parseIso(then).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
   });

--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
@@ -12,6 +12,7 @@ import {
 import { ContentBlock, Message, FileAttachmentData } from '../../../services/models/message.model';
 import { FileAttachmentBadgeComponent, ImageAttachmentGroupComponent } from './file-attachment';
 import { LocalSettingsService } from '../../../../services/local-settings.service';
+import { parseIso } from '../../../../utils/date';
 
 function isImageMimeType(mimeType: string): boolean {
   return mimeType.startsWith('image/');
@@ -150,7 +151,7 @@ export class UserMessageComponent implements AfterViewInit {
     if (diffMinutes < 60) return `${diffMinutes}m ago`;
     if (diffHours < 24) return `${diffHours}h ago`;
 
-    return new Date(sentMs).toLocaleString(undefined, {
+    return parseIso(sentMs).toLocaleString(undefined, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',

--- a/frontend/ai.client/src/app/settings/pages/api-keys/api-keys.page.ts
+++ b/frontend/ai.client/src/app/settings/pages/api-keys/api-keys.page.ts
@@ -17,6 +17,7 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { ConfigService } from '../../../services/config.service';
 import { ModelService } from '../../../session/services/model/model.service';
 import { ApiKeyService, ApiKey, CreateApiKeyResponse } from './api-key.service';
+import { parseIso } from '../../../utils/date';
 
 type ResponseType = 'non-streaming' | 'streaming';
 type ExampleFormat = 'simple' | 'conversation';
@@ -470,7 +471,7 @@ export class ApiKeysPage {
   readonly isExpired = computed(() => {
     const key = this.apiKey();
     if (!key) return false;
-    return new Date(key.expires_at).getTime() < Date.now();
+    return parseIso(key.expires_at).getTime() < Date.now();
   });
 
   constructor() {
@@ -616,13 +617,13 @@ export class ApiKeysPage {
   }
 
   daysUntil(dateStr: string): string {
-    const diff = Math.ceil((new Date(dateStr).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+    const diff = Math.ceil((parseIso(dateStr).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
     if (diff <= 0) return 'today';
     return `in ${diff} day${diff === 1 ? '' : 's'}`;
   }
 
   formatDate(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString(undefined, {
+    return parseIso(dateStr).toLocaleDateString(undefined, {
       month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
     });
   }

--- a/frontend/ai.client/src/app/utils/date.spec.ts
+++ b/frontend/ai.client/src/app/utils/date.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeIsoTimestamp, parseIso } from './date';
+
+/**
+ * The legacy spelling still sitting in DynamoDB. Rows written before the backend fix keep
+ * it forever — `createdAt` is never rewritten — so the SPA has to tolerate it rather than
+ * rely on a backfill.
+ */
+const LEGACY = '2026-07-27T05:09:55.853557+00:00Z';
+const VALID = '2026-07-27T05:09:55.853557Z';
+
+describe('parseIso', () => {
+  it('is the bug: plain `new Date` cannot parse the legacy form', () => {
+    // Guards the guard — if this ever starts passing, these tests prove nothing.
+    expect(Number.isNaN(new Date(LEGACY).getTime())).toBe(true);
+  });
+
+  it('parses the legacy +00:00Z form to the correct instant', () => {
+    expect(parseIso(LEGACY).toISOString()).toBe(new Date(VALID).toISOString());
+  });
+
+  it('leaves an already-valid timestamp alone', () => {
+    expect(parseIso(VALID).toISOString()).toBe(new Date(VALID).toISOString());
+  });
+
+  it('passes epoch millis through, so mixed call sites stay safe', () => {
+    expect(parseIso(1_785_160_195_000).getTime()).toBe(1_785_160_195_000);
+  });
+
+  it('passes an existing Date through untouched', () => {
+    const d = new Date(VALID);
+    expect(parseIso(d)).toBe(d);
+  });
+
+  it('returns an Invalid Date for null/undefined rather than throwing', () => {
+    // Callers already branch on Number.isNaN(getTime()); preserve that contract.
+    expect(Number.isNaN(parseIso(null).getTime())).toBe(true);
+    expect(Number.isNaN(parseIso(undefined).getTime())).toBe(true);
+  });
+
+  it('still yields an Invalid Date for genuinely unparseable input', () => {
+    expect(Number.isNaN(parseIso('not a date').getTime())).toBe(true);
+  });
+});
+
+describe('normalizeIsoTimestamp', () => {
+  it('rewrites the doubled offset', () => {
+    expect(normalizeIsoTimestamp(LEGACY)).toBe(VALID);
+  });
+
+  it('is a no-op on a valid value', () => {
+    expect(normalizeIsoTimestamp(VALID)).toBe(VALID);
+  });
+
+  it('leaves a genuine non-UTC offset intact', () => {
+    // Only the `+00:00Z` pair is wrong; a real offset must survive.
+    expect(normalizeIsoTimestamp('2026-07-27T00:09:55-05:00')).toBe(
+      '2026-07-27T00:09:55-05:00',
+    );
+  });
+});

--- a/frontend/ai.client/src/app/utils/date.ts
+++ b/frontend/ai.client/src/app/utils/date.ts
@@ -1,0 +1,38 @@
+/**
+ * Date parsing that tolerates the legacy `…+00:00Z` timestamps still in the database.
+ *
+ * A tz-aware `datetime.now(timezone.utc).isoformat()` already renders the offset as
+ * `+00:00`; appending `"Z"` produced `2026-07-27T05:09:55.853557+00:00Z` — an offset *and*
+ * a Z — which is not valid ISO 8601. `new Date()` returns `Invalid Date` for it, so every
+ * surface that formatted such a value silently showed a placeholder: the agent detail page
+ * rendered "Last updated —" on an agent edited minutes earlier, and the admin Reports queue
+ * rendered "recently" for every report ever filed.
+ *
+ * The backend writers are fixed (`apis.shared.timestamps`), but rows written before that
+ * deploy keep the bad spelling forever — `createdAt` in particular is never rewritten. We
+ * normalize on read rather than backfilling, because those values are embedded in GSI sort
+ * keys (`GSI5_SK = CREATED#{created_at}`) and rewriting them is far riskier than tolerating
+ * two spellings here.
+ *
+ * ⚠️ **Use `parseIso` instead of `new Date(...)` for anything that came from the API.**
+ * It is a drop-in: non-string inputs (epoch millis, an existing `Date`) pass straight
+ * through, so it is safe on mixed call sites.
+ */
+
+/** Repair a legacy `+00:00Z` timestamp. A no-op for already-valid values. */
+export function normalizeIsoTimestamp(value: string): string {
+  return value.replace('+00:00Z', 'Z');
+}
+
+/**
+ * `new Date(...)`, but tolerant of the legacy timestamp spelling.
+ *
+ * Returns an Invalid Date for genuinely unparseable input, exactly as `new Date` would —
+ * callers that already guard with `Number.isNaN(d.getTime())` keep working unchanged.
+ */
+export function parseIso(value: string | number | Date | null | undefined): Date {
+  if (value instanceof Date) return value;
+  if (typeof value === 'number') return new Date(value);
+  if (value === null || value === undefined) return new Date(NaN);
+  return new Date(normalizeIsoTimestamp(value));
+}


### PR DESCRIPTION
## The bug

`datetime.now(timezone.utc)` is tz-aware, so `.isoformat()` already renders the offset as `+00:00`. Appending `"Z"` produced:

```
2026-07-27T05:09:55.853557+00:00Z
```

An offset **and** a Z — not valid ISO 8601. `new Date()` returns `Invalid Date`, and every SPA formatter falls back defensively, so it read as missing data rather than a defect:

| Surface | Showed | Should have shown |
|---|---|---|
| Agent detail → Details | **"Last updated —"** | the edit from minutes earlier |
| Admin → Reports | **"recently"**, always | the real age of the report |

Found while smoke-testing the Agent epic on dev.

**Not an epic regression.** It is long-standing; the epic's new date-rendering surfaces are just the first place anyone actually read one of these values. Three call sites had already hit it and written *local* workarounds — `sync_policies._iso`, `users/sync._iso`, `users/repository._heal_iso` — which is the clearest argument for one shared implementation instead of a convention to remember.

## The fix

`apis.shared.timestamps`, promoted from the existing `sync_policies._iso`. 52 writer sites now call `utc_now_iso()` / `to_iso()`, and the two duplicate `_iso` definitions collapse onto it.

### The part that would have bitten quietly

Readers were written as:

```python
datetime.fromisoformat(value.rstrip("Z"))
```

That only worked **because** the writer was broken. Stripping `Z` off `…+00:00Z` leaves a valid offset (aware); stripping it off a correct `…Z` leaves a bare naive datetime. So fixing the writers alone would have silently flipped every round-tripped timestamp from aware to naive, and the next comparison against `datetime.now(timezone.utc)` would raise `TypeError: can't compare offset-naive and offset-aware datetimes`.

`test_skills_models.py::test_round_trip_preserves_fields` caught this — a genuine pre-existing test earning its keep. All 11 such readers now use `from_iso`.

## No backfill

Rows already written keep the old spelling (`createdAt` is never rewritten), so the SPA normalizes on read — `parseIso` in `utils/date.ts`, applied at 30 parse sites. That fixes **historical** rows too, without rewriting values embedded in GSI sort keys (`GSI5_SK = CREATED#{created_at}`, `GSI_SK`, artifacts' `GSI1SK`).

Mixed spellings compare safely: the suffix differs only *after* the full date-time-microseconds, so two distinct instants still order correctly. Only an exact microsecond tie could compare unequal, which for `created_at` is immaterial.

`parseIso` is a drop-in — non-string inputs (epoch millis, an existing `Date`) pass straight through, so it is safe on mixed call sites.

## Tests

Two tests grep the tree so neither idiom can return, both **verified failing** by reintroducing them:

```
Left contains one more item: 'apis/shared/assistants/pins.py:52'
FAILED test_the_broken_idiom_is_gone_from_the_tree
```

The SPA spec asserts the bug first (`new Date(LEGACY)` *is* Invalid) so the rest can't pass vacuously, and `test_broken_form_is_actually_rejected_by_the_matcher` does the same on the backend — the validator deliberately avoids `datetime.fromisoformat`, which happily parses the very string this module exists to prevent.

## Verification

- ruff: **164 findings, exactly the baseline** — no new lint
- backend: **5268 passed, 3 skipped**
- SPA: **147 files / 1644 tests passed**

## Deploy

`backend.yml` + `frontend-deploy.yml`. No CDK, no index, env var or IAM change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)