### PR TITLE
feat(marketplace): tell the reviewer when a listed Agent is unopenable

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -566,9 +566,12 @@ async def agent_listing_preflight_endpoint(
     only for reading order — the paths are literal and do not collide.
     """
     try:
-        exposed, block_reason = await preflight_listing(agent_id, current_user)
+        exposed, block_reason, reachability = await preflight_listing(agent_id, current_user)
         return ListingPreflightResponse(
-            agent_id=agent_id, exposed_skills=exposed, block_reason=block_reason
+            agent_id=agent_id,
+            exposed_skills=exposed,
+            block_reason=block_reason,
+            reachability=reachability,
         )
     except ListingError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -242,7 +242,9 @@ async def _resolve_proposed_publisher(user: User, publisher_id: Optional[str]) -
 
 
 # ── author transitions ───────────────────────────────────────────────────────────────
-async def preflight_listing(agent_id: str, user: User) -> Tuple[List[SkillExposure], Optional[str]]:
+async def preflight_listing(
+    agent_id: str, user: User
+) -> Tuple[List[SkillExposure], Optional[str], str]:
     """Run the D7 checks **without** transitioning, for the submit dialog.
 
     D7.1 asks the dialog to enumerate the exposed skills *before* the author commits,
@@ -252,14 +254,21 @@ async def preflight_listing(agent_id: str, user: User) -> Tuple[List[SkillExposu
 
     Owner-only, like every other author path: the skill exposure is a statement about
     what the *owner's* publication would reveal, and it is not an editor's to see.
+
+    Also returns reachability, which is *not* a D7 check and deliberately not a block:
+    the author is told their store tile will 404 for people who cannot already reach the
+    Agent, and left to decide. Returned even alongside a ``block_reason`` — the two are
+    independent facts and suppressing one behind the other just hides work from the
+    author's next attempt.
     """
     assistant = await _load_for_author(agent_id, user)
+    reachability = _reachability(assistant)
     block_reason = await _memory_space_block_reason(assistant, user)
     # Order mirrors submit_listing: an agent that cannot be published at all is not first
     # walked through a skill-exposure confirmation.
     if block_reason:
-        return [], block_reason
-    return await _exposed_skills(assistant), None
+        return [], block_reason, reachability
+    return await _exposed_skills(assistant), None, reachability
 
 
 async def submit_listing(
@@ -548,6 +557,24 @@ def _drift(assistant: Assistant, listing: AgentListing) -> Optional[str]:
     return None
 
 
+def _reachability(assistant: Assistant) -> str:
+    """Who can actually open this Agent, projected from ``visibility`` (see ``ListingReachability``).
+
+    The store browse read applies no access check, so this is the only thing standing
+    between "approved" and a shelf tile that 404s for everyone but the author. Derived on
+    every read rather than stored — ``visibility`` can change at any time and a cached
+    copy would be wrong exactly when it mattered.
+
+    ⚠️ Advisory only. Publishing a SHARED Agent to a team is legitimate; the fix for the
+    bad case is the author widening visibility, not this function refusing.
+    """
+    if assistant.visibility == "PUBLIC":
+        return "everyone"
+    if assistant.visibility == "SHARED":
+        return "shared_only"
+    return "owner_only"
+
+
 def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> AdminListingRow:
     listing = assistant.listing
     if listing is None:  # callers filter; belt-and-braces rather than a stripped assert
@@ -569,5 +596,6 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         review_note=listing.review_note,
         updated_at=assistant.updated_at,
         drift=_drift(assistant, listing),
+        reachability=_reachability(assistant),
         admin_edits=listing.admin_edits,
     )

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -38,6 +38,27 @@ ReportState = Literal["open", "resolved", "dismissed"]
 # marker gets learned-ignored.
 ListingDrift = Literal["instructions", "edited"]
 
+# Who can actually *open* a listed Agent — `visibility` projected onto the question the
+# store never asks.
+#
+# **Publication and reachability are separate axes, and the store only guards one of them.**
+# `GET /agents/store` is a pure sparse-GSI5 read with no access check, while
+# `GET /agents/{id}` enforces `get_assistant_with_access_check`. Nothing in the listing
+# lifecycle touches `visibility` — deliberately, since approving a store listing is not
+# consent to widen access — so a PRIVATE or SHARED Agent can be approved and shelved, and
+# every user who is not the owner (or on the share list) gets a tile that 404s when tapped.
+#
+# Both live dev listings were in exactly this state when this was found: one PRIVATE, one
+# SHARED. The admin copy half-knew ("members can only open one they could reach on their
+# own"), but every guard was on listing *state*, never on visibility, and neither the
+# author at submit nor the reviewer at approve was told.
+#
+# ⚠️ **This is a warning, not a gate.** SHARED-to-a-team is a legitimate thing to publish,
+# and blocking it — or silently flipping visibility on approve — would be the
+# `allowedAppRoles` trap again: a store decision quietly rewriting an access decision.
+# Derived on read, never stored, so it cannot go stale against `visibility`.
+ListingReachability = Literal["everyone", "shared_only", "owner_only"]
+
 # Severity order for the queue sweep (D15). ``inappropriate`` first for the reason above.
 REPORT_REASON_SEVERITY: Dict[str, int] = {
     "inappropriate": 0,
@@ -581,6 +602,14 @@ class ListingPreflightResponse(BaseModel):
         alias="blockReason",
         description="Why this agent cannot be submitted at all (D7.2); null when it can",
     )
+    reachability: ListingReachability = Field(
+        ...,
+        description=(
+            "Who would be able to open this Agent once shelved (see ``ListingReachability``). "
+            "Advisory: publishing a PRIVATE/SHARED Agent is allowed, but the author should "
+            "know the tile will 404 for everyone it is not shared with."
+        ),
+    )
 
 
 class ReviewListingRequest(BaseModel):
@@ -673,6 +702,14 @@ class AdminListingRow(BaseModel):
             "Post-approval drift, derived server-side (see ``ListingDrift``): ``instructions`` "
             "= measured behavior change, ``edited`` = record changed but cause unknown, absent "
             "= no drift or not applicable. Derived rather than stored so it can never go stale."
+        ),
+    )
+    reachability: ListingReachability = Field(
+        ...,
+        description=(
+            "Who can open this Agent if it is shelved (see ``ListingReachability``). "
+            "``everyone`` = PUBLIC; ``shared_only`` / ``owner_only`` mean the store tile "
+            "will 404 for most users. Advisory — never a gate."
         ),
     )
     admin_edits: List[AdminEdit] = Field(default_factory=list, alias="adminEdits", description="Admin edit log (D13)")

--- a/backend/tests/shared/test_listing_reachability.py
+++ b/backend/tests/shared/test_listing_reachability.py
@@ -1,0 +1,56 @@
+"""Reachability: publication and access are separate axes, and the store guards only one.
+
+`GET /agents/store` is a pure sparse-GSI5 read with **no** access check, while
+`GET /agents/{id}` enforces `get_assistant_with_access_check`. Nothing in the listing
+lifecycle touches `visibility`, so an approved PRIVATE or SHARED Agent gets a shelf tile
+that 404s for everyone who cannot already reach it. Both live dev listings were in exactly
+that state when this was found.
+
+These tests pin the *derivation* and, more importantly, the decision that it stays
+advisory — a gate here, or an auto-widening on approve, would make a store decision
+silently rewrite an access decision.
+"""
+
+import pytest
+
+from apis.app_api.agent_designer.services.listing_service import _reachability
+
+
+class _Assistant:
+    """Only the field the derivation reads. A full Assistant would hide what matters."""
+
+    def __init__(self, visibility: str):
+        self.visibility = visibility
+
+
+@pytest.mark.parametrize(
+    "visibility,expected",
+    [
+        ("PUBLIC", "everyone"),
+        ("SHARED", "shared_only"),
+        ("PRIVATE", "owner_only"),
+    ],
+)
+def test_reachability_projects_visibility(visibility, expected):
+    assert _reachability(_Assistant(visibility)) == expected
+
+
+def test_only_public_is_unlimited():
+    """The two non-public states must stay distinguishable.
+
+    Collapsing them to one "not public" value would lose the difference between "nobody
+    but the author" and "the team it was shared with" — which is the difference between a
+    mistake and a deliberate, legitimate publication.
+    """
+    values = {v: _reachability(_Assistant(v)) for v in ("PUBLIC", "SHARED", "PRIVATE")}
+    assert len(set(values.values())) == 3
+    assert values["PUBLIC"] == "everyone"
+
+
+def test_unknown_visibility_is_treated_as_unreachable():
+    """Fail closed on the *warning*, which is the safe direction here.
+
+    An unrecognized visibility must not resolve to `everyone` — that would suppress the
+    warning on precisely the case nobody anticipated.
+    """
+    assert _reachability(_Assistant("SOMETHING_NEW")) == "owner_only"

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -142,6 +142,27 @@ retroactively publish every existing PUBLIC agent to the whole institution with 
 `visibility` stays the access gate. `listing.state` is the publication state. **Backfill every
 existing record to no `listing` block at all** — publication is an explicit forward act.
 
+### D3.1 — the cost of the split, and why it is disclosed rather than closed
+
+Keeping the axes separate has a consequence D3 did not state, found on dev with both live
+listings in exactly this shape (one `PRIVATE`, one `SHARED`): `GET /agents/store` is a pure
+sparse-GSI5 read with **no** access check, while `GET /agents/{id}` enforces
+`get_assistant_with_access_check`. So an approved `PRIVATE`/`SHARED` Agent gets a shelf tile
+that every other user can see and nobody else can open. `submit_listing` does not check
+`status` either, so a `DRAFT` named "Untitled Agent" can reach the shelf.
+
+**Resolved as disclosure, not enforcement.** `AdminListingRow.reachability` and
+`ListingPreflightResponse.reachability` project `visibility` onto "who can open this", and
+the review queue and submit dialog each render it in their own voice from one shared
+helper. Advisory throughout.
+
+⚠️ **Three fixes were considered and rejected; do not re-propose them without new
+information.** Blocking submission on non-`PUBLIC` visibility forbids the legitimate case of
+a team publishing a `SHARED` Agent. Filtering at browse turns the deliberately-pure GSI5 read
+into N access checks per page view. Auto-setting `PUBLIC` on approve is D3's own prohibition
+re-entering through the back door — a store decision silently rewriting an access decision,
+which is the `allowedAppRoles` trap exactly.
+
 ## D4 — The shelf carries an icon, a name, and one line
 
 Browse rows and store-front tiles show **icon, name, one-line tagline** and nothing else. No model

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -7,6 +7,7 @@
  * Phase 8.
  */
 
+import { ListingReachability } from '../../../agents/models/reachability';
 import {
   AdminEdit,
   AdminStoreFrontResponse,
@@ -122,6 +123,13 @@ export interface AdminListingRow {
    * Only listings approved before the hash baseline shipped can report `'edited'`.
    */
   drift?: ListingDrift;
+
+  /**
+   * Who can open this agent if it is shelved, derived from `visibility` server-side.
+   * `everyone` = PUBLIC; the other two mean the store tile will 404 for most users.
+   * Advisory — the reviewer is told, never blocked.
+   */
+  reachability: ListingReachability;
   adminEdits: AdminEdit[];
 }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
@@ -26,6 +26,9 @@ describe('MarketplaceListingsPage — post-approval drift marker', () => {
       state: 'published',
       usageCount: 12,
       updatedAt: '2026-07-22T00:00:00Z',
+      // The default is the uninteresting case on purpose: these tests are about drift, and
+      // a fixture that was also unreachable would mix two independent warnings in one row.
+      reachability: 'everyone',
       adminEdits: [],
       ...overrides,
     };

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { ReviewQueuePage } from './review-queue.page';
+import { AdminListingRow } from '../models/marketplace.model';
+import { ListingReachability } from '../../../agents/models/reachability';
+
+/**
+ * The reachability warning on the review queue.
+ *
+ * The store browse read applies no access check while the detail read does, so approving a
+ * PRIVATE or SHARED agent shelves a tile that 404s for everyone it is not shared with.
+ * The reviewer is the last person who can notice, and nothing else on the row tells them.
+ *
+ * These assert the two things the backend cannot: that the warning **renders** for the
+ * limited states, and that it stays **advisory** — Approve is never disabled by it.
+ */
+describe('ReviewQueuePage — reachability warning', () => {
+  let mockService: any;
+
+  function row(reachability: ListingReachability): AdminListingRow {
+    return {
+      agentId: 'ast-001',
+      name: 'Policy Lookup',
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      state: 'in_review',
+      usageCount: 0,
+      updatedAt: '2026-07-22T00:00:00Z',
+      reachability,
+      adminEdits: [],
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: signal<string | null>(null),
+      loadSubmissions: vi.fn().mockResolvedValue([]),
+      review: vi.fn().mockResolvedValue(undefined),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: { open: vi.fn() } },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function renderWith(rows: AdminListingRow[]): Promise<ComponentFixture<ReviewQueuePage>> {
+    mockService.loadSubmissions.mockResolvedValue(rows);
+    const fixture = TestBed.createComponent(ReviewQueuePage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function text(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('says nothing for a public agent', async () => {
+    const fixture = await renderWith([row('everyone')]);
+    expect(text(fixture)).not.toMatch(/error when they open it|nobody else can use/i);
+  });
+
+  it('warns the reviewer that a private agent is unopenable by anyone else', async () => {
+    const fixture = await renderWith([row('owner_only')]);
+    expect(text(fixture)).toMatch(/only the author can open this/i);
+  });
+
+  it('warns on a shared agent too, in its own words', async () => {
+    const fixture = await renderWith([row('shared_only')]);
+    const rendered = text(fixture);
+    expect(rendered).toMatch(/shared/i);
+    expect(rendered).toMatch(/get an error/i);
+    // Must not be described as author-only — that is a different, more alarming claim.
+    expect(rendered).not.toMatch(/only the author can open this/i);
+  });
+
+  it('leaves Approve enabled — this is advice, not a gate', async () => {
+    // Publishing a SHARED agent to a team is legitimate. A warning that blocked it would
+    // make the reviewer's only escape route "change someone else's visibility".
+    const fixture = await renderWith([row('owner_only')]);
+    const approve = (fixture.nativeElement as HTMLElement).querySelectorAll('button');
+    const approveBtn = Array.from(approve).find((b) => b.textContent?.includes('Approve'));
+    expect(approveBtn).toBeTruthy();
+    expect(approveBtn!.hasAttribute('disabled')).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -8,10 +8,11 @@ import {
 import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroInbox, heroCheck, heroArrowUturnLeft } from '@ng-icons/heroicons/outline';
+import { heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash } from '@ng-icons/heroicons/outline';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { AdminListingRow } from '../models/marketplace.model';
 import { AgentTileComponent } from '../components/agent-tile.component';
+import { reachabilityReviewerMessage } from '../../../agents/models/reachability';
 import {
   RequestChangesDialogComponent,
   RequestChangesDialogData,
@@ -33,7 +34,7 @@ import { parseIso } from '../../../utils/date';
   selector: 'app-review-queue',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, AgentTileComponent],
-  providers: [provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft })],
+  providers: [provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash })],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
@@ -96,6 +97,23 @@ import { parseIso } from '../../../utils/date';
                   @if (row.tagline) {
                     <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
                       {{ row.tagline }}
+                    </p>
+                  }
+
+                  <!-- Reachability. Never collapsed away and never a blocker: approving a
+                       PRIVATE agent shelves a tile that 404s for everyone but its author,
+                       and that is the one fact the reviewer cannot get from anywhere else
+                       on this row. -->
+                  @if (reachabilityWarning(row); as warning) {
+                    <p
+                      class="mt-1 flex items-start gap-1.5 text-sm/6 text-amber-700 dark:text-amber-400"
+                    >
+                      <ng-icon
+                        name="heroEyeSlash"
+                        class="mt-1 size-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span>{{ warning }}</span>
                     </p>
                   }
                 </div>
@@ -188,6 +206,14 @@ export class ReviewQueuePage implements OnInit {
   }
 
   /** "yesterday" / "3 days ago", matching the mockup's queue subtitle. */
+  /**
+   * The reviewer-facing half of the shared wording. Kept as a one-line delegation so the
+   * author's dialog and this queue can never describe the same state differently.
+   */
+  reachabilityWarning(row: AdminListingRow): string | null {
+    return reachabilityReviewerMessage(row.reachability);
+  }
+
   relativeTime(iso?: string): string {
     if (!iso) return 'recently';
     const then = parseIso(iso).getTime();

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -1,8 +1,9 @@
 import { Component, ChangeDetectionStrategy, OnInit, computed, inject, signal } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroExclamationTriangle, heroEye } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash } from '@ng-icons/heroicons/outline';
 import { AgentListingService } from '../services/agent-listing.service';
+import { reachabilityAuthorMessage } from '../models/reachability';
 import {
   AgentCategory,
   AgentListingBlock,
@@ -42,7 +43,7 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
   selector: 'app-submit-listing-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
-  providers: [provideIcons({ heroXMark, heroExclamationTriangle, heroEye })],
+  providers: [provideIcons({ heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash })],
   host: {
     class: 'block',
     '(keydown.escape)': 'onCancel()',
@@ -99,6 +100,18 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
               <p>{{ reason }}</p>
             </div>
           } @else {
+            <!-- Reachability. Deliberately *below* the D7.2 block and *above* the form:
+                 it does not stop the submission, but an author who reads nothing else
+                 should still see that their tile would 404 for everyone else. -->
+            @if (reachabilityWarning(); as warning) {
+              <div
+                class="flex gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-900 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+              >
+                <ng-icon name="heroEyeSlash" class="mt-0.5 size-5 shrink-0" aria-hidden="true" />
+                <p>{{ warning }}</p>
+              </div>
+            }
+
             <div>
               <label for="listing-category" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
                 Category
@@ -232,6 +245,12 @@ export class SubmitListingDialogComponent implements OnInit {
   readonly categories = signal<AgentCategory[]>([]);
   readonly exposedSkills = signal<SkillExposure[]>([]);
   readonly blockReason = signal<string | null>(null);
+  /**
+   * Who will be able to open this once it is shelved. A *warning*, not a block — the
+   * author may legitimately publish a SHARED agent to their team, so this never disables
+   * Submit; it just makes sure "nobody can open my tile" is not discovered afterwards.
+   */
+  readonly reachabilityWarning = signal<string | null>(null);
   readonly loading = signal(true);
   readonly submitting = signal(false);
   readonly error = signal<string | null>(null);
@@ -270,6 +289,7 @@ export class SubmitListingDialogComponent implements OnInit {
       this.categories.set(categories);
       this.exposedSkills.set(preflight.exposedSkills ?? []);
       this.blockReason.set(preflight.blockReason ?? null);
+      this.reachabilityWarning.set(reachabilityAuthorMessage(preflight.reachability));
       // Only preselect a category that is still open for new listings.
       if (!categories.some((c) => c.id === this.category())) {
         this.category.set('');

--- a/frontend/ai.client/src/app/agents/models/reachability.spec.ts
+++ b/frontend/ai.client/src/app/agents/models/reachability.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ListingReachability,
+  reachabilityAuthorMessage,
+  reachabilityIsLimited,
+  reachabilityLabel,
+  reachabilityReviewerMessage,
+} from './reachability';
+
+const LIMITED: ListingReachability[] = ['owner_only', 'shared_only'];
+
+describe('reachability', () => {
+  it('says nothing at all when the agent is public', () => {
+    // The whole point is that this is quiet in the common case — a warning shown on every
+    // row is a warning nobody reads.
+    expect(reachabilityAuthorMessage('everyone')).toBeNull();
+    expect(reachabilityReviewerMessage('everyone')).toBeNull();
+    expect(reachabilityIsLimited('everyone')).toBe(false);
+  });
+
+  it.each(LIMITED)('warns both audiences when reachability is %s', (value) => {
+    expect(reachabilityIsLimited(value)).toBe(true);
+    expect(reachabilityAuthorMessage(value)).toBeTruthy();
+    expect(reachabilityReviewerMessage(value)).toBeTruthy();
+  });
+
+  it.each(LIMITED)('names the consequence, not just the state, for %s', (value) => {
+    // A message that only says "this is private" tells the reader something they can
+    // already see. Both voices have to say what will actually happen.
+    expect(reachabilityAuthorMessage(value)).toMatch(/error when they open it/);
+    expect(reachabilityReviewerMessage(value)!).toMatch(/nobody else can use|get an error/);
+  });
+
+  it('tells the author how to fix it, and does not tell the reviewer to', () => {
+    // The author owns visibility; the reviewer does not, and telling them to change it
+    // would be inviting exactly the silent access-widening this feature refuses to do.
+    expect(reachabilityAuthorMessage('owner_only')).toMatch(/set Visibility to Public/i);
+    expect(reachabilityReviewerMessage('owner_only')).not.toMatch(/set Visibility/i);
+  });
+
+  it('distinguishes owner_only from shared_only rather than collapsing them', () => {
+    expect(reachabilityAuthorMessage('owner_only')).not.toBe(
+      reachabilityAuthorMessage('shared_only'),
+    );
+    expect(reachabilityReviewerMessage('owner_only')).not.toBe(
+      reachabilityReviewerMessage('shared_only'),
+    );
+  });
+
+  it('labels each state for a table cell', () => {
+    expect(reachabilityLabel('everyone')).toBe('Public');
+    expect(reachabilityLabel('shared_only')).toBe('Shared');
+    expect(reachabilityLabel('owner_only')).toBe('Private');
+  });
+});

--- a/frontend/ai.client/src/app/agents/models/reachability.ts
+++ b/frontend/ai.client/src/app/agents/models/reachability.ts
@@ -1,0 +1,64 @@
+/**
+ * "Who can actually open this?" — one sentence, in the one place both surfaces read it from.
+ *
+ * Publication and reachability are separate axes and the store only guards one: the browse
+ * read applies no access check, while the detail read enforces one. So an approved PRIVATE
+ * or SHARED Agent gets a shelf tile that 404s for everyone it is not shared with.
+ *
+ * The author (at submit) and the reviewer (at approve) are the two people who can act on
+ * that, and they must not be told two different things — this is the same reason
+ * `runnabilityMessage` exists next door.
+ *
+ * ⚠️ Advisory, never a gate. Publishing a SHARED Agent to a team is a legitimate thing to
+ * do; the wording says what will happen, and leaves the decision where it belongs.
+ */
+
+/** Mirrors the backend `ListingReachability`. */
+export type ListingReachability = 'everyone' | 'shared_only' | 'owner_only';
+
+/** Whether this reachability is worth interrupting anyone about. */
+export function reachabilityIsLimited(value: ListingReachability): boolean {
+  return value !== 'everyone';
+}
+
+/**
+ * What the **author** is told before submitting — second person, and it names the fix.
+ * Returns null when there is nothing to say.
+ */
+export function reachabilityAuthorMessage(value: ListingReachability): string | null {
+  if (value === 'owner_only') {
+    return (
+      'Only you can open this agent. If it is published, people will see it in the store ' +
+      'but get an error when they open it — set Visibility to Public first.'
+    );
+  }
+  if (value === 'shared_only') {
+    return (
+      'Only people this agent is shared with can open it. Anyone else will see it in the ' +
+      'store but get an error when they open it — set Visibility to Public to reach the ' +
+      'whole university.'
+    );
+  }
+  return null;
+}
+
+/**
+ * What the **reviewer** is told before approving — third person, and it does not tell them
+ * to go change someone else's access. Returns null when there is nothing to say.
+ */
+export function reachabilityReviewerMessage(value: ListingReachability): string | null {
+  if (value === 'owner_only') {
+    return "Private — only the author can open this. Approving it shelves a tile nobody else can use.";
+  }
+  if (value === 'shared_only') {
+    return 'Shared — only people it is shared with can open it. Everyone else will get an error.';
+  }
+  return null;
+}
+
+/** Short label for a table cell, where the full sentence will not fit. */
+export function reachabilityLabel(value: ListingReachability): string {
+  if (value === 'owner_only') return 'Private';
+  if (value === 'shared_only') return 'Shared';
+  return 'Public';
+}

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -1,3 +1,4 @@
+import { ListingReachability } from './reachability';
 /**
  * Agent Marketplace store types (Phase 2).
  *
@@ -107,6 +108,11 @@ export interface ListingPreflight {
   agentId: string;
   exposedSkills: SkillExposure[];
   blockReason?: string | null;
+  /**
+   * Who would be able to open this agent once shelved. Advisory — publishing a
+   * PRIVATE/SHARED agent is allowed, but the tile 404s for everyone it is not shared with.
+   */
+  reachability: ListingReachability;
 }
 
 /** The listing after a submission, plus the disclosures the author was shown (D7). */


### PR DESCRIPTION
## The gap

Publication and access are separate axes (D3), and the store only guards one:

| Read | Access check |
|---|---|
| `GET /agents/store` (browse) | **none** — pure sparse-GSI5 read |
| `GET /agents/{id}` (detail) | `get_assistant_with_access_check` |

Nothing in the listing lifecycle touches `visibility`. So an approved `PRIVATE` or `SHARED` Agent gets a shelf tile that everyone can see and only its author can open.

Found while smoke-testing the Agent epic on dev, where **both** live listings were in that state — one `PRIVATE`, one `SHARED` — and the `PRIVATE` one was a `status=DRAFT` record still named "Untitled Agent", sitting on the Teaching shelf. `submit_listing` doesn't check `status` either.

The admin copy half-knew — *"members can only open one they could reach on their own"* on Default Pins, *"a tile nobody can open is worse than a short row"* on Store Front — but every guard was on listing **state**, never on visibility, and neither the author at submit nor the reviewer at approve was told.

## The fix: disclosure, not enforcement

`reachability` projects `visibility` onto "who can open this" (`everyone` / `shared_only` / `owner_only`) and rides the two surfaces where someone can act on it:

- **`AdminListingRow.reachability`** → the review queue, before Approve
- **`ListingPreflightResponse.reachability`** → the author's submit dialog, before submitting

Derived on every read, never stored — `visibility` can change at any time and a cached copy would be wrong exactly when it mattered. Same reasoning as `drift`.

**The two audiences get different words from one shared helper**, so they can't drift:

- author → *"…set Visibility to Public first."* — they own visibility, so they get the fix
- reviewer → *"Private — only the author can open this. Approving it shelves a tile nobody else can use."* — no instruction to go widen someone else's access

A test asserts that asymmetry, because collapsing it is the tempting simplification.

## Rejected alternatives (recorded in D3.1 so they aren't re-proposed)

| Option | Why not |
|---|---|
| Block submission on non-PUBLIC | Forbids the legitimate case: a team publishing a `SHARED` Agent |
| Filter at browse | Turns the deliberately-pure GSI5 read into N access checks per page view |
| Auto-set PUBLIC on approve | D3's own prohibition through the back door — a store decision silently rewriting an access decision, the `allowedAppRoles` trap exactly |

Advisory throughout: **Approve is never disabled**, and there's a test for it.

## Tests

- `test_listing_reachability.py` — the projection, that the three states stay distinguishable, and that an unrecognized visibility fails *closed* (warns) rather than resolving to `everyone`
- `reachability.spec.ts` — both voices, that each names the consequence rather than just the state, and the author/reviewer asymmetry
- `review-queue.page.spec.ts` — renders for the limited states, silent for `everyone`, Approve stays enabled

Both new SPA specs **verified non-vacuous**: neutering the helper fails 8 of them.

`listings.page.spec.ts`'s fixture gained the field rather than the model being loosened to optional — the backend always sends it, and a fixture that lies about the contract is how the `turn_agent_id` outage in #771 stayed CI-green.

## Verification

- ruff: **164, exactly baseline**
- backend: **5259 passed, 3 skipped**
- SPA: **1656 passed** (post-rebase onto #772)

## Deploy

`backend.yml` + `frontend-deploy.yml`. No CDK, no index, env var or IAM change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)