### PR TITLE
fix(agents): delete a deleted Agent's version snapshots

### DIFF
--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -982,6 +982,22 @@ async def _delete_assistant_cloud(assistant_id: str, table_name: str) -> bool:
                 exc_info=True,
             )
 
+        # Version snapshots are child rows for the same reason, and were missed when they
+        # shipped: without this a deleted Agent leaves its whole version history behind,
+        # invisible but permanent. Invisible because a deletable Agent's listing is
+        # ``private``, so its versions carry no store key — which is exactly why nothing
+        # would ever surface the leak.
+        try:
+            from .version_repository import delete_versions_for_agent
+
+            await delete_versions_for_agent(assistant_id)
+        except Exception:
+            logger.warning(
+                f"Failed to delete versions for assistant {assistant_id}; "
+                "the snapshots will be orphaned in the table",
+                exc_info=True,
+            )
+
         table.delete_item(Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"})
 
         logger.info(f"🗑️ Deleted assistant {assistant_id} from DynamoDB table {table_name}")

--- a/backend/src/apis/shared/assistants/version_repository.py
+++ b/backend/src/apis/shared/assistants/version_repository.py
@@ -253,6 +253,45 @@ async def get_latest_version(agent_id: str) -> Optional[AgentVersion]:
     return _from_item(items[0]) if items else None
 
 
+async def delete_versions_for_agent(agent_id: str) -> int:
+    """Delete every snapshot for an Agent. Called when the Agent itself is deleted.
+
+    Versions are child rows under the Agent's partition for the reason the reports module
+    states: child rows must never outlive what they concern. Without this they do — a
+    deleted Agent's snapshots sit in the table forever, invisible (a deletable Agent's
+    listing is ``private``, so its versions carry no store key) but permanent.
+
+    Immutability is about *rewriting*, not about retention: a version may never be changed,
+    and it is meaningless once the Agent it snapshots is gone. Nothing audits it either —
+    §8 flags "versions referenced by an audit record should survive" as a question for a
+    retention policy that does not exist yet, and there is no such reference today.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    table = _table()
+    condition = Key("PK").eq(_pk(agent_id)) & Key("SK").begins_with(VERSION_SK_PREFIX)
+
+    response = table.query(KeyConditionExpression=condition, ProjectionExpression="PK, SK")
+    items = response.get("Items", [])
+    while "LastEvaluatedKey" in response:
+        response = table.query(
+            KeyConditionExpression=condition,
+            ProjectionExpression="PK, SK",
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        items.extend(response.get("Items", []))
+
+    if not items:
+        return 0
+
+    with table.batch_writer() as batch:
+        for item in items:
+            batch.delete_item(Key={"PK": item["PK"], "SK": item["SK"]})
+
+    logger.info(f"🗑️ Deleted {len(items)} version(s) with agent {agent_id}")
+    return len(items)
+
+
 async def batch_get_versions(refs: List[Tuple[str, int]]) -> Dict[str, AgentVersion]:
     """Fetch specific versions by ``(agent_id, number)``, keyed by agent id.
 

--- a/backend/tests/shared/test_agent_version_resolution.py
+++ b/backend/tests/shared/test_agent_version_resolution.py
@@ -163,6 +163,43 @@ def test_an_unpublished_listing_runs_the_live_record(table, state):
     assert version is None
 
 
+def test_a_pending_withdrawal_still_runs_the_approved_snapshot(table):
+    """The seam between PR-3 (invocation) and PR-4 (withdrawal), which shipped separately.
+
+    ``withdrawal_requested`` is a *live* state: the author has asked to pull the listing and
+    an admin has not yet agreed, so the listing keeps its shelf key **and** its
+    ``publishedVersion``. Everyone but the owner must therefore still run the approved
+    snapshot — a request is not a removal, and serving the draft the moment the author asked
+    would be the unilateral change the whole epic exists to prevent, arriving through the
+    back door.
+
+    Neither PR could have caught this: they were developed in parallel and merged
+    independently, so nothing exercised the combination until now.
+    """
+    number = publish()
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS,
+        listing=listing(state="withdrawal_requested", publishedVersion=number),
+    )
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+    assert resolved.instructions == APPROVED_INSTRUCTIONS
+    assert version == number
+
+
+def test_a_granted_withdrawal_returns_everyone_to_the_live_record(table):
+    """Granting clears ``publishedVersion``, so there is no snapshot left to serve."""
+    publish()
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS,
+        listing=listing(state="private", publishedVersion=None),
+    )
+
+    resolved, version = asyncio.run(resolve_invocation_agent(live, OTHER))
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None
+
+
 def test_a_taken_down_agent_runs_the_live_record(table):
     """Takedown clears ``publishedVersion``, so a direct-link visitor is back on the draft.
 

--- a/backend/tests/shared/test_assistant_delete_listing_guard.py
+++ b/backend/tests/shared/test_assistant_delete_listing_guard.py
@@ -180,3 +180,42 @@ def test_the_guard_is_silent_for_a_non_owner(table):
     seed(table, listing_of("published"))
     asyncio.run(assert_deletable(AGENT_ID, "user-someone-else"))
     assert asyncio.run(delete_assistant(AGENT_ID, "user-someone-else")) is False
+
+
+# ── child rows must not outlive the Agent ────────────────────────────────────────────
+def test_deleting_an_agent_takes_its_version_snapshots_with_it(table):
+    """Versions are child rows, and child rows must never outlive what they concern.
+
+    Missed when snapshots shipped: nothing deleted ``VERSION#`` rows, so a deleted Agent
+    left its whole history behind. Invisible rather than harmful — a deletable Agent's
+    listing is ``private``, so its versions carry no store key — which is precisely why the
+    leak would never have surfaced on its own.
+    """
+    from apis.shared.assistants.version_repository import create_version, list_versions
+    from apis.shared.assistants.versions import snapshot_of
+    from apis.shared.assistants.service import get_assistant
+
+    seed(table, listing_of("private"))
+    agent = asyncio.run(get_assistant(AGENT_ID, OWNER))
+    for _ in range(3):
+        asyncio.run(create_version(AGENT_ID, snapshot_of(agent)))
+    assert len(asyncio.run(list_versions(AGENT_ID))) == 3
+
+    assert asyncio.run(delete_assistant(AGENT_ID, OWNER)) is True
+    assert asyncio.run(list_versions(AGENT_ID)) == []
+
+
+def test_a_refused_delete_leaves_the_versions_alone(table):
+    """The cleanup rides the delete, so a refusal must not take the history with it."""
+    from apis.shared.assistants.version_repository import create_version, list_versions
+    from apis.shared.assistants.versions import snapshot_of
+    from apis.shared.assistants.service import get_assistant
+
+    seed(table, listing_of("published", publishedVersion=1))
+    agent = asyncio.run(get_assistant(AGENT_ID, OWNER))
+    asyncio.run(create_version(AGENT_ID, snapshot_of(agent)))
+
+    with pytest.raises(AssistantListedError):
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+    assert len(asyncio.run(list_versions(AGENT_ID))) == 1


### PR DESCRIPTION
Follow-up to the version-snapshots epic (#784 · #787 · #789 · #791, all merged). Found by checking the seams between PRs that shipped in parallel and never saw each other.

## The leak

`VERSION#` child rows arrived in PR-2 (#787) and were never wired into the delete path. `_delete_assistant_cloud` cleans up `REPORT#` rows and the `METADATA` row — and nothing else. So deleting an Agent left its **entire snapshot history** in the table permanently.

`reports.py` states the principle outright:

> child rows live under this same partition **precisely so they never outlive what they concern**

Versions quietly violated it.

**Severity: low, and that is the interesting part.** Storage-only, no correctness impact — and it would never have surfaced on its own. PR-4 (#791) refuses to delete anything but a `private` listing, and a private listing's versions carry no GSI5 key, so nothing in the product would ever render an orphaned row. It is invisible by construction, which is exactly what makes it worth catching deliberately rather than discovering on a bill.

**Why deleting them is right.** Immutability is about *rewriting*, not retention: a version may never be changed, and it is meaningless once the Agent it snapshots is gone. Nothing audits it either — §8 flags "versions referenced by an audit record should survive" as a question for a retention policy that does not exist yet, and there is no such reference today. If that policy ever arrives, this is the function it hooks into.

Mirrors `reports.delete_reports_for_agent` exactly: paged query on the `VERSION#` prefix, `batch_writer` delete, best-effort at the call site so a tidy-up failure can never make an Agent undeletable.

## Also: two tests for a seam neither PR could have covered

PR-3 (invocation) and PR-4 (withdrawal lifecycle) were developed in parallel and merged independently, so nothing ever exercised `withdrawal_requested` through `resolve_invocation_agent`.

The behavior turns out to be **already correct** — a pending withdrawal keeps `publishedVersion`, so everyone but the owner still runs the approved snapshot, which is right because *a request is not a removal*. But it was untested, and an untested cross-feature interaction is precisely the kind that regresses silently. Both halves are pinned now: pending withdrawal serves the snapshot, granted withdrawal returns everyone to the live record.

## Testing

Backend **5508 passed, 3 skipped**. Merged `develop` measured at **5504** immediately before, so this is exactly the +4 new tests and no collateral.

| Test | What it holds |
|---|---|
| `test_deleting_an_agent_takes_its_version_snapshots_with_it` | the leak, closed |
| `test_a_refused_delete_leaves_the_versions_alone` | cleanup rides the delete, so a §5.2 refusal must not take the history |
| `test_a_pending_withdrawal_still_runs_the_approved_snapshot` | the PR-3 ↔ PR-4 seam |
| `test_a_granted_withdrawal_returns_everyone_to_the_live_record` | the other half of it |

## Still open from §8

Not addressed here, and both are "decide rather than discover" items:

- **Version retention.** This covers *deletion*; superseded versions on a **live** Agent still accumulate unboundedly. DynamoDB TTL on superseded versions is the cheap answer.
- **Fail-closed delisting ordering** could be made structural with `TransactWriteItems` instead of relying on call order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)