### PR TITLE
feat(agents): rewrite the Assistants signpost for first-time users

### DIFF
--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
@@ -15,9 +15,9 @@
         </h1>
 
         <p class="mt-5 max-w-xl text-base/7 text-gray-600 dark:text-gray-300">
-          Same work, same records, a bigger name — and a good deal more it can do. Everything
-          you built is already waiting under <strong class="font-semibold text-gray-900 dark:text-white">Agents</strong>,
-          exactly as you left it.
+          Nothing was lost and nothing was switched off. Everything you built is waiting for
+          you under <strong class="font-semibold text-gray-900 dark:text-white">Agents</strong>,
+          exactly as you left it — under the name the rest of the field uses for it.
         </p>
 
         <div class="mt-8 flex flex-wrap items-center gap-3">
@@ -60,7 +60,8 @@
       </div>
 
       <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-        Every one of them is under Agents right now. Nothing for you to redo.
+        Every one of them is under Agents right now, with the same name you gave it. There is
+        nothing to move, re-create or set up again.
       </p>
 
       <ul class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -86,14 +87,21 @@
          a screen reader hears the comparison rather than two lists of icons. -->
     <section class="reveal mt-16" aria-labelledby="ledger-heading">
       <h2 id="ledger-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
-        Why the name had to grow
+        Why we call them agents
       </h2>
       <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-        An assistant could hold instructions and a set of documents, and that was the whole
-        of it. An agent keeps all of that and then composes the rest of the platform around
-        it — a model, tools, skills, memory — with your role deciding what is on the table.
-        Once the editor could do all of that, calling the result an "assistant" was
-        underselling it.
+        <strong class="font-semibold text-gray-900 dark:text-white">Agent</strong> is the word
+        everyone else uses for this. It is the term you will meet in the AI tools you already
+        use, in the articles you read and in the training you take — so what you pick up out
+        there works in here, and what you learn in here travels with you. "Assistant" was our
+        own word for it, and only ever meant something here.
+      </p>
+      <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        The word matches what it does. An assistant could follow the instructions you wrote
+        and read the documents you gave it, and that was all of it. An agent still does both —
+        and you can now also choose the AI model behind it, hand it tools so it can go and do
+        things rather than only talk about them, add skills it picks up when a task calls for
+        them, and give it a memory that carries from one conversation to the next.
       </p>
 
       <div class="ledger mt-7 overflow-x-auto rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
@@ -160,9 +168,9 @@
         What that opens up
       </h2>
       <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-        A single, well-defined thing can be published, borrowed, called on and scheduled.
-        Two half-overlapping ones could not. These are live now — and they are the reason the
-        change was worth making.
+        An agent is not just yours to chat with. You can share one with everyone, use one
+        somebody else built, and call on one in the middle of a conversation. All of this
+        works today.
       </p>
 
       <div class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -189,8 +197,8 @@
         Everything you had is under Agents
       </h2>
       <p class="mx-auto mt-3 max-w-xl text-sm/6 text-gray-600 dark:text-gray-400">
-        Open it and you should recognise every one of them. The only thing to learn is what
-        you can add now.
+        Open it and you will find every one of them, working as before. The only new thing to
+        learn is what you can add to them.
       </p>
 
       <div class="mt-7 flex flex-wrap items-center justify-center gap-3">
@@ -210,7 +218,7 @@
       <p class="mx-auto mt-7 flex max-w-md items-center justify-center gap-2 text-xs/5 text-gray-500 dark:text-gray-500">
         <ng-icon name="heroLink" class="size-3.5 shrink-0" aria-hidden="true" />
         Old <code class="rounded bg-gray-200/70 px-1 py-0.5 font-mono dark:bg-gray-700/70">/assistants</code> links
-        keep working — you do not need to update your bookmarks.
+        still work — there is no need to update your bookmarks.
       </p>
     </section>
   </div>

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
@@ -7,7 +7,6 @@ import {
   heroChatBubbleLeftRight,
   heroCheck,
   heroCircleStack,
-  heroClock,
   heroCpuChip,
   heroDocumentText,
   heroLink,
@@ -47,13 +46,26 @@ interface OpensUp {
  * would be hostile. Only the list URL, which is the one people browse to, explains itself.
  *
  * The copy commits to three things, in this order, because that is the order the questions
- * actually arrive in: **where did my work go** (nowhere — same records, same ids), **why**
- * (one noun, and the old editor was strictly the smaller half of it), and **what it buys
- * me** (the bindings, the store, `@`-mention, scheduled runs).
+ * actually arrive in: **where did my work go** (nowhere — the same agents, under a new
+ * heading), **why** (because "agent" is the industry's word for this and "assistant" was
+ * only ever ours), and **what it buys me** (the model/tools/skills/memory it can now hold,
+ * the store, `@`-mention).
+ *
+ * The "why" is deliberately *not* argued as "we outgrew the old word". That framing asks the
+ * reader to care about our vocabulary history, which is our problem and not theirs. Standard
+ * naming is a benefit they can actually collect: it makes everything they read and learn
+ * elsewhere transfer, in both directions. The capability list stays, but as evidence that
+ * the standard word fits — not as the reason for the change.
+ *
+ * **Written for someone who has never used the platform**, not for someone who knows the
+ * old surface: whoever clicks "Assistants" in the sidebar may be doing it to find out what
+ * the word means. So the hero says what an agent *is* before it explains what changed, and
+ * the copy avoids house vocabulary — no "records", no "knowledge base", no "system prompt",
+ * no "bindings". If a term needs the platform explained first, it does not belong here.
  *
  * Everything claimed here is a surface that ships today. If a capability is removed or
  * gated, the claim on this page goes with it — an explainer that oversells is worse than
- * the redirect it replaced.
+ * the redirect it replaced. (This is why scheduled runs are not mentioned; see `opensUp`.)
  */
 @Component({
   selector: 'app-agents-migration',
@@ -68,7 +80,6 @@ interface OpensUp {
       heroChatBubbleLeftRight,
       heroCheck,
       heroCircleStack,
-      heroClock,
       heroCpuChip,
       heroDocumentText,
       heroLink,
@@ -89,22 +100,22 @@ export class AgentsMigrationPage {
   readonly carriedOver: readonly { label: string; detail: string; icon: string }[] = [
     {
       label: 'Every assistant you built',
-      detail: 'Same name, same instructions, same conversation starters.',
+      detail: 'The same name, the same instructions, the same opening questions.',
       icon: 'heroSparkles',
     },
     {
-      label: 'Your knowledge bases',
-      detail: 'Documents, web sources and sync policies — still indexed, still answering.',
+      label: 'Everything you gave it to read',
+      detail: 'Your files and web pages are still there, and still used to answer.',
       icon: 'heroDocumentText',
     },
     {
-      label: 'Who you shared with',
-      detail: 'Viewers and editors kept exactly the access you gave them.',
+      label: 'The people you shared with',
+      detail: 'Anyone you shared with still has it, and can still do what you allowed.',
       icon: 'heroUserGroup',
     },
     {
       label: 'Your old links',
-      detail: 'Bookmarks and shared links still work, and open the same record.',
+      detail: 'Bookmarks and links you sent people still work, and open the same thing.',
       icon: 'heroLink',
     },
   ];
@@ -116,73 +127,75 @@ export class AgentsMigrationPage {
   readonly ledger: readonly LedgerRow[] = [
     {
       label: 'Instructions',
-      detail: 'The system prompt that gives it a job and a manner.',
+      detail: 'What you write to tell it its job, and how you want it to answer.',
       icon: 'heroDocumentText',
       assistant: 'yes',
     },
     {
-      label: 'Knowledge base',
-      detail: 'Your documents and web sources, indexed and searchable.',
+      label: 'Things to read',
+      detail: 'Files and web pages you hand it, so it answers from your material.',
       icon: 'heroCircleStack',
       assistant: 'yes',
     },
     {
       label: 'Sharing',
-      detail: 'Private, shared with named people, or open to the institution.',
+      detail: 'Keep it to yourself, share it with certain people, or open it to everyone.',
       icon: 'heroUserGroup',
       assistant: 'yes',
     },
     {
       label: 'A model you choose',
-      detail: 'Pick the model and tune its settings, within the bounds your role allows.',
+      detail: 'Pick which AI model answers for it, from the ones you have been given.',
       icon: 'heroCpuChip',
       assistant: 'no',
     },
     {
       label: 'Tools',
-      detail: 'Give it the ability to act — search, run code, reach a connected system.',
+      detail: 'Let it do things, not just talk — look something up, work with a file, use a system you have connected.',
       icon: 'heroWrenchScrewdriver',
       assistant: 'no',
     },
     {
       label: 'Skills',
-      detail: 'Bundled know-how it loads on demand, so the instructions stay short.',
+      detail: 'Ready-made know-how for a particular job, which it picks up only when that job comes up.',
       icon: 'heroPuzzlePiece',
       assistant: 'no',
     },
     {
-      label: 'Memory spaces',
-      detail: 'A durable notebook it can read from, and write to when you allow it.',
+      label: 'Memory',
+      detail: 'Notes it keeps between conversations, so you are not starting from scratch each time.',
       icon: 'heroSparkles',
       assistant: 'no',
     },
   ];
 
-  /** Downstream surfaces the single noun unlocked. All of these ship today. */
+  /**
+   * Downstream surfaces the single noun unlocked. **Every card here must be a surface a
+   * reader can go and use today** — an explainer that advertises something they cannot find
+   * is worse than the silent redirect this page replaced.
+   *
+   * A "Run on a schedule" card sat here and has been pulled: scheduled runs work, but they
+   * have no navigation of their own yet, so the card promised a feature with nowhere to go.
+   * Put it back (with `heroClock`) when that surface is rolled out.
+   */
   readonly opensUp: readonly OpensUp[] = [
     {
-      title: 'A store to publish to',
+      title: 'Share it with everyone',
       body:
-        'Submit an agent for review and it appears in Discover, where anyone at the institution can find it — instead of you emailing a link to one person at a time.',
+        'Put an agent up for review and it appears in Discover, where anyone here can find it and use it — instead of you sending a link to one person at a time.',
       icon: 'heroSquares2x2',
     },
     {
-      title: 'Pin what you use',
+      title: 'Keep the ones you like',
       body:
-        "Add someone else's agent to your own set and it is one click away from every chat. Your role may start you with a few already pinned.",
+        "Found an agent someone else built? Pin it, and it sits one click away in every chat. You may find a few already pinned for you.",
       icon: 'heroBookmark',
     },
     {
-      title: 'Reach one mid-conversation',
+      title: 'Bring one into a chat',
       body:
-        'Type @ in any chat to hand the current thread to a specialist agent, then carry on. No switching pages, no starting over.',
+        'Type @ in any conversation to hand what you are working on to a different agent, then carry on. Nothing to close, nothing to start over.',
       icon: 'heroChatBubbleLeftRight',
-    },
-    {
-      title: 'Run on a schedule',
-      body:
-        'Point a scheduled run at an agent and it works while you are not watching — a Monday digest, a nightly check, a weekly report.',
-      icon: 'heroClock',
     },
   ];
 }

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -51,6 +51,37 @@
             here"; see `agents_enabled()` in the backend for the same note.
         -->
         @if (showAgents()) {
+            <!--
+                Assistants — a **signpost, not a feature**. The entry was removed in
+                Designer Phase 5 on the grounds that there is one noun; it comes back
+                because removing the word from the nav is exactly what makes someone who
+                built an assistant think theirs is gone. It does not lead to an Assistants
+                page (there is none): `/assistants` renders the migration explainer, whose
+                every route out lands on `/agents`.
+
+                Deliberately inside the `showAgents()` block. With the agent surface off,
+                every call to action on that page is dead, and a nav entry leading to a
+                page of dead links is worse than no entry.
+
+                Sits **above** Agents and wears the ordinary link treatment — no muting, no
+                "Moved" tag. Someone still thinking in the old noun scans for the word they
+                know, and a greyed-out entry with a past-tense badge reads as deactivated
+                rather than as a door. Retire it, and the "New" badge below, once the
+                rename has landed with users.
+            -->
+            <a
+                routerLink="/assistants"
+                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+                (click)="sidenavService.close()"
+                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                </div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
+            </a>
+
             <a
                 routerLink="/agents"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"
@@ -64,44 +95,18 @@
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
                 <!--
                     "New" rather than the amber "Preview" badge the preview surfaces wore:
-                    this is not unstable, it is unfamiliar. Primary blue for the same
-                    reason — amber in this nav has meant "not finished yet", and reusing
-                    it here would say the opposite of what is true.
+                    this is not unstable, it is unfamiliar.
+
+                    Ember (`secondary`), not primary blue. Blue is the nav's structural
+                    colour — the active-row wash, the links, the icons — so a blue badge
+                    sits *inside* the furniture and reads as one more piece of chrome. The
+                    one job of this badge is to be the thing your eye lands on first, and
+                    ember is the only accent here that is not already load-bearing.
 
                     Remove this once the rename has stopped being news, together with the
-                    Assistants signpost below.
+                    Assistants signpost above.
                 -->
-                <span class="ml-auto rounded-full bg-primary-50 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-primary-700 dark:bg-primary-400/15 dark:text-primary-200">New</span>
-            </a>
-
-            <!--
-                Assistants — a **signpost, not a feature**. The entry was removed in
-                Designer Phase 5 on the grounds that there is one noun; it comes back
-                because removing the word from the nav is exactly what makes someone who
-                built an assistant think theirs is gone. It does not lead to an Assistants
-                page (there is none): `/assistants` renders the migration explainer, whose
-                every route out lands on `/agents`.
-
-                Deliberately inside the `showAgents()` block. With the agent surface off,
-                every call to action on that page is dead, and a nav entry leading to a
-                page of dead links is worse than no entry.
-
-                Muted on purpose — this is the door someone leaves through once, not one of
-                the app's destinations. Retire it, and the "New" badge above, once the
-                rename has landed with users.
-            -->
-            <a
-                routerLink="/assistants"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-400 dark:text-gray-500">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Assistants</span>
-                <span class="ml-auto text-[10px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Moved</span>
+                <span class="ml-auto rounded-full bg-secondary-50 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-secondary-700 dark:bg-secondary-400/15 dark:text-secondary-200">New</span>
             </a>
         }
 


### PR DESCRIPTION
Copy and navigation pass over the Assistants → Agents signpost, aimed at the person most likely to click it.

## Why

The `/assistants` explainer was written for someone who had used the old surface: it talked about *records*, *knowledge bases*, *system prompts* and *bindings*, and argued the rename on the grounds that we had outgrown our own word. Both assumptions are wrong for the actual reader. The sidenav entry is just as likely to be clicked by someone who has never built anything here and wants to know what the word means — and "we outgrew the old name" asks that person to care about our vocabulary history, which is our problem, not theirs.

## What changed

**Written for a newcomer.** House vocabulary is gone throughout — "records" → "everything you built", "knowledge base" → "things to read", "system prompt" → "what you write to tell it its job", "within the bounds your role allows" → "from the ones you have been given". The rule going forward, recorded in the class doc: if a term needs the platform explained first, it does not belong on this page.

**The rename is argued from standard naming.** *Agent* is what the rest of the field calls this, so what a reader picks up elsewhere works here and what they learn here travels with them; *assistant* was only ever our word and only ever meant something here. The model/tools/skills/memory list stays, but as evidence that the standard word fits — not as the reason for the change. Section retitled "Why we call them agents".

**Nav — make the old noun findable and unambiguous.** Assistants moves above Agents and takes the ordinary link treatment; the muted styling and the "Moved" tag read as *deactivated* rather than as a door out. The Agents "New" badge goes ember: blue is this nav's structural colour (active row, links, icons), so a blue badge sits inside the furniture, and ember is the only accent here not already load-bearing.

**"Run on a schedule" card removed.** Scheduled runs work, but they have no navigation of their own yet, so the card promised something the reader could not go and find — the page's standing rule is that every claim on it is a surface that ships today. A comment records exactly what to restore (and the icon it needs) when that surface rolls out.

## Verification

- `npx ng test` — 1684 passing, 152 files. The sidenav specs query by `routerLink` and assert badge *text*, so neither the reorder nor the colour swap disturbed them.
- `npx tsc --noEmit -p tsconfig.app.json` clean; unused `heroClock` import dropped with the card.
- Rendered against the dev backend at `localhost:4200` in both themes. Badge contrast measured on the composited colours: **5.58:1 light, 7.78:1 dark** (AA small-text needs 4.5). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)