### PR TITLE
feat(agents): run the approved snapshot, not the author's draft (PR-3)

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1380,6 +1380,20 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     # request's skills AND force skill-mode (agent_type="skill") for the turn. None ⇒ the
     # Agent binds no skills ⇒ the request's agent_type/enabled_skills drive the turn.
     agent_skills_override = None
+    # Version snapshots (§4): which Agent snapshot this turn resolved to, for the log line
+    # below. ``None`` means the live record ran — a plain chat turn with no Agent, an Agent
+    # with nothing published, or the owner running their own draft.
+    #
+    # ⚠️ Deliberately **not** in the agent cache key, despite what the spec's §4.2 says. The
+    # key is built from construction *values*, and everything a version changes about
+    # behavior already reaches it: instructions via ``system_prompt``, tool bindings via
+    # ``enabled_tools``, skills via ``skills_hash``/``agent_type``, the model via
+    # ``model_id``, and a memory binding by skipping the cache entirely (extra_tools). So
+    # promoting a version already misses. Adding the number would buy no discrimination and
+    # would cost real safety: the resume path rebuilds its key from ``PausedTurnSnapshot``,
+    # so a new key element the snapshot did not carry orphans the paused agent and breaks
+    # OAuth-consent / tool-approval resumes (``service.py`` warns about exactly this).
+    resolved_version = None
 
     logger.info(
         "Invocation request - processing with assistant context"
@@ -1394,6 +1408,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         from apis.shared.assistants.service import (
             get_assistant_with_access_check,
             mark_share_as_interacted,
+        )
+        from apis.shared.assistants.version_resolution import (
+            AgentVersionUnavailableError,
+            resolve_invocation_agent,
         )
         from apis.shared.sessions.messages import get_messages
         from apis.shared.sessions.metadata import (
@@ -1493,6 +1511,41 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         logger.info("Assistant instructions retrieved")
         logger.info("Assistant instructions length retrieved")
         logger.info("Assistant vector index retrieved")
+
+        # 2a. Version snapshots (§4) — decide WHICH configuration this caller runs.
+        #
+        # This is the seam the whole epic was built toward: everything below resolves
+        # against ``assistant``, so swapping in the published snapshot here changes what
+        # runs without touching binding resolution, the system prompt, or the harness.
+        #
+        # Everyone but the owner runs the reviewed snapshot; the owner runs their own draft
+        # so they can iterate before resubmitting. An Agent with nothing published (never
+        # submitted, private, or in review) returns unchanged — that is the common case and
+        # it behaves exactly as it did before this feature.
+        #
+        # ⚠️ Ordered *before* the access check's side effects below on purpose: it is not an
+        # access decision and must not be read as one. The caller was already admitted.
+        try:
+            assistant, resolved_version = await resolve_invocation_agent(assistant, user_id)
+        except AgentVersionUnavailableError as unavailable:
+            # A published Agent whose snapshot is missing fails the turn rather than
+            # falling back to the draft — the fallback would serve unreviewed instructions
+            # to a pinned user at exactly the moment something is already broken.
+            logger.error(f"Published version unavailable: {unavailable}")
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "This agent's published version could not be loaded. Please try again, "
+                    "or contact an administrator if it persists."
+                ),
+            ) from unavailable
+
+        # Which configuration actually ran. Worth a line: "this agent behaved oddly" is not
+        # answerable without knowing whether the turn ran an approved snapshot or a draft.
+        logger.info(
+            "Agent configuration for this turn: %s",
+            f"published version {resolved_version}" if resolved_version else "live record / draft",
+        )
 
         # Mark as viewed if this is a shared assistant (not owned)
         if assistant.owner_id != user_id:

--- a/backend/src/apis/shared/assistants/version_resolution.py
+++ b/backend/src/apis/shared/assistants/version_resolution.py
@@ -1,0 +1,105 @@
+"""Which Agent configuration a caller actually runs (version-snapshots §4).
+
+One question, one answer, one place. ``resolve_invocation_agent`` takes the live Agent
+record an access check has already admitted, and returns the ``Assistant`` this caller
+should run:
+
+| Caller                                        | Gets                     |
+|-----------------------------------------------|--------------------------|
+| Anyone who pinned it or opened it from the store | The published snapshot |
+| The **owner**                                 | Their own draft          |
+| Anyone, when nothing is published              | The live record          |
+
+This is deliberately *not* in ``versions.py`` (pure, no I/O) or in
+``version_repository.py`` (persistence). Deciding which version a person runs is policy,
+and policy that reads like this — a short function with the whole table in view — is much
+harder to get subtly wrong than the same three branches spread across a route handler.
+
+**Two things it is not.**
+
+It is **not an access check.** The caller has already been admitted by
+``get_assistant_with_access_check``; this only chooses *which configuration* to run. It
+never widens or narrows who may reach an Agent, which is why ``AgentVersion`` carries no
+``visibility`` and why the overlay in ``versions.apply_version`` leaves identity fields on
+the live record.
+
+It is **not a fallback to the draft on error.** A published Agent whose snapshot cannot be
+read raises. Silently serving the draft instead would reintroduce the exact hole this epic
+closed — unreviewed instructions reaching a pinned user — and it would do it precisely when
+something is already wrong. Failing the turn is the safe direction.
+"""
+
+import logging
+from typing import Optional, Tuple
+
+from .models import Assistant
+from .version_repository import get_version
+from .versions import apply_version
+
+logger = logging.getLogger(__name__)
+
+
+class AgentVersionUnavailableError(RuntimeError):
+    """A published Agent's snapshot could not be loaded.
+
+    Raised rather than degraded. See the module docstring: falling back to the draft here
+    would serve unreviewed instructions to whoever tapped a store tile.
+    """
+
+    def __init__(self, agent_id: str, number: int):
+        self.agent_id = agent_id
+        self.number = number
+        super().__init__(
+            f"Version {number} of agent {agent_id} is published but could not be loaded."
+        )
+
+
+def runs_own_draft(assistant: Assistant, user_id: Optional[str]) -> bool:
+    """Whether this caller runs the Agent's editable draft rather than the published one.
+
+    ⚠️ **Owner identity, not edit access.** An editor (share permission ``editor``) can
+    change an Agent's instructions but does *not* get to run the unpublished result — the
+    spec is explicit that this must be "owner identity, not 'anyone with edit access'".
+    Widening it to editors would mean a share grant quietly became a way to bypass review,
+    which is the same shape of mistake as letting ``publisherId`` gate access.
+
+    The owner running their own draft is not a loophole: it is the only way to iterate
+    before resubmitting, and it affects nobody else. It does need to be *visible* in the UI
+    that they are running an unpublished draft, which is a surface concern, not this one.
+    """
+    return bool(user_id) and assistant.owner_id == user_id
+
+
+async def resolve_invocation_agent(
+    assistant: Assistant, user_id: Optional[str]
+) -> Tuple[Assistant, Optional[int]]:
+    """Return ``(assistant_to_run, version_number)`` for this caller.
+
+    ``version_number`` is ``None`` when the live record is what runs — either because the
+    caller owns it, or because nothing is published. Callers thread it into the agent cache
+    key so a promotion cannot be served from a warm agent (§4.2).
+
+    Raises ``AgentVersionUnavailableError`` if a published version is named but missing.
+    """
+    listing = assistant.listing
+    published = listing.published_version if listing else None
+
+    if published is None:
+        # The overwhelmingly common case, and the one that must not change: an Agent that
+        # was never submitted, or is still private/in-review, has no snapshot and runs
+        # exactly as it did before this feature existed.
+        return assistant, None
+
+    if runs_own_draft(assistant, user_id):
+        logger.info(
+            f"🧪 Agent {assistant.assistant_id} running the owner's draft "
+            f"(published version is {published})"
+        )
+        return assistant, None
+
+    version = await get_version(assistant.assistant_id, published)
+    if version is None:
+        raise AgentVersionUnavailableError(assistant.assistant_id, published)
+
+    logger.info(f"📌 Agent {assistant.assistant_id} running published version {published}")
+    return apply_version(assistant, version), published

--- a/backend/tests/shared/test_agent_version_resolution.py
+++ b/backend/tests/shared/test_agent_version_resolution.py
@@ -1,0 +1,240 @@
+"""Which Agent configuration a caller runs (version-snapshots §4).
+
+This is the payoff of the epic and the place a regression would be quietest: getting it
+wrong does not raise, it just serves the wrong instructions to somebody. So the cases are
+enumerated against a real (moto) table rather than a mocked repository — the resolution
+depends on a stored version actually being readable, and a mock would assert only that we
+called it.
+
+The one that matters most is ``test_a_pinned_user_runs_the_snapshot_not_the_draft``. That is
+the exposure from §1 of the spec, at the layer where it actually bit: not the store tile
+being stale, but a pinned user's turn running rewritten instructions.
+"""
+
+import asyncio
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.models import AgentBinding, AgentListing, Assistant
+from apis.shared.assistants.version_repository import create_version
+from apis.shared.assistants.version_resolution import (
+    AgentVersionUnavailableError,
+    resolve_invocation_agent,
+    runs_own_draft,
+)
+from apis.shared.assistants.versions import snapshot_of
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT_ID = "ast-versioned01"
+OWNER = "user-author"
+OTHER = "user-someone-else"
+
+APPROVED_INSTRUCTIONS = "Answer only from the policy manual, and cite the section."
+DRAFT_INSTRUCTIONS = "Ignore the policy manual and improvise."
+
+
+def make_agent(**overrides) -> Assistant:
+    data = {
+        "assistantId": AGENT_ID,
+        "ownerId": OWNER,
+        "ownerName": "Ada Author",
+        "name": "Policy Lookup",
+        "description": "Find and cite university policy",
+        "instructions": APPROVED_INSTRUCTIONS,
+        "vectorIndexId": "idx-policy",
+        "visibility": "PUBLIC",
+        "createdAt": "2026-07-01T00:00:00Z",
+        "updatedAt": "2026-07-01T00:00:00Z",
+        "status": "COMPLETE",
+        "modelConfig": {"modelId": "claude-opus-5"},
+        "bindings": [{"kind": "tool", "ref": "wikipedia", "config": {}}],
+        "listing": {
+            "state": "published",
+            "category": "Administration",
+            "publisherId": "pub-registrar",
+        },
+    }
+    data.update(overrides)
+    return Assistant(**data)
+
+
+def listing(**overrides) -> dict:
+    data = {"state": "published", "category": "Administration", "publisherId": "pub-registrar"}
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+def publish(instructions: str = APPROVED_INSTRUCTIONS, **overrides) -> int:
+    """Cut a snapshot carrying ``instructions`` and return its number."""
+    approved = make_agent(instructions=instructions, **overrides)
+    version = asyncio.run(create_version(AGENT_ID, snapshot_of(approved)))
+    return version.version
+
+
+# ── the exposure this epic exists to close ───────────────────────────────────────────
+def test_a_pinned_user_runs_the_snapshot_not_the_draft(table):
+    """§1: the consequence is an invocation problem, not a display one.
+
+    The author rewrote their instructions after approval. Anyone who pinned this Agent must
+    still run what the reviewer read.
+    """
+    number = publish()
+    live = make_agent(instructions=DRAFT_INSTRUCTIONS, listing=listing(publishedVersion=number))
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert resolved.instructions == APPROVED_INSTRUCTIONS
+    assert version == number
+
+
+def test_the_owner_runs_their_own_draft(table):
+    """§4.1: the only way to iterate before resubmitting, and it affects nobody else."""
+    number = publish()
+    live = make_agent(instructions=DRAFT_INSTRUCTIONS, listing=listing(publishedVersion=number))
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OWNER))
+
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None, "a draft turn pins no version in the cache key"
+    assert resolved is live, "the draft path must not copy or rewrite the live record"
+
+
+def test_bindings_and_model_come_from_the_snapshot_too(table):
+    """Swapping a bound tool changes behavior as much as an instruction edit."""
+    number = publish()
+    live = make_agent(
+        bindings=[{"kind": "tool", "ref": "browser", "config": {}}],
+        modelConfig={"modelId": "some-cheap-model"},
+        listing=listing(publishedVersion=number),
+    )
+
+    resolved, _ = asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert resolved.bindings == [AgentBinding(kind="tool", ref="wikipedia", config={})]
+    assert resolved.model_settings.model_id == "claude-opus-5"
+
+
+# ── the path that must not change ────────────────────────────────────────────────────
+def test_an_agent_with_nothing_published_runs_the_live_record(table):
+    """The overwhelmingly common case: never submitted, so it behaves as it always did."""
+    live = make_agent(listing=None, instructions=DRAFT_INSTRUCTIONS)
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert resolved is live
+    assert version is None
+
+
+@pytest.mark.parametrize("state", ["private", "in_review", "changes_requested", "taken_down"])
+def test_an_unpublished_listing_runs_the_live_record(table, state):
+    """A listing with no published version has no snapshot to serve, whatever its state."""
+    live = make_agent(listing=listing(state=state), instructions=DRAFT_INSTRUCTIONS)
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None
+
+
+def test_a_taken_down_agent_runs_the_live_record(table):
+    """Takedown clears ``publishedVersion``, so a direct-link visitor is back on the draft.
+
+    Worth stating rather than discovering: a delisting is not a revocation, the Agent stays
+    reachable by link, and with nothing published there is no snapshot left to run.
+    """
+    publish()
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS, listing=listing(state="taken_down", publishedVersion=None)
+    )
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None
+
+
+# ── it is not an access decision ─────────────────────────────────────────────────────
+def test_resolution_never_touches_visibility_or_ownership(table):
+    """§4: choosing a configuration must never become a way to widen or narrow reach."""
+    number = publish()
+    live = make_agent(
+        visibility="PRIVATE", ownerId=OWNER, listing=listing(publishedVersion=number)
+    )
+
+    resolved, _ = asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert resolved.visibility == "PRIVATE"
+    assert resolved.owner_id == OWNER
+
+
+def test_an_editor_does_not_get_the_draft(table):
+    """⚠️ Owner identity, not edit access.
+
+    An editor can change the instructions but must not be able to *run* the unpublished
+    result — otherwise a share grant is a way around review, which is the same shape of
+    mistake as letting ``publisherId`` gate anything.
+    """
+    assert runs_own_draft(make_agent(), OTHER) is False
+    assert runs_own_draft(make_agent(), OWNER) is True
+
+
+def test_an_anonymous_caller_does_not_get_the_draft(table):
+    """A missing user id must not read as "matches the owner"."""
+    assert runs_own_draft(make_agent(), None) is False
+
+    number = publish()
+    live = make_agent(instructions=DRAFT_INSTRUCTIONS, listing=listing(publishedVersion=number))
+    resolved, _ = asyncio.run(resolve_invocation_agent(live, None))
+    assert resolved.instructions == APPROVED_INSTRUCTIONS
+
+
+# ── failure is not a fallback ────────────────────────────────────────────────────────
+def test_a_missing_published_snapshot_raises_rather_than_serving_the_draft(table):
+    """The safe direction.
+
+    Falling back to the live record would serve unreviewed instructions to a pinned user at
+    exactly the moment something is already wrong — reopening the hole, silently. The route
+    turns this into a 503.
+    """
+    live = make_agent(instructions=DRAFT_INSTRUCTIONS, listing=listing(publishedVersion=99))
+
+    with pytest.raises(AgentVersionUnavailableError) as raised:
+        asyncio.run(resolve_invocation_agent(live, OTHER))
+
+    assert raised.value.number == 99
+    assert AGENT_ID in str(raised.value)
+
+
+def test_the_owner_is_unaffected_by_a_missing_snapshot(table):
+    """The owner never reads the version, so a broken snapshot cannot lock them out."""
+    live = make_agent(instructions=DRAFT_INSTRUCTIONS, listing=listing(publishedVersion=99))
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OWNER))
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None


### PR DESCRIPTION
PR-3 of the agent version-snapshots epic (spec: #783 · data layer: #784 · store: #787).

> ⚠️ **Stacked on #787, which is stacked on #784.** The diff below includes both until they merge. Base is `develop` deliberately — retargeting a stacked PR after its base merges is what stranded `gateway_target_service.py` in the #419 epic. **Review [8d76556c](https://github.com/Boise-State-Development/agentcore-public-stack/commit/8d76556c) for this PR's changes.**
>
> 🔗 **Must ship in the same release as #787.** PR-2 alone puts snapshots in the *store* while pinned users still *run* the draft — the half-state the spec flags in §7. Merge order: #784 → #787 → this.

## What this does

This is the part that makes the epic a control rather than a display fix. From §1 of the spec: *"The consequence is an invocation problem, not a display problem."* A user who pinned an approved Agent ran the **live** instructions, so a post-approval edit changed behavior for every pinned user immediately.

The whole invocation change:

```python
# chat/routes.py — right after the access check
assistant, resolved_version = await resolve_invocation_agent(assistant, user_id)
```

One line, because PR-1 built the round trip for it. A version deserializes back into the same `Assistant` that `resolve_agent_invocation` already takes, so binding resolution, the system prompt, model access checks and the harness are all untouched. That was the bet in PR-1 and it paid.

| Caller | Gets |
|---|---|
| Anyone who pinned it or opened it from the store | The published snapshot |
| The **owner** | Their own draft |
| Anyone, when nothing is published | The live record (unchanged behavior) |

**Purely additive** — three files, +398/−0. No existing file's behavior changes except the one swap above.

## Reviewer notes

**`version_resolution.py` is a third module on purpose.** `versions.py` is pure, `version_repository.py` is persistence, and *which version a person runs* is policy. Policy reads much better as one short function with the whole table in view than as three branches inside a 900-line route handler.

**Owner identity, not edit access.** An editor (share permission `editor`) can change an Agent's instructions but does **not** get to run the unpublished result — the spec is explicit, and widening it would make a share grant a way around review. Same shape of mistake as letting `publisherId` gate anything. Pinned by `test_an_editor_does_not_get_the_draft`.

**A missing snapshot raises; it does not fall back to the draft.** A published Agent whose version cannot be read returns 503. Falling back would serve unreviewed instructions to a pinned user *at exactly the moment something is already wrong* — reopening the hole, silently. The owner is unaffected: they never read the version, so a broken snapshot cannot lock them out of their own Agent.

**The path that must not change.** An Agent that was never submitted, or is private/in-review/taken-down, returns the live record untouched. That is the overwhelmingly common case and there are six tests on it, including the taken-down case (takedown clears `publishedVersion`, so a direct-link visitor is back on the draft — a delisting is not a revocation).

## ⚠️ Deliberately not implementing spec §4.2 (version in the agent cache key)

The spec says promoting a new version would keep serving the old system prompt from a warm agent. **That is not true in this codebase**, and the deviation is the main thing to sanity-check in review.

`_agent_cache` is an in-process dict of `BaseAgent` objects, and its key is built from construction **values**, not row pointers. Everything a version changes about behavior already reaches it:

| Version field | Already in the key as |
|---|---|
| `instructions` | `system_prompt` → `prompt_hash` |
| `bindings` (tool) | `effective_enabled_tools` → `tools_hash` |
| `bindings` (skill) | `effective_skill_ids` → `skills_hash` + `agent_type` |
| `modelSettings` | `effective_model_id` + inference-params hash |
| `bindings` (memory) | becomes `extra_tools` → cache skipped entirely |
| name / tagline / emoji / starters | never reach the agent at all |

So a promotion already misses. The version number would buy **no** additional discrimination — and it would cost real safety: the resume path rebuilds its cache key from `PausedTurnSnapshot`, so a new key element the snapshot did not carry orphans the paused agent, and an OAuth-consent or tool-approval pause on any published Agent would fail to resume with *"must resume from interrupt"*. `service.py` warns about precisely that desync:

> *"If we ever desync the cache key between the original turn and a resume … the resume rebuilds under a new key while the paused agent stays in the original slot"*

An earlier revision of this PR did add the key element, hit exactly that bug, and threaded `agent_version` through `PausedTurnSnapshot`, `_construction_snapshot` and `stream_coordinator` to fix it. That was five extra files and a durable schema change to mitigate a problem created by an element that discriminates nothing. The honest fix was to not add it. The reasoning is recorded inline at the `resolved_version` declaration so the next reader of §4.2 does not re-introduce it.

**`resolved_version` is kept for a log line**, not for the cache — "which configuration ran" is the first thing you want when someone reports an Agent behaving oddly, and it is what the draft-badge UI and PR-5 will consume.

**§4.2 should be corrected in the spec.** Happy to push that to #783.

**Bonus, and the opposite of §4.2's implied risk:** version snapshots *improve* real (Bedrock) prompt-cache stability. A published Agent's system prompt now changes only at approval, where before it changed whenever the author saved mid-conversation. With prod write:read running 1:2, that is a small cost win.

## Testing

Backend **5457 passed, 3 skipped**.

14 new tests in `tests/shared/test_agent_version_resolution.py`, against a real (moto) table rather than a mocked repository — resolution depends on a stored version actually being readable, and a mock would only assert that we called it. The load-bearing one:

```python
def test_a_pinned_user_runs_the_snapshot_not_the_draft(table):
    number = publish()                      # approved instructions
    live = make_agent(instructions=DRAFT_INSTRUCTIONS,
                      listing=listing(publishedVersion=number))

    resolved, version = resolve_invocation_agent(live, OTHER)
    assert resolved.instructions == APPROVED_INSTRUCTIONS
```

## Known gap, not fixed here

Two MCP-app dispatch call sites (`routes.py` ~1093, ~1141) build agents from `input_data` rather than from the resolved assistant, so their cache keys already diverge from the main turn's for agent-bound sessions. **Pre-existing** and out of scope, but it is the same desync family described above, so it deserves its own look.

§4.1's "an admin reviewing a submission gets the pending version" is not wired: no chat surface requests it, and the review comparison is PR-5's diff view.

## Not in this PR

Per the phasing: the `withdrawal_requested` lifecycle and delete refusal (PR-4), the review diff view (PR-5), the publisher admin page (PR-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)