### PR TITLE
feat(agents): explain the rename at /assistants instead of redirecting

### DIFF
--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.css
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.css
@@ -1,0 +1,143 @@
+/* Assistants → Agents explainer.
+
+   Borrows the login/first-boot signature — graph-paper grid over a soft Boise-blue
+   wash — but at a fraction of the intensity, because this page lives *inside* the app
+   shell rather than replacing it. One decorated panel (the hero), then ordinary
+   surfaces; a page that announced itself in every section would read as a takeover. */
+
+@import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ---------- Hero: graph paper over a corner wash ---------- */
+
+.hero-field {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  /* Ruled grid, faded out toward the lower right so the headline sits on paper and
+     the call-to-action sits on clean stock. */
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--color-primary-500) 9%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-500) 9%, transparent) 1px, transparent 1px);
+  background-size: 32px 32px;
+  -webkit-mask-image: radial-gradient(110% 90% at 12% 0%, black 0%, transparent 68%);
+  mask-image: radial-gradient(110% 90% at 12% 0%, black 0%, transparent 68%);
+}
+
+.hero-field::after {
+  /* The wash itself: one warm-cornered bloom of primary, kept well under the text. */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(70% 120% at 4% -10%, color-mix(in oklab, var(--color-primary-500) 14%, transparent) 0%, transparent 62%),
+    radial-gradient(50% 90% at 100% 100%, color-mix(in oklab, var(--color-primary-400) 8%, transparent) 0%, transparent 60%);
+}
+
+:host-context(html.dark) .hero-field {
+  background-image:
+    linear-gradient(to right, color-mix(in oklab, var(--color-primary-300) 10%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklab, var(--color-primary-300) 10%, transparent) 1px, transparent 1px);
+}
+
+:host-context(html.dark) .hero-field::after {
+  background:
+    radial-gradient(70% 120% at 4% -10%, color-mix(in oklab, var(--color-primary-500) 26%, transparent) 0%, transparent 62%),
+    radial-gradient(50% 90% at 100% 100%, color-mix(in oklab, var(--color-primary-400) 12%, transparent) 0%, transparent 60%);
+}
+
+/* ---------- Type details ---------- */
+
+.eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+/* "Assistants" in the headline: present, legible, and visibly the previous draft.
+   A strikethrough rather than a colour change alone, so the retirement survives
+   greyscale and does not lean on hue to carry meaning. */
+.former {
+  color: var(--color-gray-400);
+  text-decoration: line-through;
+  /* Thick enough to read as a deliberate mark at display size rather than as a
+     rendering artefact, thin enough not to cut the word in half. */
+  text-decoration-thickness: 0.07em;
+  text-decoration-color: var(--color-gray-400);
+}
+
+:host-context(html.dark) .former {
+  color: var(--color-gray-500);
+  text-decoration-color: var(--color-gray-500);
+}
+
+/* ---------- Ledger: a spotlight band down the "Agent" column ---------- */
+
+.ledger-now {
+  position: relative;
+  background: color-mix(in oklab, var(--color-primary-500) 5%, transparent);
+}
+
+/* Hairlines on both sides of the band turn it from a tint into a deliberate column. */
+.ledger thead .ledger-now::before,
+.ledger thead .ledger-now::after,
+.ledger tbody .ledger-now::before,
+.ledger tbody .ledger-now::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: color-mix(in oklab, var(--color-primary-500) 18%, transparent);
+}
+
+.ledger .ledger-now::before {
+  left: 0;
+}
+
+.ledger .ledger-now::after {
+  right: 0;
+}
+
+:host-context(html.dark) .ledger-now {
+  background: color-mix(in oklab, var(--color-primary-400) 10%, transparent);
+}
+
+:host-context(html.dark) .ledger .ledger-now::before,
+:host-context(html.dark) .ledger .ledger-now::after {
+  background: color-mix(in oklab, var(--color-primary-300) 24%, transparent);
+}
+
+/* ---------- Load ---------- */
+
+/* One orchestrated arrival: sections rise in sequence as the page settles. Purely
+   additive — `.reveal` starts visible under reduced motion and if animations never
+   run, so nothing here can strand content in an invisible state. */
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    animation: reveal-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+
+  /* `nth-child`, not `nth-of-type`: the five panels are a <header> followed by four
+     <section>s, and per-type counting would restart the sequence at the first one. */
+  .reveal:nth-child(1) { animation-delay: 0ms; }
+  .reveal:nth-child(2) { animation-delay: 90ms; }
+  .reveal:nth-child(3) { animation-delay: 160ms; }
+  .reveal:nth-child(4) { animation-delay: 220ms; }
+  .reveal:nth-child(5) { animation-delay: 270ms; }
+}
+
+@keyframes reveal-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
@@ -1,0 +1,217 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- ── Hero ──────────────────────────────────────────────────────────────
+         The graph-paper field and the blue wash are decorative and live behind
+         an aria-hidden layer; the panel's own contrast is carried by the text. -->
+    <header class="reveal relative overflow-hidden rounded-3xl border border-gray-200 bg-white px-6 py-12 sm:px-12 sm:py-16 dark:border-gray-700 dark:bg-gray-800">
+      <div class="hero-field" aria-hidden="true"></div>
+
+      <div class="relative">
+        <p class="eyebrow text-primary-600 dark:text-primary-300">What changed</p>
+
+        <h1 class="mt-4 max-w-2xl text-3xl/tight font-bold tracking-tight text-gray-900 sm:text-5xl/tight dark:text-white">
+          <span class="former">Assistants</span> are now
+          <span class="text-primary-600 dark:text-primary-300">Agents</span>.
+        </h1>
+
+        <p class="mt-5 max-w-xl text-base/7 text-gray-600 dark:text-gray-300">
+          Same work, same records, a bigger name — and a good deal more it can do. Everything
+          you built is already waiting under <strong class="font-semibold text-gray-900 dark:text-white">Agents</strong>,
+          exactly as you left it.
+        </p>
+
+        <div class="mt-8 flex flex-wrap items-center gap-3">
+          <a
+            routerLink="/agents"
+            class="group inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition-all duration-200 hover:bg-primary-600 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 active:scale-[0.98] dark:focus-visible:ring-offset-gray-800"
+          >
+            Go to my agents
+            <ng-icon
+              name="heroArrowRight"
+              class="size-4 transition-transform duration-200 group-hover:translate-x-0.5"
+              aria-hidden="true"
+            />
+          </a>
+          <a
+            routerLink="/agents/discover"
+            class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm/6 font-semibold text-gray-700 transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 dark:focus-visible:ring-offset-gray-800"
+          >
+            <ng-icon name="heroSquares2x2" class="size-4" aria-hidden="true" />
+            Browse what others built
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ── Reassurance ───────────────────────────────────────────────────────
+         First section on the page because it is the first question: the rename
+         is only interesting once you know your work survived it. -->
+    <section class="reveal mt-14" aria-labelledby="kept-heading">
+      <div class="flex items-center gap-3">
+        <span
+          class="inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400"
+          aria-hidden="true"
+        >
+          <ng-icon name="heroShieldCheck" class="size-5" />
+        </span>
+        <h2 id="kept-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
+          Your assistants are safe. They became agents.
+        </h2>
+      </div>
+
+      <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        Every one of them is under Agents right now. Nothing for you to redo.
+      </p>
+
+      <ul class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        @for (item of carriedOver; track item.label) {
+          <li class="flex gap-4 rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+            <span
+              class="inline-flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-300"
+              aria-hidden="true"
+            >
+              <ng-icon [name]="item.icon" class="size-5" />
+            </span>
+            <div class="min-w-0">
+              <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">{{ item.label }}</h3>
+              <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">{{ item.detail }}</p>
+            </div>
+          </li>
+        }
+      </ul>
+    </section>
+
+    <!-- ── The ledger ────────────────────────────────────────────────────────
+         The argument for the change, in one table. Marked up as a real table so
+         a screen reader hears the comparison rather than two lists of icons. -->
+    <section class="reveal mt-16" aria-labelledby="ledger-heading">
+      <h2 id="ledger-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
+        Why the name had to grow
+      </h2>
+      <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        An assistant could hold instructions and a set of documents, and that was the whole
+        of it. An agent keeps all of that and then composes the rest of the platform around
+        it — a model, tools, skills, memory — with your role deciding what is on the table.
+        Once the editor could do all of that, calling the result an "assistant" was
+        underselling it.
+      </p>
+
+      <div class="ledger mt-7 overflow-x-auto rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <table class="w-full min-w-lg border-collapse text-left">
+          <caption class="sr-only">
+            What an assistant could do compared with what an agent can do
+          </caption>
+          <thead>
+            <tr class="border-b border-gray-200 dark:border-gray-700">
+              <th scope="col" class="px-5 py-3.5 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                Capability
+              </th>
+              <th scope="col" class="w-28 px-3 py-3.5 text-center text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                Assistant
+              </th>
+              <th scope="col" class="ledger-now w-28 px-3 py-3.5 text-center text-xs font-semibold uppercase tracking-wider text-primary-700 dark:text-primary-300">
+                Agent
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700/60">
+            @for (row of ledger; track row.label) {
+              <tr>
+                <th scope="row" class="px-5 py-4 font-normal">
+                  <span class="flex items-start gap-3">
+                    <ng-icon
+                      [name]="row.icon"
+                      class="mt-0.5 size-4 shrink-0 text-gray-400 dark:text-gray-500"
+                      aria-hidden="true"
+                    />
+                    <span class="min-w-0">
+                      <span class="block text-sm/6 font-semibold text-gray-900 dark:text-white">{{ row.label }}</span>
+                      <span class="mt-0.5 block text-sm/6 text-gray-500 dark:text-gray-400">{{ row.detail }}</span>
+                    </span>
+                  </span>
+                </th>
+
+                <td class="px-3 py-4 text-center align-middle">
+                  @if (row.assistant === 'yes') {
+                    <ng-icon name="heroCheck" class="size-5 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                    <span class="sr-only">Yes</span>
+                  } @else {
+                    <span class="text-gray-300 dark:text-gray-600" aria-hidden="true">—</span>
+                    <span class="sr-only">No</span>
+                  }
+                </td>
+
+                <td class="ledger-now px-3 py-4 text-center align-middle">
+                  <ng-icon name="heroCheck" class="size-5 text-primary-600 dark:text-primary-300" aria-hidden="true" />
+                  <span class="sr-only">Yes</span>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ── What it opens up ──────────────────────────────────────────────────
+         The forward-looking half. One noun is what made each of these possible;
+         none of them had anywhere to live on the old surface. -->
+    <section class="reveal mt-16" aria-labelledby="opens-heading">
+      <h2 id="opens-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
+        What that opens up
+      </h2>
+      <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        A single, well-defined thing can be published, borrowed, called on and scheduled.
+        Two half-overlapping ones could not. These are live now — and they are the reason the
+        change was worth making.
+      </p>
+
+      <div class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        @for (item of opensUp; track item.title) {
+          <article class="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 transition-all duration-200 hover:border-gray-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600">
+            <span
+              class="inline-flex size-10 items-center justify-center rounded-xl bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-300"
+              aria-hidden="true"
+            >
+              <ng-icon [name]="item.icon" class="size-5" />
+            </span>
+            <h3 class="mt-4 text-base/7 font-semibold text-gray-900 dark:text-white">{{ item.title }}</h3>
+            <p class="mt-1.5 text-sm/6 text-gray-600 dark:text-gray-400">{{ item.body }}</p>
+          </article>
+        }
+      </div>
+    </section>
+
+    <!-- ── Close ─────────────────────────────────────────────────────────────
+         One door out, and the bookmark promise repeated where someone who
+         skimmed the page will still catch it. -->
+    <section class="reveal mt-16 mb-8 rounded-3xl border border-gray-200 bg-gray-50 px-6 py-10 text-center sm:px-12 dark:border-gray-700 dark:bg-gray-800/60">
+      <h2 class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
+        Everything you had is under Agents
+      </h2>
+      <p class="mx-auto mt-3 max-w-xl text-sm/6 text-gray-600 dark:text-gray-400">
+        Open it and you should recognise every one of them. The only thing to learn is what
+        you can add now.
+      </p>
+
+      <div class="mt-7 flex flex-wrap items-center justify-center gap-3">
+        <a
+          routerLink="/agents"
+          class="group inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition-all duration-200 hover:bg-primary-600 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 active:scale-[0.98] dark:focus-visible:ring-offset-gray-800"
+        >
+          Go to my agents
+          <ng-icon
+            name="heroArrowRight"
+            class="size-4 transition-transform duration-200 group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </a>
+      </div>
+
+      <p class="mx-auto mt-7 flex max-w-md items-center justify-center gap-2 text-xs/5 text-gray-500 dark:text-gray-500">
+        <ng-icon name="heroLink" class="size-3.5 shrink-0" aria-hidden="true" />
+        Old <code class="rounded bg-gray-200/70 px-1 py-0.5 font-mono dark:bg-gray-700/70">/assistants</code> links
+        keep working — you do not need to update your bookmarks.
+      </p>
+    </section>
+  </div>
+</div>

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
@@ -1,0 +1,188 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowRight,
+  heroBookmark,
+  heroChatBubbleLeftRight,
+  heroCheck,
+  heroCircleStack,
+  heroClock,
+  heroCpuChip,
+  heroDocumentText,
+  heroLink,
+  heroPuzzlePiece,
+  heroShieldCheck,
+  heroSparkles,
+  heroSquares2x2,
+  heroUserGroup,
+  heroWrenchScrewdriver,
+} from '@ng-icons/heroicons/outline';
+
+/** One row of the "what an Agent adds" ledger. */
+interface LedgerRow {
+  label: string;
+  detail: string;
+  icon: string;
+  /** Whether the old Assistant editor could do this at all. */
+  assistant: 'yes' | 'no';
+}
+
+/** One capability card under "what this opens up". */
+interface OpensUp {
+  title: string;
+  body: string;
+  icon: string;
+}
+
+/**
+ * The Assistants → Agents explainer, served at the old `/assistants` list URL.
+ *
+ * `/assistants` used to be a bare `redirectTo: 'agents'`. A silent redirect answers the
+ * routing question and none of the human one: someone who bookmarked their Assistants list
+ * lands on a page with a different name, a different tab strip and a different vocabulary,
+ * with nothing to tell them their work came with it. The two *deep* links
+ * (`/assistants/new`, `/assistants/:id/edit`) stay redirects on purpose — those are
+ * intents, not browsing, and interrupting "edit this specific record" with an announcement
+ * would be hostile. Only the list URL, which is the one people browse to, explains itself.
+ *
+ * The copy commits to three things, in this order, because that is the order the questions
+ * actually arrive in: **where did my work go** (nowhere — same records, same ids), **why**
+ * (one noun, and the old editor was strictly the smaller half of it), and **what it buys
+ * me** (the bindings, the store, `@`-mention, scheduled runs).
+ *
+ * Everything claimed here is a surface that ships today. If a capability is removed or
+ * gated, the claim on this page goes with it — an explainer that oversells is worse than
+ * the redirect it replaced.
+ */
+@Component({
+  selector: 'app-agents-migration',
+  templateUrl: './agents-migration.page.html',
+  styleUrl: './agents-migration.page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, NgIcon],
+  viewProviders: [
+    provideIcons({
+      heroArrowRight,
+      heroBookmark,
+      heroChatBubbleLeftRight,
+      heroCheck,
+      heroCircleStack,
+      heroClock,
+      heroCpuChip,
+      heroDocumentText,
+      heroLink,
+      heroPuzzlePiece,
+      heroShieldCheck,
+      heroSparkles,
+      heroSquares2x2,
+      heroUserGroup,
+      heroWrenchScrewdriver,
+    }),
+  ],
+})
+export class AgentsMigrationPage {
+  /**
+   * What came across untouched. One line each — this section answers a worry, and a worry
+   * is answered by a short concrete list, not by an explanation of the mechanism.
+   */
+  readonly carriedOver: readonly { label: string; detail: string; icon: string }[] = [
+    {
+      label: 'Every assistant you built',
+      detail: 'Same name, same instructions, same conversation starters.',
+      icon: 'heroSparkles',
+    },
+    {
+      label: 'Your knowledge bases',
+      detail: 'Documents, web sources and sync policies — still indexed, still answering.',
+      icon: 'heroDocumentText',
+    },
+    {
+      label: 'Who you shared with',
+      detail: 'Viewers and editors kept exactly the access you gave them.',
+      icon: 'heroUserGroup',
+    },
+    {
+      label: 'Your old links',
+      detail: 'Bookmarks and shared links still work, and open the same record.',
+      icon: 'heroLink',
+    },
+  ];
+
+  /**
+   * The ledger. The point of the page in one table: everything the old editor did is a
+   * "yes" in both columns, and the new rows are the reason the change was worth making.
+   */
+  readonly ledger: readonly LedgerRow[] = [
+    {
+      label: 'Instructions',
+      detail: 'The system prompt that gives it a job and a manner.',
+      icon: 'heroDocumentText',
+      assistant: 'yes',
+    },
+    {
+      label: 'Knowledge base',
+      detail: 'Your documents and web sources, indexed and searchable.',
+      icon: 'heroCircleStack',
+      assistant: 'yes',
+    },
+    {
+      label: 'Sharing',
+      detail: 'Private, shared with named people, or open to the institution.',
+      icon: 'heroUserGroup',
+      assistant: 'yes',
+    },
+    {
+      label: 'A model you choose',
+      detail: 'Pick the model and tune its settings, within the bounds your role allows.',
+      icon: 'heroCpuChip',
+      assistant: 'no',
+    },
+    {
+      label: 'Tools',
+      detail: 'Give it the ability to act — search, run code, reach a connected system.',
+      icon: 'heroWrenchScrewdriver',
+      assistant: 'no',
+    },
+    {
+      label: 'Skills',
+      detail: 'Bundled know-how it loads on demand, so the instructions stay short.',
+      icon: 'heroPuzzlePiece',
+      assistant: 'no',
+    },
+    {
+      label: 'Memory spaces',
+      detail: 'A durable notebook it can read from, and write to when you allow it.',
+      icon: 'heroSparkles',
+      assistant: 'no',
+    },
+  ];
+
+  /** Downstream surfaces the single noun unlocked. All of these ship today. */
+  readonly opensUp: readonly OpensUp[] = [
+    {
+      title: 'A store to publish to',
+      body:
+        'Submit an agent for review and it appears in Discover, where anyone at the institution can find it — instead of you emailing a link to one person at a time.',
+      icon: 'heroSquares2x2',
+    },
+    {
+      title: 'Pin what you use',
+      body:
+        "Add someone else's agent to your own set and it is one click away from every chat. Your role may start you with a few already pinned.",
+      icon: 'heroBookmark',
+    },
+    {
+      title: 'Reach one mid-conversation',
+      body:
+        'Type @ in any chat to hand the current thread to a specialist agent, then carry on. No switching pages, no starting over.',
+      icon: 'heroChatBubbleLeftRight',
+    },
+    {
+      title: 'Run on a schedule',
+      body:
+        'Point a scheduled run at an agent and it works while you are not watching — a Monday digest, a nightly check, a weekly report.',
+      icon: 'heroClock',
+    },
+  ];
+}

--- a/frontend/ai.client/src/app/app.routes.spec.ts
+++ b/frontend/ai.client/src/app/app.routes.spec.ts
@@ -6,17 +6,21 @@ import { provideLocationMocks } from '@angular/common/testing';
 import { routes } from './app.routes';
 
 /**
- * Assistant-deprecation redirects (Designer Phase 5, #746).
+ * Assistant deprecation (Designer Phase 5, #746).
  *
- * `/assistants*` no longer renders anything — it redirects onto the Agent surface. These
- * paths are in people's bookmarks, in the "edit" link of every old chat session, and in
- * links colleagues shared with each other, so the redirect is the compatibility promise:
- * the ids are the same record on both sides (the compat mapping renders a legacy
- * Assistant *as* an Agent — nothing was migrated), so the redirect lands on the same
- * thing the old URL opened.
+ * The two **deep** `/assistants/*` paths redirect onto the Agent surface. They are in
+ * people's bookmarks, in the "edit" link of every old chat session, and in links
+ * colleagues shared with each other, so the redirect is the compatibility promise: the
+ * ids are the same record on both sides (the compat mapping renders a legacy Assistant
+ * *as* an Agent — nothing was migrated), so the redirect lands on the same thing the old
+ * URL opened.
+ *
+ * The bare `/assistants` **list** URL does not redirect: it renders the migration
+ * explainer, because that URL is browsed to rather than acted on, and a silent bounce
+ * leaves "where did my assistants go" unanswered.
  *
  * Asserted against the real route table rather than a hand-built one: the bug this guards
- * against is someone deleting the redirect entries, and a fixture table would not notice.
+ * against is someone deleting these entries, and a fixture table would not notice.
  */
 describe('app routes — assistant deprecation redirects', () => {
   @Component({ template: '' })
@@ -53,9 +57,11 @@ describe('app routes — assistant deprecation redirects', () => {
     TestBed.resetTestingModule();
   });
 
-  it('sends the assistants list to the agents hub', async () => {
+  it('keeps the assistants list URL on itself so the explainer can render', async () => {
+    // Not a redirect. Someone who bookmarked their Assistants list gets told what
+    // happened to it; bouncing them silently onto /agents is the bug this guards against.
     await router.navigateByUrl('/assistants');
-    expect(router.url).toBe('/agents');
+    expect(router.url).toBe('/assistants');
   });
 
   it('sends the new-assistant form to the Designer', async () => {

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -40,12 +40,14 @@ export const routes: Routes = [
     // exist only on the Agent surface — so the old editor had strictly less to offer for
     // the same record.
     //
-    // These stay as **redirects rather than deletions**: `/assistants/:id/edit` is in
-    // people's bookmarks, in old chat sessions' "edit" links and in links colleagues have
-    // shared with each other. The ids are identical on both sides (the compat mapping
+    // The two **deep** links stay redirects rather than deletions: `/assistants/:id/edit`
+    // is in people's bookmarks, in old chat sessions' "edit" links and in links colleagues
+    // have shared with each other. The ids are identical on both sides (the compat mapping
     // renders a legacy Assistant *as* an Agent — there was no data migration), so the
     // redirect lands on the same record. Removing them would turn every one of those into
-    // a 404 for no gain.
+    // a 404 for no gain. They stay *silent* for the same reason they exist: those URLs are
+    // an intent ("edit this record"), and interrupting an intent with an announcement is
+    // hostile.
     {
         path: 'assistants/new',
         redirectTo: 'agents/new',
@@ -57,8 +59,14 @@ export const routes: Routes = [
         pathMatch: 'full',
     },
     {
+        // The **list** URL is different: it is the one people browse to, and a silent
+        // redirect answers the routing question while leaving the human one — where did my
+        // assistants go — entirely unanswered. So it renders the explainer instead, which
+        // says what changed, that nothing was lost, and what the Agent surface adds. Every
+        // path out of it lands on `/agents`.
         path: 'assistants',
-        redirectTo: 'agents',
+        loadComponent: () => import('./agents/migration/agents-migration.page').then(m => m.AgentsMigrationPage),
+        canActivate: [authGuard],
         pathMatch: 'full',
     },
     {

--- a/frontend/ai.client/src/app/assistants/README.md
+++ b/frontend/ai.client/src/app/assistants/README.md
@@ -1,10 +1,16 @@
 # `assistants/` — shared building blocks, not a feature
 
 ⚠️ **There is no Assistants feature any more.** There is one noun, and it is **Agent**
-(Marketplace D1). Designer Phase 5 retired the Assistant editor: `/assistants`,
-`/assistants/new` and `/assistants/:id/edit` are `redirectTo` entries onto `/agents`, and
-the pages behind them (`assistants.page`, `assistant-form.page`, `assistant-list`,
-`assistant-preview`) were deleted.
+(Marketplace D1). Designer Phase 5 retired the Assistant editor: `/assistants/new` and
+`/assistants/:id/edit` are `redirectTo` entries onto `/agents`, and the pages behind them
+(`assistants.page`, `assistant-form.page`, `assistant-list`, `assistant-preview`) were
+deleted.
+
+`/assistants` itself is the one exception, and it is **not** an Assistants page: it renders
+`agents/migration/agents-migration.page`, which explains the rename and sends every route
+out of it to `/agents`. It lives under `agents/` like everything else user-facing, and the
+sidenav carries a matching muted "Assistants → Moved" signpost. Both are transitional —
+retire them once the rename has stopped being news.
 
 What is left in this folder is **the parts the Agent surface still consumes.** It survives
 under this name because the underlying record is still an Assistant on the wire — the ids

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -35,12 +35,6 @@
         <!--
             Agents (Agent Designer + Marketplace) — the ONE noun (Marketplace D1).
 
-            The "Assistants" entry that used to sit above this was removed in Designer
-            Phase 5. `/assistants*` now redirects here; the ids are the same record, so
-            nothing was migrated and no link broke. The Preview badge came off with it —
-            it existed only to say which of two competing nouns was still moving, and
-            there is no longer a second one.
-
             Gated on the API surface alone (D14): `showAgents()` is "the /agents list call did
             not 404", i.e. the AGENTS_API_ENABLED / AGENT_MARKETPLACE_ENABLED kill switches.
             The former `&& isAdmin()` came off when the marketplace went GA — it hid the nav
@@ -68,6 +62,46 @@
                     </svg>
                 </div>
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
+                <!--
+                    "New" rather than the amber "Preview" badge the preview surfaces wore:
+                    this is not unstable, it is unfamiliar. Primary blue for the same
+                    reason — amber in this nav has meant "not finished yet", and reusing
+                    it here would say the opposite of what is true.
+
+                    Remove this once the rename has stopped being news, together with the
+                    Assistants signpost below.
+                -->
+                <span class="ml-auto rounded-full bg-primary-50 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-primary-700 dark:bg-primary-400/15 dark:text-primary-200">New</span>
+            </a>
+
+            <!--
+                Assistants — a **signpost, not a feature**. The entry was removed in
+                Designer Phase 5 on the grounds that there is one noun; it comes back
+                because removing the word from the nav is exactly what makes someone who
+                built an assistant think theirs is gone. It does not lead to an Assistants
+                page (there is none): `/assistants` renders the migration explainer, whose
+                every route out lands on `/agents`.
+
+                Deliberately inside the `showAgents()` block. With the agent surface off,
+                every call to action on that page is dead, and a nav entry leading to a
+                page of dead links is worse than no entry.
+
+                Muted on purpose — this is the door someone leaves through once, not one of
+                the app's destinations. Retire it, and the "New" badge above, once the
+                rename has landed with users.
+            -->
+            <a
+                routerLink="/assistants"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-400 dark:text-gray-500">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Assistants</span>
+                <span class="ml-auto text-[10px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Moved</span>
             </a>
         }
 

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -265,17 +265,40 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
   });
 
   // ── Assistant deprecation (Designer Phase 5, #746) ────────────────────────────────
-  it('ships one noun: there is no Assistants entry beside Agents', async () => {
+  //
+  // The Assistants entry is back, but as a **signpost onto the migration explainer**, not
+  // as a second authoring surface. The distinction is the whole point, so it is what these
+  // assert: the link exists, and it does NOT go anywhere an assistant can be built.
+  function assistantsNavLink(fixture: ComponentFixture<unknown>): HTMLAnchorElement | null {
+    return fixture.nativeElement.querySelector('a[href="/assistants"]');
+  }
+
+  it('keeps an Assistants signpost so the old name is still findable', async () => {
+    const fixture = await renderSidenav();
+
+    expect(assistantsNavLink(fixture)).not.toBeNull();
+    expect(assistantsNavLink(fixture)!.textContent).toContain('Assistants');
+  });
+
+  it('still ships one authoring noun — no /assistants/new or editor entry', async () => {
     const fixture = await renderSidenav();
     const html = fixture.nativeElement as HTMLElement;
 
-    expect(html.querySelector('a[href="/assistants"]')).toBeNull();
-    expect(html.textContent).not.toContain('Assistants');
-    expect(agentsNavLink(fixture)).toBeDefined();
+    expect(html.querySelector('a[href="/assistants/new"]')).toBeNull();
+    expect(html.querySelector('a[href^="/assistants/"]')).toBeNull();
   });
 
-  it('drops the Preview badge, which only existed to disambiguate two nouns', async () => {
+  it('hides the Assistants signpost when the agent surface 404s', async () => {
+    // Every route out of the explainer lands on /agents. With the surface off, the
+    // signpost points at a page of dead links, so it must go with it.
+    mockAgentService.accessible$.set(false);
     const fixture = await renderSidenav();
+    expect(assistantsNavLink(fixture)).toBeNull();
+  });
+
+  it('badges Agents as New, not as Preview — unfamiliar is not unstable', async () => {
+    const fixture = await renderSidenav();
+    expect(agentsNavLink(fixture)!.textContent).toContain('New');
     expect(agentsNavLink(fixture)!.textContent).not.toContain('Preview');
   });
 });


### PR DESCRIPTION
## What

`/assistants` was a bare `redirectTo: 'agents'`. It now renders an explainer page instead. The sidenav gets a **New** badge on Agents and the **Assistants** entry back as a muted signpost onto that page.

## Why

A silent redirect answers the routing question and none of the human one. Someone who bookmarked their Assistants list lands on a page with a different name, a different tab strip and a different vocabulary, with nothing to tell them their work came with it. And removing "Assistants" from the nav entirely is exactly what makes someone who built one think theirs is gone.

## The page

Four sections, in the order the questions actually arrive:

1. **Hero** — "~~Assistants~~ are now **Agents**." Graph-paper field and a Boise-blue corner wash, borrowed at low intensity from the login shell. Two CTAs: *Go to my agents*, *Browse what others built*.
2. **"Your assistants are safe. They became agents."** — four one-line cards: same name/instructions/starters, knowledge bases, sharing, old links.
3. **"Why the name had to grow"** — the ledger. A real `<table>` with a spotlight band down the Agent column: instructions / knowledge base / sharing are a yes in both, then model, tools, skills and memory spaces are a yes only under Agent. That table *is* the argument for the change, not decoration around it.
4. **"What that opens up"** — store publishing, pinning, `@`-mention mid-chat, scheduled runs.

Every claim maps to a surface that ships today, checked against the code rather than the spec. If one is removed or gated, the claim on this page goes with it — an explainer that oversells is worse than the redirect it replaced.

## Routing

Only the **list** URL changed. `/assistants/new` and `/assistants/:id/edit` stay silent redirects: those are an intent, not browsing, and interrupting "edit this specific record" with an announcement would be hostile. `app.routes.spec.ts` updated to assert the new split rather than the old blanket redirect.

## Sidenav

- **New** badge on Agents — same pill geometry as the retired "Preview" badge, but primary blue. Amber in this nav has meant "not finished yet"; reusing it would say the opposite of what's true.
- **Assistants** entry restored below it, muted, with a small "Moved" marker. It sits *inside* the `showAgents()` gate — with the agent surface off, every CTA on the explainer is dead, and a link to a page of dead links is worse than no link.

Both are marked in-code as transitional. Retire them together once the rename has stopped being news.

## Reviewer notes

- **The sidenav changes are test-verified, not eye-verified.** The nav entry only renders after a successful `/agents` call and there's no backend on the local dev server, so I got bounced to first-boot. The markup reuses the exact anchor from the commit that removed it (`0b22530b`) and the exact badge classes from the shipped Preview badge — but please glance at it once this is on dev.
- The page itself was checked live in the browser at several widths, light theme. Dark theme is styled but was not eye-checked.
- Accessibility: the comparison is a real table with `<caption>` and `<th scope>`, the ✓/— cells carry `sr-only` Yes/No text, decorative layers are `aria-hidden`, and the load animation is inside `prefers-reduced-motion: no-preference` with `.reveal` starting visible so nothing can strand content invisible.
- `assistants/README.md` updated — it claimed all three `/assistants*` paths were `redirectTo` entries.

## Testing

- Production build clean (the initial-bundle budget warning is pre-existing).
- Full SPA suite: **1684 tests / 152 files passing**, including four rewritten sidenav specs (signpost present, no `/assistants/*` authoring entry, hidden when the surface 404s, New-not-Preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
