### PR TITLE
feat(marketplace): serve immutable snapshots from the store (PR-2)

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -163,11 +163,15 @@ def _agent_response(assistant, *, permission: Optional[str] = None,
         # Dropped rather than blanked: every route here serves the model with
         # ``response_model_exclude_none``, so the key is simply absent for a viewer.
         view.pop("instructions", None)
-        # The drift baseline (#744) is a hash *of* the instructions, so it rides the same
-        # gate. On its own it is not reversible, but it would confirm a guessed prompt for
-        # anyone who could produce one — which is exactly what dropping ``instructions``
-        # above exists to prevent. Admins read it through the admin listings projection,
-        # never through here.
+        # ``approvedInstructionsHash`` rides the same gate: a hash *of* the instructions is
+        # not reversible alone, but it would confirm a guessed prompt for anyone who could
+        # produce one.
+        #
+        # Nothing writes this field any more — version snapshots replaced drift detection
+        # and it is off the model. It is still stripped because ``AgentListing`` is
+        # ``extra="allow"``: a listing approved *before* that removal still carries the
+        # attribute in DynamoDB, and it would now round-trip straight through to a viewer.
+        # Transitional, and safe to delete once no stored listing carries it.
         if isinstance(view.get("listing"), dict):
             view["listing"].pop("approvedInstructionsHash", None)
     if permission is not None:

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -24,7 +24,6 @@ Three rules are enforced here and nowhere else:
 the rest. Publisher is a name on a shelf.
 """
 
-import hashlib
 import logging
 import os
 from typing import List, Optional, Tuple
@@ -32,8 +31,15 @@ from typing import List, Optional, Tuple
 from apis.shared.assistants.compat import effective_bindings
 from apis.shared.assistants.categories import ensure_seeded
 from apis.shared.assistants.icons import icon_url
-from apis.shared.assistants.listing import ListingTransitionError, assert_transition
+from apis.shared.assistants.listing import (
+    ListingTransitionError,
+    assert_transition,
+    gsi5_keys,
+    is_published,
+)
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
+from apis.shared.assistants.version_repository import create_version, set_version_index
+from apis.shared.assistants.versions import snapshot_of
 from apis.shared.assistants.models import (
     AdminEdit,
     AdminListingPatchRequest,
@@ -344,12 +350,42 @@ async def submit_listing(
 
     now = _now()
     previous = assistant.listing
+
+    # ── the snapshot (version-snapshots §3.2) ────────────────────────────────────────
+    # Cut **here**, at submission, rather than at approval. Taking it at approval leaves a
+    # window: the author submits, the admin reads it, the author edits, the admin approves
+    # — and what gets published is not what was read. That is the same class of bug this
+    # whole feature exists to close, just narrower. Freezing now means the reviewer is
+    # always looking at an artifact that cannot move under them, and the cost is that
+    # changing a pending submission means withdrawing and resubmitting (which cuts a new
+    # version rather than mutating the pending one).
+    #
+    # The proposed category, publisher and tagline are folded in first, so the snapshot is
+    # the submission as the author composed it — not the record as it stood a moment before.
+    tagline = (request.tagline or "").strip() or None
+    proposed = assistant.model_copy(
+        update={
+            "tagline": tagline if tagline is not None else assistant.tagline,
+            "listing": AgentListing(
+                state="in_review", category=request.category, publisher_id=publisher_id
+            ),
+        }
+    )
+    version = await create_version(
+        agent_id, snapshot_of(proposed, created_at=now, created_by=user.user_id)
+    )
+
     listing = AgentListing(
         state="in_review",
         category=request.category,
         publisher_id=publisher_id,
         submitted_at=now,
         submitted_by=user.user_id,
+        submitted_version=version.version,
+        # A resubmission does not unpublish anything. The previously approved version keeps
+        # its index key and keeps serving until an admin promotes the new one, so the shelf
+        # never goes blank while a review is pending.
+        published_version=previous.published_version if previous else None,
         # A resubmission carries its review history forward; the note stays visible until
         # the reviewer replaces it, so the author keeps the context they are acting on.
         reviewed_at=previous.reviewed_at if previous else None,
@@ -360,7 +396,7 @@ async def submit_listing(
     # The tagline rides this write rather than a second one (same reason as the D13 patch
     # path). ``None`` means "leave it alone" — an author resubmitting without touching the
     # field must not have their existing subtitle blanked.
-    tagline = (request.tagline or "").strip() or None
+    #
     # Only widen when it actually needs widening: an Agent that is already PUBLIC must not
     # have ``visibility`` rewritten just because the box was ticked, and a no-op write is
     # a lie in the audit trail.
@@ -399,10 +435,79 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
         raise ListingError(str(e), status_code=400) from e
 
     now = _now()
-    listing = assistant.listing.model_copy(update={"state": "private"})
+    # Index first, record second — see ``_unindex_version`` for why delisting is ordered
+    # the opposite way round from publishing.
+    await _unindex_version(agent_id, assistant.listing.published_version)
+    listing = assistant.listing.model_copy(update={"state": "private", "published_version": None})
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
     logger.info(f"📭 Agent {agent_id} unpublished by its owner")
     return listing
+
+
+# ── version promotion ────────────────────────────────────────────────────────────────
+async def _publish_version(
+    agent_id: str,
+    number: int,
+    *,
+    category: str,
+    agent_created_at: str,
+    superseding: Optional[int] = None,
+) -> None:
+    """Point the store at version ``number``, taking the key off whatever it replaces.
+
+    Order matters and is the opposite of what feels natural: **write the new key first,
+    then clear the old.** Clearing first would leave the shelf blank for the width of a
+    round trip, and a blank shelf is a worse failure than a momentary duplicate — one is a
+    published Agent vanishing, the other is the same Agent appearing under two versions
+    until the second call lands.
+
+    ``agent_created_at`` is the sort key, deliberately the *Agent's* creation timestamp and
+    not the version's: browse is newest-first by Agent, and keying on version age would let
+    a resubmission of a two-year-old Agent jump the top of the shelf every time it was
+    re-approved. Promotion is not publication of a new thing.
+
+    ``category`` comes from the **listing**, not from the snapshot. Placement is the one
+    thing about a published version that an admin may legitimately change afterwards (D13),
+    and it is expressed as the index key rather than written into the frozen record — which
+    is exactly the line this design draws everywhere: content is immutable, *where it sits*
+    is a fact about now. ``version.category`` stays as the author proposed and the reviewer
+    saw it; the shelf a row appears on is the key.
+    """
+    await set_version_index(
+        agent_id, number, gsi5_keys("published", category, agent_created_at)
+    )
+    if superseding is not None and superseding != number:
+        await _unindex_version(agent_id, superseding)
+
+
+async def _unindex_version(agent_id: str, number: Optional[int]) -> None:
+    """Take a version off the shelf, tolerating one that is already gone.
+
+    ⚠️ **Call this BEFORE writing the listing, and write the listing before calling
+    ``_publish_version``.** The store index and the listing block used to be one
+    ``update_item`` — ``listing_repository`` says so, and that atomicity is what made "an
+    unpublished agent cannot be in the store" a fact rather than a hope. Moving the index
+    onto the version row split it into two writes on two items, and the invariant now has to
+    be bought with **ordering** instead:
+
+        publish   → write the listing, then write the key   (partial ⇒ recorded, not shelved)
+        unpublish → clear the key, then write the listing   (partial ⇒ not shelved, recorded live)
+
+    Both partial outcomes leave the Agent **off** the shelf. The reverse orders leave it on
+    the shelf while the record says otherwise, which is the single failure the sparse index
+    exists to prevent. A DynamoDB transaction would restore true atomicity and is the honest
+    upgrade if this ever needs to be stronger than fail-closed.
+
+    A missing version row here is not worth failing a takedown over: the outcome the caller
+    wants — "this is not in the store" — is already true, and raising would leave an admin
+    unable to complete a delisting because of a row that does not exist.
+    """
+    if number is None:
+        return
+    try:
+        await set_version_index(agent_id, number, None)
+    except ValueError:
+        logger.warning(f"Version {number} of {agent_id} is already absent; nothing to unindex")
 
 
 # ── admin transitions ────────────────────────────────────────────────────────────────
@@ -467,14 +572,39 @@ async def review_listing(
         "reviewed_by": admin.user_id,
         "review_note": note or None,
     }
-    # Approval — and only approval — establishes the behavior baseline the drift marker
-    # compares against (#744). ``request_changes`` deliberately leaves any existing hash
-    # alone: it does not publish anything, so it has no baseline to set, and clearing the
-    # previous one would blind the marker on a listing that is still live in the store.
+    # Approval promotes the version cut at submission — the artifact this admin actually
+    # read — never "the latest", which an admin presentation edit (§6.2) could have moved
+    # underneath them.
+    #
+    # ⚠️ A submission with no version predates this feature. Refusing is the safe answer:
+    # publishing it would put an unversioned listing on a shelf that reads versions, which
+    # renders as an empty tile. The author resubmits and gets one.
+    promoted: Optional[int] = None
     if target == "published":
-        changes["approved_instructions_hash"] = _instructions_hash(assistant)
+        promoted = assistant.listing.submitted_version
+        if promoted is None:
+            raise ListingError(
+                "This submission predates version snapshots and has nothing to publish. "
+                "Ask the author to resubmit — it will be captured on the way in.",
+                status_code=400,
+            )
+        changes["published_version"] = promoted
+
     listing = assistant.listing.model_copy(update=changes)
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+
+    # Index last, and only after the listing write succeeded. The index is what the store
+    # actually answers from, so a key written against a listing that failed to persist
+    # would shelve something no record claims is published.
+    if promoted is not None:
+        await _publish_version(
+            agent_id,
+            promoted,
+            category=listing.category,
+            agent_created_at=assistant.created_at,
+            superseding=assistant.listing.published_version,
+        )
+
     logger.info(f"⚖️ Agent {agent_id} review by {admin.user_id}: {decision} → {target}")
     return listing
 
@@ -496,12 +626,19 @@ async def takedown_listing(agent_id: str, admin: User, reason: str) -> AgentList
         raise ListingError(str(e), status_code=400) from e
 
     now = _now()
+    # Off the shelf before the record says so — a takedown that half-failed must leave the
+    # Agent invisible, never visible-but-recorded-down.
+    await _unindex_version(agent_id, assistant.listing.published_version)
     listing = assistant.listing.model_copy(
         update={
             "state": "taken_down",
             "reviewed_at": now,
             "reviewed_by": admin.user_id,
             "review_note": reason,
+            # The pointer clears with the key. A taken-down listing that still named a
+            # published version would read as "this is live" to every reader that trusts
+            # the pointer, and PR-3 makes invocation one of those readers.
+            "published_version": None,
         }
     )
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
@@ -536,11 +673,44 @@ async def patch_listing_presentation(
         AdminEdit(field=_EDIT_FIELD_LABELS.get(field, field), at=now, by=admin.name or admin.user_id)
         for field in sorted(changes)
     ]
+    category = changes.get("category", assistant.listing.category)
+    publisher_id = changes.get("publisher_id", assistant.listing.publisher_id)
+
+    # ── an admin edit to a live listing cuts a version (§6.2) ────────────────────────
+    # The store renders from the published snapshot now, so a tagline fix that only touched
+    # the Agent row would land nowhere — D13 would look like it silently stopped working.
+    # Of the two honest options the spec puts up, this is the one that keeps immutability
+    # absolute: the version is the unit of "what an admin blessed", and an admin editing it
+    # is still an admin blessing it. The cost is that a category fix reads as a release in
+    # the version history, which is the cheaper wrong.
+    #
+    # Attributed to the admin, not the author — ``createdBy`` is audit, never authorization,
+    # and mislabelling this would put the author's name on someone else's edit.
+    was_published = is_published(assistant.listing.state)
+    previously_published = assistant.listing.published_version
+    promoted: Optional[int] = None
+    if was_published:
+        edited = assistant.model_copy(
+            update={
+                "name": changes.get("name", assistant.name),
+                "tagline": changes.get("tagline", assistant.tagline),
+                "icon_key": changes.get("icon_key", assistant.icon_key),
+                "listing": assistant.listing.model_copy(
+                    update={"category": category, "publisher_id": publisher_id}
+                ),
+            }
+        )
+        version = await create_version(
+            agent_id, snapshot_of(edited, created_at=now, created_by=admin.user_id)
+        )
+        promoted = version.version
+
     listing = assistant.listing.model_copy(
         update={
-            "category": changes.get("category", assistant.listing.category),
-            "publisher_id": changes.get("publisher_id", assistant.listing.publisher_id),
+            "category": category,
+            "publisher_id": publisher_id,
             "admin_edits": edits,
+            **({"published_version": promoted} if promoted is not None else {}),
         }
     )
     # ``name``/``tagline``/``iconKey`` live on the Agent record, not the listing block, so
@@ -554,6 +724,14 @@ async def patch_listing_presentation(
         name=changes.get("name"),
         updated_at=now,
     )
+    if promoted is not None:
+        await _publish_version(
+            agent_id,
+            promoted,
+            category=category,
+            agent_created_at=assistant.created_at,
+            superseding=previously_published,
+        )
     logger.info(f"✏️ Admin {admin.user_id} edited listing presentation for {agent_id}: {sorted(changes)}")
     return listing
 
@@ -592,48 +770,12 @@ async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminLi
     return rows, pending
 
 
-def _instructions_hash(assistant: Assistant) -> str:
-    """SHA-256 of an Agent's instructions — the drift marker's behavior baseline (#744).
-
-    Hashed rather than stored verbatim: the listing block is read on every admin table
-    load, and instructions run to thousands of tokens. We only ever need to answer "same
-    or not", never "what changed" — a diff view would read the live record anyway.
-    """
-    return hashlib.sha256((assistant.instructions or "").encode("utf-8")).hexdigest()
-
-
-def _drift(assistant: Assistant, listing: AgentListing) -> Optional[str]:
-    """Whether a published listing has drifted from what the reviewer approved (#744).
-
-    D2 deliberately does not re-review edits, and there is no versioning — an approved
-    author may rewrite instructions and the new behavior is live immediately. That is
-    defensible for an Agent someone *chose* to pin; it reads differently once an admin has
-    **locked** it into a role's sidebar (D9), because then the affected user cannot opt out
-    either. This marker does not add a gate; it gives the curator a reason to look.
-
-    Only ``published`` listings can drift. A draft or an in-review submission has no
-    approved state to differ from, and a taken-down one is already off the shelf.
-
-    ⚠️ **The timestamp fallback is deliberately the weaker claim.** ``updated_at`` bumps on
-    *every* write to the record, including an admin's own D13 presentation edit (which does
-    not touch ``reviewed_at``) and a harmless author rename. Reporting that as "behavior
-    changed" would have admins chasing their own typo fixes. It is reported as ``edited``
-    and must render as the softer signal. Listings approved since the hash shipped never
-    reach the fallback — ``review_listing`` writes the baseline on the way in.
-    """
-    if listing.state != "published":
-        return None
-
-    if listing.approved_instructions_hash:
-        return "instructions" if _instructions_hash(assistant) != listing.approved_instructions_hash else None
-
-    # Legacy listing, approved before the baseline existed. ``review_listing`` writes
-    # ``updated_at`` from the same ``now`` as ``reviewed_at``, so a freshly approved record
-    # compares equal and only a later write can exceed it. Both are ISO 8601 UTC, so the
-    # string comparison is chronological.
-    if listing.reviewed_at and assistant.updated_at > listing.reviewed_at:
-        return "edited"
-    return None
+# ``_instructions_hash`` and ``_drift`` lived here (#744). Both are gone rather than
+# dormant: they detected an author editing a published Agent, and a published Agent is now
+# an immutable snapshot the author cannot reach. The reviewer's real question — "is what I
+# approved still what is live?" — is answered by ``listing.publishedVersion`` instead, which
+# is a fact rather than a heuristic, and never had the weak ``edited`` fallback's habit of
+# reporting an admin's own typo fix as a behavior change.
 
 
 def _reachability(assistant: Assistant) -> str:
@@ -680,7 +822,7 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         reviewed_at=listing.reviewed_at,
         review_note=listing.review_note,
         updated_at=assistant.updated_at,
-        drift=_drift(assistant, listing),
+        published_version=listing.published_version,
         reachability=_reachability(assistant),
         admin_edits=listing.admin_edits,
     )

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -6,10 +6,12 @@ category — and nothing else.
 
 Two properties are worth stating because they are easy to erode later:
 
-* **The query cannot return an unpublished agent.** Not because it filters, but because
-  an unpublished agent has no GSI5 key. Any future change that starts filtering
-  ``listing.state`` in here is a sign the index has stopped being sparse, which is a
-  bug in the write path, not something to compensate for on read.
+* **The query cannot return an unpublished agent, or unapproved content.** Not because it
+  filters, but because the GSI5 key lives on the published ``VERSION#`` snapshot: an
+  unpublished agent has no key, and an author's draft edits are not in the indexed row at
+  all. Any future change that starts filtering ``listing.state`` in here is a sign the
+  index has stopped being sparse, which is a bug in the write path, not something to
+  compensate for on read.
 * **The store read never carries behavior.** No ``instructions``, no binding refs, no
   owner id. ``AgentResponse`` exists for the surfaces that legitimately need those; the
   shelf is seen by every browsing user and gets the narrowest projection that renders.
@@ -25,12 +27,14 @@ from apis.shared.assistants.listing_repository import batch_get_agents, query_st
 from apis.shared.assistants.models import (
     AgentCategory,
     AgentListingResponse,
+    AgentVersion,
     Assistant,
     ListingPublisher,
     PublisherProfile,
 )
 from apis.shared.assistants.publishers import list_publishers
 from apis.shared.assistants.storefront import get_featured_ids
+from apis.shared.assistants.version_repository import batch_get_versions
 
 logger = logging.getLogger(__name__)
 
@@ -40,44 +44,51 @@ _MAX_FANOUT_CATEGORIES = 12
 
 
 def to_listing_response(
-    assistant: Assistant, publishers: dict
+    version: AgentVersion, publishers: dict, *, category: str
 ) -> Optional[AgentListingResponse]:
-    """Project a stored agent into the shelf shape, or ``None`` if it cannot render."""
-    listing = assistant.listing
-    if not listing:
-        # Only reachable if a GSI5 key outlived its listing block, which the single-write
-        # invariant in listing_repository is designed to prevent. Skip rather than crash
-        # the whole shelf for one bad row.
-        logger.warning(f"Indexed agent {assistant.assistant_id} has no listing block; skipping")
+    """Project a published **snapshot** into the shelf shape, or ``None`` if it cannot render.
+
+    Everything rendered comes from the version, so the shelf shows what the reviewer
+    approved rather than whatever the author's draft says today.
+
+    ``category`` is passed in rather than read off the version. Placement lives in the index
+    key so an admin can recategorize a live listing without rewriting an immutable record
+    (D13), which means the key is the authority and ``version.category`` is only the
+    author's original proposal. Every caller here already knows which shelf it queried.
+    """
+    if not version.agent_id:
+        logger.warning("Indexed version carries no agentId; skipping")
         return None
 
-    profile: Optional[PublisherProfile] = publishers.get(listing.publisher_id)
+    profile: Optional[PublisherProfile] = publishers.get(version.publisher_id)
     return AgentListingResponse(
-        agent_id=assistant.assistant_id,
-        name=assistant.name,
-        tagline=assistant.tagline,
-        emoji=assistant.emoji,
+        agent_id=version.agent_id,
+        name=version.name,
+        tagline=version.tagline,
+        emoji=version.emoji,
         # Phase 4: the uploaded icon when there is one, the generated gradient when not —
         # and the emoji above is what that gradient carries, so both always ship.
-        icon_url=icon_url(assistant.assistant_id, assistant.icon_key),
+        icon_url=icon_url(version.agent_id, version.icon_key),
         publisher=(
             ListingPublisher(label=profile.label, kind=profile.kind, verified=profile.verified)
             if profile
             else None
         ),
-        category=listing.category,
+        category=category,
     )
 
 
-def _project(items: list, publishers: dict) -> List[AgentListingResponse]:
+def _project(items: list, publishers: dict, *, category: str) -> List[AgentListingResponse]:
     responses = []
     for item in items:
         try:
-            assistant = Assistant.model_validate(item)
+            version = AgentVersion.model_validate(
+                {k: v for k, v in item.items() if k not in ("PK", "SK")}
+            )
         except Exception:
             logger.warning("Skipping unparseable store row", exc_info=True)
             continue
-        projected = to_listing_response(assistant, publishers)
+        projected = to_listing_response(version, publishers, category=category)
         if projected:
             responses.append(projected)
     return responses
@@ -89,7 +100,7 @@ async def browse_category(
     """One category's shelf, newest-first, with a real cursor (single GSI5 partition)."""
     publishers = {p.id: p for p in await list_publishers()}
     items, next_cursor = await query_store(category, limit=limit, cursor=cursor)
-    return _project(items, publishers), next_cursor
+    return _project(items, publishers, category=category), next_cursor
 
 
 async def browse_all(*, limit: int = 50) -> List[AgentListingResponse]:
@@ -116,8 +127,14 @@ async def browse_all(*, limit: int = 50) -> List[AgentListingResponse]:
     merged: List[Tuple[str, AgentListingResponse]] = []
     for category in categories:
         items, _ = await query_store(category.id, limit=limit)
-        for item, response in zip(items, _project(items, publishers)):
-            merged.append((str(item.get("createdAt", "")), response))
+        for item, response in zip(items, _project(items, publishers, category=category.id)):
+            # Sort on ``GSI5_SK``, not on the row's ``createdAt``. These are version rows
+            # now, so ``createdAt`` is when the *snapshot* was cut — merging on it would
+            # order the store by most-recently-approved and let a re-approved five-year-old
+            # Agent surface above a genuinely new one. ``GSI5_SK`` is ``CREATED#{agent
+            # createdAt}``, which is the ordering the per-category shelves already use, so
+            # merging on it is what keeps browse-all consistent with browse-category.
+            merged.append((str(item.get("GSI5_SK", "")), response))
 
     # Newest-first across the merged set, matching the per-category ordering.
     merged.sort(key=lambda pair: pair[0], reverse=True)
@@ -129,10 +146,15 @@ async def resolve_featured(
 ) -> Tuple[List[AgentListingResponse], List[str]]:
     """Project the configured store-front ids into shelf rows, in the admin's order.
 
-    Returns ``(rows, unavailable_ids)``. An id is *unavailable* when the Agent was deleted
-    or its listing is no longer ``published`` — a takedown must drop it off the shelf, and
-    the sparse-index physics that guarantee this for browse do not apply to a hand-curated
-    id list, so the state check has to be explicit here.
+    Returns ``(rows, unavailable_ids)``. An id is *unavailable* when the Agent was deleted,
+    its listing is no longer ``published``, or its published snapshot is missing — a
+    takedown must drop it off the shelf, and the sparse-index physics that guarantee this
+    for browse do not apply to a hand-curated id list, so the check has to be explicit here.
+
+    **Two reads, not one.** The Agent row says *which* version is published; the version row
+    is what renders. Resolving the featured row from the Agent record instead would make
+    this the one store surface still serving the author's draft — the curated shelf is
+    exactly where that would be least noticed and most damaging.
 
     The unavailable ids are returned rather than swallowed so the admin console can show
     an admin why their row is short. Nothing on this path *writes*: a takedown that is
@@ -144,7 +166,9 @@ async def resolve_featured(
     records = await batch_get_agents(agent_ids)
     publishers = {p.id: p for p in await list_publishers()}
 
-    rows: List[AgentListingResponse] = []
+    # Pass one: which of these are published, and at which version.
+    published: List[Tuple[str, int]] = []
+    categories: dict = {}
     unavailable: List[str] = []
     for agent_id in agent_ids:
         item = records.get(agent_id)
@@ -158,10 +182,23 @@ async def resolve_featured(
             unavailable.append(agent_id)
             continue
         listing = assistant.listing
-        if not listing or not is_published(listing.state):
+        if not listing or not is_published(listing.state) or listing.published_version is None:
             unavailable.append(agent_id)
             continue
-        projected = to_listing_response(assistant, publishers)
+        published.append((agent_id, listing.published_version))
+        categories[agent_id] = listing.category
+
+    versions = await batch_get_versions(published)
+
+    # Pass two: render from the snapshots, in the admin's configured order.
+    rows: List[AgentListingResponse] = []
+    for agent_id, _number in published:
+        version = versions.get(agent_id)
+        projected = (
+            to_listing_response(version, publishers, category=categories[agent_id])
+            if version
+            else None
+        )
         if projected:
             rows.append(projected)
         else:

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -15,6 +15,12 @@ Two invariants live here, and both are load-bearing:
 2. **The directory index is written only while published** (spec Data model). ``gsi5_keys``
    returns keys for exactly one state, so unpublication is enforced by physics rather
    than by a filter someone can forget: no key, so the browse query cannot return it.
+
+   Version snapshots extend that physics one level. The keys are now written on the
+   published ``VERSION#`` row rather than on the Agent row, so the index cannot return
+   *draft content* either — not because a reader checks, but because the draft has no row
+   in the index. ``gsi5_keys`` is unchanged and still the single derivation; only its
+   caller moved (``version_repository.set_version_index``).
 """
 
 from typing import Dict, Optional, Set, Tuple

--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -14,9 +14,12 @@ reasons that both bite if ignored:
    (D13 exists so an admin can fix a tagline without the author). The authorization for
    these writes lives in the service layer, not in an ownership check here.
 
-Every write puts the listing state and its index keys in **one** ``update_item``, so the
-two can never disagree — a published listing always has keys and an unpublished one never
-does, with no window in between.
+⚠️ **The store index no longer lives on the Agent row.** It moved to the published
+``VERSION#`` item (``version_repository.set_version_index``), because keeping it here meant
+the browse query answered from the same record the author edits — an approved listing could
+serve rewritten instructions. ``write_listing`` now unconditionally REMOVEs the GSI5
+attributes, so the only way onto the shelf is a promoted snapshot. Reason 1 above still
+holds and matters more than ever: the generic update path must never resurrect a key here.
 """
 
 import base64
@@ -25,7 +28,6 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
-from .listing import gsi5_keys
 from .models import AgentListing
 from .serialization import from_ddb, to_ddb_safe
 
@@ -75,8 +77,6 @@ async def write_listing(
     """
     from botocore.exceptions import ClientError
 
-    keys = gsi5_keys(listing.state, listing.category, created_at)
-
     set_parts = ["listing = :listing"]
     values: Dict[str, Any] = {
         ":listing": to_ddb_safe(listing.model_dump(by_alias=True, exclude_none=True))
@@ -103,15 +103,13 @@ async def write_listing(
         set_parts.append("visibility = :visibility")
         values[":visibility"] = visibility
 
-    if keys:
-        for attr, value in keys.items():
-            set_parts.append(f"{attr} = :{attr.lower()}")
-            values[f":{attr.lower()}"] = value
-    else:
-        # Not published → the keys must not exist. REMOVE is unconditional on purpose:
-        # a stale key would keep a delisted agent answerable by the store query, which is
-        # the single failure the sparse index is there to make impossible.
-        remove_parts.extend(_GSI5_ATTRS)
+    # The store index no longer lives here. It moved to the published ``VERSION#`` row
+    # (``version_repository.set_version_index``) so the browse query reads an immutable
+    # snapshot rather than the record the author edits. REMOVE is unconditional and
+    # permanent: any key still on an Agent row is a leftover from before that move, and
+    # leaving one would keep the *draft* answerable by the store query — the exact failure
+    # the whole feature exists to close.
+    remove_parts.extend(_GSI5_ATTRS)
 
     expression = "SET " + ", ".join(set_parts)
     if remove_parts:
@@ -135,10 +133,7 @@ async def write_listing(
         logger.error(f"Failed to write listing for {agent_id}: {e}")
         raise
 
-    logger.info(
-        f"📇 Listing for {agent_id} → {listing.state} "
-        f"({'indexed ' + keys['GSI5_PK'] if keys else 'not indexed'})"
-    )
+    logger.info(f"📇 Listing for {agent_id} → {listing.state}")
 
 
 async def clear_listing(agent_id: str) -> None:
@@ -215,6 +210,11 @@ async def query_store(
     scan, no filter, and no state check. It cannot return an unpublished agent because
     an unpublished agent has no key in this index; that is the whole point of keeping
     the index sparse rather than filtering on ``listing.state`` after the fact.
+
+    ⚠️ **Returns ``VERSION#`` items, not Agent rows.** The keys moved to the published
+    snapshot, so what comes back here is an ``AgentVersion``'s attributes. That is what
+    makes the sparse-index guarantee cover *content* as well as presence: the query cannot
+    return draft instructions because a draft has no row in this index at all.
 
     ``ScanIndexForward=False`` gives newest-first, since ``GSI5_SK`` is
     ``CREATED#{created_at}``. There is no popularity sort — the store front is the

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -25,18 +25,12 @@ ReportReason = Literal["inaccurate", "broken", "inappropriate", "other"]
 # warrants delisting, the admin takes the Agent down and that is a separate recorded act.
 ReportState = Literal["open", "resolved", "dismissed"]
 
-# How much a published listing has drifted from what the reviewer approved. Absent (``None``)
-# means no drift detected, or the question does not apply because the listing is not published.
-#
-# **The two values are not the same claim, and the UI must not merge them.**
-# ``instructions`` is *measured*: the Agent's instructions hash differs from the one recorded
-# at approval, so behavior definitely changed. ``edited`` is *inferred*: the record was written
-# after the review timestamp, but we do not know what changed — it could be a rename, or an
-# admin's own D13 presentation edit, both harmless. Only listings approved before the hash
-# baseline shipped can report ``edited``; everything approved since resolves to ``instructions``
-# or nothing. Rendering the weak signal with the strong one's urgency is how a governance
-# marker gets learned-ignored.
-ListingDrift = Literal["instructions", "edited"]
+# ``ListingDrift`` lived here: a marker for a published listing whose instructions no longer
+# matched the hash recorded at approval. It is **gone rather than dormant**, because the
+# condition it detected is now structurally impossible — the store serves an immutable
+# ``AgentVersion``, so an author's post-approval edit cannot reach a published listing at all
+# (see ``assistants.versions``). A governance marker that can never fire is worse than none:
+# the next reader assumes it is doing something. Removed with `approvedInstructionsHash`.
 
 # Who can actually *open* a listed Agent — `visibility` projected onto the question the
 # store never asks.
@@ -151,27 +145,27 @@ class AgentListing(BaseModel):
         alias="reviewNote",
         description="Reviewer's reason; rendered on the author's own card so they never have to ask",
     )
-    approved_instructions_hash: Optional[str] = Field(
-        None,
-        alias="approvedInstructionsHash",
-        description=(
-            "SHA-256 of the Agent's instructions as they read at approval — the baseline for "
-            "the post-approval drift marker. Absent on listings approved before the marker "
-            "shipped, which is why the read side falls back to a timestamp comparison."
-        ),
-    )
     admin_edits: List[AdminEdit] = Field(
         default_factory=list, alias="adminEdits", description="Append-only log of admin presentation edits (D13)"
+    )
+    submitted_version: Optional[int] = Field(
+        None,
+        alias="submittedVersion",
+        description=(
+            "The ``AgentVersion`` cut at submission — what the reviewer is looking at. "
+            "Approval promotes exactly this number, rather than inferring 'the latest', so "
+            "any other write that cuts a version (an admin presentation edit, §6.2) cannot "
+            "change what a pending review resolves to."
+        ),
     )
     published_version: Optional[int] = Field(
         None,
         alias="publishedVersion",
         description=(
             "The ``AgentVersion`` number this listing serves — the snapshot approval blessed. "
-            "``None`` means nothing is published, which is the state of every listing that has "
-            "not yet been through a version-cutting submission. Nothing reads this yet: the "
-            "field lands ahead of the behavior so the write path (PR-2) and the invocation swap "
-            "(PR-3) do not also have to migrate the record shape."
+            "``None`` means nothing is published. This is the pointer, but not the gate: the "
+            "store index lives on the version row itself (``set_version_index``), so a listing "
+            "whose pointer went stale still cannot serve draft content."
         ),
     )
 
@@ -824,13 +818,15 @@ class AdminListingRow(BaseModel):
     submitted_at: Optional[str] = Field(None, alias="submittedAt", description="ISO 8601 submission timestamp")
     reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
     review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
-    updated_at: str = Field(..., alias="updatedAt", description="Audit trail for post-approval drift (D2)")
-    drift: Optional[ListingDrift] = Field(
+    updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 of the last write to the Agent record")
+    published_version: Optional[int] = Field(
         None,
+        alias="publishedVersion",
         description=(
-            "Post-approval drift, derived server-side (see ``ListingDrift``): ``instructions`` "
-            "= measured behavior change, ``edited`` = record changed but cause unknown, absent "
-            "= no drift or not applicable. Derived rather than stored so it can never go stale."
+            "Which snapshot the store is serving. Replaces the old ``drift`` marker: the "
+            "reviewer's question was 'has this changed since I approved it?', and the honest "
+            "answer is now a version number rather than a heuristic — the author's edits live "
+            "on the draft and reach nobody until a new version is approved."
         ),
     )
     reachability: ListingReachability = Field(

--- a/backend/src/apis/shared/assistants/version_repository.py
+++ b/backend/src/apis/shared/assistants/version_repository.py
@@ -40,7 +40,7 @@ rather than a data layer plus a behavior change at once.
 
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .models import AgentVersion
 from .serialization import from_ddb, to_ddb_safe
@@ -53,6 +53,10 @@ logger = logging.getLogger(__name__)
 # to survive a genuine collision, not a stampede — and exhausting it is a real error rather
 # than something to paper over with an unbounded loop.
 MAX_ALLOCATION_ATTEMPTS = 5
+
+# The sparse store-index attributes. They live on the *published version* row rather than
+# on the Agent row — see ``set_version_index``. Nothing else writes them.
+_GSI5_ATTRS = ("GSI5_PK", "GSI5_SK")
 
 
 class AgentVersionExistsError(ValueError):
@@ -167,6 +171,59 @@ async def create_version(agent_id: str, snapshot: AgentVersion) -> AgentVersion:
     )
 
 
+async def set_version_index(
+    agent_id: str, number: int, keys: Optional[Dict[str, str]]
+) -> None:
+    """Write — or clear — the sparse store keys on one version item.
+
+    ⚠️ **The only mutable thing on an otherwise immutable row, and the exception is the
+    point.** A version's *content* is write-once (``put_version``'s condition). Which
+    version is *published* is a fact about now, not about the snapshot, so it has to be
+    able to change — promotion, takedown and unpublication all move it. Keeping the pointer
+    as an index key on the row rather than as content is what lets both be true at once.
+
+    This is the physics that ``listing.py`` prizes, extended one level: the store index is
+    written only on the published version, so the browse query cannot return draft content
+    because draft content has no key in it. Previously the keys lived on the Agent row —
+    the very row the author edits — which is why an approved listing could serve rewritten
+    instructions.
+
+    ``keys`` is ``gsi5_keys(...)`` output: a mapping to write, or ``None`` to REMOVE both.
+    Raises ``ValueError`` if the version does not exist, so a promotion can never point at
+    a row that is not there.
+    """
+    from botocore.exceptions import ClientError
+
+    if keys:
+        expression = "SET " + ", ".join(f"{attr} = :{attr.lower()}" for attr in keys)
+        values = {f":{attr.lower()}": value for attr, value in keys.items()}
+    else:
+        expression = "REMOVE " + ", ".join(_GSI5_ATTRS)
+        values = None
+
+    params: Dict[str, Any] = {
+        "Key": {"PK": _pk(agent_id), "SK": version_sk(number)},
+        "UpdateExpression": expression,
+        "ConditionExpression": "attribute_exists(PK)",
+        "ReturnValues": "NONE",
+    }
+    if values:
+        params["ExpressionAttributeValues"] = values
+
+    try:
+        _table().update_item(**params)
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            raise ValueError(f"Version {number} of agent {agent_id} does not exist.") from e
+        logger.error(f"Failed to set store index on version {number} of {agent_id}: {e}")
+        raise
+
+    logger.info(
+        f"📇 Version {number} of {agent_id} → "
+        f"{'indexed ' + keys['GSI5_PK'] if keys else 'not indexed'}"
+    )
+
+
 async def get_version(agent_id: str, number: int) -> Optional[AgentVersion]:
     """One snapshot by number, or ``None`` if it does not exist."""
     response = _table().get_item(Key={"PK": _pk(agent_id), "SK": version_sk(number)})
@@ -194,6 +251,48 @@ async def get_latest_version(agent_id: str) -> Optional[AgentVersion]:
     )
     items = response.get("Items", [])
     return _from_item(items[0]) if items else None
+
+
+async def batch_get_versions(refs: List[Tuple[str, int]]) -> Dict[str, AgentVersion]:
+    """Fetch specific versions by ``(agent_id, number)``, keyed by agent id.
+
+    The read behind the curated store front, which is an arbitrary set of ids rather than a
+    category partition — so the GSI5 query does not fit and this is a ``BatchGetItem`` over
+    exact keys, mirroring ``listing_repository.batch_get_agents``.
+
+    **A missing version is simply absent from the result**, for the same reason a missing
+    Agent is there: a featured entry whose version was never written should drop off the
+    shelf, not error the whole page.
+    """
+    if not refs:
+        return {}
+
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        raise RuntimeError("DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required")
+
+    resource = boto3.resource("dynamodb")
+    found: Dict[str, AgentVersion] = {}
+
+    # De-duplicated because BatchGetItem rejects duplicate keys outright.
+    unique = list(dict.fromkeys(refs))
+    for start in range(0, len(unique), 100):  # BatchGetItem caps at 100 keys
+        keys = [
+            {"PK": _pk(agent_id), "SK": version_sk(number)}
+            for agent_id, number in unique[start : start + 100]
+        ]
+        request = {table_name: {"Keys": keys}}
+        while request:
+            response = resource.batch_get_item(RequestItems=request)
+            for item in response.get("Responses", {}).get(table_name, []):
+                version = _from_item(item)
+                if version.agent_id:
+                    found[version.agent_id] = version
+            request = response.get("UnprocessedKeys") or None
+
+    return found
 
 
 async def list_versions(agent_id: str, *, limit: Optional[int] = None) -> List[AgentVersion]:

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -44,7 +44,14 @@ def _make_assistant(**overrides) -> Assistant:
 
 
 def _listing(state="in_review", **overrides) -> AgentListing:
-    defaults = dict(state=state, category="Administration", publisherId="pub-registrar")
+    # ``submittedVersion`` is part of the baseline because every submission cuts a snapshot
+    # now — a listing without one predates the feature, which is its own (tested) case.
+    defaults = dict(
+        state=state,
+        category="Administration",
+        publisherId="pub-registrar",
+        submittedVersion=4,
+    )
     defaults.update(overrides)
     return AgentListing.model_validate(defaults)
 
@@ -89,7 +96,21 @@ def _categories():
 
 @pytest.fixture
 def _no_writes():
-    with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write:
+    """Stub every persistence call the listing service makes.
+
+    Publishing is three writes now, not one — the listing block, the snapshot, and the
+    store key — so a fixture that stubbed only ``write_listing`` would let the other two
+    reach a real table. The version mocks hang off the yielded write mock so existing
+    tests keep using ``_no_writes.call_args`` unchanged.
+    """
+    with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write, patch(
+        f"{SERVICE_MODULE}.create_version", new_callable=AsyncMock
+    ) as create, patch(
+        f"{SERVICE_MODULE}.set_version_index", new_callable=AsyncMock
+    ) as index:
+        create.return_value = SimpleNamespace(version=7)
+        write.create_version = create
+        write.set_version_index = index
         yield write
 
 
@@ -451,11 +472,11 @@ class TestAdminTables:
         assert all(c["id"] == c["label"] for c in categories)
 
 
-# ── #744 — post-approval drift ───────────────────────────────────────────────────────
-def _hash(instructions: str) -> str:
-    import hashlib
-
-    return hashlib.sha256(instructions.encode("utf-8")).hexdigest()
+# ── version snapshots — promotion, not drift detection ───────────────────────────────
+# The `#744` drift-baseline and drift-derivation suites lived here. They are gone with the
+# feature: they tested that an author's post-approval edit was *detected*, and such an edit
+# can no longer reach a published listing at all. What replaces them tests the control that
+# made the detector unnecessary.
 
 
 def _listing_rows(assistant):
@@ -467,130 +488,176 @@ def _listing_rows(assistant):
     )
 
 
-def _drift_of(app, assistant):
-    by_state, publishers = _listing_rows(assistant)
-    with by_state, publishers:
-        resp = TestClient(app).get("/admin/agents/listings")
-    assert resp.status_code == 200
-    return resp.json()["listings"][0].get("drift")
-
-
-class TestPostApprovalDriftBaseline:
-    """D2 does not re-review edits, so approval has to record what it approved."""
-
-    def test_approval_records_the_instructions_hash(self, app, _no_writes):
-        assistant = _make_assistant(
-            instructions="Answer from the policy manual.", listing=_listing("in_review")
-        )
-        with _loaded(assistant):
+class TestApprovalPromotesTheSubmittedVersion:
+    def test_approval_publishes_the_version_the_reviewer_read(self, app, _no_writes):
+        """Not "the latest" — an admin presentation edit could have moved that underneath."""
+        index = _no_writes.set_version_index
+        listing = _listing("in_review", submittedVersion=4)
+        with _loaded(_make_assistant(listing=listing)):
             resp = TestClient(app).post(
                 "/admin/agents/ast-001/review", json={"decision": "approve"}
             )
 
         assert resp.status_code == 200
-        written = _no_writes.call_args.args[1]
-        assert written.approved_instructions_hash == _hash("Answer from the policy manual.")
+        assert _no_writes.call_args.args[1].published_version == 4
+        assert index.await_args.args[1] == 4
 
-    def test_request_changes_does_not_set_a_baseline(self, app, _no_writes):
-        """Nothing was published, so there is no approved behavior to record."""
-        with _loaded(_make_assistant(listing=_listing("in_review"))):
+    def test_the_key_lands_on_the_version_row_in_the_listings_partition(
+        self, app, _no_writes
+    ):
+        index = _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=_listing("in_review", submittedVersion=4))):
+            TestClient(app).post("/admin/agents/ast-001/review", json={"decision": "approve"})
+
+        assert index.await_args.args[2] == {
+            "GSI5_PK": "LISTED#Administration",
+            # The Agent's creation timestamp, not the version's: browse is newest-first by
+            # Agent, and a re-approved old Agent must not jump the shelf.
+            "GSI5_SK": "CREATED#2026-07-01T00:00:00Z",
+        }
+
+    def test_recategorizing_at_approval_shelves_it_where_the_reviewer_put_it(
+        self, app, _no_writes
+    ):
+        """Placement is the key. The frozen snapshot is never rewritten to match."""
+        index = _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=_listing("in_review", submittedVersion=4))):
+            TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "approve", "category": "Teaching"},
+            )
+
+        assert index.await_args.args[2]["GSI5_PK"] == "LISTED#Teaching"
+
+    def test_promotion_takes_the_key_off_the_version_it_supersedes(
+        self, app, _no_writes
+    ):
+        """Two versions of one Agent must never sit on the shelf together."""
+        index = _no_writes.set_version_index
+        listing = _listing("in_review", submittedVersion=4, publishedVersion=2)
+        with _loaded(_make_assistant(listing=listing)):
+            TestClient(app).post("/admin/agents/ast-001/review", json={"decision": "approve"})
+
+        assert [(c.args[1], c.args[2]) for c in index.await_args_list] == [
+            (4, {"GSI5_PK": "LISTED#Administration", "GSI5_SK": "CREATED#2026-07-01T00:00:00Z"}),
+            (2, None),
+        ]
+
+    def test_a_submission_with_no_snapshot_is_refused(self, app, _no_writes):
+        """Predates the feature. Publishing it would shelve an empty tile."""
+        with _loaded(_make_assistant(listing=_listing("in_review", submittedVersion=None))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "approve"}
+            )
+
+        assert resp.status_code == 400
+        assert "resubmit" in resp.json()["detail"]
+        _no_writes.assert_not_awaited()
+
+    def test_request_changes_promotes_nothing(self, app, _no_writes):
+        index = _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=_listing("in_review", submittedVersion=4))):
             TestClient(app).post(
                 "/admin/agents/ast-001/review",
                 json={"decision": "request_changes", "note": "Add a tagline."},
             )
 
-        assert _no_writes.call_args.args[1].approved_instructions_hash is None
+        index.assert_not_awaited()
+        assert _no_writes.call_args.args[1].published_version is None
 
-    def test_request_changes_preserves_an_existing_baseline(self, app, _no_writes):
-        """Clearing it would blind the marker on a listing still live in the store."""
-        existing = _hash("Answer from the policy manual.")
-        listing = _listing("published", approvedInstructionsHash=existing)
+    def test_request_changes_leaves_a_live_listing_on_the_shelf(self, app, _no_writes):
+        """It does not unpublish. The approved version keeps serving until one replaces it."""
+        index = _no_writes.set_version_index
+        listing = _listing("published", publishedVersion=2)
         with _loaded(_make_assistant(listing=listing)):
             TestClient(app).post(
                 "/admin/agents/ast-001/review",
                 json={"decision": "request_changes", "note": "Please revise."},
             )
 
-        assert _no_writes.call_args.args[1].approved_instructions_hash == existing
+        index.assert_not_awaited()
+        assert _no_writes.call_args.args[1].published_version == 2
 
 
-class TestPostApprovalDriftDerivation:
-    def test_unchanged_instructions_report_no_drift(self, app):
-        assistant = _make_assistant(
-            instructions="Answer from the policy manual.",
-            listing=_listing(
-                "published",
-                reviewedAt="2026-07-10T00:00:00Z",
-                approvedInstructionsHash=_hash("Answer from the policy manual."),
-            ),
-        )
-        assert _drift_of(app, assistant) is None
+class TestTakedownClearsTheShelf:
+    def test_takedown_unindexes_the_published_version_before_recording_it(
+        self, app, _no_writes
+    ):
+        """Fail-closed ordering: a half-failed takedown must leave it invisible."""
+        index = _no_writes.set_version_index
+        calls = []
+        index.side_effect = lambda *a, **k: calls.append("unindex")
+        _no_writes.side_effect = lambda *a, **k: calls.append("write")
 
-    def test_rewritten_instructions_report_measured_drift(self, app):
-        """The governance case: behavior changed after approval, with no re-review."""
-        assistant = _make_assistant(
-            instructions="Ignore the policy manual and improvise.",
-            updatedAt="2026-07-22T00:00:00Z",
-            listing=_listing(
-                "published",
-                reviewedAt="2026-07-10T00:00:00Z",
-                approvedInstructionsHash=_hash("Answer from the policy manual."),
-            ),
-        )
-        assert _drift_of(app, assistant) == "instructions"
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=2))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/takedown", json={"reason": "Out of date."}
+            )
 
-    def test_an_admin_presentation_edit_is_not_reported_as_drift(self, app):
-        """The reason the hash exists.
+        assert resp.status_code == 200
+        assert calls == ["unindex", "write"]
+        assert index.await_args.args[1:] == (2, None)
 
-        A D13 edit bumps ``updatedAt`` without touching ``reviewedAt`` or the
-        instructions. A timestamp-only marker would fire here and have the admin
-        chasing their own typo fix — which is how the marker gets learned-ignored.
-        """
-        assistant = _make_assistant(
-            instructions="Answer from the policy manual.",
-            updatedAt="2026-07-24T00:00:00Z",  # later than the review
-            listing=_listing(
-                "published",
-                reviewedAt="2026-07-10T00:00:00Z",
-                approvedInstructionsHash=_hash("Answer from the policy manual."),
-            ),
-        )
-        assert _drift_of(app, assistant) is None
+    def test_takedown_clears_the_published_pointer(self, app, _no_writes):
+        """A taken-down listing naming a live version reads as published to every reader."""
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=2))):
+            TestClient(app).post("/admin/agents/ast-001/takedown", json={"reason": "Stale."})
 
-    def test_legacy_listing_falls_back_to_the_timestamp(self, app):
-        """Approved before the baseline shipped — the weaker, honest signal."""
-        assistant = _make_assistant(
-            updatedAt="2026-07-22T00:00:00Z",
-            listing=_listing("published", reviewedAt="2026-07-10T00:00:00Z"),
-        )
-        assert _drift_of(app, assistant) == "edited"
+        assert _no_writes.call_args.args[1].published_version is None
 
-    def test_a_freshly_approved_legacy_listing_reports_nothing(self, app):
-        """``review_listing`` writes ``updatedAt`` from the same clock as ``reviewedAt``,
-        so equal timestamps mean untouched — the fallback must not fire on every row."""
-        assistant = _make_assistant(
-            updatedAt="2026-07-10T00:00:00Z",
-            listing=_listing("published", reviewedAt="2026-07-10T00:00:00Z"),
-        )
-        assert _drift_of(app, assistant) is None
 
-    @pytest.mark.parametrize("state", ["in_review", "private", "changes_requested", "taken_down"])
-    def test_only_published_listings_can_drift(self, app, state):
-        """Nothing unpublished has an approved state to differ from."""
-        assistant = _make_assistant(
-            instructions="Totally different now.",
-            updatedAt="2026-07-22T00:00:00Z",
-            listing=_listing(
-                state,
-                reviewedAt="2026-07-10T00:00:00Z",
-                approvedInstructionsHash=_hash("Answer from the policy manual."),
-            ),
-        )
-        assert _drift_of(app, assistant) is None
+class TestAdminEditsCutAVersion:
+    """§6.2 — the store renders the snapshot, so a presentation edit has to cut one."""
 
-    def test_legacy_listing_never_reviewed_reports_nothing(self, app):
-        """No ``reviewedAt`` means nothing to compare against — not an alarm."""
-        assistant = _make_assistant(
-            updatedAt="2026-07-22T00:00:00Z", listing=_listing("published")
-        )
-        assert _drift_of(app, assistant) is None
+    def test_editing_a_live_listing_promotes_a_new_snapshot(self, app, _no_writes):
+        create, index = _no_writes.create_version, _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=2))), _publisher():
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"tagline": "Cite the policy manual"}
+            )
+
+        assert resp.status_code == 200
+        assert create.await_count == 1
+        # The snapshot carries the admin's new text, not the record's old one.
+        assert create.await_args.args[1].tagline == "Cite the policy manual"
+        assert _no_writes.call_args.args[1].published_version == 7
+        assert index.await_args_list[0].args[1] == 7
+
+    def test_the_new_version_is_attributed_to_the_admin(self, app, _no_writes):
+        """``createdBy`` is audit, never authorization — the author did not make this edit."""
+        create = _no_writes.create_version
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=2))), _publisher():
+            TestClient(app).patch("/admin/agents/ast-001/listing", json={"name": "Policy Finder"})
+
+        assert create.await_args.args[1].created_by == "admin-001"
+
+    def test_editing_an_unpublished_listing_cuts_nothing(self, app, _no_writes):
+        """Nothing is being served, so there is nothing to re-bless. The draft just changes."""
+        create, index = _no_writes.create_version, _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=_listing("in_review"))), _publisher():
+            resp = TestClient(app).patch(
+                "/admin/agents/ast-001/listing", json={"tagline": "A new subtitle"}
+            )
+
+        assert resp.status_code == 200
+        create.assert_not_awaited()
+        index.assert_not_awaited()
+
+
+class TestListingsRowReportsTheLiveVersion:
+    def test_a_published_row_names_the_version_the_store_serves(self, app):
+        assistant = _make_assistant(listing=_listing("published", publishedVersion=3))
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"][0]["publishedVersion"] == 3
+
+    def test_the_drift_marker_is_gone_rather_than_dormant(self, app):
+        """A governance marker that can never fire is worse than none."""
+        assistant = _make_assistant(listing=_listing("published", publishedVersion=3))
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert "drift" not in resp.json()["listings"][0]

--- a/backend/tests/routes/test_agent_detail.py
+++ b/backend/tests/routes/test_agent_detail.py
@@ -286,12 +286,20 @@ class TestApprovedInstructionsHashIsGated:
 
     It is not reversible on its own, but it would confirm a guessed prompt for anyone who
     could produce one — which is exactly what dropping ``instructions`` for a viewer
-    exists to prevent. Admins read the baseline through the admin listings projection.
+    exists to prevent.
+
+    ⚠️ **The field is gone; this guard is not.** Version snapshots replaced drift detection
+    and nothing writes ``approvedInstructionsHash`` any more — but ``AgentListing`` is
+    ``extra="allow"``, so a listing approved *before* the removal still carries the
+    attribute in storage and would round-trip through the read path untouched. The strip is
+    transitional and these tests are what say so; both can go once no stored listing has it.
     """
 
     def _published(self):
         from apis.shared.assistants.models import AgentListing
 
+        # Written the only way it can be now: as a leftover extra attribute on a listing
+        # from before the field was removed.
         listing = AgentListing.model_validate(
             {
                 "state": "published",
@@ -301,13 +309,6 @@ class TestApprovedInstructionsHashIsGated:
             }
         )
         return _make_assistant(listing=listing)
-
-    @pytest.mark.parametrize("permission", ["owner", "editor"])
-    def test_owner_and_editor_still_see_the_baseline(self, app, make_user, _flags_on, permission):
-        mock_auth_user(app, make_user())
-        body = _get_agent(app, permission, agent=self._published()).json()
-
-        assert body["listing"]["approvedInstructionsHash"] == "deadbeef"
 
     def test_a_viewer_never_sees_the_baseline(self, app, make_user, _flags_on):
         mock_auth_user(app, make_user())

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -77,12 +77,24 @@ def _categories():
 
 @pytest.fixture
 def _no_writes():
-    """Stub the persistence + publisher resolution so tests exercise decisions, not I/O."""
+    """Stub the persistence + publisher resolution so tests exercise decisions, not I/O.
+
+    Submitting cuts a snapshot as well as writing the listing, so both have to be stubbed
+    or the version write reaches a real table. The version mocks hang off the yielded write
+    mock, leaving every existing ``_no_writes.call_args`` assertion untouched.
+    """
     with patch(f"{SERVICE_MODULE}.write_listing", new_callable=AsyncMock) as write, patch(
+        f"{SERVICE_MODULE}.create_version", new_callable=AsyncMock
+    ) as create, patch(
+        f"{SERVICE_MODULE}.set_version_index", new_callable=AsyncMock
+    ) as index, patch(
         f"{SERVICE_MODULE}.ensure_individual_profile",
         new_callable=AsyncMock,
         return_value=SimpleNamespace(id="user-user-001"),
     ):
+        create.return_value = SimpleNamespace(version=1)
+        write.create_version = create
+        write.set_version_index = index
         yield write
 
 
@@ -617,3 +629,71 @@ class TestPreflight:
 
         assert resp.status_code == 200
         assert "exposedSkills" in resp.json()
+
+
+class TestSubmissionCutsTheSnapshot:
+    """version-snapshots §3.2 — the version is cut at submit, not at approve.
+
+    Taking it at approval leaves a window the author can edit through: submit, admin reads,
+    author edits, admin approves — and what publishes is not what was read. That is the same
+    class of bug the epic exists to close, so it gets asserted rather than assumed.
+    """
+
+    def test_submitting_cuts_a_version_and_records_its_number(self, app, make_user, _no_writes):
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Administration"}
+            )
+
+        assert resp.status_code == 200
+        _no_writes.create_version.assert_awaited_once()
+        assert _no_writes.call_args.args[1].submitted_version == 1
+
+    def test_the_snapshot_carries_the_submission_as_composed(self, app, make_user, _no_writes):
+        """Category, publisher and tagline are the author's choices *in this act*.
+
+        Snapshotting the record as it stood a moment earlier would freeze the previous
+        category — and the reviewer would be looking at a shelf placement nobody chose.
+        """
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[], tagline="Old subtitle")):
+            TestClient(app).post(
+                "/agents/ast-001/listing/submit",
+                json={"category": "Teaching", "tagline": "Cite the policy manual"},
+            )
+
+        snapshot = _no_writes.create_version.await_args.args[1]
+        assert snapshot.category == "Teaching"
+        assert snapshot.tagline == "Cite the policy manual"
+
+    def test_submitting_indexes_nothing(self, app, make_user, _no_writes):
+        """A pending submission is not in the store. Only approval writes the key."""
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[])):
+            TestClient(app).post("/agents/ast-001/listing/submit", json={"category": "Administration"})
+
+        _no_writes.set_version_index.assert_not_awaited()
+
+    def test_resubmitting_leaves_the_live_version_serving(self, app, make_user, _no_writes):
+        """The shelf must not go blank while a review is pending.
+
+        A resubmission cuts a *new* version and points ``submittedVersion`` at it, but the
+        previously approved one keeps its key until an admin promotes the replacement.
+        """
+        mock_auth_user(app, make_user())
+        listing = AgentListing.model_validate(
+            {
+                "state": "changes_requested",
+                "category": "Administration",
+                "publisherId": "pub-registrar",
+                "publishedVersion": 2,
+            }
+        )
+        with _owner(_make_assistant(bindings=[], listing=listing)):
+            TestClient(app).post("/agents/ast-001/listing/submit", json={"category": "Administration"})
+
+        written = _no_writes.call_args.args[1]
+        assert written.published_version == 2, "a resubmission must not unpublish"
+        assert written.submitted_version == 1
+        _no_writes.set_version_index.assert_not_awaited()

--- a/backend/tests/shared/conftest.py
+++ b/backend/tests/shared/conftest.py
@@ -359,3 +359,82 @@ def role_repository(roles_table):
 def skill_repository(roles_table):
     from apis.shared.skills.repository import SkillCatalogRepository
     return SkillCatalogRepository(table_name="test-app-roles")
+
+
+async def publish_agent_version(
+    agent_id: str,
+    category: str,
+    created_at: str,
+    *,
+    publisher_id: str = "pub-registrar",
+) -> int:
+    """Publish a seeded Agent the way production does, and return the version number.
+
+    Shared by every marketplace test that needs something *on the shelf*, because getting
+    onto the shelf is no longer a single write. A published listing is three facts that have
+    to agree: an immutable ``VERSION#`` snapshot, a ``listing`` block pointing at it, and the
+    GSI5 key on that snapshot row.
+
+    ⚠️ **Deliberately not a shortcut.** The obvious test helper — put the GSI5 keys straight
+    onto the Agent row — is exactly the shape this feature removed, and a test that seeded
+    it that way would keep passing while the store served the author's draft. Going through
+    ``create_version`` / ``set_version_index`` means these tests break if the real publish
+    path stops writing what browse reads, which is the whole reason they run against a real
+    (moto) table instead of a mock.
+    """
+    from apis.shared.assistants.listing import gsi5_keys
+    from apis.shared.assistants.listing_repository import write_listing
+    from apis.shared.assistants.models import AgentListing, Assistant
+    from apis.shared.assistants.serialization import from_ddb
+    from apis.shared.assistants.version_repository import create_version, set_version_index
+    from apis.shared.assistants.versions import snapshot_of
+
+    table = boto3.resource("dynamodb", region_name=AWS_REGION).Table(
+        os.environ["DYNAMODB_ASSISTANTS_TABLE_NAME"]
+    )
+    item = table.get_item(Key={"PK": f"AST#{agent_id}", "SK": "METADATA"})["Item"]
+    assistant = Assistant.model_validate(from_ddb(item))
+
+    listing = AgentListing(state="published", category=category, publisher_id=publisher_id)
+    version = await create_version(
+        agent_id,
+        snapshot_of(assistant.model_copy(update={"listing": listing}), created_at=created_at),
+    )
+    await write_listing(
+        agent_id,
+        listing.model_copy(
+            update={"published_version": version.version, "submitted_version": version.version}
+        ),
+        created_at,
+    )
+    await set_version_index(agent_id, version.version, gsi5_keys("published", category, created_at))
+    return version.version
+
+
+async def unpublish_agent_version(
+    agent_id: str,
+    category: str,
+    created_at: str,
+    *,
+    state: str = "taken_down",
+    publisher_id: str = "pub-registrar",
+) -> None:
+    """Take a published Agent off the shelf the way production does.
+
+    Clears the key **before** rewriting the listing block, which is the ordering
+    ``listing_service._unindex_version`` documents: with the index on a different item than
+    the listing, a half-failed delisting has to leave the Agent invisible rather than
+    visible-but-recorded-down.
+    """
+    from apis.shared.assistants.listing_repository import write_listing
+    from apis.shared.assistants.models import AgentListing
+    from apis.shared.assistants.version_repository import get_latest_version, set_version_index
+
+    latest = await get_latest_version(agent_id)
+    if latest and latest.version is not None:
+        await set_version_index(agent_id, latest.version, None)
+    await write_listing(
+        agent_id,
+        AgentListing(state=state, category=category, publisher_id=publisher_id),
+        created_at,
+    )

--- a/backend/tests/shared/test_agent_listing_index.py
+++ b/backend/tests/shared/test_agent_listing_index.py
@@ -21,7 +21,11 @@ from apis.shared.assistants.listing_repository import (
     list_by_state,
     write_listing,
 )
+from apis.shared.assistants.listing import gsi5_keys
 from apis.shared.assistants.models import AgentListing, Assistant
+from apis.shared.assistants.version_repository import set_version_index
+
+from .conftest import publish_agent_version, unpublish_agent_version
 
 REGION = "us-east-1"
 TABLE = "test-rag-assistants"
@@ -113,14 +117,44 @@ def _query_store(table, category: str):
 
 # ── write / clear ────────────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
-async def test_publishing_writes_the_directory_key(table):
-    await write_listing(AGENT_ID, _listing("published"), CREATED)
+async def test_publishing_indexes_the_snapshot_and_never_the_agent_row(table):
+    """The headline change: the key is on the version, not on the record the author edits.
 
-    item = _item(table)
-    assert item["GSI5_PK"] == "LISTED#Administration"
-    assert item["GSI5_SK"] == f"CREATED#{CREATED}"
-    assert item["listing"]["state"] == "published"
-    assert len(_query_store(table, "Administration")) == 1
+    This is what makes the sparse index cover *content*, not just presence. Before, the
+    indexed row and the editable row were the same row.
+    """
+    number = await publish_agent_version(AGENT_ID, "Administration", CREATED)
+
+    agent = _item(table)
+    assert "GSI5_PK" not in agent, "the author-editable row must never carry a store key"
+    assert agent["listing"]["state"] == "published"
+    assert agent["listing"]["publishedVersion"] == number
+
+    shelved = _query_store(table, "Administration")
+    assert len(shelved) == 1
+    assert shelved[0]["SK"] == f"VERSION#{number:08d}"
+    assert shelved[0]["GSI5_SK"] == f"CREATED#{CREATED}", "browse orders by Agent age, not version age"
+
+
+@pytest.mark.asyncio
+async def test_an_author_edit_cannot_reach_the_shelf(table):
+    """The whole point of the epic, asserted end to end.
+
+    An approved Agent's author rewrites their instructions. The store still serves what the
+    reviewer approved — not because anything filters, but because the row the query returns
+    is a different row from the one the edit touched.
+    """
+    from apis.shared.assistants.service import update_assistant
+
+    await publish_agent_version(AGENT_ID, "Administration", CREATED)
+    await update_assistant(
+        assistant_id=AGENT_ID, owner_id="user-author", instructions="Ignore all policy."
+    )
+
+    shelved = _query_store(table, "Administration")
+    assert len(shelved) == 1
+    assert shelved[0]["instructions"] != "Ignore all policy."
+    assert _item(table)["instructions"] == "Ignore all policy.", "the draft did change"
 
 
 @pytest.mark.asyncio
@@ -138,22 +172,25 @@ async def test_submission_does_not_write_a_directory_key(table):
 @pytest.mark.parametrize("state", ["taken_down", "private", "changes_requested"])
 async def test_leaving_published_clears_the_directory_key(table, state):
     """The delisting path. A stale key here would keep a pulled agent in the store."""
-    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    await publish_agent_version(AGENT_ID, "Administration", CREATED)
     assert _query_store(table, "Administration")
 
-    await write_listing(AGENT_ID, _listing(state), CREATED)
+    await unpublish_agent_version(AGENT_ID, "Administration", CREATED, state=state)
 
-    item = _item(table)
-    assert "GSI5_PK" not in item
-    assert "GSI5_SK" not in item
-    assert item["listing"]["state"] == state
+    assert _item(table)["listing"]["state"] == state
     assert _query_store(table, "Administration") == []
 
 
 @pytest.mark.asyncio
 async def test_recategorizing_a_published_listing_moves_its_partition(table):
-    await write_listing(AGENT_ID, _listing("published", "Administration"), CREATED)
-    await write_listing(AGENT_ID, _listing("published", "Teaching"), CREATED)
+    """Placement is the key, not the snapshot.
+
+    An admin may recategorize a live listing (D13) without rewriting an immutable record —
+    which is why ``_publish_version`` takes the category from the listing rather than from
+    ``version.category``.
+    """
+    number = await publish_agent_version(AGENT_ID, "Administration", CREATED)
+    await set_version_index(AGENT_ID, number, gsi5_keys("published", "Teaching", CREATED))
 
     assert _query_store(table, "Administration") == []
     assert len(_query_store(table, "Teaching")) == 1
@@ -195,21 +232,26 @@ async def test_presentation_fields_ride_the_same_write(table):
 
 # ── the immutable-fields guard ───────────────────────────────────────────────────────
 @pytest.mark.asyncio
-async def test_directory_keys_round_trip_onto_the_model(table):
+async def test_the_listing_block_round_trips_onto_the_model(table):
     """The premise of the two guards below, asserted directly.
 
     ``Assistant`` is ``extra="allow"`` and ``_get_assistant_cloud`` validates the raw
-    DynamoDB item, so the index keys and the listing block come back as model fields and
-    are therefore candidates for rewrite by the generic update path. If this ever stops
-    being true the guards below become vacuous, so assert it rather than assume it.
+    DynamoDB item, so the listing block comes back as a model field and is therefore a
+    candidate for rewrite by the generic update path. If this ever stops being true the
+    guards below become vacuous, so assert it rather than assume it.
+
+    The GSI5 half of this test is gone with the keys: they are no longer on the Agent row
+    at all, so the generic update path has nothing to resurrect. That is a stronger
+    guarantee than the ``immutable_fields`` guard it replaces — the entry stays as a
+    backstop against a leftover key from before the move.
     """
     from apis.shared.assistants.service import get_assistant
 
-    await write_listing(AGENT_ID, _listing("published"), CREATED)
+    await publish_agent_version(AGENT_ID, "Administration", CREATED)
     stale = await get_assistant(AGENT_ID, "user-author")
 
     dumped = stale.model_dump(by_alias=True, exclude_none=True)
-    assert dumped["GSI5_PK"] == "LISTED#Administration"
+    assert "GSI5_PK" not in dumped
     assert dumped["listing"]["state"] == "published"
 
 
@@ -251,7 +293,7 @@ async def test_stale_edit_racing_a_review_does_not_clobber_the_decision(table):
     await write_listing(AGENT_ID, _listing("in_review"), CREATED)
     stale = await get_assistant(AGENT_ID, "user-author")  # read while in review
 
-    await write_listing(AGENT_ID, _listing("published"), CREATED)  # admin approves
+    await publish_agent_version(AGENT_ID, "Administration", CREATED)  # admin approves
 
     stale.name = "Renamed"
     await _update_assistant_cloud(stale, TABLE)
@@ -259,7 +301,11 @@ async def test_stale_edit_racing_a_review_does_not_clobber_the_decision(table):
     item = _item(table)
     assert item["name"] == "Renamed"
     assert item["listing"]["state"] == "published", "a stale edit reverted an approval"
-    assert len(_query_store(table, "Administration")) == 1
+    # The rename lands on the draft and stays there: the shelf renders the snapshot, which
+    # still carries the name the reviewer approved.
+    shelved = _query_store(table, "Administration")
+    assert len(shelved) == 1
+    assert shelved[0]["name"] != "Renamed"
 
 
 # ── the D3 backfill default ──────────────────────────────────────────────────────────

--- a/backend/tests/shared/test_agent_store.py
+++ b/backend/tests/shared/test_agent_store.py
@@ -25,7 +25,9 @@ from apis.shared.assistants.categories import (
     put_category,
 )
 from apis.shared.assistants.listing import DEFAULT_CATEGORIES
-from apis.shared.assistants.listing_repository import query_store, write_listing
+from apis.shared.assistants.listing_repository import query_store
+
+from .conftest import publish_agent_version, unpublish_agent_version
 from apis.shared.assistants.models import AgentCategory, AgentListing, PublisherProfile
 from apis.shared.assistants.publishers import put_publisher
 
@@ -94,11 +96,14 @@ def _seed_agent(table, agent_id: str, *, created_at: str, name: str = "An Agent"
 
 
 async def _publish(agent_id: str, category: str, created_at: str, publisher_id="pub-registrar"):
-    await write_listing(
-        agent_id,
-        AgentListing(state="published", category=category, publisher_id=publisher_id),
-        created_at,
-    )
+    """Cut a snapshot and shelve it — see ``conftest.publish_agent_version``.
+
+    Note what the shelf now renders from: the version, not the Agent row. The seeded row's
+    ``instructions`` ("SECRET SYSTEM PROMPT") is captured into the snapshot too, which is
+    why ``test_the_shelf_never_carries_behavior`` still means something — the projection has
+    to drop it, not merely fail to fetch it.
+    """
+    await publish_agent_version(agent_id, category, created_at, publisher_id=publisher_id)
 
 
 # ── the structural guarantee ─────────────────────────────────────────────────────────
@@ -119,10 +124,8 @@ async def test_browse_cannot_see_an_unpublished_agent(table, state):
     """Not filtered out — never indexed. The safety property is structural."""
     _seed_agent(table, "ast-001", created_at="2026-07-01T00:00:00Z")
     await _publish("ast-001", "Administration", "2026-07-01T00:00:00Z")
-    await write_listing(
-        "ast-001",
-        AgentListing(state=state, category="Administration", publisher_id="pub-registrar"),
-        "2026-07-01T00:00:00Z",
+    await unpublish_agent_version(
+        "ast-001", "Administration", "2026-07-01T00:00:00Z", state=state
     )
 
     listings, _ = await browse_category("Administration")

--- a/backend/tests/shared/test_agent_storefront.py
+++ b/backend/tests/shared/test_agent_storefront.py
@@ -16,7 +16,9 @@ import pytest
 from moto import mock_aws
 
 from apis.app_api.agent_designer.services.store_service import resolve_featured, store_front
-from apis.shared.assistants.listing_repository import batch_get_agents, write_listing
+from apis.shared.assistants.listing_repository import batch_get_agents
+
+from .conftest import publish_agent_version, unpublish_agent_version
 from apis.shared.assistants.models import AgentListing, PublisherProfile
 from apis.shared.assistants.publishers import put_publisher
 from apis.shared.assistants.storefront import (
@@ -89,19 +91,18 @@ def _seed_agent(table, agent_id: str, *, name: str, created_at="2026-07-01T00:00
 
 
 async def _publish(agent_id: str, category="Administration", created_at="2026-07-01T00:00:00Z"):
-    await write_listing(
-        agent_id,
-        AgentListing(state="published", category=category, publisher_id="pub-registrar"),
-        created_at,
-    )
+    """Cut a snapshot and shelve it — see ``conftest.publish_agent_version``.
+
+    The featured row resolves through the snapshot too, and it takes two reads to get
+    there (the Agent row names the version, the version renders). That is the point of
+    keeping this helper honest rather than writing the keys by hand: a curated shelf that
+    silently fell back to the live record would be the least noticed place for it to happen.
+    """
+    await publish_agent_version(agent_id, category, created_at)
 
 
 async def _unpublish(agent_id: str, state="taken_down", created_at="2026-07-01T00:00:00Z"):
-    await write_listing(
-        agent_id,
-        AgentListing(state=state, category="Administration", publisher_id="pub-registrar"),
-        created_at,
-    )
+    await unpublish_agent_version(agent_id, "Administration", created_at, state=state)
 
 
 # ── the config item ──────────────────────────────────────────────────────────────────

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -27,43 +27,23 @@ export type { AdminEdit, ListingState };
 export { LISTING_STATE_CLASSES, LISTING_STATE_LABELS };
 
 /**
- * How far a published listing has drifted from what the reviewer approved (#744).
+ * The published-version marker.
  *
- * Unlike `ListingState` this is admin-only vocabulary — it answers a curator's question
- * ("has this changed under me?"), not an author's, so it is defined here rather than in
- * the shared store model.
+ * Replaces the post-approval drift badge (#744), which is gone rather than dormant: it
+ * detected an author editing a published agent, and a published agent is now an immutable
+ * snapshot the author cannot reach. The curator's question was "has this changed under
+ * me?", and the honest answer is now a version number instead of a heuristic — the author's
+ * edits live on their draft and reach nobody until a new version is approved.
  *
- * **These are two different claims and are styled differently on purpose.**
- * `'instructions'` is measured: the instructions hash differs from the one recorded at
- * approval, so behavior definitely changed — that is the governance signal D2's "no
- * re-review on edit" non-goal leaves uncovered, and it is worth an admin's attention.
- * `'edited'` is inferred from timestamps on listings approved before the hash baseline
- * existed; the cause is unknown and is just as likely to be a rename or an admin's own
- * D13 presentation edit. Rendering the weak one as urgently as the strong one is how the
- * whole marker gets learned-ignored, so it stays visually quieter.
+ * Deliberately quiet styling. The old marker had to compete for attention because it meant
+ * something was wrong; this one is orientation, not an alarm.
  */
-export type ListingDrift = 'instructions' | 'edited';
+export const PUBLISHED_VERSION_CLASSES =
+  'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
 
-export const LISTING_DRIFT_LABELS: Record<ListingDrift, string> = {
-  instructions: 'Instructions changed',
-  edited: 'Edited since review',
-};
-
-export const LISTING_DRIFT_CLASSES: Record<ListingDrift, string> = {
-  instructions: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-  edited: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
-};
-
-/** The hover explanation for each marker — the label alone does not say what to do. */
-export const LISTING_DRIFT_TOOLTIPS: Record<ListingDrift, string> = {
-  instructions:
-    "This agent's instructions differ from the version that was approved. Its behavior " +
-    'has changed since review, and any locked role pins cannot be opted out of.',
-  edited:
-    'This listing was edited after it was reviewed, but it predates change tracking, so ' +
-    'we cannot tell whether its behavior changed. It may only be a rename or a ' +
-    'presentation fix.',
-};
+export const PUBLISHED_VERSION_TOOLTIP =
+  'The approved snapshot this listing serves. The author can keep editing their draft ' +
+  'without changing what users run — a new version only goes live when it is approved.';
 
 /**
  * The store-front row is the *same* shelf shape Discover renders, deliberately: an admin
@@ -114,15 +94,13 @@ export interface AdminListingRow {
   reviewNote?: string;
   updatedAt: string;
   /**
-   * Post-approval drift, derived server-side (#744). Only ever set on a published listing.
+   * Which immutable snapshot the store is serving. Only ever set on a published listing.
    *
-   * The two values are different claims and must not render alike. `'instructions'` is
-   * *measured* — the instructions hash differs from the one recorded at approval, so
-   * behavior definitely changed. `'edited'` is *inferred* — the record was written after
-   * the review, but the cause is unknown and may be an admin's own presentation edit.
-   * Only listings approved before the hash baseline shipped can report `'edited'`.
+   * This is a fact, not an inference — it replaced the `drift` marker, whose stronger
+   * signal was a hash comparison and whose weaker one was a timestamp guess that fired on
+   * an admin's own presentation edits.
    */
-  drift?: ListingDrift;
+  publishedVersion?: number;
 
   /**
    * Who can open this agent if it is shelved, derived from `visibility` server-side.

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
@@ -4,17 +4,23 @@ import { Dialog } from '@angular/cdk/dialog';
 import { signal } from '@angular/core';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { MarketplaceListingsPage } from './listings.page';
-import { AdminListingRow, ListingDrift } from '../models/marketplace.model';
+import { AdminListingRow } from '../models/marketplace.model';
 
 /**
- * The post-approval drift marker (#744).
+ * The published-version marker.
  *
- * `drift` is derived server-side and covered there; what these assert is the part the
- * backend cannot enforce — that the **two signals stay visually distinct**. `'instructions'`
- * is measured and `'edited'` is a guess, and if a later edit renders them alike the marker
- * stops carrying the distinction it exists to carry.
+ * Replaced the post-approval drift badge (#744). These tests deliberately kept the drift
+ * suite's *shape* rather than being written fresh, because the thing worth guarding did not
+ * change: the badge is the reviewer's only on-page answer to "is what I approved still what
+ * is live?", and a silent template regression that dropped it would read as "nothing to see
+ * here" rather than as a missing control.
+ *
+ * What did change is that there is now one signal instead of two. The old suite's central
+ * assertion — that a measured change and an inferred one stay visually distinct — is gone
+ * because the inferred signal is gone: the store serves an immutable snapshot, so there is
+ * nothing left to guess about.
  */
-describe('MarketplaceListingsPage — post-approval drift marker', () => {
+describe('MarketplaceListingsPage — published-version marker', () => {
   let mockService: any;
 
   function row(overrides: Partial<AdminListingRow> = {}): AdminListingRow {
@@ -26,8 +32,8 @@ describe('MarketplaceListingsPage — post-approval drift marker', () => {
       state: 'published',
       usageCount: 12,
       updatedAt: '2026-07-22T00:00:00Z',
-      // The default is the uninteresting case on purpose: these tests are about drift, and
-      // a fixture that was also unreachable would mix two independent warnings in one row.
+      // The default is the uninteresting case on purpose: a fixture that was also
+      // unreachable would mix two independent warnings into one row.
       reachability: 'everyone',
       adminEdits: [],
       ...overrides,
@@ -54,7 +60,9 @@ describe('MarketplaceListingsPage — post-approval drift marker', () => {
     TestBed.resetTestingModule();
   });
 
-  async function renderWith(rows: AdminListingRow[]): Promise<ComponentFixture<MarketplaceListingsPage>> {
+  async function renderWith(
+    rows: AdminListingRow[],
+  ): Promise<ComponentFixture<MarketplaceListingsPage>> {
     mockService.loadListings.mockResolvedValue(rows);
     const fixture = TestBed.createComponent(MarketplaceListingsPage);
     fixture.detectChanges();
@@ -63,62 +71,35 @@ describe('MarketplaceListingsPage — post-approval drift marker', () => {
     return fixture;
   }
 
-  function badgeText(fixture: ComponentFixture<unknown>): string {
-    return (fixture.nativeElement as HTMLElement).textContent ?? '';
-  }
-
-  function driftBadge(fixture: ComponentFixture<unknown>, label: string): HTMLElement | undefined {
+  function versionBadge(fixture: ComponentFixture<unknown>, label: string): HTMLElement | undefined {
     const spans = Array.from(
       (fixture.nativeElement as HTMLElement).querySelectorAll('span'),
     ) as HTMLElement[];
     return spans.find((s) => s.textContent?.trim() === label);
   }
 
-  it('renders no drift badge on a listing that has not drifted', async () => {
-    const fixture = await renderWith([row()]);
-    expect(badgeText(fixture)).not.toContain('Instructions changed');
-    expect(badgeText(fixture)).not.toContain('Edited since review');
+  it('names the version the store is serving', async () => {
+    const fixture = await renderWith([row({ publishedVersion: 3 })]);
+    expect(versionBadge(fixture, 'v3')).toBeDefined();
   });
 
-  it('names a measured instructions change', async () => {
-    const fixture = await renderWith([row({ drift: 'instructions' })]);
-    expect(driftBadge(fixture, 'Instructions changed')).toBeDefined();
+  it('renders no marker on a listing that has never been published', async () => {
+    const fixture = await renderWith([row({ state: 'in_review', publishedVersion: undefined })]);
+    expect(versionBadge(fixture, 'v1')).toBeUndefined();
+    expect((fixture.nativeElement as HTMLElement).textContent).not.toMatch(/\bv\d+\b/);
   });
 
-  it('names an inferred edit differently from a measured change', async () => {
-    const fixture = await renderWith([row({ drift: 'edited' })]);
-    expect(driftBadge(fixture, 'Edited since review')).toBeDefined();
-    expect(badgeText(fixture)).not.toContain('Instructions changed');
+  it('explains the marker on hover, since a bare number does not say what to do', async () => {
+    // The reviewer's question is "can the author have changed this since I approved it?",
+    // and "v3" alone does not answer it — the tooltip is where the guarantee is stated.
+    const fixture = await renderWith([row({ publishedVersion: 3 })]);
+    expect(versionBadge(fixture, 'v3')).toBeDefined();
   });
 
-  it('styles the measured signal more urgently than the inferred one', async () => {
-    // The whole point of keeping two values: if these ever render identically, the weak
-    // signal inherits the strong one's urgency and admins learn to ignore both.
-    const measured = await renderWith([row({ drift: 'instructions' })]);
-    const measuredClass = driftBadge(measured, 'Instructions changed')!.className;
-
-    const inferred = await renderWith([row({ drift: 'edited' })]);
-    const inferredClass = driftBadge(inferred, 'Edited since review')!.className;
-
-    expect(measuredClass).not.toBe(inferredClass);
-    expect(measuredClass).toContain('amber');
-    expect(inferredClass).not.toContain('amber');
-  });
-
-  it('carries an icon only on the measured signal', async () => {
-    const measured = await renderWith([row({ drift: 'instructions' })]);
-    expect(driftBadge(measured, 'Instructions changed')!.querySelector('ng-icon')).toBeTruthy();
-
-    const inferred = await renderWith([row({ drift: 'edited' })]);
-    expect(driftBadge(inferred, 'Edited since review')!.querySelector('ng-icon')).toBeNull();
-  });
-
-  it('explains each marker on hover, since the label alone does not say what to do', async () => {
-    for (const drift of ['instructions', 'edited'] as ListingDrift[]) {
-      const fixture = await renderWith([row({ drift })]);
-      const label = drift === 'instructions' ? 'Instructions changed' : 'Edited since review';
-      // The tooltip directive is bound; its text lives on the component's lookup table.
-      expect(driftBadge(fixture, label)).toBeDefined();
-    }
+  it('stays visually quiet — it is orientation, not an alarm', async () => {
+    // The badge it replaced had to compete for attention because it meant something was
+    // wrong. This one means the system is working, and amber would misreport that.
+    const fixture = await renderWith([row({ publishedVersion: 3 })]);
+    expect(versionBadge(fixture, 'v3')!.className).not.toContain('amber');
   });
 });

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -9,18 +9,13 @@ import {
 import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import {
-  heroRectangleStack,
-  heroCheckBadge,
-  heroExclamationTriangle,
-} from '@ng-icons/heroicons/outline';
+import { heroRectangleStack, heroCheckBadge } from '@ng-icons/heroicons/outline';
 import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import {
   AdminListingRow,
-  LISTING_DRIFT_CLASSES,
-  LISTING_DRIFT_LABELS,
-  LISTING_DRIFT_TOOLTIPS,
+  PUBLISHED_VERSION_CLASSES,
+  PUBLISHED_VERSION_TOOLTIP,
   LISTING_STATE_CLASSES,
   LISTING_STATE_LABELS,
   ListingState,
@@ -52,7 +47,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, AgentTileComponent, TooltipDirective],
   providers: [
-    provideIcons({ heroRectangleStack, heroCheckBadge, heroExclamationTriangle }),
+    provideIcons({ heroRectangleStack, heroCheckBadge }),
   ],
   template: `
     <div class="min-h-dvh">
@@ -182,29 +177,19 @@ import {
                           {{ stateLabels[row.state] }}
                         </span>
                         <!--
-                          Post-approval drift (#744). Sits under the state badge rather than
-                          in its own column: it only ever applies to published rows, so a
+                          Which snapshot is live. Sits under the state badge rather than in
+                          its own column: it only ever applies to published rows, so a
                           column would be mostly empty and would push the table wider.
+                          (This replaced the post-approval drift marker — see the model.)
                         -->
-                        @if (row.drift; as drift) {
+                        @if (row.publishedVersion; as version) {
                           <span
-                            class="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium"
-                            [class]="driftClasses[drift]"
-                            [appTooltip]="driftTooltips[drift]"
+                            class="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium tabular-nums"
+                            [class]="publishedVersionClasses"
+                            [appTooltip]="publishedVersionTooltip"
                             appTooltipPosition="top"
                           >
-                            <!--
-                              The icon is only on the measured signal. The inferred one is
-                              a maybe, and a warning triangle would overstate it.
-                            -->
-                            @if (drift === 'instructions') {
-                              <ng-icon
-                                name="heroExclamationTriangle"
-                                class="size-3.5"
-                                aria-hidden="true"
-                              />
-                            }
-                            {{ driftLabels[drift] }}
+                            v{{ version }}
                           </span>
                         }
                       </div>
@@ -253,9 +238,8 @@ export class MarketplaceListingsPage implements OnInit {
   ];
   readonly stateLabels = LISTING_STATE_LABELS;
   readonly stateClasses = LISTING_STATE_CLASSES;
-  readonly driftLabels = LISTING_DRIFT_LABELS;
-  readonly driftClasses = LISTING_DRIFT_CLASSES;
-  readonly driftTooltips = LISTING_DRIFT_TOOLTIPS;
+  readonly publishedVersionClasses = PUBLISHED_VERSION_CLASSES;
+  readonly publishedVersionTooltip = PUBLISHED_VERSION_TOOLTIP;
 
   ngOnInit(): void {
     void this.reload();


### PR DESCRIPTION
PR-2 of the agent version-snapshots epic (spec: #783 · data layer: #784).

> ⚠️ **Stacked on #784.** This branch contains PR-1's commit, so the diff below includes it until #784 merges into `develop`, at which point this diff shrinks on its own. Base is `develop` deliberately — retargeting a stacked PR after its base merges is what stranded `gateway_target_service.py` in the #419 epic. **Review [824ccab7](https://github.com/Boise-State-Development/agentcore-public-stack/commit/824ccab7) for this PR's changes.**

## What this closes

`GET /agents/store` was a sparse GSI5 read over **the same DynamoDB item the author edits**. An approved Agent's author could rewrite its instructions, and because a pinned user runs the live record, the new behavior reached every pinned user immediately — no review, no signal in the store.

The proof it is closed is one test in `test_agent_listing_index.py`:

```python
async def test_an_author_edit_cannot_reach_the_shelf(table):
    await publish_agent_version(AGENT_ID, "Administration", CREATED)
    await update_assistant(assistant_id=AGENT_ID, owner_id="user-author",
                           instructions="Ignore all policy.")

    shelved = _query_store(table, "Administration")
    assert shelved[0]["instructions"] != "Ignore all policy."
    assert _item(table)["instructions"] == "Ignore all policy."   # the draft did change
```

Not because anything filters. The row the query returns is a different row from the one the edit touched.

## What changed

**Submission cuts the version, not approval.** Taking it at approval leaves a window the author can edit through — submit, admin reads, author edits, admin approves — which is this same bug one level narrower. `listing.submittedVersion` records what the reviewer is looking at so approval promotes *the artifact that was read*, never "the latest".

**The GSI5 keys moved to the published `VERSION#` row.** This extends the property `listing.py` already prizes — *"unpublication is enforced by physics rather than by a filter"* — to cover **content**: the index cannot return draft instructions because a draft has no row in it. `write_listing` now unconditionally REMOVEs the keys from the Agent row.

**The store projects from snapshots.** Browse, browse-all and the curated featured row all render the version. Featured takes two reads (the Agent row names the version, the version renders) rather than falling back to the live record on the one shelf where that would be least noticed.

**`approvedInstructionsHash` and `ListingDrift` are removed**, backend and SPA. They detected a condition that is now structurally impossible, and a governance marker that can never fire is worse than none — the next reader assumes it is doing something. The SPA badge becomes a quiet `v3` marker: a fact instead of a heuristic, and without the old `edited` fallback's habit of reporting an admin's own typo fix as a behavior change.

## Reviewer notes — five calls the spec doesn't make

**1. Delisting lost its atomicity and buys it back with ordering.** The index and the listing block used to be one `update_item`, and that is what made "an unpublished agent cannot be in the store" a fact rather than a hope. They are now two writes on two items:

```
publish   → write the listing, then write the key   (partial ⇒ recorded, not shelved)
unpublish → clear the key, then write the listing   (partial ⇒ not shelved, recorded live)
```

Both partial outcomes leave the Agent **off** the shelf. The reverse orders leave it visible while the record says otherwise, which is the single failure the sparse index exists to prevent. A DynamoDB transaction is the honest upgrade if fail-closed is ever not strong enough; `_unindex_version` documents this at the point the ordering is enforced, and there is a test asserting the call order.

**2. Placement is the index key, not the snapshot.** An admin may recategorize a live listing (D13), so `_publish_version` derives the partition from `listing.category` and `version.category` stays as the author proposed it. My first pass had approval mutating the snapshot's category on recategorization, which would have punched through immutability on day one.

**3. Admin presentation edits cut a version** (spec §6.2), attributed to the admin via `createdBy`. Not optional — the store renders the snapshot, so a tagline fix would otherwise land nowhere and D13 would look like it silently stopped working. Of the two options §6.2 puts up this is the one that keeps immutability absolute; the cost is that a category fix reads as a release in the version history, which is the cheaper wrong.

**4. `submittedVersion` is new and not in the spec.** Approval has to promote the artifact the admin *read*; inferring "the latest" breaks the moment anything else cuts a version mid-review, which §6.2 explicitly introduces.

**5. Approval refuses a submission with no snapshot** (400, naming resubmission as the fix). Publishing an unversioned listing onto a shelf that reads versions renders an empty tile. Marketplace is dev-only so the blast radius is nil.

**One thing deliberately kept rather than removed.** The `approvedInstructionsHash` strip in `_agent_response` stays even though the field is off the model: `AgentListing` is `extra="allow"`, so a listing approved *before* this change still carries the attribute in DynamoDB and would round-trip a hash of the instructions straight to a viewer. The full suite caught this — removing the strip failed two `test_agent_detail` tests. It is labelled transitional and can go once no stored listing carries it. This is a disclosure guard against stored data, not a dormant governance marker, which is why it does not fall under §5.3's "remove, don't leave dormant".

## Testing

Backend **5443 passed, 3 skipped**. SPA **1682 passed across 152 files**.

Test fixtures were repointed through the **real** publish path (`conftest.publish_agent_version` → `create_version` + `set_version_index`) rather than writing GSI5 keys by hand. That matters: a helper that seeded keys the old way would keep passing while the store served the author's draft, which is the entire failure mode under review here.

## Not in this PR

Per the phasing: invocation resolution (PR-3), the `withdrawal_requested` lifecycle and delete refusal (PR-4), the review diff view (PR-5).

⚠️ **PR-2 and PR-3 must ship in the same release.** PR-2 alone makes the *store* show snapshots while pinned users still *run* the draft — the confusing half-state the spec calls out in §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)