### PR TITLE
feat(marketplace): withdrawal becomes a request, and delete respects it (PR-4)

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -22,6 +22,7 @@ from apis.app_api.agent_designer.services.listing_service import (
     list_admin_listings,
     patch_listing_presentation,
     review_listing,
+    decide_withdrawal,
     takedown_listing,
 )
 from apis.shared.assistants.categories import (
@@ -61,6 +62,7 @@ from apis.shared.assistants.models import (
     ReviewListingRequest,
     StoreFrontUpdateRequest,
     TakedownRequest,
+    WithdrawalDecisionRequest,
 )
 from apis.shared.assistants.storefront import (
     MAX_FEATURED,
@@ -103,9 +105,13 @@ async def require_marketplace_admin(admin: User = Depends(require_marketplace_sc
 # ── review queue + listings (D10) ────────────────────────────────────────────────────
 @router.get("/submissions", response_model=AdminListingsResponse)
 async def list_submissions(admin: User = Depends(require_marketplace_admin)):
-    """The Review queue: every submission awaiting a decision (D2)."""
+    """The Review queue: everything awaiting an admin decision (D2, §5.1).
+
+    Submissions *and* withdrawal requests. One queue rather than two surfaces — §5.1 is
+    explicit about that, and a second queue is one an admin has to remember exists.
+    """
     try:
-        rows, pending = await list_admin_listings(state="in_review")
+        rows, pending = await list_admin_listings(state="pending")
         return AdminListingsResponse(listings=rows, pending_count=pending)
     except Exception as e:
         logger.error(f"Error listing agent submissions: {e}", exc_info=True)
@@ -178,6 +184,34 @@ async def takedown_agent_listing(
     except Exception as e:
         logger.error(f"Error taking down agent listing: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to take down listing: {str(e)}")
+
+
+@router.post("/{agent_id}/withdrawal", response_model=AgentListing)
+async def decide_agent_withdrawal(
+    agent_id: str,
+    request: WithdrawalDecisionRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Grant or decline an author's request to pull a live listing (§5.1).
+
+    Deliberately **not** folded into ``POST /{agent_id}/review``. That endpoint answers "may
+    this go into the store?"; this one answers "may this come out?", and the two decisions
+    have different inputs, different notes and opposite defaults. One endpoint with four
+    decision values would make an accidental unpublication a one-character mistake.
+
+    ``grant`` → ``private`` and off the shelf. ``decline`` → back to ``published``, which
+    restores nothing because the listing never stopped being live while the request was
+    pending — that is the point of leaving the store index alone in ``withdrawal_requested``.
+    """
+    try:
+        return await decide_withdrawal(
+            agent_id, admin, decision=request.decision, note=request.note
+        )
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error deciding agent withdrawal: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to decide withdrawal: {str(e)}")
 
 
 @router.patch("/{agent_id}/listing", response_model=AgentListing)

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -64,6 +64,7 @@ from apis.shared.assistants.service import (
     assistant_exists,
     create_assistant,
     create_assistant_draft,
+    AssistantListedError,
     delete_assistant,
     get_assistant_with_access_check,
     list_assistant_shares,
@@ -478,6 +479,10 @@ async def delete_agent_endpoint(agent_id: str, current_user: User = Depends(requ
             raise HTTPException(status_code=404, detail=f"Agent not found: {agent_id}")
     except HTTPException:
         raise
+    except AssistantListedError as e:
+        # 409, not 400: the request is well-formed and the caller is allowed — the Agent is
+        # simply in a state that forbids it, and the message says how to change that.
+        raise HTTPException(status_code=409, detail=e.message)
     except Exception as e:
         logger.error(f"Error deleting agent: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to delete agent: {str(e)}")

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -26,16 +26,19 @@ the rest. Publisher is a name on a shelf.
 
 import logging
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Set, Tuple
 
 from apis.shared.assistants.compat import effective_bindings
 from apis.shared.assistants.categories import ensure_seeded
 from apis.shared.assistants.icons import icon_url
 from apis.shared.assistants.listing import (
+    PENDING_DECISION_STATES,
+    ListingAuthorityError,
     ListingTransitionError,
+    assert_author_target,
     assert_transition,
     gsi5_keys,
-    is_published,
+    is_listed,
 )
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
 from apis.shared.assistants.version_repository import create_version, set_version_index
@@ -88,6 +91,11 @@ _EDIT_FIELD_LABELS = {
     "icon_key": "icon",
     "publisher_id": "publisher",
 }
+
+
+# What the Review queue asks for: "everything needing a decision", spelled as a state so the
+# route keeps one query parameter instead of growing a second one.
+_PENDING_QUERY = "pending"
 
 
 def _now() -> str:
@@ -419,9 +427,18 @@ async def submit_listing(
 
 
 async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
-    """Author unpublishes or withdraws a submission — back to ``private`` (D2).
+    """Author withdraws — immediately if nothing is live, as a *request* if something is.
 
-    Unpublishing revokes nothing retroactively: people who pinned it keep their pin,
+    **The same endpoint, two different acts, and the listing state decides which.** Before
+    publication, withdrawing is the author's alone: a pending submission is their own work
+    and pulling it costs nobody anything. Once a listing is live, other people have pinned
+    it, so removal becomes something an admin sees — the same reasoning that makes
+    publication go through a queue in the first place (D2). Splitting these across two
+    endpoints was the alternative and is worse: the author's intent is identical either way
+    ("take this down"), and making them pick the right verb for their listing's state is
+    asking them to know the state machine.
+
+    Neither act revokes anything retroactively: people who pinned it keep their pin,
     conversations underway keep running, and the agent stays reachable by direct link
     because ``visibility`` is a separate axis. It is a delisting, not a recall.
     """
@@ -429,18 +446,83 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
     if not assistant.listing:
         raise ListingError("This agent has no marketplace listing.", status_code=404)
 
+    # A live listing can only be *requested* down; anything else goes straight to private.
+    target = "withdrawal_requested" if is_listed(assistant.listing.state) else "private"
+
     try:
-        assert_transition(assistant.listing.state, "private")
+        assert_transition(assistant.listing.state, target)
+        assert_author_target(target)
+    except ListingTransitionError as e:
+        raise ListingError(str(e), status_code=400) from e
+    except ListingAuthorityError as e:  # pragma: no cover - both targets are author states
+        raise ListingError(str(e), status_code=403) from e
+
+    now = _now()
+    if target == "withdrawal_requested":
+        # ⚠️ The index is deliberately NOT cleared and ``publishedVersion`` deliberately
+        # kept. The listing stays live while the request is pending — an author whose
+        # request took it off the shelf immediately would have unilaterally unpublished it,
+        # which is exactly what this state exists to prevent. A declined request then needs
+        # no repair, because nothing was undone.
+        listing = assistant.listing.model_copy(
+            update={"state": target, "withdrawal_requested_at": now}
+        )
+        await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+        logger.info(f"🙋 Agent {agent_id} withdrawal requested by its owner {user.user_id}")
+        return listing
+
+    # Pre-publication withdrawal: nothing is on the shelf, so this is immediate. The
+    # unindex is belt-and-braces for a listing whose pointer outlived its key.
+    await _unindex_version(agent_id, assistant.listing.published_version)
+    listing = assistant.listing.model_copy(update={"state": target, "published_version": None})
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+    logger.info(f"📭 Agent {agent_id} submission withdrawn by its owner")
+    return listing
+
+
+async def decide_withdrawal(
+    agent_id: str, admin: User, *, decision: str, note: Optional[str] = None
+) -> AgentListing:
+    """Admin grants or declines an author's withdrawal request (§5.1).
+
+    ``grant`` takes the listing to ``private`` and off the shelf. ``decline`` returns it to
+    ``published`` and changes nothing else — the listing never stopped being live, so there
+    is no key to restore and no version to re-promote. That asymmetry is the payoff of
+    leaving the index alone while the request was pending.
+
+    A declining admin should say why, since the author asked for something and is not
+    getting it; ``note`` renders on their card exactly as a request-changes reason does.
+    """
+    assistant = await _load_any(agent_id)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+    if assistant.listing.state != "withdrawal_requested":
+        raise ListingError(
+            "This agent has no pending withdrawal request.",
+            status_code=400,
+        )
+
+    target = "private" if decision == "grant" else "published"
+    try:
+        assert_transition(assistant.listing.state, target)
     except ListingTransitionError as e:
         raise ListingError(str(e), status_code=400) from e
 
     now = _now()
-    # Index first, record second — see ``_unindex_version`` for why delisting is ordered
-    # the opposite way round from publishing.
-    await _unindex_version(agent_id, assistant.listing.published_version)
-    listing = assistant.listing.model_copy(update={"state": "private", "published_version": None})
+    changes: dict = {
+        "state": target,
+        "reviewed_at": now,
+        "reviewed_by": admin.user_id,
+        "review_note": note or None,
+    }
+    if target == "private":
+        changes["published_version"] = None
+        # Key first, record second — the fail-closed ordering in ``_unindex_version``.
+        await _unindex_version(agent_id, assistant.listing.published_version)
+
+    listing = assistant.listing.model_copy(update=changes)
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
-    logger.info(f"📭 Agent {agent_id} unpublished by its owner")
+    logger.info(f"🙋 Agent {agent_id} withdrawal {decision}ed by {admin.user_id}")
     return listing
 
 
@@ -686,10 +768,10 @@ async def patch_listing_presentation(
     #
     # Attributed to the admin, not the author — ``createdBy`` is audit, never authorization,
     # and mislabelling this would put the author's name on someone else's edit.
-    was_published = is_published(assistant.listing.state)
+    was_listed = is_listed(assistant.listing.state)
     previously_published = assistant.listing.published_version
     promoted: Optional[int] = None
-    if was_published:
+    if was_listed:
         edited = assistant.model_copy(
             update={
                 "name": changes.get("name", assistant.name),
@@ -738,12 +820,27 @@ async def patch_listing_presentation(
 
 # ── admin reads ──────────────────────────────────────────────────────────────────────
 async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminListingRow], int]:
-    """Rows for the Review queue / Listings tables, plus the pending-review count.
+    """Rows for the Review queue / Listings tables, plus the pending-decision count.
 
     The count badges the admin nav so the queue is visible rather than discovered — the
     operational half of D2's answer to "a review queue makes publication stop".
+
+    ``state`` accepts the pseudo-value ``"pending"``, which is what the Review queue asks
+    for: both submissions and withdrawal requests (``PENDING_DECISION_STATES``). §5.1 is
+    explicit that withdrawal requests belong in the *existing* queue — "one queue rather
+    than a second surface to remember" — and a queue an admin has to remember to check is
+    a queue that grows.
     """
-    raw = await list_by_state(state)
+    wanted: Optional[Set[str]] = None
+    if state == _PENDING_QUERY:
+        wanted = set(PENDING_DECISION_STATES)
+    elif state is not None:
+        wanted = {state}
+
+    # A multi-state ask scans once and filters here rather than issuing one scan per state.
+    # The population is every Agent anyone has ever submitted and the caller is a human
+    # clicking a nav item, so one pass is cheaper than two round trips.
+    raw = await list_by_state(state if wanted and len(wanted) == 1 else None)
     publishers = {p.id: p for p in await list_publishers()}
 
     rows: List[AdminListingRow] = []
@@ -755,17 +852,25 @@ async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminLi
             continue
         if not assistant.listing:
             continue
+        if wanted is not None and assistant.listing.state not in wanted:
+            continue
         rows.append(_to_row(assistant, publishers.get(assistant.listing.publisher_id)))
 
     rows.sort(key=lambda r: (r.submitted_at or r.updated_at), reverse=True)
 
-    # The badge counts the review queue, not whatever slice the caller asked for — an
-    # admin filtering the Listings table to "published" still needs to see work waiting.
+    # The badge counts the whole decision queue, not whatever slice the caller asked for —
+    # an admin filtering the Listings table to "published" still needs to see work waiting.
     # When the fetched rows already cover the queue, count them instead of re-scanning.
-    if state is None or state == "in_review":
-        pending = len([r for r in rows if r.state == "in_review"])
+    if wanted is None or wanted >= set(PENDING_DECISION_STATES):
+        pending = len([r for r in rows if r.state in PENDING_DECISION_STATES])
     else:
-        pending = len(await list_by_state("in_review"))
+        pending = len(
+            [
+                item
+                for item in await list_by_state(None)
+                if (item.get("listing") or {}).get("state") in PENDING_DECISION_STATES
+            ]
+        )
 
     return rows, pending
 

--- a/backend/src/apis/app_api/agent_designer/services/pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/pin_service.py
@@ -55,7 +55,7 @@ from apis.shared.assistants.pins import (
     get_pin_state,
     remove_pin,
 )
-from apis.shared.assistants.listing import is_published
+from apis.shared.assistants.listing import is_listed
 from apis.shared.assistants.publishers import list_publishers
 from apis.shared.assistants.role_pins import list_pins_for_roles
 from apis.shared.assistants.service import (
@@ -284,7 +284,7 @@ async def pin_agent(user: User, agent_id: str) -> PinnedAgentResponse:
                 exc_info=True,
             )
             existing = None
-        if existing is not None and existing.listing and is_published(existing.listing.state):
+        if existing is not None and existing.listing and is_listed(existing.listing.state):
             logger.warning(
                 f"Pin denied on published agent {agent_id} for {user.user_id}: "
                 f"visibility is {existing.visibility}"

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 
 from apis.shared.assistants.categories import ensure_seeded, list_categories
 from apis.shared.assistants.icons import icon_url
-from apis.shared.assistants.listing import is_published
+from apis.shared.assistants.listing import is_listed
 from apis.shared.assistants.listing_repository import batch_get_agents, query_store
 from apis.shared.assistants.models import (
     AgentCategory,
@@ -182,7 +182,7 @@ async def resolve_featured(
             unavailable.append(agent_id)
             continue
         listing = assistant.listing
-        if not listing or not is_published(listing.state) or listing.published_version is None:
+        if not listing or not is_listed(listing.state) or listing.published_version is None:
             unavailable.append(agent_id)
             continue
         published.append((agent_id, listing.published_version))

--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -39,6 +39,8 @@ from apis.shared.assistants.service import (
     assistant_exists,
     create_assistant,
     create_assistant_draft,
+    AssistantListedError,
+    assert_deletable,
     delete_assistant,
     get_assistant_with_access_check,
     list_assistant_shares,
@@ -407,6 +409,15 @@ async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depe
     logger.info("DELETE /assistants/{assistant_id}")
 
     try:
+        # 0. Refuse a listed Agent BEFORE touching anything (§5.2).
+        #
+        # ⚠️ Order is load-bearing. Steps 2 and 3 below are destructive — documents
+        # soft-deleted, sync policies removed — and they run before the record delete. If
+        # the listing check fired down there instead, a refused delete would leave the Agent
+        # gutted but still in the store: exactly the failure the refusal exists to prevent,
+        # with a live listing pointing at a broken Agent.
+        await assert_deletable(assistant_id, user_id)
+
         # 1. List all documents for the assistant
         docs, _ = await list_assistant_documents(
             assistant_id=assistant_id,
@@ -441,6 +452,10 @@ async def delete_assistant_endpoint(assistant_id: str, current_user: User = Depe
 
     except HTTPException:
         raise
+    except AssistantListedError as e:
+        # 409, not 400: the request is well-formed and the caller is allowed — the Agent is
+        # simply in a state that forbids it, and the message says how to change that.
+        raise HTTPException(status_code=409, detail=e.message)
     except Exception as e:
         logger.error(f"Error deleting assistant: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to delete assistant: {str(e)}")

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -51,6 +51,7 @@ LISTING_STATES: Tuple[str, ...] = (
     "published",
     "changes_requested",
     "taken_down",
+    "withdrawal_requested",
 )
 
 # The transition table. ``None`` is the pre-state of a record that has never been
@@ -70,21 +71,56 @@ LISTING_STATES: Tuple[str, ...] = (
 #   taken_down        → changes_requested  admin annotates an already-delisted listing
 #   in_review         → private            author withdraws a pending submission
 #   changes_requested → private            author withdraws
-#   published         → private            author unpublishes (DELETE /agents/{id}/listing)
+#   published         → withdrawal_requested author ASKS to pull a live listing
+#   withdrawal_requested → private          admin grants the withdrawal
+#   withdrawal_requested → published        admin declines; the listing stays live
+#   withdrawal_requested → taken_down       admin pulls it outright instead
 #
-# Deliberately absent: anything → published other than from in_review. Approval is the
-# only door into the store, so a bug elsewhere cannot publish by accident.
+# Deliberately absent: anything → published other than from in_review or
+# withdrawal_requested. Approval is the only door *into* the store, so a bug elsewhere
+# cannot publish by accident; declining a withdrawal is not a new publication, it is a
+# refusal to unpublish.
+#
+# ⚠️ ``published → private`` is deliberately GONE. An author could previously pull a live
+# listing unilaterally, with no admin ever seeing it — the D2 review queue makes
+# publication stop for a human, and unpublication should not be a side door around that.
+# Withdrawal is now a request an admin acts on (see §5.1 of the version-snapshots spec).
+# The edges an author still owns alone are the pre-publication ones: ``private → in_review``
+# and withdrawing a *pending* submission (``in_review``/``changes_requested`` → ``private``).
 ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     None: {"in_review"},
     "private": {"in_review"},
     "in_review": {"published", "changes_requested", "private"},
     "changes_requested": {"in_review", "private"},
-    "published": {"taken_down", "changes_requested", "private"},
+    "published": {"taken_down", "changes_requested", "withdrawal_requested"},
     "taken_down": {"in_review", "changes_requested"},
+    "withdrawal_requested": {"private", "published", "taken_down"},
 }
 
 # States an author may drive. Everything else is the reviewer's (``require_admin``).
-AUTHOR_TARGET_STATES: Set[str] = {"in_review", "private"}
+#
+# ⚠️ This set was **dead** until the withdrawal work — declared and never read, so the
+# comment above was aspirational rather than enforced. ``assert_author_target`` now uses it,
+# because "an author cannot pull a live listing" deserves a real gate and not just an absent
+# edge in the table. Both checks run on the author path: the table says the move is legal at
+# all, this says the author is allowed to be the one making it.
+AUTHOR_TARGET_STATES: Set[str] = {"in_review", "private", "withdrawal_requested"}
+
+# Listing states whose Agent is live in the store.
+#
+# **Not the same question as ``state == "published"``, and the difference is the point of
+# ``withdrawal_requested``.** A pending withdrawal request leaves the listing serving: the
+# author has *asked* to pull it, an admin has not yet agreed, and dropping it off the shelf
+# the moment they asked would hand the author exactly the unilateral delisting this state
+# exists to prevent. So the store index stays written, and a declined request needs no
+# repair.
+LISTED_STATES: Set[str] = {"published", "withdrawal_requested"}
+
+# Listing states waiting on an admin decision — what the Review queue shows and what the
+# nav badge counts. §5.1 puts withdrawal requests in the *existing* queue rather than a
+# second surface, on the grounds that a queue an admin has to remember to check is a queue
+# that grows.
+PENDING_DECISION_STATES: Set[str] = {"in_review", "withdrawal_requested"}
 
 
 class ListingTransitionError(ValueError):
@@ -135,16 +171,51 @@ def assert_transition(current: Optional[str], target: str) -> None:
         raise ListingTransitionError(current, target)
 
 
+class ListingAuthorityError(ValueError):
+    """An author attempted a transition that belongs to a reviewer."""
+
+
+def assert_author_target(target: str) -> None:
+    """Raise unless ``target`` is a state an author may drive themselves.
+
+    Separate from ``assert_transition`` because they answer different questions, and
+    collapsing them would lose the useful error. The table says whether the move is legal at
+    all; this says whether the *author* gets to make it. ``published → private`` is now
+    illegal for everyone (it is not in the table), while ``withdrawal_requested → private``
+    is legal but an admin's alone.
+    """
+    if target not in AUTHOR_TARGET_STATES:
+        raise ListingAuthorityError(
+            f"Moving a listing to '{target}' is a reviewer's decision, not the author's."
+        )
+
+
 def is_published(state: Optional[str]) -> bool:
-    """Whether a listing state means "visible in the store"."""
+    """Whether a listing state is exactly ``published``.
+
+    ⚠️ Usually **not** the question you want — see ``is_listed``. This is the narrow test
+    for "approved and not under any pending request", and the only callers that should use
+    it are ones deciding something about the approval itself.
+    """
     return state == "published"
+
+
+def is_listed(state: Optional[str]) -> bool:
+    """Whether a listing state means "live in the store" (see ``LISTED_STATES``).
+
+    This is the predicate almost everything wants: the store index, the featured row, and
+    "does an admin edit need to cut a new version". It is true for ``withdrawal_requested``
+    as well as ``published``, because a requested withdrawal is not a granted one.
+    """
+    return state in LISTED_STATES
 
 
 def gsi5_keys(state: Optional[str], category: Optional[str], created_at: str) -> Optional[Dict[str, str]]:
     """The sparse ``AgentDirectoryIndex`` (GSI5) key pair, or ``None`` when unlisted.
 
     ``GSI5_PK = LISTED#{category}`` / ``GSI5_SK = CREATED#{created_at}``, written **only**
-    while ``state == "published"`` — the ``DueSyncIndex`` precedent on this same table.
+    while the listing is live (``is_listed`` — ``published`` or ``withdrawal_requested``) —
+    the ``DueSyncIndex`` precedent on this same table.
 
     Returning ``None`` is the caller's signal to REMOVE both attributes, not to skip the
     write: leaving a stale key behind would keep a delisted agent queryable in the store,
@@ -154,13 +225,13 @@ def gsi5_keys(state: Optional[str], category: Optional[str], created_at: str) ->
     key (a hot-item rewrite per use) and is deferred, not approximated — the store front
     is the manual ranking lever instead.
     """
-    if not is_published(state):
+    if not is_listed(state):
         return None
     if not category:
-        # Defensive: a published listing with no category has no shelf to sit on. The
-        # service validates category at submit and at admin PATCH, so this is a
-        # can't-happen that we refuse to paper over with a "LISTED#None" partition.
-        raise ValueError("A published listing must carry a category.")
+        # Defensive: a listed agent with no category has no shelf to sit on. The service
+        # validates category at submit and at admin PATCH, so this is a can't-happen that
+        # we refuse to paper over with a "LISTED#None" partition.
+        raise ValueError("A listed agent must carry a category.")
     return {
         "GSI5_PK": f"LISTED#{category}",
         "GSI5_SK": f"CREATED#{created_at}",

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -12,7 +12,16 @@ BindingKind = Literal["knowledge_base", "tool", "skill", "memory_space"]
 
 # Agent Marketplace Phase 1 (D2): the listing lifecycle. The transition table and the
 # sparse-index key derivation live in ``assistants.listing`` — this is only the wire type.
-ListingState = Literal["private", "in_review", "published", "changes_requested", "taken_down"]
+# ``withdrawal_requested`` is a *live* state: the author has asked to pull the listing and an
+# admin has not yet agreed, so it is still on the shelf (see ``listing.LISTED_STATES``).
+ListingState = Literal[
+    "private",
+    "in_review",
+    "published",
+    "changes_requested",
+    "taken_down",
+    "withdrawal_requested",
+]
 PublisherKind = Literal["institution", "department", "individual"]
 
 # Agent Marketplace Phase 8 (D15): problem reports. A small fixed set so the queue can be
@@ -147,6 +156,15 @@ class AgentListing(BaseModel):
     )
     admin_edits: List[AdminEdit] = Field(
         default_factory=list, alias="adminEdits", description="Append-only log of admin presentation edits (D13)"
+    )
+    withdrawal_requested_at: Optional[str] = Field(
+        None,
+        alias="withdrawalRequestedAt",
+        description=(
+            "ISO 8601 when the author asked to pull a live listing (§5.1). Kept after the "
+            "decision rather than cleared, so the author's card can say what happened and "
+            "when — a request that vanishes on decline reads as though it was never made."
+        ),
     )
     submitted_version: Optional[int] = Field(
         None,
@@ -747,6 +765,27 @@ class ReviewListingRequest(BaseModel):
     category: Optional[str] = Field(None, description="Optionally recategorize at approval (D12/D13)")
     publisher_id: Optional[str] = Field(
         None, alias="publisherId", description="Optionally reattribute at approval — approval makes it authoritative (D12)"
+    )
+
+
+class WithdrawalDecisionRequest(BaseModel):
+    """Admin grants or declines an author's withdrawal request (§5.1).
+
+    ``grant``/``decline`` rather than ``approve``/``reject``: "approve" already means
+    "publish this" everywhere else in this surface, and an admin approving a *withdrawal*
+    reads dangerously like approving the listing.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    decision: Literal["grant", "decline"] = Field(..., description="Grant the withdrawal, or decline it")
+    note: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description=(
+            "Reason, rendered on the author's card. They asked for something — a decline "
+            "without a reason is the thing that generates a follow-up email."
+        ),
     )
 
 

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -861,22 +861,84 @@ async def _list_user_assistants_cloud(
         return [], None
 
 
+class AssistantListedError(Exception):
+    """A hard delete refused because the Agent carries a marketplace listing (§5.2).
+
+    Separate from returning ``False`` (which means "not found / not yours") because the
+    caller has to tell these apart: one is a 404, the other is a 409 whose message names the
+    way forward.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+async def assert_deletable(assistant_id: str, owner_id: str) -> None:
+    """Raise ``AssistantListedError`` if this Agent's listing forbids deletion (§5.2).
+
+    Exists so a caller that does destructive work *before* the record delete can refuse
+    up front. ``/assistants/{id}`` soft-deletes documents and removes sync policies first,
+    so discovering the refusal at the record write would leave the Agent gutted and still
+    in the store — worse than either outcome on its own.
+
+    Silent when the Agent is missing or not the caller's: that is the delete path's own 404,
+    and pre-empting it here would turn "not found" into "not deletable".
+    """
+    existing = await get_assistant(assistant_id, owner_id)
+    if existing:
+        _assert_listing_allows_delete(existing)
+
+
+def _assert_listing_allows_delete(existing) -> None:
+    """The §5.2 rule itself, so the guard and the delete cannot disagree."""
+    listing = getattr(existing, "listing", None)
+    state = getattr(listing, "state", None) if listing else None
+    if state is None or state == "private":
+        return
+    # The message names the path forward rather than just refusing — an author who is told
+    # "no" without being told "do this instead" files a ticket.
+    nudge = (
+        "Request withdrawal first, then delete it once an admin has removed it from the store."
+        if state in ("published", "withdrawal_requested")
+        else "Take it back to private first, then delete it."
+    )
+    raise AssistantListedError(
+        f"This agent can't be deleted while it has a marketplace listing ({state}). {nudge}"
+    )
+
+
 async def delete_assistant(assistant_id: str, owner_id: str) -> bool:
     """
     Delete an assistant permanently (hard delete)
+
+    ⚠️ **Refused while a listing exists** (version-snapshots §5.2). Ownership alone used to
+    be enough, so an author could hard-delete an approved Agent straight out of the store —
+    the same unilateral removal that ``withdrawal_requested`` exists to stop, except
+    irreversible and taking the review history with it.
+
+    ``taken_down`` is covered deliberately: an author must not be able to delete their way
+    out of a takedown record. So is ``withdrawal_requested`` — a pending request is not a
+    granted one. Only ``private`` (or no listing at all) may be deleted, which is reachable
+    from every other state through the normal paths.
 
     Args:
         assistant_id: Assistant identifier
         owner_id: User identifier (for ownership verification)
 
     Returns:
-        True if deleted successfully, False otherwise
+        True if deleted successfully, False if not found or not owned
+
+    Raises:
+        AssistantListedError: the Agent has a listing that is not ``private``
     """
     # Verify ownership first
     existing = await get_assistant(assistant_id, owner_id)
 
     if not existing:
         return False
+
+    _assert_listing_allows_delete(existing)
 
     assistants_table = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
     if not assistants_table:

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -661,3 +661,101 @@ class TestListingsRowReportsTheLiveVersion:
             resp = TestClient(app).get("/admin/agents/listings")
 
         assert "drift" not in resp.json()["listings"][0]
+
+
+class TestWithdrawalDecision:
+    """§5.1 — withdrawal is a request an admin acts on, in the existing queue."""
+
+    def test_granting_takes_it_private_and_off_the_shelf(self, app, _no_writes):
+        with _loaded(
+            _make_assistant(listing=_listing("withdrawal_requested", publishedVersion=2))
+        ):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal", json={"decision": "grant"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "private"
+        written = _no_writes.call_args.args[1]
+        assert written.published_version is None
+        assert _no_writes.set_version_index.await_args.args[1:] == (2, None)
+
+    def test_declining_restores_nothing_because_nothing_was_undone(self, app, _no_writes):
+        """The payoff of leaving the index alone while the request was pending.
+
+        A decline is a plain state change: no key to re-write, no version to re-promote. If
+        this ever needs to restore something, ``withdrawal_requested`` has stopped being a
+        live state and the guarantee in §5.1 has quietly broken.
+        """
+        with _loaded(
+            _make_assistant(listing=_listing("withdrawal_requested", publishedVersion=2))
+        ):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal",
+                json={"decision": "decline", "note": "Still needed by Advising."},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "published"
+        assert _no_writes.call_args.args[1].published_version == 2
+        _no_writes.set_version_index.assert_not_awaited()
+
+    def test_the_decline_reason_reaches_the_author(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("withdrawal_requested", publishedVersion=2))):
+            TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal",
+                json={"decision": "decline", "note": "Still needed by Advising."},
+            )
+
+        assert _no_writes.call_args.args[1].review_note == "Still needed by Advising."
+
+    @pytest.mark.parametrize("state", ["published", "in_review", "private", "taken_down"])
+    def test_deciding_without_a_pending_request_is_refused(self, app, _no_writes, state):
+        with _loaded(_make_assistant(listing=_listing(state))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal", json={"decision": "grant"}
+            )
+
+        assert resp.status_code == 400
+        assert "no pending withdrawal" in resp.json()["detail"].lower()
+        _no_writes.assert_not_awaited()
+
+    def test_an_unknown_decision_is_rejected_at_the_boundary(self, app, _no_writes):
+        """``grant``/``decline``, not ``approve`` — "approve" means "publish" everywhere else."""
+        with _loaded(_make_assistant(listing=_listing("withdrawal_requested"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal", json={"decision": "approve"}
+            )
+
+        assert resp.status_code == 422
+
+
+class TestReviewQueueIncludesWithdrawalRequests:
+    """One queue, not two (§5.1) — a second surface is one an admin forgets exists."""
+
+    def _rows(self, app, *states):
+        rows = [
+            {
+                "PK": f"AST#ast-{i}",
+                **_make_assistant(
+                    assistantId=f"ast-{i}", listing=_listing(state)
+                ).model_dump(by_alias=True, exclude_none=True),
+            }
+            for i, state in enumerate(states)
+        ]
+        with patch(
+            f"{SERVICE_MODULE}.list_by_state", new_callable=AsyncMock, return_value=rows
+        ), patch(f"{SERVICE_MODULE}.list_publishers", new_callable=AsyncMock, return_value=[]):
+            return TestClient(app).get("/admin/agents/submissions").json()
+
+    def test_the_queue_shows_submissions_and_withdrawal_requests(self, app):
+        body = self._rows(app, "in_review", "withdrawal_requested", "published")
+        assert sorted(r["state"] for r in body["listings"]) == [
+            "in_review",
+            "withdrawal_requested",
+        ]
+
+    def test_the_nav_badge_counts_both(self, app):
+        """An admin who only sees submissions in the badge never learns a request is waiting."""
+        body = self._rows(app, "in_review", "withdrawal_requested", "published", "private")
+        assert body["pendingCount"] == 2

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -523,10 +523,21 @@ class TestSubmit:
 
 # ── withdraw ─────────────────────────────────────────────────────────────────────────
 class TestWithdraw:
-    def test_owner_unpublishes_back_to_private(self, app, make_user, _no_writes):
+    """One endpoint, two acts — the listing state decides which (§5.1)."""
+
+    def test_withdrawing_a_live_listing_becomes_a_request(self, app, make_user, _no_writes):
+        """The author asks; an admin decides. This used to go straight to ``private``.
+
+        That was the side door around the review queue: D2 makes publication stop for a
+        human, and un-publication did not — so an author could pull an approved Agent out
+        from under everyone who pinned it, with no admin ever seeing it.
+        """
         assistant = _make_assistant(
             listing=AgentListing(
-                state="published", category="Teaching", publisherId="user-user-001"
+                state="published",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=3,
             )
         )
         mock_auth_user(app, make_user())
@@ -534,7 +545,60 @@ class TestWithdraw:
             resp = TestClient(app).delete("/agents/ast-001/listing")
 
         assert resp.status_code == 200
+        assert resp.json()["state"] == "withdrawal_requested"
+        assert resp.json()["withdrawalRequestedAt"]
+
+    def test_a_pending_request_stays_on_the_shelf(self, app, make_user, _no_writes):
+        """⚠️ The load-bearing half. Asking must not itself unpublish anything.
+
+        If the request cleared the index or the pointer, the author would have unilaterally
+        delisted it just by asking — and a declined request would need the shelf rebuilt.
+        """
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="published",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=3,
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            TestClient(app).delete("/agents/ast-001/listing")
+
+        written = _no_writes.call_args.args[1]
+        assert written.published_version == 3, "asking to withdraw must not unpublish"
+        _no_writes.set_version_index.assert_not_awaited()
+
+    @pytest.mark.parametrize("state", ["in_review", "changes_requested"])
+    def test_withdrawing_a_pending_submission_is_immediate(
+        self, app, make_user, _no_writes, state
+    ):
+        """Nothing is on the shelf yet, so this stays the author's own call."""
+        assistant = _make_assistant(
+            listing=AgentListing(state=state, category="Teaching", publisherId="user-user-001")
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 200
         assert resp.json()["state"] == "private"
+
+    def test_a_second_request_on_an_already_requested_listing_is_refused(
+        self, app, make_user, _no_writes
+    ):
+        """``withdrawal_requested → withdrawal_requested`` is not an edge; nothing self-loops."""
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="withdrawal_requested", category="Teaching", publisherId="user-user-001"
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 400
 
     def test_withdrawing_an_unsubmitted_agent_is_404(self, app, make_user, _no_writes):
         mock_auth_user(app, make_user())

--- a/backend/tests/routes/test_delete_endpoints.py
+++ b/backend/tests/routes/test_delete_endpoints.py
@@ -203,12 +203,52 @@ class TestAssistantDeleteEndpoint:
 
     ROUTES_MODULE = "apis.app_api.assistants.routes"
 
+    @pytest.fixture(autouse=True)
+    def _deletable(self):
+        """Stub the §5.2 listing guard, which runs before any of the work these test.
+
+        The guard reads the Agent to check its listing state, so without this every test
+        below would hit a real table. It is stubbed rather than fed a fixture because these
+        tests are about delete *orchestration* — what gets cleaned up, in what order — and
+        the guard's own rules have a dedicated suite in
+        ``tests/shared/test_assistant_delete_listing_guard.py``.
+        """
+        with patch(
+            f"{self.ROUTES_MODULE}.assert_deletable", new_callable=AsyncMock
+        ) as guard:
+            yield guard
+
     @pytest.fixture
     def app(self):
         _app = FastAPI()
         _app.include_router(assistants_router)
         _app.dependency_overrides[get_current_user_from_session] = _make_user
         return _app
+
+    def test_a_listed_agent_is_refused_before_anything_is_cleaned_up(self, app, _deletable):
+        """⚠️ Ordering, not just refusal.
+
+        Steps 2 and 3 of this handler are destructive. If the guard fired after them, a
+        refused delete would leave the Agent gutted *and* still in the store — worse than
+        either outcome alone, and exactly what the refusal exists to prevent.
+        """
+        from apis.shared.assistants.service import AssistantListedError
+
+        _deletable.side_effect = AssistantListedError("still listed")
+
+        with patch(
+            f"{self.ROUTES_MODULE}.list_assistant_documents", new_callable=AsyncMock
+        ) as docs, patch(
+            f"{DOC_SERVICE}.batch_soft_delete_documents", new_callable=AsyncMock
+        ) as soft_delete, patch(
+            f"{self.ROUTES_MODULE}.delete_assistant", new_callable=AsyncMock
+        ) as hard_delete:
+            resp = TestClient(app).delete(f"/assistants/{ASSISTANT_ID}")
+
+        assert resp.status_code == 409
+        docs.assert_not_awaited()
+        soft_delete.assert_not_awaited()
+        hard_delete.assert_not_awaited()
 
     def test_delete_soft_deletes_all_docs(self, app):
         """Req 8.1: All documents are batch soft-deleted before assistant is removed."""

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -12,10 +12,15 @@ import pytest
 from apis.shared.assistants.listing import (
     ALLOWED_TRANSITIONS,
     DEFAULT_CATEGORIES,
+    LISTED_STATES,
     LISTING_STATES,
+    PENDING_DECISION_STATES,
+    ListingAuthorityError,
     ListingTransitionError,
+    assert_author_target,
     assert_transition,
     gsi5_keys,
+    is_listed,
     is_published,
 )
 
@@ -45,9 +50,41 @@ def test_resubmit_after_takedown():
     assert_transition("taken_down", "in_review")
 
 
-def test_author_may_withdraw_from_every_reachable_state():
-    for state in ("in_review", "changes_requested", "published"):
+def test_author_may_withdraw_a_pending_submission_outright():
+    """Before publication, withdrawing is the author's alone — nobody else has it yet."""
+    for state in ("in_review", "changes_requested"):
         assert_transition(state, "private")
+
+
+def test_a_live_listing_can_only_be_requested_down():
+    """§5.1 — an author cannot pull a live listing unilaterally.
+
+    ``published → private`` was the side door around the review queue: publication stops for
+    a human, and un-publication did not. Now it is a request an admin acts on.
+    """
+    with pytest.raises(ListingTransitionError):
+        assert_transition("published", "private")
+    assert_transition("published", "withdrawal_requested")
+
+
+def test_an_admin_may_grant_or_decline_a_withdrawal():
+    assert_transition("withdrawal_requested", "private")   # granted
+    assert_transition("withdrawal_requested", "published")  # declined
+    assert_transition("withdrawal_requested", "taken_down")  # pulled outright instead
+
+
+def test_author_target_states_gate_the_authors_own_moves():
+    """The set was dead until now — declared and never read. Assert it is load-bearing.
+
+    ``withdrawal_requested → private`` is a legal edge but an admin's alone, so the table
+    alone cannot express "the author may not do this". That is what the second gate is for.
+    """
+    assert_author_target("withdrawal_requested")
+    assert_author_target("private")
+    assert_author_target("in_review")
+    for reviewer_only in ("published", "changes_requested", "taken_down"):
+        with pytest.raises(ListingAuthorityError):
+            assert_author_target(reviewer_only)
 
 
 # ── the edges that must not exist ────────────────────────────────────────────────────
@@ -58,7 +95,13 @@ def test_approval_is_the_only_door_into_the_store():
     reach ``published``, a bug elsewhere could publish an agent nobody reviewed.
     """
     publishable = {s for s in ALLOWED_TRANSITIONS if "published" in ALLOWED_TRANSITIONS[s]}
-    assert publishable == {"in_review"}
+    # ``withdrawal_requested`` is the one addition, and it is not a door *into* the store:
+    # the listing never left, so declining a withdrawal is a refusal to unpublish rather
+    # than a new publication. Nothing unreviewed can reach ``published`` through it — you
+    # can only get to ``withdrawal_requested`` from ``published`` in the first place.
+    assert publishable == {"in_review", "withdrawal_requested"}
+    assert ALLOWED_TRANSITIONS["withdrawal_requested"] <= {"private", "published", "taken_down"}
+    assert {s for s, t in ALLOWED_TRANSITIONS.items() if "withdrawal_requested" in t} == {"published"}
 
 
 def test_private_cannot_jump_straight_to_published():
@@ -112,16 +155,45 @@ def test_published_yields_both_keys():
     assert keys == {"GSI5_PK": "LISTED#Teaching", "GSI5_SK": f"CREATED#{CREATED}"}
 
 
-@pytest.mark.parametrize("state", [s for s in LISTING_STATES if s != "published"] + [None])
-def test_every_unpublished_state_yields_no_keys(state):
+@pytest.mark.parametrize(
+    "state", [s for s in LISTING_STATES if s not in LISTED_STATES] + [None]
+)
+def test_every_unlisted_state_yields_no_keys(state):
     """The sparse half of the sparse index — no key, so the store query can't see it."""
     assert gsi5_keys(state, "Teaching", CREATED) is None
 
 
-def test_is_published_is_the_single_predicate():
+def test_a_pending_withdrawal_keeps_its_keys():
+    """§5.1 — the listing stays live while the request is pending.
+
+    This is the whole reason ``is_listed`` exists separately from ``is_published``. If a
+    withdrawal request dropped the keys, the author would have unilaterally delisted it
+    just by asking, and a declined request would need the index rebuilt.
+    """
+    assert gsi5_keys("withdrawal_requested", "Teaching", CREATED) == {
+        "GSI5_PK": "LISTED#Teaching",
+        "GSI5_SK": f"CREATED#{CREATED}",
+    }
+
+
+def test_is_published_is_the_narrow_predicate():
+    """``is_published`` means exactly ``published`` — usually not the question you want."""
     assert is_published("published")
     for state in [s for s in LISTING_STATES if s != "published"] + [None]:
         assert not is_published(state)
+
+
+def test_is_listed_is_the_predicate_the_store_uses():
+    for state in ("published", "withdrawal_requested"):
+        assert is_listed(state)
+    for state in [s for s in LISTING_STATES if s not in LISTED_STATES] + [None]:
+        assert not is_listed(state)
+
+
+def test_the_two_predicates_disagree_on_exactly_one_state():
+    """If these ever coincide again, ``withdrawal_requested`` has silently stopped being live."""
+    disagree = {s for s in LISTING_STATES if is_published(s) != is_listed(s)}
+    assert disagree == {"withdrawal_requested"}
 
 
 def test_published_without_a_category_refuses_rather_than_inventing_a_partition():

--- a/backend/tests/shared/test_assistant_delete_listing_guard.py
+++ b/backend/tests/shared/test_assistant_delete_listing_guard.py
@@ -1,0 +1,182 @@
+"""Delete is refused while a marketplace listing exists (version-snapshots §5.2).
+
+Ownership alone used to be enough, so an author could hard-delete an approved Agent
+straight out of the store — the same unilateral removal `withdrawal_requested` exists to
+stop, except irreversible and taking the review history with it.
+
+The case worth the most attention is
+``test_the_guard_runs_before_any_destructive_cleanup``. The `/assistants/{id}` delete path
+soft-deletes documents and removes sync policies *before* it deletes the record, so a
+refusal discovered at the record write would leave the Agent gutted **and** still in the
+store — strictly worse than either outcome alone.
+"""
+
+import asyncio
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.shared.assistants.service import (
+    AssistantListedError,
+    assert_deletable,
+    delete_assistant,
+)
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT_ID = "ast-deletable01"
+OWNER = "user-author"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(TABLE)
+
+
+def seed(table, listing=None):
+    item = {
+        "PK": f"AST#{AGENT_ID}",
+        "SK": "METADATA",
+        "assistantId": AGENT_ID,
+        "ownerId": OWNER,
+        "ownerName": "Ada Author",
+        "name": "Policy Lookup",
+        "description": "Find and cite university policy",
+        "instructions": "Answer from the policy manual.",
+        "vectorIndexId": "idx",
+        "visibility": "PUBLIC",
+        "createdAt": "2026-07-01T00:00:00Z",
+        "updatedAt": "2026-07-01T00:00:00Z",
+        "status": "COMPLETE",
+    }
+    if listing:
+        item["listing"] = listing
+    table.put_item(Item=item)
+
+
+def listing_of(state: str, **extra) -> dict:
+    return {
+        "state": state,
+        "category": "Administration",
+        "publisherId": "pub-registrar",
+        **extra,
+    }
+
+
+def exists(table) -> bool:
+    return "Item" in table.get_item(Key={"PK": f"AST#{AGENT_ID}", "SK": "METADATA"})
+
+
+# ── what may be deleted ──────────────────────────────────────────────────────────────
+def test_an_agent_with_no_listing_deletes(table):
+    """The common case, and it must not change: most Agents were never submitted."""
+    seed(table)
+    assert asyncio.run(delete_assistant(AGENT_ID, OWNER)) is True
+    assert not exists(table)
+
+
+def test_a_private_listing_deletes(table):
+    """``private`` is reachable from every other state, so this is the way out."""
+    seed(table, listing_of("private"))
+    assert asyncio.run(delete_assistant(AGENT_ID, OWNER)) is True
+    assert not exists(table)
+
+
+# ── what may not ─────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "state", ["published", "in_review", "changes_requested", "taken_down", "withdrawal_requested"]
+)
+def test_a_listed_agent_is_refused_and_survives(table, state):
+    seed(table, listing_of(state))
+
+    with pytest.raises(AssistantListedError):
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+    assert exists(table), "a refused delete must not have deleted anything"
+
+
+def test_taken_down_is_refused_deliberately(table):
+    """An author must not be able to delete their way out of a takedown record."""
+    seed(table, listing_of("taken_down"))
+    with pytest.raises(AssistantListedError):
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+
+def test_a_pending_withdrawal_is_refused(table):
+    """A requested withdrawal is not a granted one — deleting would pre-empt the admin."""
+    seed(table, listing_of("withdrawal_requested"))
+    with pytest.raises(AssistantListedError):
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+
+def test_the_refusal_names_the_path_forward(table):
+    """An author told "no" without being told "do this instead" files a ticket."""
+    seed(table, listing_of("published"))
+    with pytest.raises(AssistantListedError) as raised:
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+    assert "Request withdrawal first" in raised.value.message
+
+    seed(table, listing_of("changes_requested"))
+    with pytest.raises(AssistantListedError) as raised:
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+    assert "back to private" in raised.value.message
+
+
+# ── the ordering guard ───────────────────────────────────────────────────────────────
+def test_the_guard_runs_before_any_destructive_cleanup(table):
+    """``assert_deletable`` exists so a caller can refuse *before* doing damage.
+
+    ``/assistants/{id}`` soft-deletes documents and removes sync policies before the record
+    delete. Discovering the refusal down there would leave a live listing pointing at a
+    gutted Agent — the failure this refusal exists to prevent, made worse.
+    """
+    seed(table, listing_of("published"))
+    with pytest.raises(AssistantListedError):
+        asyncio.run(assert_deletable(AGENT_ID, OWNER))
+
+
+def test_the_guard_and_the_delete_agree(table):
+    """Two call sites, one rule. If these diverge, one path silently permits the other's no."""
+    for state in ("published", "in_review", "taken_down", "withdrawal_requested"):
+        seed(table, listing_of(state))
+        with pytest.raises(AssistantListedError):
+            asyncio.run(assert_deletable(AGENT_ID, OWNER))
+        with pytest.raises(AssistantListedError):
+            asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+    for state in (None, "private"):
+        seed(table, listing_of(state) if state else None)
+        asyncio.run(assert_deletable(AGENT_ID, OWNER))  # does not raise
+        assert asyncio.run(delete_assistant(AGENT_ID, OWNER)) is True
+
+
+def test_the_guard_is_silent_on_a_missing_agent(table):
+    """"Not found" is the delete path's own 404; pre-empting it would mislabel the error."""
+    asyncio.run(assert_deletable("ast-nope", OWNER))
+
+
+def test_the_guard_is_silent_for_a_non_owner(table):
+    """Same reason — ownership is the delete path's decision, not this guard's."""
+    seed(table, listing_of("published"))
+    asyncio.run(assert_deletable(AGENT_ID, "user-someone-else"))
+    assert asyncio.run(delete_assistant(AGENT_ID, "user-someone-else")) is False

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -27,7 +27,15 @@ export type ListingState =
   | 'in_review'
   | 'published'
   | 'changes_requested'
-  | 'taken_down';
+  | 'taken_down'
+  /**
+   * The author has asked to pull a live listing and an admin has not yet decided (§5.1).
+   *
+   * ⚠️ Still **live in the store**. Dropping it off the shelf the moment the author asked
+   * would hand them the unilateral delisting this state exists to prevent, so it reads as a
+   * pending request rather than as a removal.
+   */
+  | 'withdrawal_requested';
 
 /** One admin edit to a listing's presentation, surfaced back to the author (D13). */
 export interface AdminEdit {
@@ -44,6 +52,7 @@ export const LISTING_STATE_LABELS: Record<ListingState, string> = {
   published: 'Published',
   changes_requested: 'Changes requested',
   taken_down: 'Taken down',
+  withdrawal_requested: 'Withdrawal requested',
 };
 
 /**
@@ -56,6 +65,9 @@ export const LISTING_STATE_CLASSES: Record<ListingState, string> = {
   published: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
   changes_requested: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
   taken_down: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+  // Amber like in_review, not rose: this is work waiting on an admin, not a problem with
+  // the listing — and it is still published while it waits.
+  withdrawal_requested: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
 };
 
 /**


### PR DESCRIPTION
PR-4 of the agent version-snapshots epic (§5). Spec: #783 · #790 · data layer: #784 · store: #787 · invocation: #789.

Independent of #789 — this is lifecycle, that is invocation. Branches off `develop` with no stacking.

## What this closes

D2 makes publication stop for a human. **Un-publication did not.** Two paths let an author remove a live listing with no admin ever seeing it:

- `published → private` was in `AUTHOR_TARGET_STATES` — the author could pull an approved Agent out from under everyone who had pinned it.
- `delete_assistant` guarded on ownership alone, so they could hard-delete it out of the store entirely, taking the review history with it.

## `withdrawal_requested` is a **live** state — this is the crux

The author asks; the listing **stays on the shelf** until an admin decides.

If asking had cleared the store index, the author would have unilaterally delisted it just by asking — exactly what this state exists to prevent. Keeping it live makes the decline path free: nothing was undone, so there is no key to restore and no version to re-promote. There is a test asserting precisely that (`test_declining_restores_nothing_because_nothing_was_undone`), because if a decline ever *needs* to restore something, the guarantee has quietly broken.

That forced a distinction the code did not have:

| Predicate | Means |
|---|---|
| `is_published(state)` | exactly `published` — usually *not* the question you want |
| `is_listed(state)` | live in the store: `published` **or** `withdrawal_requested` |

Three of the four existing `is_published` call sites actually meant "live in the store" (the GSI5 key derivation, the featured row, and whether a D13 admin edit must cut a version) and moved to `is_listed`. A test asserts the two predicates **disagree on exactly one state**, so if they ever coincide again someone has silently made a pending withdrawal into a removal.

## The rest

**One endpoint, two acts.** `DELETE /agents/{id}/listing` branches on state: a request when the listing is live, immediate when it is not. Splitting them was the alternative and is worse — the author's intent is identical either way ("take this down"), and making them pick the right verb for their listing's state is asking them to know the state machine.

**`POST /admin/agents/{id}/withdrawal`** takes `grant` / `decline`. Deliberately **not** folded into `/review`: that endpoint answers "may this go into the store?", this one answers "may this come out?", and `approve` already means `publish` everywhere else on this surface. One endpoint with four decision values makes an accidental unpublication a one-character mistake.

**Requests land in the existing review queue**, and the nav badge counts them (§5.1). A second queue is one an admin has to remember exists.

**Delete is refused unless the listing is `private` or absent** (§5.2), with a message naming the way out ("Request withdrawal first…"). `taken_down` is covered deliberately — an author must not be able to delete their way out of a takedown record — and so is `withdrawal_requested`, since a requested withdrawal is not a granted one.

## Two things found while building it

**`AUTHOR_TARGET_STATES` was dead code.** §5.1 says `published → private` "leaves `AUTHOR_TARGET_STATES`", but that set was declared and **never read** — the mechanism the spec names enforced nothing. It is load-bearing now via `assert_author_target`, because the transition table alone cannot express "this edge is legal but only for an admin", and `withdrawal_requested → private` is exactly that. Both gates run on the author path: the table says the move is legal at all, the set says the author may be the one making it.

**⚠️ An ordering hazard in the delete path.** `/assistants/{id}` soft-deletes documents and removes sync policies **before** it deletes the record. Putting the listing check only inside `delete_assistant` would mean a refused delete left the Agent gutted *and* still in the store — strictly worse than either outcome alone, and a live listing pointing at a broken Agent. So there is an `assert_deletable` guard at step 0, sharing one rule function with the delete itself (`_assert_listing_allows_delete`), plus tests that the two agree and that nothing is cleaned up when the guard refuses.

I initially tested that guard only in isolation; the full suite caught four existing `test_delete_endpoints` tests hitting a real table through it. Fixed with a class-level fixture, and the handler-level ordering assertion I should have written first is now there.

## Testing

Backend **5504 passed, 3 skipped**. SPA **1682 passed across 152 files**.

New: `tests/shared/test_assistant_delete_listing_guard.py` (14). Rewritten: the state-machine suite (64) now asserts the new edges, both predicates, and that `published → private` raises. Extended: author-side withdraw, admin withdrawal decisions, and queue/badge inclusion.

## SPA

`withdrawal_requested` added to the `ListingState` union with an amber badge — like `in_review`, not rose: this is work waiting on an admin, not a problem with the listing, and it is still published while it waits.

## Not in this PR

PR-5 (review diff view) and PR-6 (publisher admin page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)