### PR TITLE
feat(rbac): enforce delegated admin scopes on admin routes

### DIFF
--- a/backend/src/apis/app_api/admin/README.md
+++ b/backend/src/apis/app_api/admin/README.md
@@ -1,314 +1,134 @@
 # Admin API Module
 
-This module provides role-based access control (RBAC) for administrative endpoints.
+> Rewritten 2026-07-27. The previous version documented RBAC helpers that do not
+> exist (`require_roles`, `require_all_roles`, `has_any_role`, `require_faculty`,
+> …), five endpoints that are not in this module (`/admin/me`,
+> `/admin/sessions/all`, `/admin/stats`, `/admin/conditional-example`,
+> `/admin/require-multiple-roles-example`), and an `ENABLE_AUTHENTICATION=false`
+> switch that no longer exists (it is `SKIP_AUTH` now). Treat any surviving
+> reference to those as stale.
 
-## Overview
+Privileged endpoints, mounted under `/admin`. `routes.py` owns the root router
+and includes every sub-router; each sub-package is one admin feature area.
 
-The admin module demonstrates how to use the shared authentication RBAC utilities to create protected endpoints that require specific roles from JWT tokens.
+## Authorization model
 
-## Architecture
-
-### JWT Role Extraction
-
-Roles are automatically extracted from the JWT token by `CognitoJWTValidator` (`apis/shared/auth/cognito_jwt_validator.py`) and populated in the `User` model (`apis/shared/auth/models.py`).
-
-### RBAC Dependencies
-
-The shared auth module provides FastAPI dependencies for role checking:
-
-- `require_roles(*roles)` - User must have at least ONE of the specified roles (OR logic)
-- `require_all_roles(*roles)` - User must have ALL of the specified roles (AND logic)
-- `has_any_role(user, *roles)` - Helper function for conditional logic
-- `has_all_roles(user, *roles)` - Helper function for conditional logic
-
-### Predefined Role Checkers
-
-For convenience, common role checkers are available:
-
-- `require_admin` - Requires "Admin" or "SuperAdmin" role
-- `require_faculty` - Requires "Faculty" role
-- `require_staff` - Requires "Staff" role
-- `require_developer` - Requires "DotNetDevelopers" role
-- `require_aws_ai_access` - Requires "AWS-BoiseStateAI" role
-
-## Usage Examples
-
-### Basic Admin Endpoint
+Admin access is **not** a single bit. Each router package is governed by one
+*admin scope* that a system admin can delegate to another role.
 
 ```python
-from fastapi import APIRouter, Depends
-from apis.shared.auth import User, require_admin
+# tools/routes.py
+from apis.shared.auth import User, require_admin_scope
 
-router = APIRouter(prefix="/admin", tags=["admin"])
+router = APIRouter(prefix="/tools", tags=["admin-tools"])
 
-@router.get("/stats")
-async def get_stats(admin_user: User = Depends(require_admin)):
-    """Admin-only endpoint. Requires Admin or SuperAdmin role."""
-    return {"stats": "..."}
+require_tools_admin = require_admin_scope("admin.tools")
+
+@router.get("")
+async def list_tools(admin: User = Depends(require_tools_admin)):
+    ...
 ```
 
-### Custom Role Requirements
+`system_admin` satisfies every scope implicitly, so a full admin sees no change.
+Scope ids come from the closed registry in `apis/shared/rbac/admin_scopes.py`.
+
+**Two packages are non-delegable and keep bare `require_admin`:**
+
+| Package | Why |
+|---|---|
+| `roles/` | Editing a role is how admin power is handed out — anyone who can PATCH a role can grant themselves anything. |
+| `auth_providers/` | Role resolution starts from JWT claims, so controlling IdP attribute mapping controls which AppRoles resolve. Role administration by another route. |
+
+## Feature areas
+
+| Package | Prefix | Scope |
+|---|---|---|
+| `routes.py` (root) | `/admin` | `admin.models` |
+| `quota/` | `/admin/quota` | `admin.quota` |
+| `costs/` | `/admin/costs` | `admin.costs` |
+| `users/` | `/admin/users` | `admin.users` |
+| `tools/` | `/admin/tools` | `admin.tools` |
+| `skills/` | `/admin/skills` | `admin.skills` |
+| `agents/` | `/admin/agents` | `admin.marketplace` |
+| `roles/agent_pins.py` | `/admin/roles/{id}/agent-pins` | `admin.marketplace` ¹ |
+| `oauth/` | `/admin/oauth-providers` | `admin.connectors` |
+| `file_sources/` | `/admin/file-source-adapters` | `admin.file_sources` |
+| `export_targets/` | `/admin/export-target-adapters` | `admin.export_targets` |
+| `system_prompts/` | `/admin/system-prompts` | `admin.system_prompts` |
+| `user_menu_links/` | `/admin/user-menu-links` | `admin.user_menu_links` |
+| `fine_tuning/` | `/admin/fine-tuning` | `admin.fine_tuning` |
+| `roles/` | `/admin/roles` | **non-delegable** |
+| `auth_providers/` | `/admin/auth-providers` | **non-delegable** |
+
+¹ The one place the "scope = package" rule doesn't hold. `agent_pins.py` mounts
+under the `/roles` prefix but is marketplace functionality; it inherits
+`admin.marketplace` through `require_marketplace_admin`. Covered by an explicit
+test so it can't drift.
+
+**Conditionally mounted:** `skills/` (`SKILLS_ENABLED`), `fine_tuning/`
+(`FINE_TUNING_ENABLED`), and `agents/` (always mounted but 404s through
+`require_marketplace_admin` when `AGENT_MARKETPLACE_ENABLED` is off).
+
+## Adding an admin endpoint
+
+**To an existing package** — add the route and use the package's existing
+`require_<area>_admin` dependency:
 
 ```python
-from apis.shared.auth import require_roles
-
-@router.post("/faculty-portal")
-async def faculty_endpoint(user: User = Depends(require_roles("Faculty", "Staff"))):
-    """Requires Faculty OR Staff role."""
-    return {"message": "Access granted"}
+@router.post("/{tool_id}/archive")
+async def archive_tool(tool_id: str, admin: User = Depends(require_tools_admin)):
+    ...
 ```
 
-### Multiple Required Roles
+**A new feature area** — four steps, and the tests will tell you if you miss one:
 
-```python
-from apis.shared.auth import require_all_roles
+1. Add an `AdminScope` to `apis/shared/rbac/admin_scopes.py`.
+2. Create the package with `require_<area>_admin = require_admin_scope("admin.<area>")`
+   — named after the area, mirroring `require_marketplace_admin`, so tests have
+   a stable public handle to override.
+3. Include the router in `routes.py`.
+4. Register the module → scope mapping in
+   `tests/architecture/test_admin_scope_coverage.py`.
 
-@router.post("/critical-operation")
-async def critical_endpoint(user: User = Depends(require_all_roles("Admin", "Security"))):
-    """Requires BOTH Admin AND Security roles."""
-    return {"message": "Access granted"}
-```
+That test walks every mounted admin route and fails if one has no authorization
+dependency, if a package uses bare `require_admin` without being on the
+non-delegable list, or if a registry scope governs nothing. The regression it
+exists to catch is a new admin route added with no scope — silently reachable by
+every delegated admin.
 
-### Conditional Admin Features
+## RBAC gotcha: write-through
 
-```python
-from apis.shared.auth import get_current_user, has_any_role
+The tool, model, and skill pages each offer a "which roles can use this?" picker
+that writes *through* into role records (`set_roles_for_tool` and siblings), all
+of which land in `AppRoleAdminService.update_role`. That is intended — granting a
+tool is a tool admin's job.
 
-@router.get("/dashboard")
-async def dashboard(user: User = Depends(get_current_user)):
-    """Available to all authenticated users, with extra data for admins."""
-    response = {"user": user.email}
+What is guarded: if the target role is protected or carries `grantedAdminScopes`,
+the actor must hold `system_admin`. Otherwise a delegated `admin.tools` holder
+could add grants to an admin-bearing role from a surface never meant to
+administer roles. The check lives in `update_role` rather than the three callers,
+so any future resource surface that grows a role picker inherits it. It raises
+`RoleMutationForbidden` → 403 (not `ValueError` → 400, which would misreport a
+denied escalation as a bad request).
 
-    # Add admin-specific data conditionally
-    if has_any_role(user, "Admin", "SuperAdmin"):
-        response["admin_data"] = {"debug_info": "..."}
+## Errors
 
-    return response
-```
+| Status | Meaning |
+|---|---|
+| 401 | No valid session cookie. |
+| 403 | Authenticated but lacks the scope, or a blocked role mutation. |
+| 404 | Feature area disabled by its kill switch (reads as unmounted). |
 
-## Available Endpoints
+## Local development
 
-### `GET /admin/me`
-Get information about the current admin user.
+`SKIP_AUTH=true` returns a fake user whose roles come from `SKIP_AUTH_ROLES`
+(default `admin`). Those roles still resolve through the AppRole table, so the
+mapped role must reach `system_admin` for admin routes to open. `app_api/main.py`
+refuses to boot when `SKIP_AUTH` is combined with deployed-environment
+indicators.
 
-**Required Role:** Admin or SuperAdmin
+## See also
 
-**Response:**
-```json
-{
-  "email": "admin@example.com",
-  "user_id": "123456789",
-  "name": "Admin User",
-  "roles": ["Admin", "Faculty"],
-  "picture": "https://..."
-}
-```
-
-### `GET /admin/sessions/all`
-List all sessions across all users (for monitoring/support).
-
-**Required Role:** Admin or SuperAdmin
-
-**Query Parameters:**
-- `limit` (optional): Maximum sessions to return (1-1000, default 100)
-- `next_token` (optional): Pagination token
-
-**Response:**
-```json
-{
-  "sessions": [...],
-  "total_count": 42,
-  "next_token": "..."
-}
-```
-
-### `DELETE /admin/sessions/{session_id}`
-Delete any user's session (for abuse handling, privacy requests).
-
-**Required Role:** Admin or SuperAdmin
-
-**Response:**
-```json
-{
-  "success": true,
-  "session_id": "abc123",
-  "message": "Session deleted by admin user@example.com"
-}
-```
-
-### `GET /admin/stats`
-Get system-wide statistics.
-
-**Required Role:** Admin or SuperAdmin
-
-**Response:**
-```json
-{
-  "total_users": 150,
-  "total_sessions": 450,
-  "active_sessions": 23,
-  "total_messages": 12000,
-  "stats_as_of": "2025-12-10T12:00:00Z"
-}
-```
-
-### `GET /admin/users/{user_id}/sessions`
-Get all sessions for a specific user (for support).
-
-**Required Role:** Admin or SuperAdmin
-
-**Query Parameters:**
-- `limit` (optional): Maximum sessions to return (1-1000, default 100)
-- `next_token` (optional): Pagination token
-
-**Response:**
-```json
-{
-  "sessions": [...],
-  "next_token": "..."
-}
-```
-
-### `GET /admin/conditional-example`
-Example showing conditional admin features.
-
-**Required Role:** Any authenticated user
-
-**Response for regular users:**
-```json
-{
-  "message": "Welcome!",
-  "user_email": "user@example.com",
-  "user_roles": ["Faculty"]
-}
-```
-
-**Response for admins:**
-```json
-{
-  "message": "Welcome!",
-  "user_email": "admin@example.com",
-  "user_roles": ["Admin", "Faculty"],
-  "admin_data": {
-    "debug_info": "Additional admin information",
-    "system_health": "All systems operational"
-  }
-}
-```
-
-### `POST /admin/require-multiple-roles-example`
-Example requiring one of multiple specific roles.
-
-**Required Role:** Admin, SuperAdmin, or DotNetDevelopers
-
-**Response:**
-```json
-{
-  "message": "Access granted",
-  "user": "dev@example.com",
-  "matched_roles": ["DotNetDevelopers"]
-}
-```
-
-## Error Responses
-
-### 401 Unauthorized
-Returned when no JWT token is provided or token is invalid.
-
-```json
-{
-  "detail": "Authentication required. Please provide a valid Bearer token in the Authorization header."
-}
-```
-
-### 403 Forbidden
-Returned when user is authenticated but lacks required role(s).
-
-```json
-{
-  "detail": "Access denied. Required roles: Admin, SuperAdmin"
-}
-```
-
-## Testing
-
-### With Authentication Enabled (Production)
-
-Test with a valid JWT token in the Authorization header:
-
-```bash
-curl -H "Authorization: Bearer <your-jwt-token>" \
-  http://localhost:8000/admin/me
-```
-
-### With Authentication Disabled (Development)
-
-Set `ENABLE_AUTHENTICATION=false` in your `.env` file:
-
-```bash
-# .env
-ENABLE_AUTHENTICATION=false
-```
-
-This bypasses authentication and returns an anonymous user:
-- Email: `anonymous@local.dev`
-- User ID: `anonymous`
-- Name: `Anonymous User`
-- Roles: `[]` (empty - will fail role checks)
-
-**Note:** With authentication disabled and no roles, you'll still get 403 errors from role-protected endpoints. To test admin endpoints without authentication, you would need to modify the role checker or use mock data.
-
-## Adding New Admin Endpoints
-
-1. **Import dependencies:**
-```python
-from apis.shared.auth import User, require_admin, require_roles
-```
-
-2. **Add route with role dependency:**
-```python
-@router.post("/my-admin-feature")
-async def my_admin_feature(admin_user: User = Depends(require_admin)):
-    logger.info(f"Admin {admin_user.email} accessed feature")
-    return {"message": "Success"}
-```
-
-3. **Access user information:**
-```python
-admin_user.email      # Email address
-admin_user.user_id    # 9-digit employee number
-admin_user.name       # Full name
-admin_user.roles      # List of roles
-admin_user.picture    # Profile picture URL (optional)
-```
-
-## Security Considerations
-
-1. **Always validate roles server-side** - Never trust client-side role checks
-2. **Log admin actions** - All admin operations should be logged for audit trails
-3. **Use specific roles** - Prefer `require_admin` over `get_current_user` for sensitive operations
-4. **Disable auth only in development** - Never set `ENABLE_AUTHENTICATION=false` in production
-5. **Review JWT claims** - Ensure your Entra ID app registration includes role claims
-
-## Role Configuration
-
-Roles are configured in Entra ID (Azure AD) app registration:
-1. Define app roles in the app manifest
-2. Assign roles to users/groups
-3. Roles appear in the JWT token's `roles` claim
-4. Backend validates and extracts roles automatically
-
-See `apis/shared/auth/cognito_jwt_validator.py` for role extraction logic.
-
-## Future Enhancements
-
-Potential additions to the admin module:
-
-- User management (list, create, update, disable users)
-- Audit log viewing
-- System configuration management
-- Usage analytics and reporting
-- Session management (force logout, view active sessions)
-- Cost tracking and budgeting
-- Tool usage monitoring
-- Rate limiting configuration
+- `apis/shared/auth/RBAC_QUICK_REFERENCE.md` — the dependency surface.
+- `docs/specs/granular-admin-permissions.md` — why the scope model is shaped this
+  way, including the escalation analysis.

--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -1,7 +1,7 @@
 """Admin API routes for the Agent Marketplace (Phases 1-2, 5).
 
 Mounted under ``/admin/agents`` per the CLAUDE.md route convention — admin CRUD lives at
-``/admin/resource/``, never ``/resource/admin/``. Every route is ``Depends(require_admin)``
+``/admin/resource/``, never ``/resource/admin/``. Every route is ``Depends(require_marketplace_scope)``
 (= ``require_app_roles("system_admin")``); D2 is explicit that a granular "marketplace
 curator" permission is a deliberate follow-up, so do not open a second permission axis here.
 
@@ -75,7 +75,7 @@ from apis.shared.assistants.publishers import (
     put_publisher,
     set_eligibility,
 )
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.feature_flags import agent_marketplace_enabled
 from apis.shared.timestamps import utc_now_iso
 
@@ -83,12 +83,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agents", tags=["admin-agent-marketplace"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_marketplace_scope = require_admin_scope("admin.marketplace")
+
 
 def _now() -> str:
     return utc_now_iso()
 
 
-async def require_marketplace_admin(admin: User = Depends(require_admin)) -> User:
+async def require_marketplace_admin(admin: User = Depends(require_marketplace_scope)) -> User:
     """Admin auth + the environment kill switch (404 when off, so it reads as unmounted)."""
     if not agent_marketplace_enabled():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")

--- a/backend/src/apis/app_api/admin/auth_providers/routes.py
+++ b/backend/src/apis/app_api/admin/auth_providers/routes.py
@@ -1,7 +1,13 @@
 """Admin API routes for OIDC authentication provider management.
 
-All endpoints require system admin access since authentication
-configuration is a security-sensitive operation.
+**Non-delegable — these routes keep bare ``require_admin`` on purpose.**
+This is the non-obvious half of the rule. Role resolution starts from JWT
+claims: ``resolve_user_permissions`` walks the user's claim-derived roles
+through ``jwtRoleMappings`` to reach an AppRole. So whoever controls IdP
+attribute mapping controls which groups arrive, and therefore which AppRoles
+resolve at all — it is role administration by another route. The matching
+registry entry is ``admin.auth_providers``, marked ``delegable=False`` in
+``apis/shared/rbac/admin_scopes.py``.
 """
 
 import logging

--- a/backend/src/apis/app_api/admin/costs/routes.py
+++ b/backend/src/apis/app_api/admin/costs/routes.py
@@ -14,7 +14,7 @@ import csv
 import io
 import json
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from .models import (
     TopUserCost,
     SystemCostSummary,
@@ -29,6 +29,11 @@ from .service import AdminCostService
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/costs", tags=["admin-costs"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_costs_admin = require_admin_scope("admin.costs")
 
 
 # ========== Dependencies ==========
@@ -59,7 +64,7 @@ async def get_cost_dashboard(
         alias="includeTrends",
         description="Include daily trends for the period"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -113,7 +118,7 @@ async def get_cost_dashboard(
 @router.get("/sessions/{session_id}/calls", response_model=SessionCostAnatomy)
 async def get_session_cost_anatomy(
     session_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -193,7 +198,7 @@ async def get_top_users(
         alias="tierId",
         description="Filter by quota tier (not yet implemented)"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -250,7 +255,7 @@ async def get_system_summary(
         pattern=r"^(daily|monthly)$",
         description="Period type: 'daily' or 'monthly'"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -300,7 +305,7 @@ async def get_usage_by_model(
         description="Period (YYYY-MM), defaults to current month",
         pattern=r"^\d{4}-\d{2}$"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -343,7 +348,7 @@ async def get_usage_by_tier(
         description="Period (YYYY-MM), defaults to current month",
         pattern=r"^\d{4}-\d{2}$"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -394,7 +399,7 @@ async def get_cost_trends(
         description="End date (YYYY-MM-DD)",
         pattern=r"^\d{4}-\d{2}-\d{2}$"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """
@@ -450,7 +455,7 @@ async def export_cost_data(
         pattern=r"^(csv|json)$",
         description="Export format: 'csv' or 'json'"
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_costs_admin),
     service: AdminCostService = Depends(get_cost_service)
 ):
     """

--- a/backend/src/apis/app_api/admin/export_targets/routes.py
+++ b/backend/src/apis/app_api/admin/export_targets/routes.py
@@ -14,13 +14,18 @@ from typing import List
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 
 from apis.app_api.export_targets.registry import registry
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/export-target-adapters", tags=["admin-export-targets"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_export_targets_admin = require_admin_scope("admin.export_targets")
 
 
 class ExportTargetAdapterInfo(BaseModel):
@@ -54,7 +59,7 @@ class ExportTargetAdapterListResponse(BaseModel):
 
 @router.get("/", response_model=ExportTargetAdapterListResponse)
 async def list_export_target_adapters(
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_export_targets_admin),
 ) -> ExportTargetAdapterListResponse:
     """List every export-target adapter shipped in this release. Admin only."""
     logger.info("Admin listing export-target adapters")

--- a/backend/src/apis/app_api/admin/file_sources/routes.py
+++ b/backend/src/apis/app_api/admin/file_sources/routes.py
@@ -12,13 +12,18 @@ from typing import List
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 
 from apis.app_api.file_sources.registry import registry
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/file-source-adapters", tags=["admin-file-sources"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_file_sources_admin = require_admin_scope("admin.file_sources")
 
 
 class FileSourceAdapterInfo(BaseModel):
@@ -47,7 +52,7 @@ class FileSourceAdapterListResponse(BaseModel):
 
 @router.get("/", response_model=FileSourceAdapterListResponse)
 async def list_file_source_adapters(
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_file_sources_admin),
 ) -> FileSourceAdapterListResponse:
     """List every file-source adapter shipped in this release. Admin only."""
     logger.info("Admin listing file-source adapters")

--- a/backend/src/apis/app_api/admin/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/admin/fine_tuning/routes.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 import logging
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.app_api.fine_tuning.repository import (
     FineTuningAccessRepository,
     get_fine_tuning_access_repository,
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/fine-tuning", tags=["admin-fine-tuning"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_fine_tuning_admin = require_admin_scope("admin.fine_tuning")
+
 
 # ========== Dependencies ==========
 
@@ -56,7 +61,7 @@ def get_inf_repository() -> InferenceRepository:
 
 @router.get("/access", response_model=AccessListResponse)
 async def list_access(
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
     """List all users with fine-tuning access (admin only)."""
@@ -76,7 +81,7 @@ async def list_access(
 @router.post("/access", response_model=FineTuningAccessGrant, status_code=status.HTTP_201_CREATED)
 async def grant_access(
     request: GrantAccessRequest,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
     """Grant fine-tuning access to a user by email (admin only)."""
@@ -99,7 +104,7 @@ async def grant_access(
 @router.get("/access/{email}", response_model=FineTuningAccessGrant)
 async def get_access(
     email: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
     """Get fine-tuning access info for a specific user (admin only)."""
@@ -118,7 +123,7 @@ async def get_access(
 async def update_quota(
     email: str,
     request: UpdateQuotaRequest,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
     """Update GPU-hour quota for a user (admin only)."""
@@ -142,7 +147,7 @@ async def update_quota(
 @router.delete("/access/{email}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_access(
     email: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
     """Revoke fine-tuning access for a user (admin only)."""
@@ -167,7 +172,7 @@ async def revoke_access(
 @router.get("/jobs", response_model=JobListResponse)
 async def list_all_jobs(
     status_filter: Optional[str] = Query(None, alias="status"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     jobs_repo: FineTuningJobsRepository = Depends(get_jobs_repository),
 ):
     """List all fine-tuning jobs across all users (admin only)."""
@@ -211,7 +216,7 @@ async def list_all_jobs(
 @router.get("/inference-jobs", response_model=InferenceJobListResponse)
 async def list_all_inference_jobs(
     status_filter: Optional[str] = Query(None, alias="status"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     inf_repo: InferenceRepository = Depends(get_inf_repository),
 ):
     """List all inference jobs across all users (admin only)."""
@@ -248,7 +253,7 @@ async def get_cost_dashboard(
         description="Billing period in YYYY-MM format. Defaults to current month.",
         regex=r"^\d{4}-\d{2}$",
     ),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_fine_tuning_admin),
     jobs_repo: FineTuningJobsRepository = Depends(get_jobs_repository),
     inf_repo: InferenceRepository = Depends(get_inf_repository),
 ):

--- a/backend/src/apis/app_api/admin/oauth/routes.py
+++ b/backend/src/apis/app_api/admin/oauth/routes.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from apis.app_api.export_targets.registry import registry as export_target_registry
 from apis.app_api.file_sources.registry import registry
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.oauth.agentcore_registrar import (
     AgentCoreRegistrar,
     CredentialProviderConflictError,
@@ -43,6 +43,11 @@ from apis.shared.timestamps import utc_now_iso
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/oauth-providers", tags=["admin-oauth"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_connectors_admin = require_admin_scope("admin.connectors")
 
 # Rollback backoff schedule. Two retries after the initial attempt, ~2.5s
 # total worst case — short enough to keep the create request responsive,
@@ -139,7 +144,7 @@ def _emit_orphan_metric(provider_id: str) -> None:
 @router.get("/", response_model=OAuthProviderListResponse)
 async def list_providers(
     enabled_only: bool = Query(False, description="Only return enabled providers"),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_connectors_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
 ):
     """List all OAuth providers. Admin only."""
@@ -154,7 +159,7 @@ async def list_providers(
 @router.get("/{provider_id}", response_model=OAuthProviderResponse)
 async def get_provider(
     provider_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_connectors_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
 ):
     """Get a provider by ID. Admin only."""
@@ -172,7 +177,7 @@ async def get_provider(
 )
 async def create_provider(
     provider_data: OAuthProviderCreate,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_connectors_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     registrar: AgentCoreRegistrar = Depends(get_agentcore_registrar),
 ):
@@ -252,7 +257,7 @@ async def create_provider(
 async def update_provider(
     provider_id: str,
     updates: OAuthProviderUpdate,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_connectors_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     registrar: AgentCoreRegistrar = Depends(get_agentcore_registrar),
 ):
@@ -347,7 +352,7 @@ async def update_provider(
 @router.delete("/{provider_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_provider(
     provider_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_connectors_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
     registrar: AgentCoreRegistrar = Depends(get_agentcore_registrar),
 ):

--- a/backend/src/apis/app_api/admin/quota/routes.py
+++ b/backend/src/apis/app_api/admin/quota/routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from typing import List, Optional
 import logging
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.costs.aggregator import CostAggregator
 from agents.main_agent.quota.repository import QuotaRepository
 from agents.main_agent.quota.resolver import QuotaResolver
@@ -22,6 +22,11 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/quota", tags=["admin-quota"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_quota_admin = require_admin_scope("admin.quota")
 
 
 # ========== Dependencies ==========
@@ -61,7 +66,7 @@ def get_quota_service(
 @router.post("/tiers", response_model=QuotaTier, status_code=status.HTTP_201_CREATED)
 async def create_tier(
     tier_data: QuotaTierCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -96,7 +101,7 @@ async def create_tier(
 @router.get("/tiers", response_model=List[QuotaTier])
 async def list_tiers(
     enabled_only: bool = False,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -123,7 +128,7 @@ async def list_tiers(
 @router.get("/tiers/{tier_id}", response_model=QuotaTier)
 async def get_tier(
     tier_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -154,7 +159,7 @@ async def get_tier(
 async def update_tier(
     tier_id: str,
     updates: QuotaTierUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -190,7 +195,7 @@ async def update_tier(
 @router.delete("/tiers/{tier_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_tier(
     tier_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -226,7 +231,7 @@ async def delete_tier(
 @router.post("/assignments", response_model=QuotaAssignment, status_code=status.HTTP_201_CREATED)
 async def create_assignment(
     assignment_data: QuotaAssignmentCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -262,7 +267,7 @@ async def create_assignment(
 async def list_assignments(
     assignment_type: Optional[str] = None,
     enabled_only: bool = False,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -293,7 +298,7 @@ async def list_assignments(
 @router.get("/assignments/{assignment_id}", response_model=QuotaAssignment)
 async def get_assignment(
     assignment_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -324,7 +329,7 @@ async def get_assignment(
 async def update_assignment(
     assignment_id: str,
     updates: QuotaAssignmentUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -361,7 +366,7 @@ async def update_assignment(
 @router.delete("/assignments/{assignment_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_assignment(
     assignment_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -394,7 +399,7 @@ async def get_user_quota_info(
     user_id: str,
     email: str = "",
     roles: str = "",
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -434,7 +439,7 @@ async def get_user_quota_info(
 @router.post("/overrides", response_model=QuotaOverride, status_code=status.HTTP_201_CREATED)
 async def create_override(
     override_data: QuotaOverrideCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -473,7 +478,7 @@ async def create_override(
 async def list_overrides(
     user_id: Optional[str] = None,
     active_only: bool = False,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -504,7 +509,7 @@ async def list_overrides(
 @router.get("/overrides/{override_id}", response_model=QuotaOverride)
 async def get_override(
     override_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -539,7 +544,7 @@ async def get_override(
 async def update_override(
     override_id: str,
     updates: QuotaOverrideUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -574,7 +579,7 @@ async def update_override(
 @router.delete("/overrides/{override_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_override(
     override_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """
@@ -609,7 +614,7 @@ async def get_events(
     tier_id: Optional[str] = None,
     event_type: Optional[str] = None,
     limit: int = 50,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_quota_admin),
     service: QuotaAdminService = Depends(get_quota_service)
 ):
     """

--- a/backend/src/apis/app_api/admin/roles/routes.py
+++ b/backend/src/apis/app_api/admin/roles/routes.py
@@ -1,4 +1,12 @@
-"""Admin API routes for AppRole management."""
+"""Admin API routes for AppRole management.
+
+**Non-delegable — these routes keep bare ``require_admin`` on purpose.**
+Editing a role is how admin power is handed out: anyone who can PATCH a role
+can add ``grantedAdminScopes`` (or ``grantedTools: ["*"]``) to a role they
+themselves hold. Delegating this surface would make every other scope
+meaningless. The matching registry entry is ``admin.roles``, marked
+``delegable=False`` in ``apis/shared/rbac/admin_scopes.py``.
+"""
 
 import logging
 

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -29,7 +29,7 @@ from apis.shared.models.models import (
     ManagedModel,
     ModelRoleAssignment,
 )
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.feature_flags import skills_enabled
 from apis.shared.models.managed_models import (
     create_managed_model,
@@ -43,6 +43,11 @@ from .services.model_roles import get_model_role_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_models_admin = require_admin_scope("admin.models")
 
 
 
@@ -83,7 +88,7 @@ async def list_bedrock_models(
         ]
     ] = Query(None, description="Filter by customization type"),
     max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return (client-side limit)"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List available AWS Bedrock foundation models (admin only).
@@ -196,7 +201,7 @@ async def list_bedrock_models(
 @router.get("/gemini/models", response_model=GeminiModelsResponse)
 async def list_gemini_models(
     max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List available Google Gemini models (admin only).
@@ -308,7 +313,7 @@ async def list_gemini_models(
 @router.get("/openai/models", response_model=OpenAIModelsResponse)
 async def list_openai_models(
     max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List available OpenAI models (admin only).
@@ -404,7 +409,7 @@ async def list_openai_models(
 async def list_mantle_models(
     region: Optional[str] = Query(None, description="AWS region to query (defaults to the service region)"),
     max_results: Optional[int] = Query(None, ge=1, le=1000, description="Maximum number of models to return"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List available Amazon Bedrock Mantle models (admin only).
@@ -507,7 +512,7 @@ async def list_mantle_models(
 
 @router.get("/managed-models", response_model=ManagedModelsListResponse)
 async def list_managed_models_endpoint(
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List all enabled models (admin only).
@@ -556,7 +561,7 @@ async def list_managed_models_endpoint(
 @router.post("/managed-models", response_model=ManagedModel, status_code=status.HTTP_201_CREATED)
 async def create_managed_model_endpoint(
     model_data: ManagedModelCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     Create a new enabled model (admin only).
@@ -612,7 +617,7 @@ async def create_managed_model_endpoint(
 @router.get("/managed-models/{model_id}", response_model=ManagedModel)
 async def get_managed_model_endpoint(
     model_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     Get a specific enabled model by ID (admin only).
@@ -662,7 +667,7 @@ async def get_managed_model_endpoint(
 async def update_managed_model_endpoint(
     model_id: str,
     updates: ManagedModelUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     Update an enabled model (admin only).
@@ -748,7 +753,7 @@ async def update_managed_model_endpoint(
 @router.delete("/managed-models/{model_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_managed_model_endpoint(
     model_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     Delete an enabled model (admin only).
@@ -801,7 +806,7 @@ async def delete_managed_model_endpoint(
 @router.get("/managed-models/{model_id}/roles", response_model=List[ModelRoleAssignment])
 async def get_managed_model_roles(
     model_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_models_admin),
 ):
     """
     List every AppRole that grants access to a model, and how.

--- a/backend/src/apis/app_api/admin/skills/routes.py
+++ b/backend/src/apis/app_api/admin/skills/routes.py
@@ -11,7 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.skills.models import (
     AddRemoveSkillRolesRequest,
     AdminSkillListResponse,
@@ -29,13 +29,18 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/skills", tags=["admin-skills"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_skills_admin = require_admin_scope("admin.skills")
+
 
 @router.get("/", response_model=AdminSkillListResponse)
 async def admin_list_all_skills(
     status: Optional[str] = Query(
         None, description="Filter by status (active, draft, disabled)"
     ),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """List all skills in the catalog with their role assignments."""
     logger.info("Admin listing full skill catalog")
@@ -52,7 +57,7 @@ async def admin_list_all_skills(
 @router.get("/{skill_id}", response_model=AdminSkillResponse)
 async def admin_get_skill(
     skill_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Get a specific skill by ID, with its directly-granting roles."""
     logger.info("Admin getting skill")
@@ -71,7 +76,7 @@ async def admin_get_skill(
 @router.post("/", response_model=AdminSkillResponse)
 async def admin_create_skill(
     request: SkillCreateRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Create a new skill catalog entry.
 
@@ -110,7 +115,7 @@ async def admin_create_skill(
 async def admin_update_skill(
     skill_id: str,
     request: SkillUpdateRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Update skill metadata. Re-validates bound tools when they change."""
     logger.info("Admin updating skill")
@@ -139,7 +144,7 @@ async def admin_delete_skill(
     hard: bool = Query(
         False, description="If true, permanently delete instead of soft delete"
     ),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Delete a skill. Soft (disable) by default; hard=true permanently deletes."""
     logger.info("Admin deleting skill")
@@ -166,7 +171,7 @@ async def admin_delete_skill(
 @router.get("/{skill_id}/roles", response_model=SkillRolesResponse)
 async def get_skill_roles(
     skill_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Get AppRoles that grant access to this skill (direct/inherited)."""
     logger.info("Admin getting roles for skill")
@@ -184,7 +189,7 @@ async def get_skill_roles(
 async def set_skill_roles(
     skill_id: str,
     request: SetSkillRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Replace which AppRoles grant access to this skill (bidirectional sync)."""
     logger.info("Admin setting roles for skill")
@@ -201,7 +206,7 @@ async def set_skill_roles(
 async def add_roles_to_skill(
     skill_id: str,
     request: AddRemoveSkillRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Add AppRoles to skill access (preserves existing)."""
     logger.info("Admin adding roles to skill")
@@ -218,7 +223,7 @@ async def add_roles_to_skill(
 async def remove_roles_from_skill(
     skill_id: str,
     request: AddRemoveSkillRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Remove AppRoles from skill access."""
     logger.info("Admin removing roles from skill")
@@ -245,7 +250,7 @@ def _resource_value_error(e: ValueError) -> HTTPException:
 @router.get("/{skill_id}/resources", response_model=SkillResourcesResponse)
 async def list_skill_resources(
     skill_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """List a skill's reference-file manifest (no bytes)."""
     logger.info("Admin listing skill reference files")
@@ -264,7 +269,7 @@ async def upload_skill_resource(
     skill_id: str,
     file: UploadFile = File(...),
     kind: str = Form("reference"),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Upload (or replace) one supporting file for a skill.
 
@@ -301,7 +306,7 @@ async def upload_skill_resource(
 async def read_skill_resource(
     skill_id: str,
     filename: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Return the raw bytes of one reference file with its content type."""
     logger.info("Admin reading skill reference file")
@@ -325,7 +330,7 @@ async def read_skill_resource(
 async def delete_skill_resource(
     skill_id: str,
     filename: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_skills_admin),
 ):
     """Delete one reference file from a skill. Returns the updated manifest."""
     logger.info("Admin deleting skill reference file")

--- a/backend/src/apis/app_api/admin/system_prompts/routes.py
+++ b/backend/src/apis/app_api/admin/system_prompts/routes.py
@@ -9,7 +9,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.system_prompts.models import (
     SystemPromptAdminListResponse,
     SystemPromptAdminResponse,
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/system-prompts", tags=["admin-system-prompts"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_system_prompts_admin = require_admin_scope("admin.system_prompts")
+
 
 @router.get(
     "/",
@@ -30,7 +35,7 @@ router = APIRouter(prefix="/system-prompts", tags=["admin-system-prompts"])
 )
 async def list_system_prompts(
     enabled_only: bool = Query(False, description="Filter to enabled prompts only"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_system_prompts_admin),
 ) -> SystemPromptAdminListResponse:
     """List all system prompts. Admin sees both enabled and disabled."""
     service = get_system_prompts_service()
@@ -48,7 +53,7 @@ async def list_system_prompts(
 )
 async def get_system_prompt(
     prompt_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_system_prompts_admin),
 ) -> SystemPromptAdminResponse:
     service = get_system_prompts_service()
     prompt = await service.get_prompt(prompt_id)
@@ -68,7 +73,7 @@ async def get_system_prompt(
 )
 async def create_system_prompt(
     data: SystemPromptCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_system_prompts_admin),
 ) -> SystemPromptAdminResponse:
     try:
         service = get_system_prompts_service()
@@ -89,7 +94,7 @@ async def create_system_prompt(
 async def update_system_prompt(
     prompt_id: str,
     updates: SystemPromptUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_system_prompts_admin),
 ) -> SystemPromptAdminResponse:
     try:
         service = get_system_prompts_service()
@@ -114,7 +119,7 @@ async def update_system_prompt(
 )
 async def delete_system_prompt(
     prompt_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_system_prompts_admin),
 ) -> None:
     service = get_system_prompts_service()
     deleted = await service.delete_prompt(prompt_id)

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -8,7 +8,7 @@ import httpx
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.oauth.agentcore_identity import (
     CallbackUrlUnavailableError,
     WorkloadTokenUnavailableError,
@@ -46,6 +46,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tools", tags=["admin-tools"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_tools_admin = require_admin_scope("admin.tools")
+
 
 def _raise_gateway_http(err: Exception) -> "HTTPException":
     """Map a Gateway target lifecycle failure to an HTTPException.
@@ -72,7 +77,7 @@ def _raise_gateway_http(err: Exception) -> "HTTPException":
 @router.get("/", response_model=AdminToolListResponse)
 async def admin_list_all_tools(
     status: Optional[str] = Query(None, description="Filter by status (active, deprecated, disabled)"),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     List all tools in the catalog with their role assignments.
@@ -100,7 +105,7 @@ async def admin_list_all_tools(
 @router.get("/{tool_id}", response_model=AdminToolResponse)
 async def admin_get_tool(
     tool_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Get a specific tool by ID.
@@ -132,7 +137,7 @@ async def admin_get_tool(
 @router.post("/", response_model=AdminToolResponse)
 async def admin_create_tool(
     request: ToolCreateRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Create a new tool catalog entry.
@@ -200,7 +205,7 @@ async def admin_create_tool(
 async def admin_update_tool(
     tool_id: str,
     request: ToolUpdateRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Update tool metadata.
@@ -260,7 +265,7 @@ async def admin_update_tool(
 async def admin_delete_tool(
     tool_id: str,
     hard: bool = Query(False, description="If true, permanently delete instead of soft delete"),
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Delete a tool from the catalog.
@@ -367,7 +372,7 @@ def _discovery_failure_detail(status: int) -> str:
 @router.post("/discover", response_model=MCPDiscoverResponse)
 async def admin_discover_mcp_tools(
     request: MCPDiscoverRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
     provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
 ):
     """Connect to an MCP server with the given config and return its tool list.
@@ -514,7 +519,7 @@ async def admin_discover_mcp_tools(
 @router.post("/{tool_id}/discover", response_model=MCPDiscoverResponse)
 async def admin_discover_saved_tool_tools(
     tool_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """List the individual tools a *saved* catalog tool exposes.
 
@@ -540,7 +545,7 @@ async def admin_discover_saved_tool_tools(
 @router.get("/{tool_id}/gateway-status", response_model=GatewayTargetStatusResponse)
 async def admin_gateway_target_status(
     tool_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """Return the live AgentCore Gateway health for a protocol='mcp' tool.
 
@@ -607,7 +612,7 @@ async def admin_gateway_target_status(
 @router.get("/{tool_id}/roles", response_model=ToolRolesResponse)
 async def get_tool_roles(
     tool_id: str,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Get AppRoles that grant access to this tool.
@@ -639,7 +644,7 @@ async def get_tool_roles(
 async def set_tool_roles(
     tool_id: str,
     request: SetToolRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Set which AppRoles grant access to this tool.
@@ -672,7 +677,7 @@ async def set_tool_roles(
 async def add_roles_to_tool(
     tool_id: str,
     request: AddRemoveRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Add AppRoles to tool access (preserves existing).
@@ -702,7 +707,7 @@ async def add_roles_to_tool(
 async def remove_roles_from_tool(
     tool_id: str,
     request: AddRemoveRolesRequest,
-    admin: User = Depends(require_admin),
+    admin: User = Depends(require_tools_admin),
 ):
     """
     Remove AppRoles from tool access.

--- a/backend/src/apis/app_api/admin/user_menu_links/routes.py
+++ b/backend/src/apis/app_api/admin/user_menu_links/routes.py
@@ -9,7 +9,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.user_menu_links.models import (
     UserMenuLinkCreate,
     UserMenuLinkListResponse,
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/user-menu-links", tags=["admin-user-menu-links"])
 
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_user_menu_links_admin = require_admin_scope("admin.user_menu_links")
+
 
 @router.get(
     "/",
@@ -30,7 +35,7 @@ router = APIRouter(prefix="/user-menu-links", tags=["admin-user-menu-links"])
 )
 async def list_user_menu_links(
     enabled_only: bool = Query(False, description="Filter to enabled links only"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_user_menu_links_admin),
 ) -> UserMenuLinkListResponse:
     """List all user-menu links (admin sees disabled ones too)."""
     service = get_user_menu_links_service()
@@ -48,7 +53,7 @@ async def list_user_menu_links(
 )
 async def get_user_menu_link(
     link_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_user_menu_links_admin),
 ) -> UserMenuLinkResponse:
     service = get_user_menu_links_service()
     link = await service.get_link(link_id)
@@ -68,7 +73,7 @@ async def get_user_menu_link(
 )
 async def create_user_menu_link(
     data: UserMenuLinkCreate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_user_menu_links_admin),
 ) -> UserMenuLinkResponse:
     try:
         service = get_user_menu_links_service()
@@ -89,7 +94,7 @@ async def create_user_menu_link(
 async def update_user_menu_link(
     link_id: str,
     updates: UserMenuLinkUpdate,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_user_menu_links_admin),
 ) -> UserMenuLinkResponse:
     try:
         service = get_user_menu_links_service()
@@ -114,7 +119,7 @@ async def update_user_menu_link(
 )
 async def delete_user_menu_link(
     link_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_user_menu_links_admin),
 ) -> None:
     service = get_user_menu_links_service()
     deleted = await service.delete_link(link_id)

--- a/backend/src/apis/app_api/admin/users/routes.py
+++ b/backend/src/apis/app_api/admin/users/routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from typing import Optional, List
 import logging
 
-from apis.shared.auth import User, require_admin
+from apis.shared.auth import User, require_admin_scope
 from apis.shared.costs.aggregator import CostAggregator
 from agents.main_agent.quota.repository import QuotaRepository
 from agents.main_agent.quota.resolver import QuotaResolver
@@ -19,6 +19,11 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/users", tags=["admin-users"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_users_admin = require_admin_scope("admin.users")
 
 
 # ========== Dependencies ==========
@@ -68,7 +73,7 @@ async def list_users(
     domain: Optional[str] = Query(None, description="Filter by email domain"),
     limit: int = Query(25, ge=1, le=100),
     cursor: Optional[str] = Query(None, description="Pagination cursor"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_users_admin),
     service: UserAdminService = Depends(get_user_admin_service)
 ):
     """
@@ -99,7 +104,7 @@ async def list_users(
 @router.get("/search", response_model=UserListResponse)
 async def search_users(
     email: str = Query(..., description="Email to search (exact match)"),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_users_admin),
     service: UserAdminService = Depends(get_user_admin_service)
 ):
     """
@@ -126,7 +131,7 @@ async def search_users(
 @router.get("/domains/list", response_model=List[str])
 async def list_email_domains(
     limit: int = Query(50, ge=1, le=200),
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_users_admin),
     service: UserAdminService = Depends(get_user_admin_service)
 ):
     """
@@ -144,7 +149,7 @@ async def list_email_domains(
 @router.get("/{user_id}", response_model=UserDetailResponse)
 async def get_user_detail(
     user_id: str,
-    admin_user: User = Depends(require_admin),
+    admin_user: User = Depends(require_users_admin),
     service: UserAdminService = Depends(get_user_admin_service)
 ):
     """

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -113,11 +113,13 @@ app = FastAPI(
 # parameter names, and reflected user input never leak into HTTP responses.
 from apis.shared.security import (
     register_aws_client_error_handler,
+    register_role_mutation_forbidden_handler,
     register_validation_error_handler,
 )
 from apis.shared.feature_flags import skills_enabled
 register_aws_client_error_handler(app)
 register_validation_error_handler(app)
+register_role_mutation_forbidden_handler(app)
 logger.info("Registered AWS ClientError handler")
 
 # Add CORS middleware - origins from CDK-provided CORS_ORIGINS env var

--- a/backend/src/apis/shared/auth/RBAC_QUICK_REFERENCE.md
+++ b/backend/src/apis/shared/auth/RBAC_QUICK_REFERENCE.md
@@ -1,173 +1,143 @@
 # RBAC Quick Reference
 
-## Import Statement
+> Rewritten 2026-07-27. The previous version documented helpers that do not
+> exist (`require_roles`, `require_all_roles`, `has_any_role`, `has_all_roles`,
+> `get_current_user`, `require_faculty`, `require_staff`, `require_developer`,
+> `require_aws_ai_access`) and described `require_admin` as "Admin or
+> SuperAdmin". None of that was accurate. If you find those names in other docs
+> or comments, they are stale too.
+
+## What `apis.shared.auth` actually exports
 
 ```python
-from apis.shared.auth import User, require_admin, require_roles, require_all_roles, has_any_role, has_all_roles, get_current_user
+from apis.shared.auth import (
+    User,
+    get_current_user_from_session,   # authentication
+    require_app_roles,               # authorization: AppRole check
+    require_admin,                   # authorization: system_admin only
+    require_admin_scope,             # authorization: one delegated admin area
+)
 ```
 
-## Common Patterns
+That is the whole surface. There are no per-cohort helpers and no `has_*_role`
+predicates — every authorization decision resolves through the AppRole system.
 
-### 1. Admin-Only Endpoint
+## Authentication
+
+The SPA sends an httpOnly session cookie, not `Authorization: Bearer`. Every
+user-facing route under `apis/app_api/` uses:
 
 ```python
-@router.get("/admin/feature")
-async def admin_feature(admin: User = Depends(require_admin)):
-    return {"message": f"Hello {admin.email}"}
+@router.get("/my-thing")
+async def my_thing(user: User = Depends(get_current_user_from_session)):
+    ...
 ```
 
-### 2. Multiple Allowed Roles (OR)
+A Bearer-only dependency on a SPA-facing route causes a 401 → redirect loop.
+The only exceptions are the API-key feature (`auth/api_keys/`, `X-API-Key`) and
+voice mode (`voice/`, voice-ticket cookie); do not use either as a template.
+
+## Authorization
+
+### Ordinary AppRole check
 
 ```python
-@router.get("/staff-area")
-async def staff_area(user: User = Depends(require_roles("Staff", "Faculty", "Admin"))):
-    return {"message": "Access granted"}
+@router.get("/reports")
+async def reports(user: User = Depends(require_app_roles("analyst", "faculty"))):
+    ...
 ```
 
-### 3. All Roles Required (AND)
+OR logic across the listed AppRole ids. Fails closed — if permission resolution
+raises, access is denied.
+
+### Full admin
 
 ```python
-@router.post("/critical")
-async def critical(user: User = Depends(require_all_roles("Admin", "Security"))):
-    return {"message": "Critical access granted"}
+@router.post("/roles")
+async def create_role(admin: User = Depends(require_admin)):
+    ...
 ```
 
-### 4. Conditional Admin Features
+`require_admin` is exactly `require_app_roles("system_admin")`.
+
+**Reserved for the two non-delegable surfaces** — `admin/roles/` and
+`admin/auth_providers/`. Everything else uses a scope (below). An architecture
+test enforces this: `tests/architecture/test_admin_scope_coverage.py`.
+
+### Delegated admin area
 
 ```python
-@router.get("/dashboard")
-async def dashboard(user: User = Depends(get_current_user)):
-    response = {"user": user.email}
+# apis/app_api/admin/tools/routes.py
+_require = require_admin_scope("admin.tools")
 
-    if has_any_role(user, "Admin", "SuperAdmin"):
-        response["admin_panel"] = {...}
-
-    return response
+@router.get("")
+async def list_tools(admin: User = Depends(_require)):
+    ...
 ```
 
-### 5. Role-Based Logic
+One scope per admin router package, declared once at module level. `system_admin`
+satisfies every scope implicitly, so adding a scope never removes access from an
+existing admin. Scope ids come from the closed registry in
+`apis/shared/rbac/admin_scopes.py` — you cannot invent one, and two
+(`admin.roles`, `admin.auth_providers`) can never be granted to a role.
 
-```python
-@router.get("/data")
-async def get_data(user: User = Depends(get_current_user)):
-    if has_any_role(user, "Admin"):
-        # Return all data
-        return get_all_data()
-    elif has_any_role(user, "Faculty"):
-        # Return faculty data
-        return get_faculty_data(user.user_id)
-    else:
-        # Return user's own data
-        return get_user_data(user.user_id)
-```
+## How a request becomes a permission
 
-## User Object Properties
+1. **IdP → Cognito.** The provider's roles claim is mapped into `custom:roles`
+   by the auth-provider attribute mapping.
+2. **Login.** The BFF decodes the *ID token* and upserts the Users table. The
+   access token carries only a Cognito-internal group name, not the real roles.
+3. **Per request.** `get_current_user_from_session` validates the session's
+   access token, then `_enrich_user_from_store` overwrites `user.roles` from the
+   Users table (the ID-token-derived values). Cached ~5 min, invalidated by the
+   roles-version watermark.
+4. **JWT role → AppRole.** `AppRoleService.resolve_user_permissions` looks up
+   each JWT role via GSI1 (`JWT_ROLE#…`), loads the matching AppRoles, and drops
+   disabled ones.
+5. **Merge.** Tools, models, skills, and admin scopes union across roles; quota
+   tier comes from the highest-`priority` role.
 
-```python
-user.email       # "user@example.com"
-user.user_id     # "123456789" (9-digit employee number)
-user.name        # "John Doe"
-user.roles       # ["Admin", "Faculty"]
-user.picture     # "https://..." (optional)
-```
+### `default` is a fallback, not a universal role
 
-## Predefined Role Checkers
+Step 4 consults `default` **only when the user matched zero AppRoles**. It is
+never merged alongside a matched role. Granting something to `default` therefore
+reaches only users who match nothing else — *not* everyone. Reaching everyone
+means granting to each cohort role.
 
-```python
-require_admin             # Admin or SuperAdmin
-require_faculty           # Faculty
-require_staff             # Staff
-require_developer         # DotNetDevelopers
-require_aws_ai_access     # AWS-BoiseStateAI
-```
+## The AppRole record is the source of truth
 
-## Helper Functions
+A role grants a tool/model/skill/admin-area by listing it in its own
+`grantedTools` / `grantedModels` / `grantedSkills` / `grantedAdminScopes` (or by
+granting `*` on the first three, or inheriting from a parent — **admin scopes do
+not inherit, and have no `*`**).
 
-```python
-# Check if user has any of the roles
-if has_any_role(user, "Admin", "Faculty"):
-    # Do something
+`allowedAppRoles` on a resource is a *derived, display-only* projection. It never
+grants anything on its own. A "which roles can use this?" picker must write
+through to each role's `granted*` list.
 
-# Check if user has all of the roles
-if has_all_roles(user, "Admin", "Security"):
-    # Do something critical
-```
+## Gotchas
 
-## HTTP Status Codes
+- **The roles UI has no free-text entry.** Its grant controls are built from
+  resource catalogs, so an id that is not a catalog entry cannot be granted from
+  the UI at all. This is what made the earlier `skills` and `scheduled-runs`
+  capability gates inoperable. A new grant axis needs its own registry and its
+  own control — that is why `admin_scopes.py` exists.
+- **The permission cache is per-process.** `bump_roles_version()` is an
+  in-process counter, not distributed, so a revoked grant can survive up to the
+  5-minute TTL on ECS tasks that did not serve the mutation.
+- **`SKIP_AUTH=true`** (local dev only) returns a fake user whose roles come from
+  `SKIP_AUTH_ROLES`. Those roles still have to resolve through the AppRole table
+  for `require_admin` to pass. `app_api/main.py` refuses to boot if this is
+  combined with deployed-environment indicators.
 
-- **200**: Success
-- **401**: No token or invalid token
-- **403**: Valid token but insufficient roles
+## Where things live
 
-## Error Responses
-
-```json
-// 401 Unauthorized
-{
-  "detail": "Authentication required. Please provide a valid Bearer token in the Authorization header."
-}
-
-// 403 Forbidden
-{
-  "detail": "Access denied. Required roles: Admin, SuperAdmin"
-}
-```
-
-## Testing with curl
-
-```bash
-# With JWT token
-curl -H "Authorization: Bearer YOUR_TOKEN_HERE" \
-  http://localhost:8000/admin/me
-
-# Check if endpoint is protected (should return 401)
-curl http://localhost:8000/admin/me
-```
-
-## Common Roles in System
-
-Common roles configured in the OIDC auth providers:
-
-- `Admin` / `SuperAdmin` - Administrative access
-- `Faculty` - Faculty member
-- `Staff` - Staff member
-- `PSSTUCURTERM` - Current student
-- `DotNetDevelopers` - Developer access
-- `All-Students Entra Sync` - All students
-- `All-Employees Entra Sync` - All employees
-- `AWS-BoiseStateAI` - AWS AI platform access
-
-## Creating Custom Role Checker
-
-```python
-# In your routes file
-require_student = require_roles("PSSTUCURTERM", "All-Students Entra Sync")
-
-@router.get("/student-portal")
-async def student_portal(student: User = Depends(require_student)):
-    return {"message": "Student access granted"}
-```
-
-## Logging Best Practice
-
-```python
-import logging
-logger = logging.getLogger(__name__)
-
-@router.post("/admin/action")
-async def admin_action(admin: User = Depends(require_admin)):
-    logger.info(f"Admin action performed by {admin.email} ({admin.user_id})")
-    # ... perform action
-    return {"success": True}
-```
-
-## Development Mode
-
-Disable authentication for local testing:
-
-```bash
-# .env
-ENABLE_AUTHENTICATION=false
-```
-
-**Warning:** This returns an anonymous user with **no roles**, so role-protected endpoints will still return 403.
+| Concern | File |
+|---|---|
+| Dependencies (`require_*`) | `apis/shared/auth/rbac.py` |
+| Session authentication | `apis/shared/auth/dependencies.py` |
+| Runtime resolution + merge | `apis/shared/rbac/service.py` |
+| Role CRUD + effective permissions | `apis/shared/rbac/admin_service.py` |
+| Mutation constraints | `apis/shared/rbac/role_constraints.py` |
+| Admin scope registry | `apis/shared/rbac/admin_scopes.py` |
+| DynamoDB item shapes | `apis/shared/rbac/repository.py` |

--- a/backend/src/apis/shared/auth/__init__.py
+++ b/backend/src/apis/shared/auth/__init__.py
@@ -3,7 +3,7 @@
 from .dependencies import get_current_user_from_session, security
 from .models import User
 from .state_store import StateStore, InMemoryStateStore, DynamoDBStateStore, create_state_store
-from .rbac import require_app_roles, require_admin
+from .rbac import require_app_roles, require_admin, require_admin_scope
 
 __all__ = [
     "get_current_user_from_session",
@@ -15,4 +15,5 @@ __all__ = [
     "create_state_store",
     "require_app_roles",
     "require_admin",
+    "require_admin_scope",
 ]

--- a/backend/src/apis/shared/auth/rbac.py
+++ b/backend/src/apis/shared/auth/rbac.py
@@ -67,9 +67,69 @@ def require_app_roles(*required_app_roles: str) -> Callable:
     return checker
 
 
+def require_admin_scope(scope: str) -> Callable:
+    """
+    Create a dependency guarding one delegated admin surface.
+
+    A user passes if they hold the ``system_admin`` AppRole (the superuser
+    satisfies every scope implicitly, so this is a no-op change for existing
+    admins) *or* if any of their roles grants ``scope``.
+
+    Takes a **single** scope, deliberately — ``require_app_roles(*roles)`` is OR
+    logic, but an OR across admin scopes has no legitimate use here and would
+    defeat the route-coverage test in ``tests/architecture/test_admin_scope_coverage.py``,
+    which reads one scope per admin route.
+
+    Fails closed: if permission resolution raises, access is denied.
+
+    Args:
+        scope: An id from ``apis.shared.rbac.admin_scopes.ADMIN_SCOPES``.
+
+    Returns:
+        A FastAPI dependency that validates the scope and returns the User.
+
+    Raises:
+        HTTPException: 403 if the user holds neither system_admin nor the scope.
+    """
+    async def checker(user: User = Depends(get_current_user_from_session)) -> User:
+        from apis.shared.rbac.service import get_app_role_service
+
+        try:
+            service = get_app_role_service()
+            permissions = await service.resolve_user_permissions(user)
+
+            if "system_admin" in permissions.app_roles:
+                return user
+
+            if scope in permissions.admin_scopes:
+                logger.debug(
+                    f"User {user.name} authorized for admin scope {scope}"
+                )
+                return user
+        except Exception:
+            logger.exception(
+                f"Failed to resolve admin scope {scope} for {user.name}, denying access"
+            )
+
+        logger.warning(
+            f"User {user.name} (jwt_roles: {user.roles}) denied access — "
+            f"required admin scope: {scope}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied.",
+        )
+
+    return checker
+
+
 # ---------------------------------------------------------------------------
 # Predefined checkers
 # ---------------------------------------------------------------------------
 
-# Admin access — any JWT group mapped to the "system_admin" AppRole.
+# Full admin access — any JWT group mapped to the "system_admin" AppRole.
+#
+# Reserved for the two surfaces that can never be delegated: role administration
+# and auth-provider configuration (see `rbac/admin_scopes.py` for why the latter
+# belongs in that set). Every other admin surface uses `require_admin_scope`.
 require_admin = require_app_roles("system_admin")

--- a/backend/src/apis/shared/rbac/admin_service.py
+++ b/backend/src/apis/shared/rbac/admin_service.py
@@ -9,7 +9,12 @@ from .models import AppRole, EffectivePermissions, AppRoleCreate, AppRoleUpdate
 from .repository import AppRoleRepository
 from .cache import AppRoleCache, get_app_role_cache
 from .admin_scopes import normalize_scopes
-from .role_constraints import validate_admin_scopes, validate_jwt_role_mappings
+from .role_constraints import (
+    RoleMutationForbidden,
+    is_protected_role,
+    validate_admin_scopes,
+    validate_jwt_role_mappings,
+)
 from .version import bump_roles_version
 
 logger = logging.getLogger(__name__)
@@ -34,6 +39,23 @@ class AppRoleAdminService:
         """Initialize admin service with repository and cache."""
         self.repository = repository or AppRoleRepository()
         self.cache = cache or get_app_role_cache()
+        self._perm_service = None
+
+    def _permission_service(self):
+        """A resolver sharing *this* service's repository and cache.
+
+        Deliberately not ``get_app_role_service()``: that global singleton
+        builds its own repository, which would bypass this instance's injected
+        one — real DynamoDB traffic from a unit test, and two different views of
+        the same data in any caller that injects a repository on purpose.
+        """
+        if self._perm_service is None:
+            from .service import AppRoleService
+
+            self._perm_service = AppRoleService(
+                repository=self.repository, cache=self.cache
+            )
+        return self._perm_service
 
     # =========================================================================
     # CRUD Operations
@@ -133,6 +155,9 @@ class AppRoleAdminService:
         existing = await self.repository.get_role(role_id)
         if not existing:
             return None
+
+        # Who may touch *this* role at all — see the method docstring.
+        await self._assert_actor_may_mutate(existing, admin)
 
         # System role protection
         if existing.is_system_role and role_id == "system_admin":
@@ -325,6 +350,70 @@ class AppRoleAdminService:
             skills=list(all_skills),
             quota_tier=None,  # Quota tier comes from direct configuration
             admin_scopes=normalize_scopes(role.granted_admin_scopes),
+        )
+
+    async def _assert_actor_may_mutate(self, role: AppRole, actor: User) -> None:
+        """Gate mutation of admin-bearing roles to ``system_admin``.
+
+        ``update_role`` is not only reached from the roles admin. The tool,
+        model, and skill admin pages each offer a "which roles can use this?"
+        picker that writes *through* into role records — ``set_roles_for_tool``,
+        ``set_roles_for_model``, ``set_roles_for_skill`` all land here. That is
+        by design: granting a tool is a tool-admin's job.
+
+        What is not their job is touching a role that carries administrative
+        power. Without this guard a delegated ``admin.tools`` holder could add a
+        tool grant to ``system_admin`` — or to any role carrying
+        ``grantedAdminScopes`` — from a surface that was never meant to
+        administer roles.
+
+        So: if the target role is protected or scope-bearing, the actor must
+        hold ``system_admin``. Everything else is untouched, which keeps the
+        legitimate case (a tools admin granting a tool to ``faculty``) working.
+
+        This sits in ``update_role`` rather than in the three write-through
+        callers so that any *future* resource surface that grows a role picker
+        inherits the guard instead of having to remember it.
+
+        Fails closed: if permission resolution raises, the mutation is denied.
+
+        Raises:
+            RoleMutationForbidden: if the actor lacks ``system_admin`` and the
+                target role is protected or carries admin scopes.
+        """
+        sensitive = is_protected_role(role.role_id) or bool(role.granted_admin_scopes)
+        if not sensitive:
+            return
+
+        try:
+            permissions = await self._permission_service().resolve_user_permissions(
+                actor
+            )
+            if "system_admin" in permissions.app_roles:
+                return
+        except Exception:
+            logger.exception(
+                "Failed to resolve permissions for %s while gating a mutation of "
+                "role %s, denying",
+                actor.user_id,
+                role.role_id,
+            )
+            raise RoleMutationForbidden(
+                "Unable to verify permissions for this change."
+            )
+
+        logger.warning(
+            "Blocked non-system_admin mutation of admin-bearing role %s",
+            role.role_id,
+            extra={
+                "event": "role_mutation_blocked",
+                "role_id": role.role_id,
+                "actor_user_id": actor.user_id,
+            },
+        )
+        raise RoleMutationForbidden(
+            f"Role '{role.role_id}' grants administrative access and can only "
+            "be modified by a system administrator."
         )
 
     async def _validate_inheritance(self, inherits_from: List[str]):

--- a/backend/src/apis/shared/rbac/role_constraints.py
+++ b/backend/src/apis/shared/rbac/role_constraints.py
@@ -65,6 +65,18 @@ class RoleConstraintError(ValueError):
     """Raised when a role mutation violates a security constraint."""
 
 
+class RoleMutationForbidden(Exception):
+    """Raised when the *actor* is not permitted to mutate a particular role.
+
+    Distinct from :class:`RoleConstraintError` (which is about the *content* of
+    a mutation) because this one is an authorization failure and must surface
+    as a 403, not a 400. Deliberately not a ``ValueError``: the resource admin
+    routes that can trigger a write-through catch ``ValueError`` and map it to
+    400, which would misreport a denied privilege escalation as a bad request.
+    ``app_api.main`` registers a handler that maps this to 403.
+    """
+
+
 def _is_forbidden_for_protected(value: str) -> bool:
     return value.strip().lower() in _FORBIDDEN_PROTECTED_MAPPINGS
 

--- a/backend/src/apis/shared/security/__init__.py
+++ b/backend/src/apis/shared/security/__init__.py
@@ -18,6 +18,7 @@ from apis.shared.security.ownership import (
 )
 from apis.shared.security.error_handler import (
     register_aws_client_error_handler,
+    register_role_mutation_forbidden_handler,
     register_safe_500_handler,
     register_validation_error_handler,
 )

--- a/backend/src/apis/shared/security/error_handler.py
+++ b/backend/src/apis/shared/security/error_handler.py
@@ -124,3 +124,33 @@ def register_safe_500_handler(app: Any) -> None:
         return JSONResponse(status_code=500, content={"detail": _GENERIC_INTERNAL_ERROR})
 
     app.add_exception_handler(Exception, _handler)
+
+
+def register_role_mutation_forbidden_handler(app: Any) -> None:
+    """Install a FastAPI handler mapping ``RoleMutationForbidden`` to 403.
+
+    Raised when a delegated admin tries to mutate a role that carries
+    administrative power (a protected role, or one with ``grantedAdminScopes``)
+    from a resource surface such as the tool/model/skill role pickers.
+
+    It needs its own handler because those routes catch ``ValueError`` and map
+    it to 400 — a denied privilege escalation reported as "bad request" is both
+    misleading to the caller and invisible in a 4xx-by-status dashboard. The
+    exception's message is safe to return: it names only the role id the caller
+    just submitted, and the escalation is denied either way.
+    """
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    from apis.shared.rbac.role_constraints import RoleMutationForbidden
+
+    async def _handler(request: Request, exc: RoleMutationForbidden) -> JSONResponse:
+        logger.warning(
+            "Role mutation forbidden on %s %s: %s",
+            request.method,
+            request.url.path,
+            exc,
+        )
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    app.add_exception_handler(RoleMutationForbidden, _handler)

--- a/backend/tests/apis/app_api/admin/auth_providers/test_cognito_redirect_uri.py
+++ b/backend/tests/apis/app_api/admin/auth_providers/test_cognito_redirect_uri.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from apis.shared.auth.models import User
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ def _create_app(admin_user: User) -> FastAPI:
     admin_router = APIRouter(prefix="/admin")
     admin_router.include_router(router)
     app.include_router(admin_router)
-    app.dependency_overrides[require_admin] = lambda: admin_user
+    override_admin_auth(app, lambda: admin_user)
     return app
 
 

--- a/backend/tests/apis/app_api/admin/test_mantle_models_route.py
+++ b/backend/tests/apis/app_api/admin/test_mantle_models_route.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.auth.models import User
 
 from apis.app_api.admin import routes as admin_routes
@@ -29,7 +30,7 @@ def _admin() -> User:
 def client() -> TestClient:
     app = FastAPI()
     app.include_router(admin_routes.router)
-    app.dependency_overrides[require_admin] = _admin
+    override_admin_auth(app, _admin)
     return TestClient(app)
 
 

--- a/backend/tests/apis/app_api/skills/test_admin_skill_routes.py
+++ b/backend/tests/apis/app_api/skills/test_admin_skill_routes.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.rbac.models import AppRoleCreate
 from apis.app_api.admin.skills import routes as skill_routes
 
@@ -18,7 +19,7 @@ def client(skill_service, admin_user, monkeypatch):
     monkeypatch.setattr(skill_routes, "get_skill_catalog_service", lambda: skill_service)
     app = FastAPI()
     app.include_router(skill_routes.router)
-    app.dependency_overrides[require_admin] = lambda: admin_user
+    override_admin_auth(app, lambda: admin_user)
     return TestClient(app)
 
 

--- a/backend/tests/apis/app_api/skills/test_skill_resource_routes.py
+++ b/backend/tests/apis/app_api/skills/test_skill_resource_routes.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.app_api.admin.skills import routes as skill_routes
 from apis.app_api.skills import service as skill_service_module
 
@@ -24,7 +25,7 @@ def client(skill_service, admin_user, monkeypatch):
     )
     app = FastAPI()
     app.include_router(skill_routes.router)
-    app.dependency_overrides[require_admin] = lambda: admin_user
+    override_admin_auth(app, lambda: admin_user)
     return TestClient(app)
 
 

--- a/backend/tests/apis/app_api/test_export_target_adapters_admin.py
+++ b/backend/tests/apis/app_api/test_export_target_adapters_admin.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.auth.models import User
 from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
 
@@ -196,7 +197,7 @@ class TestListExportTargetAdaptersEndpoint:
     def client(self) -> TestClient:
         app = FastAPI()
         app.include_router(adapter_routes.router)
-        app.dependency_overrides[require_admin] = _admin
+        override_admin_auth(app, _admin)
         return TestClient(app)
 
     def test_lists_shipped_adapters(self, client: TestClient, registered_stub):

--- a/backend/tests/apis/app_api/test_file_source_adapters_admin.py
+++ b/backend/tests/apis/app_api/test_file_source_adapters_admin.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.auth.models import User
 from apis.shared.oauth.models import OAuthProvider, OAuthProviderType
 
@@ -92,7 +93,7 @@ class TestListFileSourceAdaptersEndpoint:
     def client(self) -> TestClient:
         app = FastAPI()
         app.include_router(adapter_routes.router)
-        app.dependency_overrides[require_admin] = _admin
+        override_admin_auth(app, _admin)
         return TestClient(app)
 
     def test_lists_shipped_adapters(self, client: TestClient):

--- a/backend/tests/architecture/test_admin_scope_coverage.py
+++ b/backend/tests/architecture/test_admin_scope_coverage.py
@@ -1,0 +1,216 @@
+"""Every admin route is governed by exactly one known admin scope.
+
+The regression this exists to prevent: someone adds a route under ``/admin``
+and forgets the scope, leaving it reachable by *every* delegated admin. That
+failure is silent — the route works, the tests pass, and the hole is only
+visible by reading the dependency.
+
+So rather than trusting review, this walks the mounted admin router and asserts
+every route resolves to either a registry scope or one of the two explicitly
+non-delegable modules.
+
+See ``docs/specs/granular-admin-permissions.md`` §6.3.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+
+import pytest
+
+from apis.shared.rbac.admin_scopes import (
+    ALL_SCOPE_IDS,
+    NON_DELEGABLE_SCOPES,
+)
+
+ADMIN_SRC = (
+    pathlib.Path(__file__).resolve().parents[2] / "src" / "apis" / "app_api" / "admin"
+)
+
+# The only modules permitted to guard routes with bare `require_admin`.
+# Both are non-delegable by design; see the module docstrings on each.
+NON_DELEGABLE_MODULES = {
+    "roles/routes.py",
+    "auth_providers/routes.py",
+}
+
+# Scope claimed by each router module. `roles/agent_pins.py` is the one place
+# the directory-boundary heuristic doesn't hold: it mounts under the /roles
+# prefix but is marketplace functionality, guarded by require_marketplace_admin.
+EXPECTED_MODULE_SCOPES = {
+    "routes.py": "admin.models",
+    "quota/routes.py": "admin.quota",
+    "costs/routes.py": "admin.costs",
+    "users/routes.py": "admin.users",
+    "tools/routes.py": "admin.tools",
+    "skills/routes.py": "admin.skills",
+    "agents/routes.py": "admin.marketplace",
+    "oauth/routes.py": "admin.connectors",
+    "file_sources/routes.py": "admin.file_sources",
+    "export_targets/routes.py": "admin.export_targets",
+    "user_menu_links/routes.py": "admin.user_menu_links",
+    "system_prompts/routes.py": "admin.system_prompts",
+    "fine_tuning/routes.py": "admin.fine_tuning",
+}
+
+# Each admin package names its dependency after its area (mirroring the
+# pre-existing `require_marketplace_admin`), so tests and readers have a
+# stable public handle instead of a private `_require`.
+_SCOPE_DECL = re.compile(r'^require_\w+\s*=\s*require_admin_scope\(\s*"([^"]+)"\s*\)', re.M)
+
+
+def _admin_route_modules() -> list[pathlib.Path]:
+    """Every module under app_api/admin/ that declares an APIRouter."""
+    return sorted(
+        p
+        for p in ADMIN_SRC.rglob("*.py")
+        if "__pycache__" not in p.parts
+        and "APIRouter(" in p.read_text()
+    )
+
+
+def _rel(path: pathlib.Path) -> str:
+    return str(path.relative_to(ADMIN_SRC))
+
+
+# ---------------------------------------------------------------------------
+# Static checks — hold regardless of which feature flags are on, because they
+# read the source tree rather than the mounted router. `skills`, `fine_tuning`,
+# and the marketplace are conditionally mounted.
+# ---------------------------------------------------------------------------
+
+
+def test_every_router_module_is_accounted_for() -> None:
+    """A new admin router package must be classified, not silently ungoverned."""
+    found = {_rel(p) for p in _admin_route_modules()}
+    known = set(EXPECTED_MODULE_SCOPES) | NON_DELEGABLE_MODULES | {
+        "roles/agent_pins.py",  # inherits admin.marketplace via the wrapper
+    }
+
+    assert found == known, (
+        "Admin router modules changed. Every module must either declare an "
+        "admin scope or be explicitly non-delegable.\n"
+        f"  unclassified: {sorted(found - known)}\n"
+        f"  missing:      {sorted(known - found)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "module,expected", sorted(EXPECTED_MODULE_SCOPES.items())
+)
+def test_module_declares_its_expected_scope(module: str, expected: str) -> None:
+    source = (ADMIN_SRC / module).read_text()
+    declared = _SCOPE_DECL.findall(source)
+
+    assert declared == [expected], (
+        f"{module} should declare exactly one scope ({expected}), found {declared}"
+    )
+
+
+@pytest.mark.parametrize("module", sorted(EXPECTED_MODULE_SCOPES))
+def test_scoped_module_does_not_use_bare_require_admin(module: str) -> None:
+    """A scoped package must not also hold a full-admin dependency."""
+    source = (ADMIN_SRC / module).read_text()
+    stripped = source.replace("require_admin_scope", "")
+
+    assert "require_admin" not in stripped, (
+        f"{module} is scope-governed but still references bare require_admin"
+    )
+
+
+@pytest.mark.parametrize("module", sorted(NON_DELEGABLE_MODULES))
+def test_non_delegable_module_uses_require_admin(module: str) -> None:
+    source = (ADMIN_SRC / module).read_text()
+    stripped = source.replace("require_admin_scope", "")
+
+    assert "require_admin" in stripped, f"{module} must keep bare require_admin"
+    assert not _SCOPE_DECL.findall(source), (
+        f"{module} is non-delegable and must not declare an admin scope"
+    )
+
+
+def test_declared_scopes_are_all_known_and_delegable() -> None:
+    for module, scope in EXPECTED_MODULE_SCOPES.items():
+        assert scope in ALL_SCOPE_IDS, f"{module} declares unknown scope {scope}"
+        assert scope not in NON_DELEGABLE_SCOPES, (
+            f"{module} declares non-delegable scope {scope} — a route guarded by "
+            "a non-delegable scope would be unreachable by anyone but system_admin, "
+            "which is what bare require_admin is for"
+        )
+
+
+def test_every_delegable_scope_is_claimed_by_a_module() -> None:
+    """Catches a scope that outlives its router and becomes a grantable no-op.
+
+    Asserted against the source tree rather than the mounted app so it still
+    holds when SKILLS_ENABLED / FINE_TUNING_ENABLED are off.
+    """
+    claimed = set(EXPECTED_MODULE_SCOPES.values())
+    delegable = ALL_SCOPE_IDS - NON_DELEGABLE_SCOPES
+
+    assert delegable == claimed, (
+        "Every delegable scope must govern at least one router module.\n"
+        f"  granted but unused: {sorted(delegable - claimed)}\n"
+        f"  used but unlisted:  {sorted(claimed - delegable)}"
+    )
+
+
+def test_agent_pins_inherits_the_marketplace_scope() -> None:
+    """The one documented exception to the directory-boundary rule."""
+    source = (ADMIN_SRC / "roles" / "agent_pins.py").read_text()
+
+    assert "require_marketplace_admin" in source
+    assert not _SCOPE_DECL.findall(source), (
+        "agent_pins.py should inherit the marketplace scope through "
+        "require_marketplace_admin, not declare its own"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime check — walk the routes actually mounted in this configuration.
+# ---------------------------------------------------------------------------
+
+
+def test_every_mounted_admin_route_has_a_scope_dependency() -> None:
+    """No route under /admin may be reachable without a scope or full-admin check.
+
+    This is the backstop for the static checks: it catches a handler that
+    declares no auth dependency at all, which no amount of module-level
+    grepping would notice.
+    """
+    from apis.app_api.admin.routes import router as admin_router
+
+    ungoverned = []
+
+    for route in admin_router.routes:
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            continue
+
+        sources = []
+        for dep in dependant.dependencies:
+            call = dep.call
+            if call is None:
+                continue
+            try:
+                sources.append(inspect.getsource(call))
+            except (OSError, TypeError):
+                sources.append(getattr(call, "__qualname__", ""))
+
+        blob = "\n".join(sources)
+        # `checker` is the closure returned by require_app_roles /
+        # require_admin_scope; require_marketplace_admin wraps one of them.
+        governed = (
+            "resolve_user_permissions" in blob
+            or "require_marketplace_admin" in blob
+            or "agent_marketplace_enabled" in blob
+        )
+        if not governed:
+            ungoverned.append(f"{sorted(route.methods)} {route.path}")
+
+    assert not ungoverned, (
+        "Admin routes with no authorization dependency:\n  "
+        + "\n  ".join(sorted(ungoverned))
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -118,3 +118,83 @@ def _clear_env_config_bleed():
         for k, v in saved.items():
             os.environ[k] = v
 
+
+
+# ---------------------------------------------------------------------------
+# Admin authorization overrides
+# ---------------------------------------------------------------------------
+#
+# Admin routes are no longer guarded by a single `require_admin`: each admin
+# router package declares its own `require_admin_scope(...)` dependency
+# (delegated admin scopes, docs/specs/granular-admin-permissions.md). A test
+# that mounts the root admin router therefore has several distinct dependency
+# objects to satisfy, and overriding `require_admin` alone silently 401s.
+#
+# `override_admin_auth` overrides all of them at once, so a new admin area is
+# covered automatically instead of breaking every route test that mounts the
+# root router.
+
+
+# The closures returned by the dependency factories in
+# `apis/shared/auth/rbac.py`. Matching on qualname rather than importing the
+# module-level names is deliberate: `test_skills_feature_flag.py` reloads
+# `apis.app_api.admin.routes`, which rebuilds every `require_*_admin` object in
+# it. A test app built before that reload still holds the *old* dependency
+# objects, so an import-based override list silently stops matching and every
+# request 401s. Reading the dependencies off the app can't go stale.
+_AUTH_CHECKER_QUALNAMES = frozenset(
+    {
+        "require_app_roles.<locals>.checker",   # includes require_admin
+        "require_admin_scope.<locals>.checker",
+    }
+)
+
+
+def _walk_dependants(dependant):
+    """Yield a route's dependency tree, sub-dependencies included."""
+    for dep in dependant.dependencies:
+        yield dep
+        yield from _walk_dependants(dep)
+
+
+def override_admin_auth(app, impl) -> None:
+    """Point every admin authorization dependency on ``app`` at ``impl``.
+
+    Walks the app's own routes, so it covers whichever admin areas the test
+    mounted and picks up new ones for free.
+
+    Note it targets only the *authorization closures*, not wrappers built on
+    them. `require_marketplace_admin` is a wrapper that also enforces the
+    AGENT_MARKETPLACE_ENABLED kill switch (404 when off); overriding it would
+    authorize the caller *and* silently disable the kill switch, so a test
+    asserting the disabled behavior would sail straight past it. Overriding the
+    scope check it wraps leaves the wrapper running.
+
+    Args:
+        app: The FastAPI app under test.
+        impl: A zero-arg callable returning the User to inject — or one that
+            raises, to exercise the denied path.
+
+    Raises:
+        AssertionError: if the app exposes no authorization dependency at all,
+            which means the test would have 401'd for a non-obvious reason.
+    """
+    matched = 0
+
+    for route in app.routes:
+        dependant = getattr(route, "dependant", None)
+        if dependant is None:
+            continue
+        for dep in _walk_dependants(dependant):
+            call = dep.call
+            if call is None:
+                continue
+            if getattr(call, "__qualname__", "") in _AUTH_CHECKER_QUALNAMES:
+                app.dependency_overrides[call] = impl
+                matched += 1
+
+    assert matched, (
+        "override_admin_auth found no authorization dependency on this app — "
+        "did the router fail to mount, or was the app built before a module "
+        "reload replaced its dependencies?"
+    )

--- a/backend/tests/fine_tuning/test_admin_routes.py
+++ b/backend/tests/fine_tuning/test_admin_routes.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from apis.shared.auth.models import User
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.rbac import require_admin
+from tests.conftest import override_admin_auth
 from apis.app_api.fine_tuning.repository import FineTuningAccessRepository
 
 
@@ -28,7 +29,7 @@ def _create_app():
 
 def _override_auth(app: FastAPI, user: User):
     app.dependency_overrides[get_current_user_from_session] = lambda: user
-    app.dependency_overrides[require_admin] = lambda: user
+    override_admin_auth(app, lambda: user)
 
 
 def _override_repo(app: FastAPI, repo: MagicMock):
@@ -80,7 +81,7 @@ class TestListAccess:
 
         def _raise_403():
             raise HTTPException(status_code=403, detail="Forbidden")
-        app.dependency_overrides[require_admin] = _raise_403
+        override_admin_auth(app, _raise_403)
 
         client = TestClient(app)
         resp = client.get("/admin/fine-tuning/access")
@@ -130,7 +131,7 @@ class TestGrantAccess:
 
         def _raise_403():
             raise HTTPException(status_code=403, detail="Forbidden")
-        app.dependency_overrides[require_admin] = _raise_403
+        override_admin_auth(app, _raise_403)
 
         client = TestClient(app)
         resp = client.post(
@@ -305,7 +306,7 @@ class TestListAllJobs:
 
         def _raise_403():
             raise HTTPException(status_code=403, detail="Forbidden")
-        app.dependency_overrides[require_admin] = _raise_403
+        override_admin_auth(app, _raise_403)
 
         client = TestClient(app)
         resp = client.get("/admin/fine-tuning/jobs")
@@ -377,7 +378,7 @@ class TestListAllInferenceJobs:
 
         def _raise_403():
             raise HTTPException(status_code=403, detail="Forbidden")
-        app.dependency_overrides[require_admin] = _raise_403
+        override_admin_auth(app, _raise_403)
 
         client = TestClient(app)
         resp = client.get("/admin/fine-tuning/inference-jobs")

--- a/backend/tests/rbac/test_admin_scope_enforcement.py
+++ b/backend/tests/rbac/test_admin_scope_enforcement.py
@@ -1,0 +1,298 @@
+"""Enforcement of delegated admin scopes.
+
+PR-2 of ``docs/specs/granular-admin-permissions.md``. Covers the authorization
+dependency and the write-through guard that stops a delegated admin from
+reaching an admin-bearing role through a resource surface.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from apis.shared.auth.models import User
+from apis.shared.auth.rbac import require_admin_scope
+from apis.shared.rbac.admin_service import AppRoleAdminService
+from apis.shared.rbac.models import AppRoleUpdate, UserEffectivePermissions
+from apis.shared.rbac.role_constraints import RoleMutationForbidden
+
+
+def _user(user_id: str = "u-1") -> User:
+    return User(
+        email=f"{user_id}@example.com",
+        user_id=user_id,
+        name=user_id,
+        roles=["SomeGroup"],
+    )
+
+
+def _permissions(app_roles: list[str], admin_scopes: list[str]) -> UserEffectivePermissions:
+    return UserEffectivePermissions(
+        user_id="u-1",
+        app_roles=app_roles,
+        tools=[],
+        models=[],
+        quota_tier=None,
+        resolved_at="2026-07-27T00:00:00Z",
+        admin_scopes=admin_scopes,
+    )
+
+
+def _service_returning(permissions) -> AsyncMock:
+    svc = AsyncMock()
+    if isinstance(permissions, Exception):
+        svc.resolve_user_permissions = AsyncMock(side_effect=permissions)
+    else:
+        svc.resolve_user_permissions = AsyncMock(return_value=permissions)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# require_admin_scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_holder_is_authorized() -> None:
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(_permissions(["content_admin"], ["admin.tools"]))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        assert await checker(user=_user()) is not None
+
+
+@pytest.mark.asyncio
+async def test_system_admin_satisfies_every_scope() -> None:
+    """The superuser holds no scopes explicitly and must still pass."""
+    svc = _service_returning(_permissions(["system_admin"], []))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        for scope in ("admin.tools", "admin.costs", "admin.marketplace"):
+            checker = require_admin_scope(scope)
+            assert await checker(user=_user()) is not None
+
+
+@pytest.mark.asyncio
+async def test_holder_of_a_different_scope_is_denied() -> None:
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(_permissions(["content_admin"], ["admin.skills"]))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=_user())
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_user_with_no_scopes_is_denied() -> None:
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(_permissions(["faculty"], []))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=_user())
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_denial_detail_does_not_name_the_scope() -> None:
+    """Don't hand an unauthorized caller the vocabulary of the permission model."""
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(_permissions(["faculty"], []))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=_user())
+
+    assert "admin.tools" not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_when_resolution_raises() -> None:
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(RuntimeError("dynamo is down"))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=_user())
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_wildcard_scope_grants_nothing() -> None:
+    """A stray `"*"` in a role's scopes must not act as a superuser grant."""
+    checker = require_admin_scope("admin.tools")
+    svc = _service_returning(_permissions(["odd_role"], ["*"]))
+
+    with patch("apis.shared.rbac.service.get_app_role_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=_user())
+
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Write-through guard (spec I3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service(mock_app_role_repo, mock_app_role_cache) -> AppRoleAdminService:
+    return AppRoleAdminService(repository=mock_app_role_repo, cache=mock_app_role_cache)
+
+
+def _wire_roles(mock_app_role_repo, roles: dict, actor_role_id: str) -> None:
+    """Serve `roles` by id, and resolve the actor's JWT group to `actor_role_id`.
+
+    Exercises the real resolution path — the guard shares this service's
+    injected repository rather than reaching for the global singleton, so a
+    unit test can wire the actor's identity the same way production resolves it.
+    """
+    mock_app_role_repo.get_role.side_effect = lambda rid: roles.get(rid)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda jwt: (
+        [actor_role_id] if jwt == "SomeGroup" else []
+    )
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_cannot_grant_into_a_scope_bearing_role(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    """The escalation this guard exists for.
+
+    A delegated `admin.tools` holder uses the tool page's role picker to add a
+    tool to a role that carries admin scopes. Granting tools is their job;
+    touching an admin-bearing role is not.
+    """
+    _wire_roles(
+        mock_app_role_repo,
+        {
+            "content_admin": make_app_role(
+                role_id="content_admin", granted_admin_scopes=["admin.skills"]
+            ),
+            "tool_admin": make_app_role(
+                role_id="tool_admin", admin_scopes=["admin.tools"]
+            ),
+        },
+        actor_role_id="tool_admin",
+    )
+
+    with pytest.raises(RoleMutationForbidden):
+        await service.update_role(
+            "content_admin",
+            AppRoleUpdate(granted_tools=["some_tool"]),
+            _user(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_cannot_grant_into_a_protected_role(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    _wire_roles(
+        mock_app_role_repo,
+        {
+            "system_admin": make_app_role(role_id="system_admin", is_system_role=True),
+            "tool_admin": make_app_role(
+                role_id="tool_admin", admin_scopes=["admin.tools"]
+            ),
+        },
+        actor_role_id="tool_admin",
+    )
+
+    with pytest.raises(RoleMutationForbidden):
+        await service.update_role(
+            "system_admin",
+            AppRoleUpdate(granted_tools=["some_tool"]),
+            _user(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_may_still_grant_into_an_ordinary_role(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    """The legitimate case must keep working — this is a tools admin's job."""
+    _wire_roles(
+        mock_app_role_repo,
+        {
+            "faculty": make_app_role(role_id="faculty"),
+            "tool_admin": make_app_role(
+                role_id="tool_admin", admin_scopes=["admin.tools"]
+            ),
+        },
+        actor_role_id="tool_admin",
+    )
+    mock_app_role_repo.update_role.side_effect = lambda r: r
+
+    updated = await service.update_role(
+        "faculty",
+        AppRoleUpdate(granted_tools=["some_tool"]),
+        _user(),
+    )
+
+    assert updated is not None
+    assert "some_tool" in updated.granted_tools
+
+
+@pytest.mark.asyncio
+async def test_system_admin_may_mutate_an_admin_bearing_role(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    """The guard must not lock the roles admin out of its own job."""
+    _wire_roles(
+        mock_app_role_repo,
+        {
+            "content_admin": make_app_role(
+                role_id="content_admin", granted_admin_scopes=["admin.skills"]
+            ),
+            "system_admin": make_app_role(role_id="system_admin", is_system_role=True),
+        },
+        actor_role_id="system_admin",
+    )
+    mock_app_role_repo.update_role.side_effect = lambda r: r
+
+    updated = await service.update_role(
+        "content_admin",
+        AppRoleUpdate(granted_tools=["some_tool"]),
+        _user(),
+    )
+
+    assert updated is not None
+
+
+@pytest.mark.asyncio
+async def test_write_through_guard_fails_closed(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    mock_app_role_repo.get_role.side_effect = lambda rid: (
+        make_app_role(role_id="content_admin", granted_admin_scopes=["admin.skills"])
+        if rid == "content_admin"
+        else None
+    )
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = RuntimeError("dynamo is down")
+
+    with pytest.raises(RoleMutationForbidden):
+        await service.update_role(
+            "content_admin",
+            AppRoleUpdate(granted_tools=["some_tool"]),
+            _user(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_ordinary_role_mutation_skips_permission_resolution(
+    service, mock_app_role_repo, make_app_role
+) -> None:
+    """The common path must not pay for an extra permission lookup."""
+    mock_app_role_repo.get_role.side_effect = lambda rid: make_app_role(role_id="faculty")
+    mock_app_role_repo.update_role.side_effect = lambda r: r
+
+    await service.update_role("faculty", AppRoleUpdate(granted_tools=["t"]), _user())
+
+    mock_app_role_repo.get_roles_for_jwt_role.assert_not_called()

--- a/backend/tests/rbac/test_admin_scopes.py
+++ b/backend/tests/rbac/test_admin_scopes.py
@@ -205,8 +205,17 @@ async def test_create_role_rejects_non_delegable_scope(service, admin) -> None:
 async def test_update_role_rejects_non_delegable_scope(
     service, mock_app_role_repo, make_app_role, admin
 ) -> None:
-    role = make_app_role(role_id="content_admin", granted_admin_scopes=["admin.skills"])
-    mock_app_role_repo.get_role.return_value = role
+    # The target already carries scopes, so the write-through guard applies:
+    # wire the actor to resolve as system_admin, which is who actually edits
+    # roles. Otherwise the guard denies before content validation is reached.
+    roles = {
+        "content_admin": make_app_role(
+            role_id="content_admin", granted_admin_scopes=["admin.skills"]
+        ),
+        "system_admin": make_app_role(role_id="system_admin", is_system_role=True),
+    }
+    mock_app_role_repo.get_role.side_effect = lambda rid: roles.get(rid)
+    mock_app_role_repo.get_roles_for_jwt_role.side_effect = lambda jwt: ["system_admin"]
 
     with pytest.raises(RoleConstraintError):
         await service.update_role(

--- a/backend/tests/routes/test_admin.py
+++ b/backend/tests/routes/test_admin.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 
 from apis.app_api.admin.routes import router
 from apis.shared.auth.rbac import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.models.models import ManagedModel
 from tests.routes.conftest import mock_auth_user, mock_no_auth
 
@@ -66,7 +67,7 @@ def app():
 
 def _override_require_admin(app: FastAPI, user):
     """Override the require_admin dependency to return the given user."""
-    app.dependency_overrides[require_admin] = lambda: user
+    override_admin_auth(app, lambda: user)
 
 
 def _override_require_admin_403(app: FastAPI):
@@ -79,7 +80,7 @@ def _override_require_admin_403(app: FastAPI):
             detail="Access denied.",
         )
 
-    app.dependency_overrides[require_admin] = _raise
+    override_admin_auth(app, _raise)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from apis.app_api.admin.agents.routes import router
 from apis.shared.assistants.models import AgentListing, Assistant, PublisherProfile
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 
 SERVICE_MODULE = "apis.app_api.agent_designer.services.listing_service"
 ADMIN_MODULE = "apis.app_api.admin.agents.routes"
@@ -50,8 +51,11 @@ def _listing(state="in_review", **overrides) -> AgentListing:
 def app(make_user):
     _app = FastAPI()
     _app.include_router(router, prefix="/admin")
-    _app.dependency_overrides[require_admin] = lambda: make_user(
-        user_id="admin-001", name="Sam Admin", roles=["system_admin"]
+    override_admin_auth(
+        _app,
+        lambda: make_user(
+            user_id="admin-001", name="Sam Admin", roles=["system_admin"]
+        ),
     )
     return _app
 

--- a/backend/tests/routes/test_admin_bedrock_models.py
+++ b/backend/tests/routes/test_admin_bedrock_models.py
@@ -24,6 +24,7 @@ from fastapi.testclient import TestClient
 
 from apis.app_api.admin.routes import router
 from apis.shared.auth.rbac import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.security import (
     register_aws_client_error_handler,
     register_validation_error_handler,
@@ -47,7 +48,7 @@ def app() -> FastAPI:
 
 def _admin_client(app: FastAPI, make_user) -> TestClient:
     user = make_user(roles=["system_admin"])
-    app.dependency_overrides[require_admin] = lambda: user
+    override_admin_auth(app, lambda: user)
     return TestClient(app)
 
 

--- a/backend/tests/routes/test_admin_lows.py
+++ b/backend/tests/routes/test_admin_lows.py
@@ -30,6 +30,7 @@ from apis.app_api.admin.fine_tuning.routes import (
 )
 from apis.app_api.admin.routes import router as admin_router
 from apis.shared.auth.rbac import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.security import (
     register_aws_client_error_handler,
     register_validation_error_handler,
@@ -60,7 +61,7 @@ def app(monkeypatch) -> FastAPI:
 
 def _admin(app: FastAPI, make_user) -> TestClient:
     user = make_user(roles=["system_admin"])
-    app.dependency_overrides[require_admin] = lambda: user
+    override_admin_auth(app, lambda: user)
     return TestClient(app)
 
 

--- a/backend/tests/routes/test_agent_pins.py
+++ b/backend/tests/routes/test_agent_pins.py
@@ -25,6 +25,7 @@ from apis.shared.assistants.models import (
     UserPinState,
 )
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from tests.routes.conftest import mock_auth_user
 
 PIN_SERVICE = "apis.app_api.agent_designer.services.pin_service"
@@ -72,7 +73,7 @@ def _flags_on(monkeypatch):
 @pytest.fixture
 def client(app, make_user):
     mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
-    app.dependency_overrides[require_admin] = lambda: make_user(user_id="admin-1")
+    override_admin_auth(app, lambda: make_user(user_id="admin-1"))
     return TestClient(app)
 
 

--- a/backend/tests/routes/test_agent_reports.py
+++ b/backend/tests/routes/test_agent_reports.py
@@ -23,6 +23,7 @@ from apis.app_api.admin.agents.routes import router as admin_router
 from apis.app_api.agent_designer.routes import router as agents_router
 from apis.shared.assistants.models import AgentListing, AgentReport, Assistant
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from tests.routes.conftest import mock_auth_user
 
 REPORT_SERVICE = "apis.app_api.agent_designer.services.report_service"
@@ -88,8 +89,9 @@ def _flags_on(monkeypatch):
 @pytest.fixture
 def client(app, make_user):
     mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
-    app.dependency_overrides[require_admin] = lambda: make_user(
-        user_id="admin-1", email="admin@example.edu"
+    override_admin_auth(
+        app,
+        lambda: make_user(user_id="admin-1", email="admin@example.edu"),
     )
     return TestClient(app)
 

--- a/backend/tests/routes/test_role_agent_pins.py
+++ b/backend/tests/routes/test_role_agent_pins.py
@@ -30,6 +30,7 @@ from apis.shared.assistants.models import (
     UserPinState,
 )
 from apis.shared.auth import require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.rbac.models import AppRole, EffectivePermissions, UserEffectivePermissions
 from tests.routes.conftest import mock_auth_user
 
@@ -137,7 +138,7 @@ def _flags_on(monkeypatch):
 @pytest.fixture
 def client(app, make_user):
     mock_auth_user(app, make_user(user_id="user-001", email="pat@example.edu"))
-    app.dependency_overrides[require_admin] = lambda: make_user(user_id="admin-1")
+    override_admin_auth(app, lambda: make_user(user_id="admin-1"))
     return TestClient(app)
 
 

--- a/backend/tests/shared/test_system_prompts_routes.py
+++ b/backend/tests/shared/test_system_prompts_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import get_current_user_from_session, require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.auth.models import User
 from apis.shared.system_prompts import repository as repo_module
 from apis.shared.system_prompts import service as service_module
@@ -80,7 +81,7 @@ _PAYLOAD = {
 def admin_client(system_prompts_table):
     app = _build_admin_app()
     admin = _make_user(roles=["system_admin"])
-    app.dependency_overrides[require_admin] = lambda: admin
+    override_admin_auth(app, lambda: admin)
     return TestClient(app)
 
 
@@ -170,8 +171,11 @@ class TestAdminRoutes:
         """Non-admin dependency raises 403 — verify route doesn't bypass it."""
         from fastapi import HTTPException
         app = _build_admin_app()
-        app.dependency_overrides[require_admin] = lambda: (_ for _ in ()).throw(
-            HTTPException(status_code=403, detail="Forbidden")
+        override_admin_auth(
+            app,
+            lambda: (_ for _ in ()).throw(
+                HTTPException(status_code=403, detail="Forbidden")
+            ),
         )
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.get("/admin/system-prompts/")
@@ -184,7 +188,7 @@ class TestUserRoutes:
         # Seed via admin
         admin_app = _build_admin_app()
         admin = _make_user(roles=["system_admin"])
-        admin_app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(admin_app, lambda: admin)
         admin_client = TestClient(admin_app)
         admin_client.post("/admin/system-prompts/", json=_PAYLOAD)
         admin_client.post("/admin/system-prompts/", json={**_PAYLOAD, "name": "Hidden", "status": "disabled"})

--- a/backend/tests/shared/test_user_menu_links_routes.py
+++ b/backend/tests/shared/test_user_menu_links_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from apis.shared.auth import get_current_user_from_session, require_admin
+from tests.conftest import override_admin_auth
 from apis.shared.auth.models import User
 from apis.shared.user_menu_links import repository as repo_module
 from apis.shared.user_menu_links import service as service_module
@@ -77,7 +78,7 @@ class TestAdminRoutes:
     def test_create_returns_201(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         resp = client.post(
@@ -92,7 +93,7 @@ class TestAdminRoutes:
     def test_create_rejects_non_http_url_with_422(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         resp = client.post(
@@ -104,7 +105,7 @@ class TestAdminRoutes:
     def test_create_missing_url_for_external_returns_422(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         resp = client.post(
@@ -119,7 +120,7 @@ class TestAdminRoutes:
         def _forbid():
             raise HTTPException(status_code=403, detail="Forbidden")
 
-        app.dependency_overrides[require_admin] = _forbid
+        override_admin_auth(app, _forbid)
 
         client = TestClient(app)
         resp = client.get("/admin/user-menu-links/")
@@ -128,7 +129,7 @@ class TestAdminRoutes:
     def test_list_then_get_round_trips(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         created = client.post(
@@ -147,7 +148,7 @@ class TestAdminRoutes:
     def test_get_missing_returns_404(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         resp = client.get("/admin/user-menu-links/does-not-exist")
@@ -156,7 +157,7 @@ class TestAdminRoutes:
     def test_update_returns_400_on_invariant_violation(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         created = client.post(
@@ -176,7 +177,7 @@ class TestAdminRoutes:
     def test_delete_returns_204_then_404(self, user_menu_links_table):
         app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(app, lambda: admin)
 
         client = TestClient(app)
         created = client.post(
@@ -200,7 +201,7 @@ class TestPublicRoute:
     def test_returns_only_enabled_links(self, user_menu_links_table):
         admin_app = _build_admin_app()
         admin = _make_user(email="admin@example.com", roles=["system_admin"])
-        admin_app.dependency_overrides[require_admin] = lambda: admin
+        override_admin_auth(admin_app, lambda: admin)
         admin_client = TestClient(admin_app)
 
         # Seed one enabled + one disabled link via the admin API.


### PR DESCRIPTION
**PR-2** of [`docs/specs/granular-admin-permissions.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/granular-admin-permissions.md). Follows #770 (data + registry) and #769 (decisions).

Makes the scopes added in PR-1 actually govern access. **Behavior for `system_admin` is unchanged** — the superuser satisfies every scope implicitly, and no role carries scopes yet. Full backend suite green: 5396 passed, 3 skipped.

## What this does

`require_admin_scope(scope)` in `apis/shared/auth/rbac.py`, and the migration of **13 admin router packages** to it — one scope per package, so the permission boundary is the package boundary. Each package names its dependency after its area (`require_tools_admin`, `require_costs_admin`, …), mirroring the pre-existing `require_marketplace_admin`.

`roles/` and `auth_providers/` keep bare `require_admin` and now carry module docstrings explaining why they can never be delegated. The second is the one that gets argued about: role resolution starts from JWT claims, so whoever controls IdP attribute mapping controls which AppRoles resolve at all.

## Write-through guard (spec I3)

The tool, model, and skill role pickers write *through* into role records — `set_roles_for_tool` and siblings all land in `AppRoleAdminService.update_role`. If the target role is protected or carries `grantedAdminScopes`, the actor must hold `system_admin`. Ordinary roles are untouched, so a tools admin granting a tool to `faculty` still works.

The check sits in `update_role` rather than the three callers so that a *future* resource surface that grows a role picker inherits it instead of having to remember. It raises `RoleMutationForbidden` → 403 through a new app-level handler — not `ValueError` → 400, which those routes already catch and which would misreport a denied privilege escalation as a bad request.

## The test that keeps this from rotting

`tests/architecture/test_admin_scope_coverage.py` walks the mounted admin router and fails if any route lacks an authorization dependency, if a scoped package reverts to bare `require_admin`, or if a registry scope governs nothing. Static checks read the source tree so they hold with `SKILLS_ENABLED` / `FINE_TUNING_ENABLED` off.

**I verified it actually fails.** Injecting an unguarded `/admin/costs/oops-unguarded` route → caught. Pointing `tools/routes.py` at a non-delegable scope → caught.

## Notes for review

**A latent test fragility surfaced.** `test_skills_feature_flag.py` reloads `apis.app_api.admin.routes`, rebuilding every dependency object in it. A test app built before that reload holds the *old* objects, so an import-based override list silently stops matching and every request 401s — order-dependent, invisible when the file runs alone. `require_admin` was immune only because it lives in a module nobody reloads. The new `override_admin_auth` helper reads dependencies off the app itself, so it can't go stale.

**`override_admin_auth` deliberately does not override `require_marketplace_admin`.** That wrapper is not just auth — it also enforces the `AGENT_MARKETPLACE_ENABLED` kill switch. Overriding it authorizes the caller *and* silently disables the kill switch; the test asserting 404-when-off got a 500 instead. It overrides the scope check the wrapper wraps, so the wrapper still runs.

**DI fix in `_assert_actor_may_mutate`.** It initially called the global `get_app_role_service()`, which builds its own repository — bypassing any injected one and issuing real DynamoDB calls from unit tests. It now resolves through a service built from the instance's own repository and cache.

## Not included

`docs/specs/granular-admin-permissions.md` §6.2 still describes the dependency as `_require` across "15 files"; it shipped as `require_<area>_admin` across 13. Left alone here to avoid conflicting with #769, which was in flight against the same file. Worth a small follow-up.

## Next

PR-3 (API surface: `adminScopes` on `/users/me/permissions`, registry endpoint) and PR-4 (SPA guards + nav filtering). Until PR-4, a scoped admin can reach the API but the SPA still gates `/admin` on `system_admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
