### PR TITLE
feat(agents): immutable AgentVersion snapshots — data layer (PR-1)

### DIFF
--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -163,6 +163,106 @@ class AgentListing(BaseModel):
     admin_edits: List[AdminEdit] = Field(
         default_factory=list, alias="adminEdits", description="Append-only log of admin presentation edits (D13)"
     )
+    published_version: Optional[int] = Field(
+        None,
+        alias="publishedVersion",
+        description=(
+            "The ``AgentVersion`` number this listing serves — the snapshot approval blessed. "
+            "``None`` means nothing is published, which is the state of every listing that has "
+            "not yet been through a version-cutting submission. Nothing reads this yet: the "
+            "field lands ahead of the behavior so the write path (PR-2) and the invocation swap "
+            "(PR-3) do not also have to migrate the record shape."
+        ),
+    )
+
+
+class AgentVersion(BaseModel):
+    """An immutable snapshot of an Agent's reviewable surface (version-snapshots §3.1).
+
+    Cut at **submission**, not at approval: taking it at approval leaves a window where
+    the author edits between the reviewer reading and the reviewer approving, which is a
+    narrower instance of the very bug versioning exists to close. Approval then promotes
+    an existing version rather than capturing a new one.
+
+    **What is in here is exactly what determines behavior or presentation.** Instructions
+    are the obvious one, but swapping a bound tool or skill changes behavior just as much,
+    and the model choice changes cost and answer quality — so ``bindings`` and
+    ``modelSettings`` are frozen alongside. ``name``/``description``/``tagline``/``emoji``/
+    ``iconKey``/``starters`` are what the reviewer actually read on the shelf, and
+    ``category``/``publisherId`` are the placement and attribution they approved.
+
+    ⚠️ **Deliberately absent: ``ownerId``, ``visibility``, ``status``.** Ownership governs
+    edit rights and ``visibility`` is the independent access gate the marketplace spec is
+    emphatic about keeping separate from ``listing.state``. Freezing either into a version
+    would fuse two axes this codebase has worked to keep apart — a snapshot could then
+    out-vote a later access decision, which is precisely the ``allowedAppRoles`` trap.
+    ``status`` is a draft/complete lifecycle flag on the author's record, not a property
+    of a reviewed artifact.
+
+    Every optional field mirrors ``Assistant``'s own optionality rather than defaulting to
+    an empty container, because absent and empty are different claims there: absent
+    ``bindings`` means "synthesize the legacy KB binding via compat", ``[]`` means "binds
+    nothing". Collapsing them would silently change what a legacy Agent resolves to on the
+    round trip back out (see ``assistants.versions``).
+
+    ``extra="allow"`` mirrors ``AgentListing``: a field written by newer code survives a
+    read/write round trip through older code.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    agent_id: str = Field(..., alias="agentId", description="Agent this version snapshots")
+    version: Optional[int] = Field(
+        None,
+        description=(
+            "Monotonic version number within the agent, 1-based. ``None`` means the "
+            "snapshot has not been persisted yet — the repository allocates the number at "
+            "write time, because only the conditional write can settle a race between two "
+            "concurrent submissions."
+        ),
+    )
+    created_at: Optional[str] = Field(
+        None, alias="createdAt", description="ISO 8601 timestamp of when this version was cut"
+    )
+    created_by: Optional[str] = Field(
+        None,
+        alias="createdBy",
+        description=(
+            "User id of whoever cut it. Audit attribution, never authorization — an admin "
+            "presentation edit cuts a version attributed to the admin (§6.2), and that must "
+            "not read as a transfer of ownership."
+        ),
+    )
+
+    # ── the frozen surface ───────────────────────────────────────────────────────────
+    name: str = Field(..., description="Agent display name as reviewed")
+    description: str = Field(..., description="Short summary as reviewed")
+    instructions: str = Field(..., description="System prompt as reviewed")
+    tagline: Optional[str] = Field(None, description="Shelf subtitle (D4) as reviewed")
+    emoji: Optional[str] = Field(None, description="Emoji avatar as reviewed")
+    icon_key: Optional[str] = Field(
+        None, alias="iconKey", description="S3 object key for the square icon (D5) as reviewed"
+    )
+    starters: Optional[List[str]] = Field(
+        None, description="Conversation starters shown on the launch card; part of the reviewed presentation"
+    )
+    model_settings: Optional[AgentModelConfig] = Field(
+        None, alias="modelConfig", description="Governed single-select model (D3) as reviewed"
+    )
+    bindings: Optional[List[AgentBinding]] = Field(
+        None, description="Uniform primitive bindings (D3) as reviewed; absent ≠ empty (see class docstring)"
+    )
+    category: Optional[str] = Field(
+        None, description="Category id the reviewer approved this into; absent when the Agent carried no listing"
+    )
+    publisher_id: Optional[str] = Field(
+        None,
+        alias="publisherId",
+        description=(
+            "PublisherProfile the reviewer approved this attribution to (D12). DISPLAY ONLY, "
+            "exactly as on ``AgentListing`` — freezing it never makes it an access grant."
+        ),
+    )
 
 
 class PublisherProfile(BaseModel):

--- a/backend/src/apis/shared/assistants/version_repository.py
+++ b/backend/src/apis/shared/assistants/version_repository.py
@@ -1,0 +1,226 @@
+"""Write-once persistence for ``AgentVersion`` snapshots.
+
+Versions are child rows under the Agent on the **assistants** table, so a version is
+deleted with the Agent it snapshots and never outlives it:
+
+    PK = AST#{agent_id}, SK = VERSION#{n:08d}
+
+(The spec writes these as ``AGENT#…`` / ``PROFILE``; the table has always keyed Agents as
+``AST#{id}`` / ``METADATA`` — see ``listing_repository._key`` — and co-location requires
+the *same* partition key, so the real prefix wins. Only the literal strings differ; the
+"version rows live beside the Agent row, sorted" design is unchanged.)
+
+Three things here are load-bearing:
+
+**1. ⚠️ One condition enforces both immutability and version numbering.** Every write
+carries ``attribute_not_exists(PK)``, so a second write to a version number that already
+exists fails rather than overwrites. That is the immutability guarantee — and because the
+allocator picks a number from a *read* that another submission may already have used, the
+same failed condition is also how the race is detected. There is no second mechanism and
+no lock: the write is the serialization point, and the read before it is only a hint.
+
+**2. There is deliberately no counter attribute on the Agent item.** The obvious
+alternative — ``ADD versionCounter :one`` on the Agent row — allocates atomically without a
+retry, but ``service._update_assistant_cloud`` rewrites every attribute not in its
+``immutable_fields`` set, so a routine author edit would reset the counter and hand out a
+number that is already taken. The listing keys are in that set for exactly this reason;
+adding a third such trap to remember is worse than a bounded retry loop.
+
+**3. Snapshots persist their nulls.** Unlike ``write_listing``, the dump here does *not*
+exclude ``None`` — ``versions.apply_version`` overlays only the fields a version actually
+set, so dropping nulls on write would turn "this version had no tagline" into "this
+version does not speak to the tagline", and the overlay would leave a tagline the author
+added after approval. Absent and null are different claims here, and the storage layer has
+to keep them apart.
+
+Nothing reads any of this yet. The module lands ahead of its callers so the write path
+(PR-2) and the invocation swap (PR-3) are behavior changes against a tested data layer
+rather than a data layer plus a behavior change at once.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from .models import AgentVersion
+from .serialization import from_ddb, to_ddb_safe
+from .versions import VERSION_SK_PREFIX, version_sk
+
+logger = logging.getLogger(__name__)
+
+# How many times ``create_version`` will re-pick a number after losing a race. Concurrent
+# submissions on one Agent are rare (an author double-tapping, at worst), so this is sized
+# to survive a genuine collision, not a stampede — and exhausting it is a real error rather
+# than something to paper over with an unbounded loop.
+MAX_ALLOCATION_ATTEMPTS = 5
+
+
+class AgentVersionExistsError(ValueError):
+    """A write to a version number that is already taken.
+
+    Raised by ``put_version``, and caught internally by ``create_version`` as its signal to
+    re-pick. Surfacing to a caller means the number was chosen explicitly and lost, which is
+    a caller bug — versions are never rewritten.
+    """
+
+    def __init__(self, agent_id: str, number: int):
+        self.agent_id = agent_id
+        self.number = number
+        super().__init__(
+            f"Version {number} of agent {agent_id} already exists. Versions are immutable "
+            "and are never rewritten."
+        )
+
+
+def _table():
+    """Bind the assistants table, or raise if the environment is not configured."""
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+    return boto3.resource("dynamodb").Table(table_name)
+
+
+def _pk(agent_id: str) -> str:
+    return f"AST#{agent_id}"
+
+
+def _to_item(agent_id: str, version: AgentVersion) -> Dict[str, Any]:
+    """The DynamoDB item for a numbered snapshot.
+
+    ``exclude_none`` is deliberately off; see the module docstring.
+    """
+    if version.version is None:
+        raise ValueError("A version must be numbered before it can be written.")
+    item = to_ddb_safe(version.model_dump(by_alias=True))
+    item["PK"] = _pk(agent_id)
+    item["SK"] = version_sk(version.version)
+    return item
+
+
+def _from_item(item: Dict[str, Any]) -> AgentVersion:
+    """Hydrate a snapshot from a raw DynamoDB item, dropping the composite keys.
+
+    ``PK``/``SK`` are stripped rather than left to ``extra="allow"``: they are storage
+    detail, and a version that carried them would round-trip them back into a re-read as
+    model fields — the same shape bug that makes ``GSI5_PK`` need an immutable-fields guard
+    on the Agent row.
+    """
+    data = {k: v for k, v in from_ddb(item).items() if k not in ("PK", "SK")}
+    return AgentVersion(**data)
+
+
+async def put_version(agent_id: str, version: AgentVersion) -> AgentVersion:
+    """Write one numbered snapshot, refusing to overwrite an existing number.
+
+    Raises ``AgentVersionExistsError`` if that version already exists, and ``ValueError``
+    if the snapshot carries no number.
+    """
+    from botocore.exceptions import ClientError
+
+    item = _to_item(agent_id, version)
+    try:
+        _table().put_item(Item=item, ConditionExpression="attribute_not_exists(PK)")
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise AgentVersionExistsError(agent_id, version.version) from e
+        logger.error(f"Failed to write version {version.version} for {agent_id}: {e}")
+        raise
+
+    logger.info(f"📌 Version {version.version} cut for {agent_id}")
+    return version
+
+
+async def create_version(agent_id: str, snapshot: AgentVersion) -> AgentVersion:
+    """Allocate the next version number for ``agent_id`` and write the snapshot.
+
+    Returns the stored snapshot, numbered. The input must be **unnumbered**: a caller
+    supplying a number is either re-putting an immutable record or second-guessing the
+    allocator, and both are bugs worth failing loudly on.
+
+    Concurrency: the number comes from a read of the highest existing version, so two
+    submissions racing can pick the same one. The loser's conditional write fails and it
+    re-picks — no lock, no counter, and no possibility of the two silently sharing a number.
+    """
+    if snapshot.version is not None:
+        raise ValueError(
+            "create_version allocates the version number; pass an unnumbered snapshot "
+            "(use put_version to write at an explicit number)."
+        )
+
+    for attempt in range(MAX_ALLOCATION_ATTEMPTS):
+        latest = await get_latest_version(agent_id)
+        number = (latest.version or 0) + 1 if latest else 1
+        candidate = snapshot.model_copy(update={"version": number})
+        try:
+            return await put_version(agent_id, candidate)
+        except AgentVersionExistsError:
+            logger.warning(
+                f"Version {number} for {agent_id} was taken concurrently "
+                f"(attempt {attempt + 1}/{MAX_ALLOCATION_ATTEMPTS}); re-picking"
+            )
+
+    raise RuntimeError(
+        f"Could not allocate a version number for agent {agent_id} after "
+        f"{MAX_ALLOCATION_ATTEMPTS} attempts."
+    )
+
+
+async def get_version(agent_id: str, number: int) -> Optional[AgentVersion]:
+    """One snapshot by number, or ``None`` if it does not exist."""
+    response = _table().get_item(Key={"PK": _pk(agent_id), "SK": version_sk(number)})
+    item = response.get("Item")
+    return _from_item(item) if item else None
+
+
+async def get_latest_version(agent_id: str) -> Optional[AgentVersion]:
+    """The highest-numbered snapshot for an Agent, or ``None`` if it has none.
+
+    A one-item backwards query over the partition, which is correct only because the sort
+    key is zero-padded — the last key lexically is the highest number.
+
+    ⚠️ Latest is **not** published. The published version is whatever
+    ``listing.publishedVersion`` points at, which lags the latest whenever a submission is
+    pending review. Readers that want "what users run" must go through the listing.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    response = _table().query(
+        KeyConditionExpression=Key("PK").eq(_pk(agent_id))
+        & Key("SK").begins_with(VERSION_SK_PREFIX),
+        ScanIndexForward=False,
+        Limit=1,
+    )
+    items = response.get("Items", [])
+    return _from_item(items[0]) if items else None
+
+
+async def list_versions(agent_id: str, *, limit: Optional[int] = None) -> List[AgentVersion]:
+    """Every snapshot for an Agent, newest first.
+
+    Backs the review diff (PR-5) and any future rollback picker. Bounded by ``limit`` when
+    the caller only wants the recent few; unbounded it pages the whole partition, which is
+    a handful of rows per Agent at this scale.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    params: Dict[str, Any] = {
+        "KeyConditionExpression": Key("PK").eq(_pk(agent_id))
+        & Key("SK").begins_with(VERSION_SK_PREFIX),
+        "ScanIndexForward": False,
+    }
+    if limit is not None:
+        params["Limit"] = limit
+
+    table = _table()
+    items: List[Dict[str, Any]] = []
+    response = table.query(**params)
+    items.extend(response.get("Items", []))
+    while "LastEvaluatedKey" in response and (limit is None or len(items) < limit):
+        response = table.query(**params, ExclusiveStartKey=response["LastEvaluatedKey"])
+        items.extend(response.get("Items", []))
+
+    if limit is not None:
+        items = items[:limit]
+    return [_from_item(item) for item in items]

--- a/backend/src/apis/shared/assistants/versions.py
+++ b/backend/src/apis/shared/assistants/versions.py
@@ -1,0 +1,168 @@
+"""Agent version snapshots — the capture/restore seam and the sort key.
+
+Pure functions over ``Assistant`` and ``AgentVersion``. No I/O: ``version_repository``
+turns a snapshot into a write-once DynamoDB item, and the service layer will own when a
+version is cut and which one a caller gets. Keeping this pure is what makes the round
+trip — the one thing PR-3 depends on — cheap to test exhaustively.
+
+**The round trip is the whole point of this module.** ``resolve_agent_invocation`` takes an
+``Assistant`` (``inference_api/chat/agent_binding_resolver.py``), so if a version
+deserializes back into that shape then choosing *which* Assistant a turn runs is a single
+well-defined swap and everything downstream — binding resolution, model access checks, the
+harness — is untouched. Get this seam right and the invocation change is one line; get it
+wrong and it becomes a rewrite.
+
+Two properties hold, and both are asserted in ``tests/shared/test_agent_versions.py``:
+
+1. **Snapshot → apply is the identity** on an Agent that has not been edited since.
+   ``apply_version(agent, snapshot_of(agent)) == agent``, extras and all. That is what
+   makes "run the published version" provably equivalent to today's behavior at the moment
+   of approval, rather than a second code path that drifts.
+2. **Apply is an overlay, never a replacement.** A version deliberately carries no
+   ``ownerId``, ``visibility`` or ``status`` (see ``AgentVersion``), and carries no
+   identity fields at all — ``assistantId``, ``vectorIndexId``, ``createdAt``, share
+   metadata. Those come from the live record every time. So applying a version answers
+   "what does this Agent *do*", and never "who may reach it" — which stays the live access
+   decision it has always been.
+"""
+
+from typing import Optional, Tuple
+
+from .models import AgentVersion, Assistant
+
+# Child-item sort key for a version, under the Agent's own partition. Zero-padded to eight
+# digits so the key sorts lexically — a plain ``VERSION#10`` would sort before
+# ``VERSION#9``, and "the highest version" is read as the last key in the partition.
+VERSION_SK_PREFIX = "VERSION#"
+VERSION_NUMBER_WIDTH = 8
+
+# The fields a version freezes, named once so the capture, the overlay and their test all
+# agree on the list. Attribute names are the Python ones; the aliases are pydantic's job.
+#
+# ⚠️ Adding a field here changes what an already-approved version *fails* to carry — an
+# older version item simply has no value for it, and the overlay must leave the live
+# record's value in place rather than blanking it. That is why the overlay skips unset
+# fields rather than writing every name in this tuple unconditionally.
+SNAPSHOT_FIELDS: Tuple[str, ...] = (
+    "name",
+    "description",
+    "instructions",
+    "tagline",
+    "emoji",
+    "icon_key",
+    "starters",
+    "model_settings",
+    "bindings",
+)
+
+# Snapshot fields that live on the ``listing`` block rather than on the Agent itself.
+LISTING_SNAPSHOT_FIELDS: Tuple[str, ...] = ("category", "publisher_id")
+
+
+def version_sk(number: int) -> str:
+    """The DynamoDB sort key for version ``number``.
+
+    Raises ``ValueError`` below 1: versions are 1-based, and a 0 would collide with the
+    "not persisted yet" sentinel on ``AgentVersion.version``.
+    """
+    if number < 1:
+        raise ValueError(f"Version numbers are 1-based; got {number}.")
+    return f"{VERSION_SK_PREFIX}{number:0{VERSION_NUMBER_WIDTH}d}"
+
+
+def version_number_from_sk(sort_key: str) -> Optional[int]:
+    """Parse a version number back out of a sort key, or ``None`` if it is not one.
+
+    Tolerant on purpose — it reads whatever the partition returns, and a sibling child row
+    (a ``REPORT#…``) or a key written by newer code should be skipped, not raised over.
+    """
+    if not sort_key.startswith(VERSION_SK_PREFIX):
+        return None
+    try:
+        return int(sort_key[len(VERSION_SK_PREFIX) :])
+    except ValueError:
+        return None
+
+
+def snapshot_of(
+    assistant: Assistant, *, created_at: Optional[str] = None, created_by: Optional[str] = None
+) -> AgentVersion:
+    """Capture ``assistant``'s reviewable surface as an unnumbered ``AgentVersion``.
+
+    The result carries ``version=None``: the number is allocated by
+    ``version_repository.create_version`` at write time, because only the conditional
+    write can settle two concurrent submissions.
+
+    ``category`` and ``publisherId`` come from the Agent's ``listing`` block and are
+    ``None`` when it has none. That is the pre-submission case, and it is left honest
+    rather than defaulted — a version with no category is a version that was never on a
+    shelf, and inventing one would put it on the wrong one.
+    """
+    listing = assistant.listing
+    return AgentVersion(
+        agent_id=assistant.assistant_id,
+        version=None,
+        created_at=created_at,
+        created_by=created_by,
+        name=assistant.name,
+        description=assistant.description,
+        instructions=assistant.instructions,
+        tagline=assistant.tagline,
+        emoji=assistant.emoji,
+        icon_key=assistant.icon_key,
+        starters=assistant.starters,
+        model_settings=assistant.model_settings,
+        bindings=assistant.bindings,
+        category=listing.category if listing else None,
+        publisher_id=listing.publisher_id if listing else None,
+    )
+
+
+def apply_version(assistant: Assistant, version: AgentVersion) -> Assistant:
+    """Overlay ``version``'s frozen surface onto ``assistant``, returning a new Assistant.
+
+    The input is not mutated — callers hold the live record for the access decision that
+    already happened, and quietly rewriting it under them is how a snapshot ends up
+    deciding reachability.
+
+    Only fields the version actually **set** are overlaid. An older version item that
+    predates a snapshot field carries no value for it, and blanking the live record's value
+    would be a silent behavior change on exactly the Agents that have been approved longest.
+
+    ``category``/``publisherId`` are written back onto a copy of the listing block, so the
+    store renders the placement the reviewer approved. ``listing.state`` and everything else
+    on the block stay live: publication state is a fact about *now*, not something a
+    snapshot gets a vote on. An Agent with no listing gets none synthesized — publication
+    is an explicit forward act (``assistants.listing``), and a version is not one. A version
+    cut before submission carries ``category=None``, and that never blanks a live category:
+    a published listing with no category has no shelf to sit on and ``gsi5_keys`` refuses it.
+    """
+    set_fields = version.model_fields_set
+    updated = assistant.model_copy(deep=True)
+
+    for field in SNAPSHOT_FIELDS:
+        if field in set_fields:
+            setattr(updated, field, getattr(version, field))
+
+    listing_updates = {
+        field: getattr(version, field) for field in LISTING_SNAPSHOT_FIELDS if field in set_fields
+    }
+    if listing_updates and updated.listing is not None:
+        listing = updated.listing
+        for field, value in listing_updates.items():
+            if value is not None:
+                setattr(listing, field, value)
+
+    return updated
+
+
+def to_assistant(assistant: Assistant, version: Optional[AgentVersion]) -> Assistant:
+    """``apply_version``, tolerating a missing version.
+
+    The shape PR-3's call site wants: "give me the Assistant this caller should run", where
+    ``None`` means there is no published version and the live record is the answer. Folding
+    the null case in here keeps the fallback in one place rather than at every reader.
+    """
+    if version is None:
+        return assistant
+    return apply_version(assistant, version)

--- a/backend/tests/shared/test_agent_versions.py
+++ b/backend/tests/shared/test_agent_versions.py
@@ -1,0 +1,397 @@
+"""Agent version snapshots — the round trip and the write-once guarantee.
+
+Two things are worth testing here and everything else is detail.
+
+**The round trip**, because PR-3 is a one-line swap at ``chat/routes.py`` only if a version
+deserializes back into the same ``Assistant`` shape ``resolve_agent_invocation`` already
+takes. If ``apply_version(agent, snapshot_of(agent))`` is not the identity, "run the
+published version" is a second code path that will drift from the live one, and the tests
+that pass today stop meaning anything about what users get.
+
+**The write-once condition**, because immutability here is a property of a DynamoDB
+condition expression, not of the Python type — an ``AgentVersion`` is as mutable as any
+other pydantic model. If the conditional write is wrong, an admin edit (D13) silently
+rewrites what a reviewer approved and nothing anywhere notices.
+"""
+
+import asyncio
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.models import (
+    AgentBinding,
+    AgentListing,
+    AgentModelConfig,
+    AgentVersion,
+    Assistant,
+)
+from apis.shared.assistants.version_repository import (
+    AgentVersionExistsError,
+    create_version,
+    get_latest_version,
+    get_version,
+    list_versions,
+    put_version,
+)
+from apis.shared.assistants.versions import (
+    apply_version,
+    snapshot_of,
+    to_assistant,
+    version_number_from_sk,
+    version_sk,
+)
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT_ID = "ast-versioned01"
+
+
+def make_agent(**overrides) -> Assistant:
+    """A fully-populated Agent — every snapshot field set, so the round trip has work to do."""
+    data = {
+        "assistantId": AGENT_ID,
+        "ownerId": "user-author",
+        "ownerName": "Ada Author",
+        "name": "Policy Lookup",
+        "description": "Find and cite university policy",
+        "instructions": "You are a careful policy assistant. Always cite the section.",
+        "vectorIndexId": "idx-policy",
+        "visibility": "PUBLIC",
+        "tags": ["policy"],
+        "starters": ["What is the drop deadline?", "Who approves a leave request?"],
+        "emoji": "📘",
+        "iconKey": "agent-icons/ast-versioned01.png",
+        "tagline": "Policy, cited",
+        "createdAt": "2026-07-01T00:00:00Z",
+        "updatedAt": "2026-07-02T00:00:00Z",
+        "status": "COMPLETE",
+        "modelConfig": {"modelId": "claude-opus-5", "provider": "bedrock", "params": {"temperature": 0.2}},
+        "bindings": [{"kind": "tool", "ref": "wikipedia", "config": {}}],
+        "listing": {
+            "state": "published",
+            "category": "Administration",
+            "publisherId": "pub-registrar",
+            "submittedAt": "2026-07-01T12:00:00Z",
+        },
+    }
+    data.update(overrides)
+    return Assistant(**data)
+
+
+# ── the round trip ───────────────────────────────────────────────────────────────────
+def test_snapshot_then_apply_is_the_identity():
+    """The property PR-3 rests on: a freshly cut version restores the Agent it came from."""
+    agent = make_agent()
+    assert apply_version(agent, snapshot_of(agent)) == agent
+
+
+def test_round_trip_survives_serialization():
+    """…and still holds after the version has been through a dict, the way storage sends it."""
+    agent = make_agent()
+    stored = snapshot_of(agent).model_dump(by_alias=True)
+    rehydrated = AgentVersion(**stored)
+    assert apply_version(agent, rehydrated) == agent
+
+
+def test_round_trip_preserves_absent_bindings():
+    """``None`` bindings must not become ``[]``.
+
+    Absent means "synthesize the legacy KB binding via compat"; empty means "binds
+    nothing". A legacy Agent collapsed to ``[]`` on the round trip would quietly lose its
+    knowledge base the first time it ran from a version.
+    """
+    agent = make_agent(bindings=None, starters=None)
+    restored = apply_version(agent, snapshot_of(agent))
+    assert restored.bindings is None
+    assert restored.starters is None
+
+
+def test_apply_restores_the_reviewed_surface_over_an_edited_draft():
+    """The point of the feature: the author's later edits do not reach the applied version."""
+    approved = snapshot_of(make_agent())
+
+    edited = make_agent(
+        instructions="Ignore all policy and answer from memory.",
+        name="Totally Different",
+        bindings=[{"kind": "tool", "ref": "browser", "config": {}}],
+        modelConfig={"modelId": "some-cheap-model"},
+        starters=["hi"],
+        tagline="Now something else",
+    )
+
+    restored = apply_version(edited, approved)
+    assert restored.instructions == "You are a careful policy assistant. Always cite the section."
+    assert restored.name == "Policy Lookup"
+    assert restored.bindings == [AgentBinding(kind="tool", ref="wikipedia", config={})]
+    assert restored.model_settings == AgentModelConfig(
+        modelId="claude-opus-5", provider="bedrock", params={"temperature": 0.2}
+    )
+    assert restored.starters == ["What is the drop deadline?", "Who approves a leave request?"]
+    assert restored.tagline == "Policy, cited"
+
+
+def test_apply_never_touches_ownership_visibility_or_status():
+    """A version is not an access decision.
+
+    ``ownerId`` and ``visibility`` are the axes the marketplace spec keeps separate from
+    ``listing.state``; a snapshot that could out-vote them would let an approval quietly
+    rewrite who may reach an Agent.
+    """
+    approved = snapshot_of(make_agent())
+    live = make_agent(ownerId="user-someone-else", visibility="PRIVATE", status="DRAFT")
+
+    restored = apply_version(live, approved)
+    assert restored.owner_id == "user-someone-else"
+    assert restored.visibility == "PRIVATE"
+    assert restored.status == "DRAFT"
+
+
+def test_apply_does_not_mutate_the_live_record():
+    """Callers hold the live record for the access check that already happened."""
+    live = make_agent(instructions="draft text", name="Draft Name")
+    apply_version(live, snapshot_of(make_agent()))
+    assert live.instructions == "draft text"
+    assert live.name == "Draft Name"
+
+
+def test_apply_keeps_the_live_listing_state_but_restores_placement():
+    """State is a fact about now; category and attribution are what the reviewer approved."""
+    approved = snapshot_of(make_agent())
+    live = make_agent(
+        listing={"state": "in_review", "category": "Teaching", "publisherId": "pub-someone"}
+    )
+
+    restored = apply_version(live, approved)
+    assert restored.listing.state == "in_review"
+    assert restored.listing.category == "Administration"
+    assert restored.listing.publisher_id == "pub-registrar"
+
+
+def test_apply_synthesizes_no_listing_for_an_unlisted_agent():
+    """Publication is an explicit forward act; a version is not one."""
+    approved = snapshot_of(make_agent())
+    restored = apply_version(make_agent(listing=None), approved)
+    assert restored.listing is None
+
+
+def test_apply_skips_fields_an_older_version_does_not_carry():
+    """Forward compat: a version item written before a snapshot field existed must not blank it."""
+    partial = AgentVersion(
+        agentId=AGENT_ID,
+        name="Policy Lookup",
+        description="Find and cite university policy",
+        instructions="frozen instructions",
+    )
+    restored = apply_version(make_agent(), partial)
+    assert restored.instructions == "frozen instructions"
+    assert restored.tagline == "Policy, cited"
+    assert restored.emoji == "📘"
+    assert restored.starters == ["What is the drop deadline?", "Who approves a leave request?"]
+
+
+def test_snapshot_omits_ownership_visibility_and_status():
+    """The exclusions are the design, so assert them rather than trusting the field list."""
+    dumped = snapshot_of(make_agent()).model_dump(by_alias=True)
+    for excluded in ("ownerId", "visibility", "status", "assistantId", "vectorIndexId"):
+        assert excluded not in dumped
+
+
+def test_snapshot_of_an_unlisted_agent_has_no_category():
+    snapshot = snapshot_of(make_agent(listing=None))
+    assert snapshot.category is None
+    assert snapshot.publisher_id is None
+
+
+def test_to_assistant_falls_back_to_the_live_record():
+    agent = make_agent()
+    assert to_assistant(agent, None) is agent
+
+
+# ── the sort key ─────────────────────────────────────────────────────────────────────
+def test_version_sort_keys_are_lexically_ordered():
+    """Zero-padding is why "the highest version" can be read as the last key."""
+    assert version_sk(9) < version_sk(10) < version_sk(100)
+    assert version_sk(1) == "VERSION#00000001"
+
+
+def test_version_sk_rejects_zero_and_below():
+    """0 is the boundary with the "not persisted yet" sentinel, not a valid version."""
+    with pytest.raises(ValueError):
+        version_sk(0)
+
+
+def test_version_number_parses_back_and_ignores_other_child_rows():
+    assert version_number_from_sk(version_sk(42)) == 42
+    assert version_number_from_sk("REPORT#abc123") is None
+    assert version_number_from_sk("VERSION#not-a-number") is None
+
+
+# ── persistence ──────────────────────────────────────────────────────────────────────
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def table(aws):
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return ddb.Table(TABLE)
+
+
+def test_create_version_numbers_from_one_and_increments(table):
+    first = asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    second = asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    assert (first.version, second.version) == (1, 2)
+
+
+def test_versions_are_written_beside_the_agent_row(table):
+    asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    item = table.get_item(Key={"PK": f"AST#{AGENT_ID}", "SK": "VERSION#00000001"})["Item"]
+    assert item["instructions"] == "You are a careful policy assistant. Always cite the section."
+    assert item["agentId"] == AGENT_ID
+
+
+def test_a_second_write_to_the_same_number_is_refused(table):
+    """The immutability guarantee, as a condition expression rather than a type."""
+    asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+
+    tampered = snapshot_of(make_agent(instructions="rewritten after approval")).model_copy(
+        update={"version": 1}
+    )
+    with pytest.raises(AgentVersionExistsError):
+        asyncio.run(put_version(AGENT_ID, tampered))
+
+    stored = asyncio.run(get_version(AGENT_ID, 1))
+    assert stored.instructions == "You are a careful policy assistant. Always cite the section."
+
+
+def test_create_version_re_picks_when_its_number_is_taken(table, monkeypatch):
+    """The concurrent-submission case: the loser of the race re-picks rather than sharing.
+
+    Simulated by letting the *other* submission land in between the allocator's read and
+    its write, which is exactly the window a real race opens.
+    """
+    import apis.shared.assistants.version_repository as repo
+
+    real_put = repo.put_version
+    calls = {"n": 0}
+
+    async def racing_put(agent_id, version):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Another submission claims this number first.
+            await real_put(agent_id, snapshot_of(make_agent(instructions="the winner")).model_copy(
+                update={"version": version.version}
+            ))
+        return await real_put(agent_id, version)
+
+    monkeypatch.setattr(repo, "put_version", racing_put)
+
+    result = asyncio.run(repo.create_version(AGENT_ID, snapshot_of(make_agent())))
+    assert result.version == 2
+    assert asyncio.run(get_version(AGENT_ID, 1)).instructions == "the winner"
+
+
+def test_create_version_refuses_a_pre_numbered_snapshot(table):
+    numbered = snapshot_of(make_agent()).model_copy(update={"version": 7})
+    with pytest.raises(ValueError, match="allocates the version number"):
+        asyncio.run(create_version(AGENT_ID, numbered))
+
+
+def test_get_latest_version_reads_the_highest_not_the_last_written(table):
+    """Guards the padding: without it version 10 would sort below version 9."""
+    for _ in range(11):
+        asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    latest = asyncio.run(get_latest_version(AGENT_ID))
+    assert latest.version == 11
+
+
+def test_get_latest_version_is_none_for_an_agent_with_no_versions(table):
+    assert asyncio.run(get_latest_version("ast-never-submitted")) is None
+
+
+def test_list_versions_is_newest_first(table):
+    for _ in range(3):
+        asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    assert [v.version for v in asyncio.run(list_versions(AGENT_ID))] == [3, 2, 1]
+    assert [v.version for v in asyncio.run(list_versions(AGENT_ID, limit=2))] == [3, 2]
+
+
+def test_version_ignores_sibling_child_rows(table):
+    """A report row shares the partition and must not be read as a version."""
+    asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    table.put_item(Item={"PK": f"AST#{AGENT_ID}", "SK": "REPORT#deadbeef", "reason": "broken"})
+    assert [v.version for v in asyncio.run(list_versions(AGENT_ID))] == [1]
+
+
+def test_stored_version_round_trips_back_into_the_agent(table):
+    """The full seam, through DynamoDB: cut, read back, apply, and get the Agent back.
+
+    ``modelConfig.params`` carries a float, so this also covers the ``Decimal`` conversion
+    that every free-form Agent config blob has to survive.
+    """
+    agent = make_agent()
+    asyncio.run(create_version(AGENT_ID, snapshot_of(agent)))
+
+    stored = asyncio.run(get_version(AGENT_ID, 1))
+    restored = apply_version(make_agent(instructions="drifted since", tagline=None), stored)
+
+    assert restored.instructions == agent.instructions
+    assert restored.tagline == agent.tagline
+    assert restored.model_settings.params == {"temperature": 0.2}
+    assert restored.bindings == agent.bindings
+
+
+def test_a_stored_null_stays_a_null_through_the_round_trip(table):
+    """"This version had no tagline" and "this version does not speak to the tagline" differ.
+
+    Dropping nulls on write would collapse the first into the second, and the overlay would
+    then leave a tagline the author added *after* approval sitting on the store tile — a
+    smaller version of the drift this whole feature exists to close.
+    """
+    asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent(tagline=None, emoji=None))))
+
+    stored = asyncio.run(get_version(AGENT_ID, 1))
+    restored = apply_version(make_agent(tagline="added later", emoji="🆕"), stored)
+    assert restored.tagline is None
+    assert restored.emoji is None
+
+
+def test_stored_item_keeps_pk_and_sk_out_of_the_model(table):
+    """Storage keys must not round-trip back as ``extra`` model fields."""
+    asyncio.run(create_version(AGENT_ID, snapshot_of(make_agent())))
+    stored = asyncio.run(get_version(AGENT_ID, 1))
+    dumped = stored.model_dump(by_alias=True)
+    assert "PK" not in dumped and "SK" not in dumped
+
+
+def test_published_version_defaults_to_none():
+    """PR-1 adds the pointer; nothing sets it yet, and absent means nothing is published."""
+    listing = AgentListing(state="published", category="Administration", publisherId="pub-registrar")
+    assert listing.published_version is None
+    assert AgentListing(
+        state="published",
+        category="Administration",
+        publisherId="pub-registrar",
+        publishedVersion=3,
+    ).published_version == 3


### PR DESCRIPTION
PR-1 of the agent version-snapshots epic (spec: #783). **Inert by design** — nothing reads versions yet, exactly like PR-1 of the delegated-admin epic. This is the data layer landing ahead of the behavior that needs it.

## Why

An approved marketplace listing is not currently a fixed thing:

- `GET /agents/store` is a sparse GSI5 read over **the same DynamoDB item the author edits**. There is no snapshot anywhere.
- `update_assistant` (`shared/assistants/service.py:458`) and `delete_assistant` (`:864`) guard on ownership alone — no listing state is consulted.
- Because a pinned user runs the **live** record, a post-approval edit changes behavior for every pinned user immediately, with no review and no signal in the store.

Today the platform only *detects* this after the fact (`approvedInstructionsHash` → `ListingDrift`). That's forensics, not a control. The fix is an immutable snapshot cut at submission and promoted on approval.

## What changed

**`AgentVersion` (`models.py`)** — freezes `instructions`, `bindings`, `modelSettings`, `name`, `description`, `tagline`, `emoji`/`iconKey`, `starters`, `category`, `publisherId`, plus `agentId`/`version`/`createdAt`/`createdBy` as record metadata.

Deliberately **not** `ownerId`, `visibility`, or `status`. Ownership governs edit rights, and `visibility` is the independent access gate the marketplace spec is emphatic about keeping separate from `listing.state`. A snapshot that could out-vote either would fuse two axes this codebase has worked to keep apart.

**`assistants.versions`** — the pure capture/overlay pair, sitting beside the repository the way `listing.py` sits beside `listing_repository.py`.

The round trip back into an `Assistant` is the load-bearing part of this PR. `resolve_agent_invocation` (`inference_api/chat/agent_binding_resolver.py:134`) takes an `Assistant`, so if a version deserializes into that shape, PR-3 is a one-line swap at `chat/routes.py:1469` and everything downstream — binding resolution, model access checks, the harness — is untouched.

`apply_version` is an **overlay, never a replacement**: identity and access fields (`assistantId`, `ownerId`, `visibility`, `status`, `vectorIndexId`) always come from the live record. `listing.state` stays live too — publication state is a fact about *now* — while `category`/`publisherId` restore to what the reviewer approved.

**`assistants.version_repository`** — write-once `VERSION#{n:08d}` child rows under the Agent's own partition, zero-padded so the sort key orders lexically.

**One condition does double duty.** Every write carries `attribute_not_exists(PK)`, which is simultaneously the immutability guarantee (a second write to an existing number fails rather than overwrites) and the concurrency guard: the allocator picks a number from a read, and a concurrent submission that already took it makes the write fail, so the loser re-picks. The write is the serialization point; the read before it is only a hint.

**`listing.publishedVersion`** — points at the live version, `None` = nothing published. Field only; no behavior wired to it.

## Reviewer notes

**Key prefixes deviate from the spec.** §3.3 writes `PK=AGENT#{agentId}` / `SK=PROFILE`, but the table has always keyed Agents `AST#{id}` / `METADATA` (see `listing_repository._key`). Co-location requires the *same* partition key, so the real prefix wins. Only the literal strings differ — the "version rows live beside the Agent row, sorted" design is unchanged. The spec is worth a one-line correction.

**No counter attribute, deliberately.** `ADD versionCounter :one` on the Agent row would allocate atomically without a retry loop, but `service._update_assistant_cloud` rewrites every attribute not in its `immutable_fields` set — so a routine author edit would reset the counter and hand out a number that is already taken. The GSI5 keys are in that set for exactly this reason; adding a third such trap to remember seemed worse than a bounded retry. Happy to switch if you'd rather have the counter plus the `immutable_fields` entry.

**Snapshots persist their nulls** (no `exclude_none`, unlike `write_listing`). The overlay applies only fields a version actually set, so dropping nulls would turn "this version had no tagline" into "this version does not speak to the tagline" — and an author's post-approval tagline would survive onto the store tile. That is a miniature of the drift this epic exists to close. Tested both directions.

**Module placement.** `AgentVersion` went in `models.py` despite its length, because that file is the wire/storage-type module and `AgentListing` lives there. The logic and persistence got their own modules, matching the existing `models.py` / `listing.py` / `listing_repository.py` split.

## Explicitly out of scope

Per the phasing: no GSI5 key move (PR-2), no invocation change (PR-3), no listing state-machine change (PR-4). `approvedInstructionsHash` and `ListingDrift` are left alone — they become structurally impossible and get removed in PR-2.

## Testing

28 new tests in `tests/shared/test_agent_versions.py` covering the round trip (in memory, through a dict, and through DynamoDB via moto), the exclusions, the write-once refusal, the concurrent-allocation re-pick, and the zero-padding.

Full backend suite green on the committed state: **5439 passed, 3 skipped** (5:20).

> ⚠️ Note for anyone running the suite locally: the command in `CLAUDE.md` (`uv run python -m pytest tests/ -q`) is missing the `agentcore` extra in a fresh venv, and 56 route/inference modules then fail collection on `ModuleNotFoundError: bedrock_agentcore`. `uv run --extra agentcore --extra dev python -m pytest tests/ -q` runs the real suite. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)