### PR TITLE
feat(rbac): gate the admin console on delegated scopes

### DIFF
--- a/frontend/ai.client/src/app/admin/admin-scope-wiring.spec.ts
+++ b/frontend/ai.client/src/app/admin/admin-scope-wiring.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * The admin console's scope wiring holds together.
+ *
+ * SPA counterpart to `tests/architecture/test_admin_scope_coverage.py`. Two
+ * silent failures this exists to catch:
+ *
+ *  1. An admin page added without `data.scope` — the guard denies it, so the
+ *     page becomes unreachable for *everyone* including full admins, with no
+ *     error anywhere.
+ *  2. A nav entry whose scope disagrees with its route's scope — the link shows
+ *     for someone the guard will bounce, which reads as a broken console.
+ */
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Routes, Route } from '@angular/router';
+import { signal } from '@angular/core';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { adminRoutes } from './admin.routes';
+import { AdminLayout } from './admin.layout';
+import { AdminMarketplaceService } from './marketplace/services/admin-marketplace.service';
+import { UserService } from '../auth/user.service';
+import { ADMIN_SCOPE_IDS } from './admin-scope.model';
+import { adminScopeGuard } from '../auth/admin-scope.guard';
+
+/**
+ * Routes that legitimately carry no scope: pure redirects (which resolve to a
+ * guarded target) and the landing route (which has its own guard and always
+ * redirects).
+ */
+function isExempt(route: Route): boolean {
+  return route.redirectTo !== undefined || route.path === '';
+}
+
+function scopedRoutes(routes: Routes): Route[] {
+  return routes.filter(r => !isExempt(r));
+}
+
+describe('admin route scope wiring', () => {
+  it('gives every non-redirect admin route a scope and the scope guard', () => {
+    const unguarded: string[] = [];
+
+    for (const route of scopedRoutes(adminRoutes)) {
+      const scope = route.data?.['scope'];
+      const guarded = route.canActivate?.includes(adminScopeGuard);
+      if (!scope || !guarded) {
+        unguarded.push(
+          `${route.path} (scope: ${scope ?? 'MISSING'}, guard: ${guarded ? 'yes' : 'MISSING'})`
+        );
+      }
+    }
+
+    expect(unguarded).toEqual([]);
+  });
+
+  it('only uses scopes that exist in the registry', () => {
+    for (const route of scopedRoutes(adminRoutes)) {
+      expect(ADMIN_SCOPE_IDS).toContain(route.data?.['scope']);
+    }
+  });
+
+  it('guards the landing route instead of statically redirecting', () => {
+    const landing = adminRoutes.find(r => r.path === '');
+
+    expect(landing).toBeDefined();
+    // A static redirectTo would send a delegated admin to a page they cannot
+    // open; the guard resolves the first area they can reach.
+    expect(landing?.redirectTo).toBeUndefined();
+    expect(landing?.canActivate?.length).toBe(1);
+  });
+});
+
+describe('admin nav scope wiring', () => {
+  let userService: { hasAdminScope: ReturnType<typeof vi.fn>; canAccessAdmin: () => boolean };
+
+  function buildLayout(hasScope: (scope: string) => boolean) {
+    TestBed.resetTestingModule();
+    userService = {
+      hasAdminScope: vi.fn().mockImplementation(hasScope),
+      canAccessAdmin: () => true,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        // A real router: the layout's template uses routerLink, which needs
+        // more than a Router stub once the component actually renders.
+        provideRouter([]),
+        { provide: UserService, useValue: userService },
+        {
+          provide: AdminMarketplaceService,
+          useValue: {
+            pendingCount: signal(0),
+            openReportCount: signal(0),
+            refreshQueueCounts: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    });
+
+    return TestBed.createComponent(AdminLayout).componentInstance;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('points every nav entry at a route carrying the same scope', () => {
+    const layout = buildLayout(() => true);
+
+    const routeScopeByPath = new Map<string, unknown>();
+    for (const route of adminRoutes) {
+      if (route.path !== undefined && route.data?.['scope']) {
+        routeScopeByPath.set(`/admin/${route.path}`, route.data['scope']);
+      }
+    }
+
+    const mismatches: string[] = [];
+    for (const group of layout.navGroups()) {
+      for (const item of group.items) {
+        const routeScope = routeScopeByPath.get(item.route);
+        if (routeScope === undefined) {
+          mismatches.push(`${item.route} — nav links to a route with no scope`);
+        } else if (routeScope !== item.scope) {
+          mismatches.push(
+            `${item.route} — nav says ${item.scope}, route says ${routeScope}`
+          );
+        }
+      }
+    }
+
+    expect(mismatches).toEqual([]);
+  });
+
+  it('shows every group to a full admin', () => {
+    const layout = buildLayout(() => true);
+
+    // hasAdminScope short-circuits on system_admin, so a full admin's console
+    // must be byte-identical to what it was before scopes existed.
+    expect(layout.navGroups().length).toBe(5);
+  });
+
+  it('shows a skills-only admin exactly one entry', () => {
+    const layout = buildLayout(scope => scope === 'admin.skills');
+
+    const groups = layout.navGroups();
+    expect(groups.length).toBe(1);
+    expect(groups[0].items.length).toBe(1);
+    expect(groups[0].items[0].route).toBe('/admin/skills');
+  });
+
+  it('drops a group whose items are all filtered out', () => {
+    const layout = buildLayout(scope => scope === 'admin.costs');
+
+    const labels = layout.navGroups().map(g => g.label);
+    expect(labels).toEqual(['Usage & Spend']);
+  });
+
+  it('skips the marketplace badge fetch without the marketplace scope', () => {
+    // Otherwise it is a guaranteed 403 on every admin navigation.
+    const layout = buildLayout(scope => scope === 'admin.costs');
+    const marketplace = TestBed.inject(AdminMarketplaceService);
+
+    layout.ngOnInit();
+
+    expect(marketplace.refreshQueueCounts).not.toHaveBeenCalled();
+  });
+
+  it('still fetches the marketplace badge with the scope', () => {
+    const layout = buildLayout(() => true);
+    const marketplace = TestBed.inject(AdminMarketplaceService);
+
+    layout.ngOnInit();
+
+    expect(marketplace.refreshQueueCounts).toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/admin/admin-scope.model.ts
+++ b/frontend/ai.client/src/app/admin/admin-scope.model.ts
@@ -1,0 +1,68 @@
+/**
+ * Delegated admin scopes — the client mirror of
+ * `apis/shared/rbac/admin_scopes.py`.
+ *
+ * A scope names one admin feature area that a system admin can delegate to
+ * another role. `system_admin` holds every scope implicitly.
+ *
+ * The ids are duplicated here as a literal union rather than fetched, because
+ * route definitions and nav items need them at build time and a typo in a route
+ * `data: { scope }` would otherwise fail open-ended at runtime. The registry
+ * *metadata* (labels, groups, descriptions) is still served by
+ * `GET /admin/roles/admin-scopes` — this file is only the identifier contract.
+ * `admin-scope.model.spec.ts` is the reminder to keep both ends in step.
+ */
+export const ADMIN_SCOPE_IDS = [
+  'admin.costs',
+  'admin.quota',
+  'admin.fine_tuning',
+  'admin.models',
+  'admin.tools',
+  'admin.skills',
+  'admin.connectors',
+  'admin.file_sources',
+  'admin.export_targets',
+  'admin.marketplace',
+  'admin.users',
+  'admin.system_prompts',
+  'admin.user_menu_links',
+  'admin.roles',
+  'admin.auth_providers',
+] as const;
+
+export type AdminScopeId = (typeof ADMIN_SCOPE_IDS)[number];
+
+/**
+ * Scopes that can never be granted to a role.
+ *
+ * Editing a role is how admin power is handed out, and whoever controls IdP
+ * claim mapping controls which roles resolve at all — so both stay
+ * `system_admin`-only. The server rejects them regardless
+ * (`validate_admin_scopes`); this list exists so the picker can render them
+ * as unavailable rather than letting an admin submit and get a 400 back.
+ */
+export const NON_DELEGABLE_SCOPE_IDS: readonly AdminScopeId[] = [
+  'admin.roles',
+  'admin.auth_providers',
+];
+
+/**
+ * One registry entry, as returned by `GET /admin/roles/admin-scopes`.
+ */
+export interface AdminScope {
+  id: AdminScopeId;
+  label: string;
+  /** Matches the admin nav group headings, so the picker reads like the nav. */
+  group: string;
+  description: string;
+  delegable: boolean;
+}
+
+export interface AdminScopeListResponse {
+  scopes: AdminScope[];
+  total: number;
+}
+
+export function isNonDelegable(scopeId: string): boolean {
+  return (NON_DELEGABLE_SCOPE_IDS as readonly string[]).includes(scopeId);
+}

--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -8,6 +8,8 @@ import {
 } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { AdminMarketplaceService } from './marketplace/services/admin-marketplace.service';
+import { UserService } from '../auth/user.service';
+import { AdminScopeId } from './admin-scope.model';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowLeft,
@@ -35,6 +37,12 @@ interface NavItem {
   label: string;
   icon: string;
   route: string;
+  /**
+   * The admin scope that grants this entry. Must match the `data.scope` on the
+   * corresponding route in `admin.routes.ts` — an entry linking somewhere the
+   * scope guard will refuse is worse than no entry at all.
+   */
+  scope: AdminScopeId;
   /**
    * A count that badges this entry (D10). A signal rather than a number so the badge is
    * live — triaging the last report has to empty the badge without a reload, or the nav
@@ -172,23 +180,24 @@ interface NavGroup {
 export class AdminLayout implements OnInit {
   private router = inject(Router);
   private marketplace = inject(AdminMarketplaceService);
+  private userService = inject(UserService);
 
   private readonly allNavGroups: NavGroup[] = [
     {
       label: 'Usage & Spend',
       items: [
-        { label: 'Cost Analytics', icon: 'heroCurrencyDollar', route: '/admin/costs' },
-        { label: 'Quotas', icon: 'heroScale', route: '/admin/quota' },
-        { label: 'Fine-Tuning', icon: 'heroAcademicCap', route: '/admin/fine-tuning' },
+        { label: 'Cost Analytics', icon: 'heroCurrencyDollar', route: '/admin/costs', scope: 'admin.costs' },
+        { label: 'Quotas', icon: 'heroScale', route: '/admin/quota', scope: 'admin.quota' },
+        { label: 'Fine-Tuning', icon: 'heroAcademicCap', route: '/admin/fine-tuning', scope: 'admin.fine_tuning' },
       ],
     },
     {
       label: 'AI Configuration',
       items: [
-        { label: 'Models', icon: 'heroPencilSquare', route: '/admin/manage-models' },
-        { label: 'Tools', icon: 'heroWrenchScrewdriver', route: '/admin/tools' },
-        { label: 'Skills', icon: 'heroSparkles', route: '/admin/skills' },
-        { label: 'Connectors', icon: 'heroLink', route: '/admin/connectors' },
+        { label: 'Models', icon: 'heroPencilSquare', route: '/admin/manage-models', scope: 'admin.models' },
+        { label: 'Tools', icon: 'heroWrenchScrewdriver', route: '/admin/tools', scope: 'admin.tools' },
+        { label: 'Skills', icon: 'heroSparkles', route: '/admin/skills', scope: 'admin.skills' },
+        { label: 'Connectors', icon: 'heroLink', route: '/admin/connectors', scope: 'admin.connectors' },
       ],
     },
     {
@@ -204,43 +213,62 @@ export class AdminLayout implements OnInit {
           label: 'Review Queue',
           icon: 'heroInbox',
           route: '/admin/marketplace/review',
+          scope: 'admin.marketplace',
           badge: this.marketplace.pendingCount,
         },
         {
           label: 'Reports',
           icon: 'heroFlag',
           route: '/admin/marketplace/reports',
+          scope: 'admin.marketplace',
           badge: this.marketplace.openReportCount,
         },
-        { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings' },
-        { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front' },
-        { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories' },
-        { label: 'Default Pins', icon: 'heroBookmark', route: '/admin/marketplace/default-pins' },
+        { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings', scope: 'admin.marketplace' },
+        { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front', scope: 'admin.marketplace' },
+        { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories', scope: 'admin.marketplace' },
+        { label: 'Default Pins', icon: 'heroBookmark', route: '/admin/marketplace/default-pins', scope: 'admin.marketplace' },
       ],
     },
     {
       label: 'Identity & Access',
       items: [
-        { label: 'Users', icon: 'heroUsers', route: '/admin/users' },
-        { label: 'Roles', icon: 'heroKey', route: '/admin/roles' },
-        { label: 'Auth Providers', icon: 'heroFingerPrint', route: '/admin/auth-providers' },
+        { label: 'Users', icon: 'heroUsers', route: '/admin/users', scope: 'admin.users' },
+        { label: 'Roles', icon: 'heroKey', route: '/admin/roles', scope: 'admin.roles' },
+        { label: 'Auth Providers', icon: 'heroFingerPrint', route: '/admin/auth-providers', scope: 'admin.auth_providers' },
       ],
     },
     {
       label: 'Customization',
       items: [
-        { label: 'User Menu Links', icon: 'heroBars3', route: '/admin/manage-user-menu-links' },
-        { label: 'Conversation Modes', icon: 'heroSparkles', route: '/admin/system-prompts' },
+        { label: 'User Menu Links', icon: 'heroBars3', route: '/admin/manage-user-menu-links', scope: 'admin.user_menu_links' },
+        { label: 'Conversation Modes', icon: 'heroSparkles', route: '/admin/system-prompts', scope: 'admin.system_prompts' },
       ],
     },
   ];
 
   /**
-   * Nav groups. The Skills entry is always linked; access is governed by
-   * admin RBAC and the skills route only mounts when the feature is enabled
-   * (SKILLS_ENABLED), so no client-side feature gate is needed here.
+   * Nav groups the current admin can actually open.
+   *
+   * Filtered by delegated admin scope: `system_admin` sees everything (
+   * `hasAdminScope` short-circuits for it), so this is a no-op for a full
+   * admin. A group whose items are all filtered out is dropped entirely rather
+   * than left as an empty heading.
+   *
+   * Linking to a page the scope guard would bounce is worse than not linking
+   * it, which is why `NavItem.scope` is required rather than optional.
+   *
+   * Note this is presentation only. The guard is the client-side gate and the
+   * server is the actual boundary; hiding the link just means a delegated
+   * admin never clicks into a bounce.
    */
-  readonly navGroups = computed<NavGroup[]>(() => this.allNavGroups);
+  readonly navGroups = computed<NavGroup[]>(() =>
+    this.allNavGroups
+      .map(group => ({
+        ...group,
+        items: group.items.filter(item => this.userService.hasAdminScope(item.scope)),
+      }))
+      .filter(group => group.items.length > 0)
+  );
 
   /**
    * One small call for both badges, on every admin page.
@@ -252,7 +280,13 @@ export class AdminLayout implements OnInit {
    * a badge is orientation, and an unreachable count must not break the shell.
    */
   ngOnInit(): void {
-    void this.marketplace.refreshQueueCounts();
+    // Gated on the scope: the counts endpoint is guarded by `admin.marketplace`,
+    // so firing it unconditionally would mean a guaranteed 403 on every single
+    // navigation for an admin who does not hold that scope — a console full of
+    // console-errors for a badge they cannot see anyway.
+    if (this.userService.hasAdminScope('admin.marketplace')) {
+      void this.marketplace.refreshQueueCounts();
+    }
   }
 
   onMobileNavChange(event: Event): void {

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -1,26 +1,56 @@
 import { Routes } from '@angular/router';
 import { FineTuningLayout } from './fine-tuning-access/fine-tuning.layout';
+import {
+  adminLandingGuard,
+  adminScopeGuard,
+  AdminScopeRouteData,
+} from '../auth/admin-scope.guard';
 
+/**
+ * Admin console routes.
+ *
+ * Every entry carries `data.scope` and `adminScopeGuard`. The parent
+ * `adminGuard` (in `app.routes.ts`) only decides whether the console opens at
+ * all; this is what decides which pages inside it are reachable. A route added
+ * without a scope is denied by the guard rather than left open — see
+ * `adminScopeGuard`.
+ *
+ * `satisfies AdminScopeRouteData` on each `data` object makes a mistyped scope
+ * a build error instead of a page that silently denies everyone.
+ */
 export const adminRoutes: Routes = [
   {
+    // Not a static `redirectTo: 'costs'` any more: a delegated admin without
+    // `admin.costs` would land on a page they cannot open and bounce straight
+    // back out. The guard always returns a UrlTree, so `children: []` is never
+    // activated — it exists only because a route needs *something* to match.
     path: '',
-    redirectTo: 'costs',
     pathMatch: 'full',
+    canActivate: [adminLandingGuard],
+    children: [],
   },
   {
     path: 'costs',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.costs' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./costs/admin-costs.page').then(m => m.AdminCostsPage),
   },
   {
     path: 'costs/sessions/:id',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.costs' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./costs/pages/session-cost-anatomy.page').then(m => m.SessionCostAnatomyPage),
   },
   {
     path: 'quota',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.quota' } satisfies AdminScopeRouteData,
     loadChildren: () => import('./quota-tiers/quota-routing.module').then(m => m.quotaRoutes),
   },
   {
     path: 'fine-tuning',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.fine_tuning' } satisfies AdminScopeRouteData,
     component: FineTuningLayout,
     children: [
       {
@@ -35,80 +65,118 @@ export const adminRoutes: Routes = [
   },
   {
     path: 'manage-models',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-models/manage-models.page').then(m => m.ManageModelsPage),
   },
   {
     path: 'manage-models/catalog',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-models/model-catalog.page').then(m => m.ModelCatalogPage),
   },
   {
     path: 'manage-models/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-models/model-form.page').then(m => m.ModelFormPage),
   },
   {
     path: 'manage-models/edit/:id',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-models/model-form.page').then(m => m.ModelFormPage),
   },
   {
     path: 'bedrock/models',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./bedrock-models/bedrock-models.page').then(m => m.BedrockModelsPage),
   },
   {
     path: 'gemini/models',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./gemini-models/gemini-models.page').then(m => m.GeminiModelsPage),
   },
   {
     path: 'openai/models',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.models' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./openai-models/openai-models.page').then(m => m.OpenAIModelsPage),
   },
   {
     path: 'tools',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.tools' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./tools/pages/tool-list.page').then(m => m.ToolListPage),
   },
   {
     path: 'tools/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.tools' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./tools/pages/tool-form.page').then(m => m.ToolFormPage),
   },
   {
     path: 'tools/edit/:toolId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.tools' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./tools/pages/tool-form.page').then(m => m.ToolFormPage),
   },
   {
     path: 'skills',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.skills' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./skills/pages/skill-list.page').then(m => m.SkillListPage),
   },
   {
     path: 'skills/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.skills' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
   {
     path: 'skills/edit/:skillId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.skills' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./skills/pages/skill-form.page').then(m => m.SkillFormPage),
   },
   // Agent Marketplace (docs/specs/agent-marketplace.md) — six of D10's seven admin
   // surfaces. Default pins live under Roles, because the AppRole record owns a seed.
   {
     path: 'marketplace/review',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
   },
   {
     path: 'marketplace/reports',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/reports.page').then(m => m.ReportsPage),
   },
   {
     path: 'marketplace/listings',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/listings.page').then(m => m.MarketplaceListingsPage),
   },
   {
     path: 'marketplace/categories',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/categories.page').then(m => m.MarketplaceCategoriesPage),
   },
   {
     path: 'marketplace/store-front',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/store-front.page').then(m => m.MarketplaceStoreFrontPage),
   },
   {
     path: 'marketplace/default-pins',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./marketplace/pages/default-pins.page').then(m => m.MarketplaceDefaultPinsPage),
   },
   {
@@ -118,14 +186,20 @@ export const adminRoutes: Routes = [
   },
   {
     path: 'connectors',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.connectors' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./connectors/pages/connector-list.page').then(m => m.ConnectorListPage),
   },
   {
     path: 'connectors/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.connectors' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./connectors/pages/connector-form.page').then(m => m.ConnectorFormPage),
   },
   {
     path: 'connectors/edit/:providerId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.connectors' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./connectors/pages/connector-form.page').then(m => m.ConnectorFormPage),
   },
   {
@@ -145,58 +219,86 @@ export const adminRoutes: Routes = [
   },
   {
     path: 'users',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.users' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./users/pages/user-list/user-list.page').then(m => m.UserListPage),
   },
   {
     path: 'users/:userId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.users' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./users/pages/user-detail/user-detail.page').then(m => m.UserDetailPage),
   },
   {
     path: 'roles',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.roles' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./roles/pages/role-list.page').then(m => m.RoleListPage),
   },
   {
     path: 'roles/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.roles' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./roles/pages/role-form.page').then(m => m.RoleFormPage),
   },
   {
     path: 'roles/edit/:id',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.roles' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./roles/pages/role-form.page').then(m => m.RoleFormPage),
   },
   {
     path: 'auth-providers',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.auth_providers' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./auth-providers/pages/provider-list.page').then(m => m.AuthProviderListPage),
   },
   {
     path: 'auth-providers/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.auth_providers' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./auth-providers/pages/provider-form.page').then(m => m.AuthProviderFormPage),
   },
   {
     path: 'auth-providers/edit/:providerId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.auth_providers' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./auth-providers/pages/provider-form.page').then(m => m.AuthProviderFormPage),
   },
   {
     path: 'manage-user-menu-links',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.user_menu_links' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-user-menu-links/manage-user-menu-links.page').then(m => m.ManageUserMenuLinksPage),
   },
   {
     path: 'manage-user-menu-links/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.user_menu_links' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-user-menu-links/user-menu-link-form.page').then(m => m.UserMenuLinkFormPage),
   },
   {
     path: 'manage-user-menu-links/edit/:id',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.user_menu_links' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./manage-user-menu-links/user-menu-link-form.page').then(m => m.UserMenuLinkFormPage),
   },
   {
     path: 'system-prompts',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.system_prompts' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./system-prompts/manage-system-prompts.page').then(m => m.ManageSystemPromptsPage),
   },
   {
     path: 'system-prompts/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.system_prompts' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./system-prompts/system-prompt-form.page').then(m => m.SystemPromptFormPage),
   },
   {
     path: 'system-prompts/edit/:promptId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.system_prompts' } satisfies AdminScopeRouteData,
     loadComponent: () => import('./system-prompts/system-prompt-form.page').then(m => m.SystemPromptFormPage),
   },
 ];

--- a/frontend/ai.client/src/app/admin/roles/models/app-role.model.ts
+++ b/frontend/ai.client/src/app/admin/roles/models/app-role.model.ts
@@ -6,6 +6,8 @@ export interface EffectivePermissions {
   tools: string[];
   /** Model IDs accessible via this role */
   models: string[];
+  /** Admin areas granted by this role (never inherited) */
+  adminScopes: string[];
   /** Quota tier ID, if assigned */
   quotaTier: string | null;
 }
@@ -28,6 +30,12 @@ export interface AppRole {
   grantedTools: string[];
   /** Directly granted model IDs */
   grantedModels: string[];
+  /**
+   * Directly granted admin scopes. Unlike the three axes above these are never
+   * inherited from `inheritsFrom`, and there is no `'*'` wildcard — full admin
+   * is the `system_admin` role, not a scope.
+   */
+  grantedAdminScopes: string[];
   /** Pre-computed effective permissions (from grants + inheritance) */
   effectivePermissions: EffectivePermissions;
   /** Priority for quota tier selection (0-999, higher wins) */
@@ -70,6 +78,8 @@ export interface AppRoleCreateRequest {
   grantedTools?: string[];
   /** Directly granted model IDs */
   grantedModels?: string[];
+  /** Delegated admin areas. Non-delegable ids are rejected by the server. */
+  grantedAdminScopes?: string[];
   /** Priority for quota tier selection (0-999) */
   priority?: number;
   /** Whether this role is active */
@@ -93,6 +103,8 @@ export interface AppRoleUpdateRequest {
   grantedTools?: string[];
   /** Directly granted model IDs */
   grantedModels?: string[];
+  /** Delegated admin areas. Non-delegable ids are rejected by the server. */
+  grantedAdminScopes?: string[];
   /** Priority for quota tier selection (0-999) */
   priority?: number;
   /** Whether this role is active */
@@ -110,6 +122,7 @@ export interface AppRoleFormData {
   inheritsFrom: string[];
   grantedTools: string[];
   grantedModels: string[];
+  grantedAdminScopes: string[];
   priority: number;
   enabled: boolean;
 }

--- a/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
+++ b/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
@@ -23,6 +23,7 @@ import { AppRolesService } from '../services/app-roles.service';
 import { AdminToolService } from '../../tools/services/admin-tool.service';
 import { ManagedModelsService } from '../../manage-models/services/managed-models.service';
 import { AppRoleCreateRequest, AppRoleUpdateRequest } from '../models/app-role.model';
+import { AdminScope } from '../../admin-scope.model';
 
 interface RoleFormGroup {
   roleId: FormControl<string>;
@@ -32,6 +33,7 @@ interface RoleFormGroup {
   inheritsFrom: FormControl<string[]>;
   grantedTools: FormControl<string[]>;
   grantedModels: FormControl<string[]>;
+  grantedAdminScopes: FormControl<string[]>;
   priority: FormControl<number>;
   enabled: FormControl<boolean>;
 }
@@ -315,6 +317,62 @@ interface RoleFormGroup {
               </div>
             </div>
 
+            <!-- Admin Access Section -->
+            <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+              <h2 class="mb-2 text-xl/8 font-semibold text-gray-900 dark:text-white">
+                Admin Access
+              </h2>
+              <p class="mb-6 text-sm/6 text-gray-600 dark:text-gray-400">
+                Grant this role access to specific areas of the admin console. Members
+                get only the areas selected here — everything else stays hidden.
+                Managing roles and auth providers cannot be delegated, because either
+                one would let the holder grant themselves full admin.
+              </p>
+
+              @if (adminScopesLoading()) {
+                <p class="text-sm text-gray-500 dark:text-gray-400">Loading admin areas...</p>
+              } @else if (adminScopeGroups().length > 0) {
+                <div class="flex flex-col gap-6">
+                  @for (group of adminScopeGroups(); track group.label) {
+                    <div>
+                      <h3 class="mb-2 text-xs/5 font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        {{ group.label }}
+                      </h3>
+                      <div class="flex flex-wrap gap-2">
+                        @for (scope of group.scopes; track scope.id) {
+                          <button
+                            type="button"
+                            [disabled]="!scope.delegable"
+                            (click)="toggleArrayValue('grantedAdminScopes', scope.id)"
+                            [class.bg-green-600]="isSelected('grantedAdminScopes', scope.id)"
+                            [class.text-white]="isSelected('grantedAdminScopes', scope.id)"
+                            [class.bg-gray-100]="!isSelected('grantedAdminScopes', scope.id)"
+                            [class.text-gray-700]="!isSelected('grantedAdminScopes', scope.id)"
+                            [class.dark:bg-green-500]="isSelected('grantedAdminScopes', scope.id)"
+                            [class.dark:bg-gray-700]="!isSelected('grantedAdminScopes', scope.id)"
+                            [class.dark:text-gray-300]="!isSelected('grantedAdminScopes', scope.id)"
+                            class="rounded-sm px-3 py-1.5 text-sm/6 font-medium hover:opacity-80 focus:outline-hidden focus:ring-3 focus:ring-green-500/50 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:opacity-50"
+                            [title]="scope.delegable ? scope.description : scope.description + ' (cannot be delegated)'"
+                            [attr.aria-pressed]="scope.delegable ? isSelected('grantedAdminScopes', scope.id) : null"
+                          >
+                            {{ scope.label }}
+                            @if (!scope.delegable) {
+                              <span class="ml-1 text-xs" aria-hidden="true">&#128274;</span>
+                              <span class="sr-only">(cannot be delegated)</span>
+                            }
+                          </button>
+                        }
+                      </div>
+                    </div>
+                  }
+                </div>
+              } @else {
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                  Could not load admin areas.
+                </p>
+              }
+            </div>
+
             <!-- Model Permissions Section -->
             <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
               <h2 class="mb-2 text-xl/8 font-semibold text-gray-900 dark:text-white">
@@ -439,6 +497,7 @@ export class RoleFormPage implements OnInit {
     inheritsFrom: this.fb.control<string[]>([], { nonNullable: true }),
     grantedTools: this.fb.control<string[]>([], { nonNullable: true }),
     grantedModels: this.fb.control<string[]>([], { nonNullable: true }),
+    grantedAdminScopes: this.fb.control<string[]>([], { nonNullable: true }),
     priority: this.fb.control(0, {
       nonNullable: true,
       validators: [Validators.min(0), Validators.max(1000)],
@@ -456,6 +515,29 @@ export class RoleFormPage implements OnInit {
     this.managedModelsService.getManagedModels()
   );
 
+  /**
+   * The admin scope registry, grouped for display.
+   *
+   * Groups are built in first-seen order from the server's own `group` field,
+   * which mirrors the admin nav headings — so the picker reads in the same
+   * order as the sidebar the grantee will end up looking at.
+   */
+  readonly adminScopes = signal<AdminScope[]>([]);
+  readonly adminScopesLoading = signal(false);
+
+  readonly adminScopeGroups = computed(() => {
+    const groups: { label: string; scopes: AdminScope[] }[] = [];
+    for (const scope of this.adminScopes()) {
+      const existing = groups.find(g => g.label === scope.group);
+      if (existing) {
+        existing.scopes.push(scope);
+      } else {
+        groups.push({ label: scope.group, scopes: [scope] });
+      }
+    }
+    return groups;
+  });
+
   readonly availableParentRoles = computed(() => {
     const currentRoleId = this.roleId();
     return this.appRolesService
@@ -464,11 +546,29 @@ export class RoleFormPage implements OnInit {
   });
 
   ngOnInit(): void {
+    void this.loadAdminScopes();
+
     const id = this.route.snapshot.paramMap.get('id');
     if (id && id !== 'new') {
       this.isEditMode.set(true);
       this.roleId.set(id);
       this.loadRoleData(id);
+    }
+  }
+
+  private async loadAdminScopes(): Promise<void> {
+    this.adminScopesLoading.set(true);
+    try {
+      const response = await this.appRolesService.fetchAdminScopes();
+      this.adminScopes.set(response.scopes);
+    } catch (error) {
+      // Non-fatal: the rest of the form still works, and the section renders
+      // its empty state. Blocking role editing because one optional picker
+      // could not load would be a worse trade.
+      console.error('Failed to load admin scopes:', error);
+      this.adminScopes.set([]);
+    } finally {
+      this.adminScopesLoading.set(false);
     }
   }
 
@@ -484,6 +584,10 @@ export class RoleFormPage implements OnInit {
         inheritsFrom: role.inheritsFrom,
         grantedTools: role.grantedTools,
         grantedModels: role.grantedModels,
+        // `?? []` — a role written before admin scopes existed has no such
+        // field, and patchValue(undefined) would leave the control untouched
+        // rather than clearing it.
+        grantedAdminScopes: role.grantedAdminScopes ?? [],
         priority: role.priority,
         enabled: role.enabled,
       });
@@ -497,7 +601,7 @@ export class RoleFormPage implements OnInit {
   }
 
   toggleArrayValue(
-    controlName: 'inheritsFrom' | 'grantedTools' | 'grantedModels',
+    controlName: 'inheritsFrom' | 'grantedTools' | 'grantedModels' | 'grantedAdminScopes',
     value: string
   ): void {
     const control = this.roleForm.get(controlName) as FormControl<string[]>;
@@ -511,7 +615,7 @@ export class RoleFormPage implements OnInit {
   }
 
   isSelected(
-    controlName: 'inheritsFrom' | 'grantedTools' | 'grantedModels',
+    controlName: 'inheritsFrom' | 'grantedTools' | 'grantedModels' | 'grantedAdminScopes',
     value: string
   ): boolean {
     const control = this.roleForm.get(controlName) as FormControl<string[]>;
@@ -559,6 +663,7 @@ export class RoleFormPage implements OnInit {
           inheritsFrom: formValue.inheritsFrom,
           grantedTools: formValue.grantedTools,
           grantedModels: formValue.grantedModels,
+          grantedAdminScopes: formValue.grantedAdminScopes,
           priority: formValue.priority,
           enabled: formValue.enabled,
         };
@@ -572,6 +677,7 @@ export class RoleFormPage implements OnInit {
           inheritsFrom: formValue.inheritsFrom,
           grantedTools: formValue.grantedTools,
           grantedModels: formValue.grantedModels,
+          grantedAdminScopes: formValue.grantedAdminScopes,
           priority: formValue.priority,
           enabled: formValue.enabled,
         };

--- a/frontend/ai.client/src/app/admin/roles/services/app-roles.service.ts
+++ b/frontend/ai.client/src/app/admin/roles/services/app-roles.service.ts
@@ -8,6 +8,7 @@ import {
   AppRoleCreateRequest,
   AppRoleUpdateRequest,
 } from '../models/app-role.model';
+import { AdminScopeListResponse } from '../../admin-scope.model';
 
 /**
  * Service to manage AppRoles.
@@ -63,6 +64,21 @@ export class AppRolesService {
       this.http.get<AppRoleListResponse>(`${this.baseUrl()}/`)
     );
     return response;
+  }
+
+  /**
+   * Fetch the delegated admin scope registry.
+   *
+   * Served from code rather than derived from a catalog, so the role form's
+   * picker always offers exactly the scopes the server will accept. Includes
+   * non-delegable entries with `delegable: false` — the picker shows them as
+   * unavailable rather than omitting them, so an admin can see that Roles and
+   * Auth Providers exist and are deliberately withheld.
+   */
+  async fetchAdminScopes(): Promise<AdminScopeListResponse> {
+    return firstValueFrom(
+      this.http.get<AdminScopeListResponse>(`${this.baseUrl()}/admin-scopes`)
+    );
   }
 
   /**

--- a/frontend/ai.client/src/app/auth/admin-scope.guard.spec.ts
+++ b/frontend/ai.client/src/app/auth/admin-scope.guard.spec.ts
@@ -1,0 +1,180 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  adminLandingGuard,
+  adminScopeGuard,
+  adminLandingCandidates,
+} from './admin-scope.guard';
+import { UserService } from './user.service';
+import { ADMIN_SCOPE_IDS } from '../admin/admin-scope.model';
+
+describe('adminScopeGuard', () => {
+  let userService: {
+    hasAdminScope: ReturnType<typeof vi.fn>;
+    ensurePermissionsLoaded: ReturnType<typeof vi.fn>;
+  };
+  let router: { createUrlTree: ReturnType<typeof vi.fn> };
+  let state: RouterStateSnapshot;
+
+  const routeWith = (data: Record<string, unknown>) =>
+    ({ data }) as unknown as ActivatedRouteSnapshot;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    userService = {
+      hasAdminScope: vi.fn(),
+      ensurePermissionsLoaded: vi.fn().mockResolvedValue(undefined),
+    };
+    router = {
+      createUrlTree: vi.fn().mockImplementation((commands: string[]) => ({
+        toString: () => commands.join('/'),
+        commands,
+      })),
+    };
+    state = { url: '/admin/tools' } as RouterStateSnapshot;
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('admits a user holding the route scope', async () => {
+    userService.hasAdminScope.mockReturnValue(true);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      adminScopeGuard(routeWith({ scope: 'admin.tools' }), state)
+    );
+
+    expect(result).toBe(true);
+    expect(userService.hasAdminScope).toHaveBeenCalledWith('admin.tools');
+  });
+
+  it('waits for permissions before deciding', async () => {
+    // A guard that reads the signal before the fetch resolves would bounce a
+    // legitimate admin on a cold load.
+    userService.hasAdminScope.mockReturnValue(true);
+
+    await TestBed.runInInjectionContext(() =>
+      adminScopeGuard(routeWith({ scope: 'admin.tools' }), state)
+    );
+
+    expect(userService.ensurePermissionsLoaded).toHaveBeenCalled();
+  });
+
+  it('redirects to the console landing when the scope is missing', async () => {
+    userService.hasAdminScope.mockReturnValue(false);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      adminScopeGuard(routeWith({ scope: 'admin.tools' }), state)
+    );
+
+    expect(result).not.toBe(true);
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/admin']);
+  });
+
+  it('denies a route that declares no scope', async () => {
+    // Failing open here would hand every delegated admin a page nobody vetted.
+    userService.hasAdminScope.mockReturnValue(true);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      adminScopeGuard(routeWith({}), state)
+    );
+
+    expect(result).not.toBe(true);
+    expect(userService.hasAdminScope).not.toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/admin']);
+  });
+});
+
+describe('adminLandingGuard', () => {
+  let userService: {
+    hasAdminScope: ReturnType<typeof vi.fn>;
+    ensurePermissionsLoaded: ReturnType<typeof vi.fn>;
+  };
+  let router: { createUrlTree: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    userService = {
+      hasAdminScope: vi.fn().mockReturnValue(false),
+      ensurePermissionsLoaded: vi.fn().mockResolvedValue(undefined),
+    };
+    router = { createUrlTree: vi.fn().mockImplementation((c: string[]) => ({ commands: c })) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  const runLanding = () =>
+    TestBed.runInInjectionContext(() =>
+      adminLandingGuard(
+        {} as ActivatedRouteSnapshot,
+        {} as RouterStateSnapshot
+      )
+    );
+
+  it('sends a full admin to Cost Analytics', async () => {
+    userService.hasAdminScope.mockReturnValue(true);
+
+    await runLanding();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/admin/costs']);
+  });
+
+  it('sends a skills-only admin to Skills, not Cost Analytics', async () => {
+    // The trap this guard exists for: the old static `redirectTo: 'costs'`
+    // dropped every admin on a page a delegated admin cannot open.
+    userService.hasAdminScope.mockImplementation(
+      (scope: string) => scope === 'admin.skills'
+    );
+
+    await runLanding();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/admin/skills']);
+  });
+
+  it('sends a marketplace-only admin to the review queue', async () => {
+    userService.hasAdminScope.mockImplementation(
+      (scope: string) => scope === 'admin.marketplace'
+    );
+
+    await runLanding();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/admin/marketplace/review']);
+  });
+
+  it('sends a user with no scopes home rather than looping on /admin', async () => {
+    userService.hasAdminScope.mockReturnValue(false);
+
+    await runLanding();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/']);
+  });
+
+  it('only offers landing targets for known scopes', () => {
+    for (const candidate of adminLandingCandidates()) {
+      expect(ADMIN_SCOPE_IDS).toContain(candidate.scope);
+    }
+  });
+});

--- a/frontend/ai.client/src/app/auth/admin-scope.guard.ts
+++ b/frontend/ai.client/src/app/auth/admin-scope.guard.ts
@@ -1,0 +1,114 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { UserService } from './user.service';
+import { AdminScopeId } from '../admin/admin-scope.model';
+
+/**
+ * Route data contract for `adminScopeGuard`.
+ *
+ * Declared as a type so a route can be written
+ * `data: { scope: 'admin.tools' } satisfies AdminScopeRouteData` and a typo is
+ * caught at build time rather than becoming a silently unguarded page.
+ */
+export interface AdminScopeRouteData {
+  scope: AdminScopeId;
+}
+
+/**
+ * Per-page guard for the admin console.
+ *
+ * Reads the required scope off the route's `data.scope` and checks it against
+ * the user's resolved permissions. `system_admin` passes everything.
+ *
+ * **This is defence in depth, not the security boundary.** The server enforces
+ * the same scope on every admin route (`require_admin_scope`); hiding a page
+ * the API would refuse anyway is a UX concern — the point is that a delegated
+ * admin never sees a 403 screen for a page they were never meant to reach.
+ *
+ * A route wired with no `data.scope` is treated as **denied**, not allowed:
+ * the likely cause is a page added without wiring its scope, and failing open
+ * there would hand every delegated admin a surface nobody vetted.
+ */
+export const adminScopeGuard: CanActivateFn = async (route, state) => {
+  const userService = inject(UserService);
+  const router = inject(Router);
+
+  await userService.ensurePermissionsLoaded();
+
+  const scope = route.data?.['scope'] as string | undefined;
+
+  if (!scope) {
+    console.error(
+      `Admin route "${state.url}" has no data.scope — denying. ` +
+        'Add `data: { scope: "admin.<area>" }` to its route definition.'
+    );
+    return router.createUrlTree(['/admin']);
+  }
+
+  if (userService.hasAdminScope(scope)) {
+    return true;
+  }
+
+  // Back to the console rather than the home page: the user *is* an admin of
+  // something, so drop them at the landing route, which resolves to the first
+  // area they can actually open.
+  return router.createUrlTree(['/admin']);
+};
+
+/**
+ * Ordered candidates for the `/admin` landing page.
+ *
+ * Kept in the nav's own order so "first area you can open" matches what the
+ * sidebar shows at the top, rather than an arbitrary internal ordering.
+ */
+const LANDING_CANDIDATES: ReadonlyArray<{ scope: AdminScopeId; path: string }> = [
+  { scope: 'admin.costs', path: '/admin/costs' },
+  { scope: 'admin.quota', path: '/admin/quota' },
+  { scope: 'admin.fine_tuning', path: '/admin/fine-tuning' },
+  { scope: 'admin.models', path: '/admin/manage-models' },
+  { scope: 'admin.tools', path: '/admin/tools' },
+  { scope: 'admin.skills', path: '/admin/skills' },
+  { scope: 'admin.connectors', path: '/admin/connectors' },
+  { scope: 'admin.marketplace', path: '/admin/marketplace/review' },
+  { scope: 'admin.users', path: '/admin/users' },
+  { scope: 'admin.roles', path: '/admin/roles' },
+  { scope: 'admin.auth_providers', path: '/admin/auth-providers' },
+  { scope: 'admin.user_menu_links', path: '/admin/manage-user-menu-links' },
+  { scope: 'admin.system_prompts', path: '/admin/system-prompts' },
+];
+
+/**
+ * Landing redirect for `/admin`.
+ *
+ * Replaces a static `redirectTo: 'costs'`, which sent every admin to Cost
+ * Analytics — fine when admin was all-or-nothing, but a skills-only admin
+ * would land on a page they cannot open and bounce straight back out.
+ *
+ * Always returns a `UrlTree`, so the route it guards is never activated.
+ */
+export const adminLandingGuard: CanActivateFn = async () => {
+  const userService = inject(UserService);
+  const router = inject(Router);
+
+  await userService.ensurePermissionsLoaded();
+
+  const target = LANDING_CANDIDATES.find(candidate =>
+    userService.hasAdminScope(candidate.scope)
+  );
+
+  if (target) {
+    return router.createUrlTree([target.path]);
+  }
+
+  // No scopes at all — `adminGuard` should already have bounced this user, so
+  // reaching here means permissions resolved empty. Send them home rather than
+  // looping on /admin.
+  return router.createUrlTree(['/']);
+};
+
+export function adminLandingCandidates(): ReadonlyArray<{
+  scope: AdminScopeId;
+  path: string;
+}> {
+  return LANDING_CANDIDATES;
+}

--- a/frontend/ai.client/src/app/auth/admin.guard.spec.ts
+++ b/frontend/ai.client/src/app/auth/admin.guard.spec.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 describe('adminGuard', () => {
   let sessionService: { isAuthenticated: ReturnType<typeof vi.fn> };
   let userService: {
-    isAdmin: ReturnType<typeof vi.fn>;
+    canAccessAdmin: ReturnType<typeof vi.fn>;
     ensurePermissionsLoaded: ReturnType<typeof vi.fn>;
     getUser: ReturnType<typeof vi.fn>;
   };
@@ -23,7 +23,7 @@ describe('adminGuard', () => {
     };
 
     userService = {
-      isAdmin: vi.fn(),
+      canAccessAdmin: vi.fn(),
       ensurePermissionsLoaded: vi.fn().mockResolvedValue(undefined),
       getUser: vi.fn().mockReturnValue({ roles: [] }),
     };
@@ -53,9 +53,9 @@ describe('adminGuard', () => {
     TestBed.resetTestingModule();
   });
 
-  it('should return true when authenticated and user has system_admin AppRole', async () => {
+  it('should return true when authenticated and user can access admin', async () => {
     sessionService.isAuthenticated.mockReturnValue(true);
-    userService.isAdmin.mockReturnValue(true);
+    userService.canAccessAdmin.mockReturnValue(true);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 
@@ -64,15 +64,28 @@ describe('adminGuard', () => {
     expect(router.navigate).not.toHaveBeenCalled();
   });
 
-  it('should redirect to / when authenticated but lacks system_admin AppRole', async () => {
+  it('should redirect to / when authenticated but has no admin access at all', async () => {
     sessionService.isAuthenticated.mockReturnValue(true);
-    userService.isAdmin.mockReturnValue(false);
+    userService.canAccessAdmin.mockReturnValue(false);
 
     const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
 
     expect(result).toBe(false);
     expect(userService.ensurePermissionsLoaded).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('should admit a delegated admin who holds no system_admin role', async () => {
+    // The point of the feature: someone with only `admin.skills` gets into the
+    // console. Which pages they see inside it is adminScopeGuard's job.
+    sessionService.isAuthenticated.mockReturnValue(true);
+    userService.canAccessAdmin.mockReturnValue(true);
+    userService.getUser.mockReturnValue({ roles: ['faculty'] });
+
+    const result = await TestBed.runInInjectionContext(() => adminGuard(route, state));
+
+    expect(result).toBe(true);
+    expect(router.navigate).not.toHaveBeenCalled();
   });
 
   it('should redirect to /auth/login when no BFF session', async () => {

--- a/frontend/ai.client/src/app/auth/admin.guard.ts
+++ b/frontend/ai.client/src/app/auth/admin.guard.ts
@@ -4,12 +4,16 @@ import { SessionService } from './session.service';
 import { UserService } from './user.service';
 
 /**
- * Route guard that protects admin routes using backend RBAC resolution.
+ * Route guard for the `/admin` shell, using backend RBAC resolution.
  *
- * Checks the BFF session for an authenticated user, then resolves
- * AppRoles from `/users/me/permissions` and gates on `system_admin`.
- * Unauthenticated users are bounced through `/auth/login`; authenticated
- * users without the role land back on the home page.
+ * Checks the BFF session for an authenticated user, then resolves permissions
+ * from `/users/me/permissions`. Gates on `canAccessAdmin` — `system_admin`
+ * **or** any delegated admin scope — because the console is no longer
+ * all-or-nothing. Which *pages* inside it are reachable is `adminScopeGuard`'s
+ * job; this only decides whether the shell opens at all.
+ *
+ * Unauthenticated users are bounced through `/auth/login`; authenticated users
+ * with no admin access at all land back on the home page.
  */
 export const adminGuard: CanActivateFn = async (route, state) => {
   const sessionService = inject(SessionService);
@@ -25,8 +29,8 @@ export const adminGuard: CanActivateFn = async (route, state) => {
 
   await userService.ensurePermissionsLoaded();
 
-  if (!userService.isAdmin()) {
-    console.warn('User lacks system_admin AppRole:', userService.getUser()?.roles);
+  if (!userService.canAccessAdmin()) {
+    console.warn('User has no admin access:', userService.getUser()?.roles);
     router.navigate(['/']);
     return false;
   }

--- a/frontend/ai.client/src/app/auth/user.service.ts
+++ b/frontend/ai.client/src/app/auth/user.service.ts
@@ -44,7 +44,26 @@ export class UserService {
 
   readonly appRoles = signal<string[]>([]);
 
+  /**
+   * Delegated admin feature areas granted to this user.
+   *
+   * Empty for a full admin: `system_admin` satisfies every scope implicitly
+   * rather than enumerating them, so never test membership here to decide
+   * whether someone is an admin — use `hasAdminScope` or `isAdmin`.
+   */
+  readonly adminScopes = signal<string[]>([]);
+
   readonly isAdmin = computed(() => this.appRoles().includes('system_admin'));
+
+  /**
+   * May this user open the admin console at all?
+   *
+   * Distinct from `isAdmin`, which keeps its exact previous meaning and still
+   * gates genuinely superuser-only surfaces (roles, auth providers).
+   */
+  readonly canAccessAdmin = computed(
+    () => this.isAdmin() || this.adminScopes().length > 0
+  );
 
   private _permissionsPromise: Promise<void> | null = null;
 
@@ -58,6 +77,7 @@ export class UserService {
       } else {
         this._permissionsPromise = null;
         this.appRoles.set([]);
+        this.adminScopes.set([]);
       }
     });
   }
@@ -83,9 +103,15 @@ export class UserService {
         this.http.get<UserPermissions>(url, { withCredentials: true })
       );
       this.appRoles.set(permissions.appRoles);
+      // `?? []` rather than a bare read: an app-api still on a pre-PR-3 build
+      // omits the field entirely, and `undefined` here would make
+      // `adminScopes().length` throw inside `canAccessAdmin` and break the
+      // admin entry point for full admins too.
+      this.adminScopes.set(permissions.adminScopes ?? []);
     } catch (error) {
       console.error('Failed to fetch user permissions:', error);
       this.appRoles.set([]);
+      this.adminScopes.set([]);
     }
   }
 
@@ -102,6 +128,16 @@ export class UserService {
 
   hasAppRole(role: string): boolean {
     return this.appRoles().includes(role);
+  }
+
+  /**
+   * Does this user hold a given delegated admin scope?
+   *
+   * `system_admin` short-circuits to true — it satisfies every scope
+   * implicitly, exactly as `require_admin_scope` does on the server.
+   */
+  hasAdminScope(scope: string): boolean {
+    return this.isAdmin() || this.adminScopes().includes(scope);
   }
 
   refreshUser(): void {

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -37,6 +37,7 @@ describe('Sidenav', () => {
       hasAnyRole: vi.fn().mockReturnValue(false),
       currentUser: signal(null),
       isAdmin: signal(false),
+      canAccessAdmin: signal(false),
     };
     mockMemorySpaceService = {
       accessible$: signal<boolean | null>(null),
@@ -181,6 +182,9 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
       hasAnyRole: vi.fn().mockReturnValue(false),
       currentUser: signal({ user_id: 'u1', email: 'u1@example.com' }),
       isAdmin: signal(false),
+      // The sidenav's admin entry point moved to `canAccessAdmin` so delegated
+      // admins (no system_admin role, but some admin scope) still get the link.
+      canAccessAdmin: signal(false),
     };
     mockAgentService = {
       accessible$: signal<boolean | null>(true),
@@ -239,6 +243,7 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
 
   it('renders the Agents nav entry for a NON-admin once the surface is reachable', async () => {
     mockUserService.isAdmin.set(false);
+    mockUserService.canAccessAdmin.set(false);
     const fixture = await renderSidenav();
 
     // Fails against the pre-GA `@if (showAgents() && isAdmin())`.
@@ -248,6 +253,7 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
 
   it('renders the Agents nav entry for an admin', async () => {
     mockUserService.isAdmin.set(true);
+    mockUserService.canAccessAdmin.set(true);
     const fixture = await renderSidenav();
     expect(agentsNavLink(fixture)).toBeDefined();
   });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -38,8 +38,14 @@ export class Sidenav {
     return session.title || 'Untitled Session';
   });
 
-  // Check if user has system_admin AppRole (resolved from backend RBAC)
-  protected isAdmin = this.userService.isAdmin;
+  /**
+   * Whether to offer the "Admin Dashboard" entry point.
+   *
+   * `canAccessAdmin`, not `isAdmin`: a delegated admin holds no `system_admin`
+   * AppRole but does have somewhere to go inside the console, and hiding the
+   * link would leave them typing `/admin` by hand.
+   */
+  protected isAdmin = this.userService.canAccessAdmin;
 
   /**
    * Whether to show the "Memory Spaces" nav entry. Rides the spaces list


### PR DESCRIPTION
**PR-4** of [`docs/specs/granular-admin-permissions.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/granular-admin-permissions.md) — the last one. Follows #770, #774, #775.

Makes delegated admin scopes reachable through the UI: a system admin can grant areas from the role form, and the grantee gets into the console seeing only what they hold. **Full admins see no change** — `hasAdminScope` short-circuits on `system_admin`, so the console is identical to before. SPA: 1675 tests pass, AOT build clean.

## What this adds

- **`UserService`** gains `adminScopes`, `hasAdminScope()`, and `canAccessAdmin`. `isAdmin` keeps its exact previous meaning and still gates genuinely superuser-only surfaces.
- **`adminGuard`** gates the `/admin` shell on `canAccessAdmin` rather than `isAdmin`; a new **`adminScopeGuard`** gates each page on its `data.scope`.
- **Nav filtering** by scope, dropping groups left empty. `NavItem.scope` is required, not optional — a link the guard would bounce is worse than no link.
- **Role form** grows an Admin Access picker, grouped by the same headings as the admin nav, fed by `GET /admin/roles/admin-scopes`.

## Three decisions worth a look

**A route with no scope is denied, not allowed.** The likely cause is a page added without wiring its scope, and failing open there hands every delegated admin a surface nobody vetted. It logs a specific error naming the fix.

**The landing redirect was a real trap.** `/admin` used a static `redirectTo: 'costs'` — a skills-only admin would land on a page they cannot open and bounce straight back out, making the whole feature look broken. It is now a guard that resolves the first area the user can actually reach.

**Non-delegable areas render disabled with a lock, not omitted.** Otherwise an admin sees 13 areas in the picker with no way to tell that Roles and Auth Providers were withheld deliberately rather than lost to a bug.

Also: the marketplace badge fetch is now gated on `admin.marketplace`. Unconditional, it was a guaranteed 403 on *every* admin navigation for an admin without that scope.

## Tests

`admin-scope-wiring.spec.ts` is the SPA counterpart to the backend's architecture test — it fails if an admin route lacks a scope or guard, if a scope isn't in the registry, or if a nav entry's scope disagrees with its route's. **Verified to fail** on an unscoped route (3 tests catch it, including the nav-vs-route mismatch).

The sidenav specs stubbed `UserService` with `isAdmin` only, so moving the admin entry point to `canAccessAdmin` broke five of them with `ctx_r1.isAdmin is not a function`. Stubs updated rather than the source reverted — the entry point genuinely needs to show for delegated admins.

## Not verified in a browser

`localhost:4200` talks to the dev backend, which needs real SSO, so there was nothing I could exercise without a login. Suggested manual check: grant a non-admin test role `grantedAdminScopes: ["admin.skills"]` from `/admin/roles`, then confirm that user (a) gets into `/admin`, (b) lands on Skills rather than Cost Analytics, (c) sees exactly one nav group, and (d) that a full admin's console is unchanged.

## Epic complete

PR-1 data · PR-2 enforcement · PR-3 API · PR-4 SPA. Remaining: **PR-5, audit logging** for admin-surface mutations (decided in scope in #769, not yet built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
