### PR TITLE
feat(marketplace): show a reviewer what a submission changed (PR-5)

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -23,6 +23,7 @@ from apis.app_api.agent_designer.services.listing_service import (
     patch_listing_presentation,
     review_listing,
     decide_withdrawal,
+    diff_pending_version,
     takedown_listing,
 )
 from apis.shared.assistants.categories import (
@@ -52,6 +53,7 @@ from apis.shared.assistants.models import (
     AgentCategoryCreateRequest,
     AgentCategoryUpdateRequest,
     AgentListing,
+    AgentVersionDiffResponse,
     PublisherCreateRequest,
     PublisherEligibilityRequest,
     PublisherEligibilityResponse,
@@ -135,6 +137,29 @@ async def list_listings(
     except Exception as e:
         logger.error(f"Error listing agent listings: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list listings: {str(e)}")
+
+
+@router.get("/{agent_id}/diff", response_model=AgentVersionDiffResponse)
+async def get_agent_review_diff(
+    agent_id: str,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """What the pending submission changes against what is published (§6.1).
+
+    The reviewer's actual question — "what changed since I approved this?" — which the queue
+    could not answer before: a submission arrived with no reference to what it replaces, so
+    a typo fix and a full rewrite looked identical and both got the same careful read.
+
+    Admin-only for the same reason the review queue is: this returns ``instructions``, which
+    the user-facing Agent read gates to owner/editor.
+    """
+    try:
+        return await diff_pending_version(agent_id)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error building agent review diff: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to build review diff: {str(e)}")
 
 
 @router.post("/{agent_id}/review", response_model=AgentListing)

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -41,14 +41,25 @@ from apis.shared.assistants.listing import (
     is_listed,
 )
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
-from apis.shared.assistants.version_repository import create_version, set_version_index
+from apis.shared.assistants.version_diff import (
+    behavior_changed,
+    changed_fields,
+    instructions_diff,
+)
+from apis.shared.assistants.version_repository import (
+    create_version,
+    get_version,
+    set_version_index,
+)
 from apis.shared.assistants.versions import snapshot_of
 from apis.shared.assistants.models import (
     AdminEdit,
     AdminListingPatchRequest,
     AdminListingRow,
     AgentListing,
+    AgentVersionDiffResponse,
     Assistant,
+    VersionFieldChange,
     PublisherProfile,
     SkillExposure,
     SubmitListingRequest,
@@ -819,6 +830,83 @@ async def patch_listing_presentation(
 
 
 # ── admin reads ──────────────────────────────────────────────────────────────────────
+# camelCase for the wire, so the SPA reads the same field names it already knows from
+# ``AgentResponse``. Snake_case would leak the storage attribute names into the UI.
+_DIFF_FIELD_ALIASES = {
+    "model_settings": "modelConfig",
+    "icon_key": "iconKey",
+    "publisher_id": "publisherId",
+}
+
+
+def _wire_value(value):
+    """Serialize a snapshot value for the diff payload, keeping ``None`` distinct from ``[]``."""
+    if isinstance(value, list):
+        return [_wire_value(item) for item in value]
+    dump = getattr(value, "model_dump", None)
+    return dump(by_alias=True) if dump else value
+
+
+async def diff_pending_version(agent_id: str) -> AgentVersionDiffResponse:
+    """What the pending submission changes against what is published (§6.1).
+
+    Reads the two snapshots the listing points at — ``submittedVersion`` and
+    ``publishedVersion`` — rather than "the latest two". An admin presentation edit (§6.2)
+    cuts a version too, so ordinal arithmetic would sooner or later diff the wrong pair.
+
+    Raises ``ListingError`` when there is nothing under review: a diff is a thing you read
+    *before deciding*, and offering one for a listing with no pending submission would
+    invite deciding on it.
+    """
+    assistant = await _load_any(agent_id)
+    listing = assistant.listing
+    if not listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+
+    pending_number = listing.submitted_version
+    if pending_number is None or listing.state not in PENDING_DECISION_STATES:
+        raise ListingError(
+            "This agent has nothing awaiting review, so there is no diff to show.",
+            status_code=400,
+        )
+
+    pending = await get_version(agent_id, pending_number)
+    if pending is None:
+        raise ListingError(
+            f"Version {pending_number} of this agent could not be loaded.", status_code=404
+        )
+
+    published_number = listing.published_version
+    published = (
+        await get_version(agent_id, published_number) if published_number is not None else None
+    )
+    # A pointer to a version that is gone is not the same as never having published: say so
+    # by falling back to the first-submission rendering rather than diffing against nothing
+    # and reporting every field as changed.
+    first_submission = published is None
+
+    changes = [
+        VersionFieldChange(
+            field=_DIFF_FIELD_ALIASES.get(field, field),
+            before=_wire_value(before),
+            after=_wire_value(after),
+            behavior=field in ("instructions", "bindings", "model_settings"),
+        )
+        for field, before, after in changed_fields(published, pending)
+    ]
+
+    return AgentVersionDiffResponse(
+        agent_id=agent_id,
+        published_version=published.version if published else None,
+        pending_version=pending_number,
+        first_submission=first_submission,
+        behavior_changed=behavior_changed(published, pending),
+        changes=changes,
+        instructions_diff=instructions_diff(published, pending),
+    )
+
+
+
 async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminListingRow], int]:
     """Rows for the Review queue / Listings tables, plus the pending-decision count.
 

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -768,6 +768,79 @@ class ReviewListingRequest(BaseModel):
     )
 
 
+class VersionFieldChange(BaseModel):
+    """One field that differs between the approved snapshot and the pending one (§6.1).
+
+    ``before``/``after`` are the raw snapshot values, JSON-serialized as stored. The SPA
+    renders them per field — a tagline as text, ``bindings`` as a list of kinds and refs —
+    so this stays a transport shape rather than a pre-rendered string, which would put
+    presentation decisions on the wrong side of the wire.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    field: str = Field(..., description="Snapshot field name (camelCase, as the SPA knows it)")
+    before: Optional[Any] = Field(
+        None, description="Value in the published version; absent on a first submission"
+    )
+    after: Optional[Any] = Field(None, description="Value in the pending version")
+    behavior: bool = Field(
+        False,
+        description=(
+            "Whether this field changes what the Agent *does* (instructions, bindings, "
+            "model) rather than how it presents. Drives the reviewer's at-a-glance triage."
+        ),
+    )
+
+
+class AgentVersionDiffResponse(BaseModel):
+    """The pending version against the currently published one (§6.1).
+
+    Answers the reviewer's real question — "what changed since I approved this?" — which
+    the queue could not answer before: a submission arrived with no reference to what it
+    replaces, so a typo fix and a full rewrite looked identical.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    published_version: Optional[int] = Field(
+        None, alias="publishedVersion", description="The live snapshot; absent on a first submission"
+    )
+    pending_version: Optional[int] = Field(
+        None, alias="pendingVersion", description="The snapshot under review"
+    )
+    first_submission: bool = Field(
+        False,
+        alias="firstSubmission",
+        description=(
+            "Nothing is published yet, so there is nothing to diff against and the reviewer "
+            "is reading the whole thing rather than a change. A distinct signal rather than "
+            "an empty ``changes`` list, which would read as 'nothing changed'."
+        ),
+    )
+    behavior_changed: bool = Field(
+        False,
+        alias="behaviorChanged",
+        description=(
+            "Whether instructions, bindings or the model differ — the one line that decides "
+            "whether this is a seconds-long approval or a careful read."
+        ),
+    )
+    changes: List[VersionFieldChange] = Field(
+        default_factory=list, description="Differing fields, behavior first"
+    )
+    instructions_diff: List[str] = Field(
+        default_factory=list,
+        alias="instructionsDiff",
+        description=(
+            "Unified line diff of the instructions; empty when unchanged or on a first "
+            "submission. Computed server-side so the field-level answer and the line-level "
+            "one can never disagree."
+        ),
+    )
+
+
 class WithdrawalDecisionRequest(BaseModel):
     """Admin grants or declines an author's withdrawal request (§5.1).
 

--- a/backend/src/apis/shared/assistants/version_diff.py
+++ b/backend/src/apis/shared/assistants/version_diff.py
@@ -1,0 +1,126 @@
+"""What changed between two Agent snapshots (version-snapshots §6.1).
+
+The reviewer's actual question is *"what changed since I approved this?"*, and before this
+they could not see it — the queue showed a submission with no reference to what it replaces.
+A resubmission that fixes a typo should be approvable in seconds; one that rewrites the
+instructions should be impossible to miss.
+
+Pure functions over two ``AgentVersion`` objects. No I/O, no HTTP shapes: the service layer
+loads the pair and the route projects the result, so the comparison itself stays trivially
+testable against hand-built versions.
+
+**Two decisions worth stating.**
+
+*The instructions diff is computed server-side.* A client-side diff library would render
+more prettily, but it would mean a new SPA dependency (the repo pins exactly and does not
+add packages casually) and a second implementation of "did this change" that can disagree
+with the field-level answer. ``difflib`` is in the standard library and the two answers come
+from one place.
+
+*A field is "changed" by value equality, not by identity of formatting.* Two versions whose
+``bindings`` differ only in list order genuinely differ — order is meaningful to the
+resolver — so no normalization is applied. The one exception is whitespace-only instruction
+edits, which are reported as changed but produce an empty line-diff; the reviewer sees the
+field flagged and an empty diff, which is the honest rendering of "something moved but no
+line did".
+"""
+
+import difflib
+from typing import Any, List, Optional, Tuple
+
+from .models import AgentVersion
+from .versions import DIFF_FIELD_ORDER
+
+# How many lines of unchanged context to keep around each change in the instructions diff.
+# Three is the ``diff -u`` default and reads right for prose: enough to locate an edit in a
+# long prompt, not so much that a one-line fix arrives as a wall of text.
+_DIFF_CONTEXT_LINES = 3
+
+
+def _comparable(value: Any) -> Any:
+    """Normalize a snapshot value for equality, without changing what it means.
+
+    Pydantic models compare fine, but a version read from DynamoDB and one built in memory
+    can hold equal-but-not-identical nested models, so both sides are dumped. ``None`` and
+    an empty list stay distinct: absent ``bindings`` means "synthesize the legacy KB
+    binding" and ``[]`` means "binds nothing", and collapsing them here would hide a real
+    behavior change from the person reviewing it.
+    """
+    if isinstance(value, list):
+        return [_comparable(item) for item in value]
+    dump = getattr(value, "model_dump", None)
+    return dump(by_alias=True) if dump else value
+
+
+def field_changed(before: Optional[AgentVersion], after: AgentVersion, field: str) -> bool:
+    """Whether ``field`` differs between the two versions.
+
+    ``before`` is ``None`` on a first submission, where every populated field counts as new
+    — there is no prior approved state for it to match.
+    """
+    if before is None:
+        return getattr(after, field, None) is not None
+    return _comparable(getattr(before, field, None)) != _comparable(getattr(after, field, None))
+
+
+def changed_fields(
+    before: Optional[AgentVersion], after: AgentVersion
+) -> List[Tuple[str, Any, Any]]:
+    """Every differing field as ``(field, before_value, after_value)``, in reviewer order.
+
+    Iterates ``DIFF_FIELD_ORDER`` rather than the model's fields, so record metadata
+    (``version``, ``createdAt``, ``createdBy``) never shows up as a change — it differs on
+    every single version and would bury the fields that matter.
+    """
+    changes: List[Tuple[str, Any, Any]] = []
+    for field in DIFF_FIELD_ORDER:
+        if field_changed(before, after, field):
+            changes.append(
+                (
+                    field,
+                    getattr(before, field, None) if before else None,
+                    getattr(after, field, None),
+                )
+            )
+    return changes
+
+
+def instructions_diff(before: Optional[AgentVersion], after: AgentVersion) -> List[str]:
+    """A unified line diff of the instructions, or ``[]`` when they are unchanged.
+
+    Empty on a first submission too: there is nothing to compare against, and rendering the
+    entire prompt as "added" would be noise where the reviewer is going to read the whole
+    thing anyway.
+    """
+    if before is None:
+        return []
+
+    old = before.instructions or ""
+    new = after.instructions or ""
+    if old == new:
+        return []
+
+    return list(
+        difflib.unified_diff(
+            old.splitlines(),
+            new.splitlines(),
+            fromfile="approved",
+            tofile="submitted",
+            lineterm="",
+            n=_DIFF_CONTEXT_LINES,
+        )
+    )
+
+
+def behavior_changed(before: Optional[AgentVersion], after: AgentVersion) -> bool:
+    """Whether anything that changes what the Agent *does* differs.
+
+    The single most useful line in the review UI, and deliberately narrower than "did
+    anything change": instructions, bindings and model. A reviewer glancing at a queue needs
+    to know whether this is a presentation fix or a behavior change, and that distinction is
+    the same one ``BEHAVIOR_FIELDS`` draws for the D13 admin-edit guard.
+    """
+    return any(
+        field_changed(before, after, field)
+        for field in ("instructions", "bindings", "model_settings")
+    )

--- a/backend/src/apis/shared/assistants/versions.py
+++ b/backend/src/apis/shared/assistants/versions.py
@@ -59,6 +59,34 @@ SNAPSHOT_FIELDS: Tuple[str, ...] = (
 LISTING_SNAPSHOT_FIELDS: Tuple[str, ...] = ("category", "publisher_id")
 
 
+# Fields the review diff reports on, in the order a reviewer reads them (§6.1). Behavior
+# first, because that is what a review is *for*: a resubmission that only fixes a tagline
+# should be approvable in seconds, and one that rewrites the instructions should be the
+# first thing on the page.
+#
+# Derived from the snapshot lists rather than re-typed, so a field added to a version can
+# never be silently absent from the diff — which would be the worst possible failure here:
+# a reviewer told "nothing changed" about something that did.
+DIFF_FIELD_ORDER: Tuple[str, ...] = (
+    "instructions",
+    "bindings",
+    "model_settings",
+    "name",
+    "description",
+    "tagline",
+    "starters",
+    "emoji",
+    "icon_key",
+    "category",
+    "publisher_id",
+)
+
+assert set(DIFF_FIELD_ORDER) == set(SNAPSHOT_FIELDS) | set(LISTING_SNAPSHOT_FIELDS), (
+    "DIFF_FIELD_ORDER must cover exactly the snapshot fields — a field missing here is a "
+    "change a reviewer would never be shown."
+)
+
+
 def version_sk(number: int) -> str:
     """The DynamoDB sort key for version ``number``.
 

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -759,3 +759,132 @@ class TestReviewQueueIncludesWithdrawalRequests:
         """An admin who only sees submissions in the badge never learns a request is waiting."""
         body = self._rows(app, "in_review", "withdrawal_requested", "published", "private")
         assert body["pendingCount"] == 2
+
+
+class TestReviewDiff:
+    """§6.1 — the reviewer's actual question, which the queue could not answer before."""
+
+    def _versions(self, published=None, pending=None):
+        """Patch the two snapshot reads the diff makes, keyed by version number."""
+        lookup = {2: published, 4: pending}
+        return patch(
+            f"{SERVICE_MODULE}.get_version",
+            new_callable=AsyncMock,
+            side_effect=lambda _agent_id, number: lookup.get(number),
+        )
+
+    def _version(self, **overrides):
+        from apis.shared.assistants.models import AgentVersion
+
+        data = {
+            "agentId": "ast-001",
+            "version": 2,
+            "name": "Policy Lookup",
+            "description": "Find and cite university policy",
+            "instructions": "Answer from the policy manual.",
+            "tagline": "Policy, cited",
+            "category": "Administration",
+            "publisherId": "pub-registrar",
+        }
+        data.update(overrides)
+        return AgentVersion(**data)
+
+    def _get(self, app, listing, published=None, pending=None):
+        with _loaded(_make_assistant(listing=listing)), self._versions(published, pending):
+            return TestClient(app).get("/admin/agents/ast-001/diff")
+
+    def test_a_resubmission_reports_what_changed(self, app):
+        resp = self._get(
+            app,
+            _listing("in_review", submittedVersion=4, publishedVersion=2),
+            published=self._version(version=2),
+            pending=self._version(version=4, instructions="Ignore the manual.", tagline="New"),
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["publishedVersion"] == 2 and body["pendingVersion"] == 4
+        assert {c["field"] for c in body["changes"]} == {"instructions", "tagline"}
+        assert body["behaviorChanged"] is True
+        assert any(line.startswith("+Ignore the manual.") for line in body["instructionsDiff"])
+
+    def test_a_presentation_only_change_is_not_a_behavior_change(self, app):
+        """The whole point: a tagline fix should be approvable in seconds."""
+        resp = self._get(
+            app,
+            _listing("in_review", submittedVersion=4, publishedVersion=2),
+            published=self._version(version=2),
+            pending=self._version(version=4, tagline="A better subtitle"),
+        )
+
+        body = resp.json()
+        assert body["behaviorChanged"] is False
+        assert [c["field"] for c in body["changes"]] == ["tagline"]
+        assert body["instructionsDiff"] == []
+
+    def test_fields_are_named_as_the_spa_knows_them(self, app):
+        """camelCase on the wire — snake_case would leak storage names into the UI."""
+        resp = self._get(
+            app,
+            _listing("in_review", submittedVersion=4, publishedVersion=2),
+            published=self._version(version=2),
+            pending=self._version(version=4, modelConfig={"modelId": "other"}, iconKey="i.png"),
+        )
+
+        assert {c["field"] for c in resp.json()["changes"]} == {"modelConfig", "iconKey"}
+
+    def test_a_first_submission_says_so_rather_than_reporting_no_changes(self, app):
+        """An empty ``changes`` list would read as "nothing changed" — the opposite claim."""
+        resp = self._get(
+            app,
+            _listing("in_review", submittedVersion=4, publishedVersion=None),
+            pending=self._version(version=4),
+        )
+
+        body = resp.json()
+        assert body["firstSubmission"] is True
+        assert body["publishedVersion"] is None
+        assert body["behaviorChanged"] is True
+        assert body["changes"], "a first submission is all new, not all unchanged"
+
+    def test_a_withdrawal_request_is_diffable_too(self, app):
+        """It sits in the same queue, so the reviewer opens it the same way."""
+        resp = self._get(
+            app,
+            _listing("withdrawal_requested", submittedVersion=4, publishedVersion=2),
+            published=self._version(version=2),
+            pending=self._version(version=4),
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize("state", ["published", "private", "taken_down", "changes_requested"])
+    def test_there_is_no_diff_without_something_under_review(self, app, state):
+        """A diff is what you read *before deciding*; offering one invites deciding."""
+        resp = self._get(app, _listing(state, submittedVersion=4, publishedVersion=2))
+        assert resp.status_code == 400
+
+    def test_a_missing_pending_snapshot_is_404_not_a_bare_diff(self, app):
+        resp = self._get(app, _listing("in_review", submittedVersion=4), pending=None)
+        assert resp.status_code == 404
+
+    def test_a_dangling_published_pointer_falls_back_to_first_submission(self, app):
+        """Better than diffing against nothing and calling every field changed.
+
+        The reviewer is told "there is nothing live to compare against", which is true, and
+        not told "the author rewrote everything", which would not be.
+        """
+        resp = self._get(
+            app,
+            _listing("in_review", submittedVersion=4, publishedVersion=2),
+            published=None,
+            pending=self._version(version=4),
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["firstSubmission"] is True
+        assert resp.json()["publishedVersion"] is None
+
+    def test_diffing_an_unsubmitted_agent_is_404(self, app):
+        with _loaded(_make_assistant(listing=None)):
+            resp = TestClient(app).get("/admin/agents/ast-001/diff")
+        assert resp.status_code == 404

--- a/backend/tests/shared/test_agent_version_diff.py
+++ b/backend/tests/shared/test_agent_version_diff.py
@@ -1,0 +1,206 @@
+"""What changed between two snapshots (version-snapshots §6.1).
+
+The failure mode this guards is quiet and bad: a reviewer told "nothing changed" about
+something that did, approving a rewrite in the two seconds a typo fix deserves. So the
+tests lean on *coverage of the field set* rather than on a few representative fields —
+``test_every_snapshot_field_is_diffable`` is the one that would catch a future field added
+to ``AgentVersion`` and forgotten here.
+"""
+
+import pytest
+
+from apis.shared.assistants.models import AgentVersion
+from apis.shared.assistants.version_diff import (
+    behavior_changed,
+    changed_fields,
+    field_changed,
+    instructions_diff,
+)
+from apis.shared.assistants.versions import (
+    DIFF_FIELD_ORDER,
+    LISTING_SNAPSHOT_FIELDS,
+    SNAPSHOT_FIELDS,
+)
+
+APPROVED = "Answer from the policy manual.\nAlways cite the section.\nBe concise."
+
+
+def version(**overrides) -> AgentVersion:
+    data = {
+        "agentId": "ast-001",
+        "version": 1,
+        "name": "Policy Lookup",
+        "description": "Find and cite university policy",
+        "instructions": APPROVED,
+        "tagline": "Policy, cited",
+        "emoji": "📘",
+        "iconKey": "icons/policy.png",
+        "starters": ["What is the drop deadline?"],
+        "modelConfig": {"modelId": "claude-opus-5"},
+        "bindings": [{"kind": "tool", "ref": "wikipedia", "config": {}}],
+        "category": "Administration",
+        "publisherId": "pub-registrar",
+    }
+    data.update(overrides)
+    return AgentVersion(**data)
+
+
+# ── coverage of the field set ────────────────────────────────────────────────────────
+def test_every_snapshot_field_is_diffable():
+    """A field a version can carry but the diff cannot report is a change nobody is shown.
+
+    ``DIFF_FIELD_ORDER`` asserts this at import time too; this states it as a test so the
+    failure names the feature rather than arriving as an ImportError.
+    """
+    assert set(DIFF_FIELD_ORDER) == set(SNAPSHOT_FIELDS) | set(LISTING_SNAPSHOT_FIELDS)
+
+
+@pytest.mark.parametrize("field", DIFF_FIELD_ORDER)
+def test_each_field_is_detected_on_its_own(field):
+    """Change one field, see exactly one change — no false positives, no misses."""
+    mutations = {
+        "instructions": "Something else entirely.",
+        "bindings": [{"kind": "tool", "ref": "browser", "config": {}}],
+        "model_settings": {"modelId": "some-other-model"},
+        "name": "Renamed",
+        "description": "A different summary",
+        "tagline": "A different subtitle",
+        "starters": ["A different starter"],
+        "emoji": "🧭",
+        "icon_key": "icons/other.png",
+        "category": "Teaching",
+        "publisher_id": "pub-other",
+    }
+    alias = {"model_settings": "modelConfig", "icon_key": "iconKey", "publisher_id": "publisherId"}
+    after = version(**{alias.get(field, field): mutations[field]})
+
+    changed = [name for name, _b, _a in changed_fields(version(), after)]
+    assert changed == [field]
+
+
+def test_an_identical_resubmission_reports_nothing():
+    """The typo-fix-that-was-not case: approvable in seconds precisely because it is empty."""
+    assert changed_fields(version(), version(version=2)) == []
+    assert instructions_diff(version(), version(version=2)) == []
+    assert behavior_changed(version(), version(version=2)) is False
+
+
+def test_record_metadata_is_never_reported_as_a_change():
+    """``version``/``createdAt``/``createdBy`` differ on every snapshot by construction.
+
+    Reporting them would bury the fields that matter under three that always fire.
+    """
+    before = version(version=1, createdAt="2026-07-01T00:00:00Z", createdBy="user-a")
+    after = version(version=2, createdAt="2026-07-02T00:00:00Z", createdBy="user-b")
+    assert changed_fields(before, after) == []
+
+
+# ── the behavior/presentation split ──────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("instructions", "Ignore the manual."),
+        ("bindings", [{"kind": "tool", "ref": "browser", "config": {}}]),
+        ("modelConfig", {"modelId": "cheap-model"}),
+    ],
+)
+def test_behavior_fields_flag_a_behavior_change(field, value):
+    """The one line that decides a careful read from a glance."""
+    assert behavior_changed(version(), version(**{field: value})) is True
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("tagline", "New subtitle"), ("emoji", "🧭"), ("name", "Renamed"), ("category", "Teaching")],
+)
+def test_presentation_fields_do_not(field, value):
+    changed = version(**{field: value})
+    assert behavior_changed(version(), changed) is False
+    assert changed_fields(version(), changed), "still reported, just not as behavior"
+
+
+# ── absent is not empty ──────────────────────────────────────────────────────────────
+def test_absent_bindings_differ_from_empty_bindings():
+    """A real behavior change that a laxer comparison would swallow.
+
+    Absent means "synthesize the legacy KB binding via compat"; ``[]`` means "binds
+    nothing". Collapsing them would tell a reviewer nothing happened while the Agent
+    quietly lost its knowledge base.
+    """
+    assert field_changed(version(bindings=None), version(bindings=[]), "bindings") is True
+    assert behavior_changed(version(bindings=None), version(bindings=[])) is True
+
+
+def test_binding_order_is_a_change():
+    """Order is meaningful to the resolver, so no normalization is applied."""
+    two = [
+        {"kind": "tool", "ref": "wikipedia", "config": {}},
+        {"kind": "tool", "ref": "browser", "config": {}},
+    ]
+    assert field_changed(version(bindings=two), version(bindings=list(reversed(two))), "bindings")
+
+
+def test_equal_values_from_different_sources_compare_equal():
+    """A version rehydrated from storage must not diff against an identical in-memory one.
+
+    Nested pydantic models are equal-but-not-identical across that boundary; without
+    normalizing, every reviewed resubmission would claim its bindings changed.
+    """
+    rehydrated = AgentVersion(**version().model_dump(by_alias=True))
+    assert changed_fields(version(), rehydrated) == []
+
+
+# ── the instructions diff ────────────────────────────────────────────────────────────
+def test_the_diff_shows_only_the_changed_line():
+    """A one-line fix in a long prompt should read as a one-line fix."""
+    after = version(instructions=APPROVED.replace("Be concise.", "Be thorough."))
+    diff = instructions_diff(version(), after)
+
+    assert any(line == "-Be concise." for line in diff)
+    assert any(line == "+Be thorough." for line in diff)
+    # Unchanged lines ride along as context, never as changes.
+    assert not any(line.startswith(("+", "-")) and "policy manual" in line for line in diff)
+
+
+def test_the_diff_is_empty_when_instructions_are_untouched():
+    assert instructions_diff(version(), version(tagline="Different")) == []
+
+
+def test_the_diff_labels_which_side_is_which():
+    """"approved" vs "submitted" — a reviewer must never have to guess the direction."""
+    diff = instructions_diff(version(), version(instructions="Totally different."))
+    assert diff[0].startswith("--- approved")
+    assert diff[1].startswith("+++ submitted")
+
+
+def test_a_whitespace_only_edit_is_flagged_but_diffs_to_nothing_visible():
+    """Honest rather than tidy: the field changed, and no line did.
+
+    Silently reporting "unchanged" would be wrong — the stored bytes differ, and the
+    reviewer is approving the bytes.
+    """
+    after = version(instructions=APPROVED + "   ")
+    assert field_changed(version(), after, "instructions") is True
+    assert instructions_diff(version(), after)
+
+
+# ── first submission ─────────────────────────────────────────────────────────────────
+def test_a_first_submission_reports_its_populated_fields_as_new():
+    changed = [name for name, _b, _a in changed_fields(None, version())]
+    assert "instructions" in changed and "name" in changed
+
+
+def test_a_first_submission_has_no_instructions_diff():
+    """Nothing to compare against, and the reviewer is reading the whole prompt anyway."""
+    assert instructions_diff(None, version()) == []
+
+
+def test_a_first_submission_does_not_report_absent_fields():
+    """An unset tagline on a brand-new listing is not a change to anything."""
+    changed = [name for name, _b, _a in changed_fields(None, version(tagline=None))]
+    assert "tagline" not in changed
+
+
+def test_behavior_changed_is_true_for_a_first_submission():
+    """There is no approved behavior yet, so all of it is unreviewed."""
+    assert behavior_changed(None, version()) is True

--- a/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { ReviewDiffComponent } from './review-diff.component';
+import { AgentVersionDiff } from '../models/marketplace.model';
+
+/**
+ * The review diff (§6.1).
+ *
+ * Two properties are worth guarding, and neither is about how it looks.
+ *
+ * **It must not fetch until asked.** The queue is a list of decisions; a diff per row on
+ * load would pull every pending agent's full instructions down to render a control nobody
+ * opened. That is a behavior the template can silently lose.
+ *
+ * **"First submission" must not read as "nothing changed".** They are opposite claims —
+ * one means "read all of this", the other means "approve it" — and the backend sends a
+ * distinct flag precisely so the UI cannot collapse them.
+ */
+describe('ReviewDiffComponent', () => {
+  let mockService: { loadDiff: ReturnType<typeof vi.fn> };
+
+  function diff(overrides: Partial<AgentVersionDiff> = {}): AgentVersionDiff {
+    return {
+      agentId: 'ast-001',
+      publishedVersion: 2,
+      pendingVersion: 4,
+      firstSubmission: false,
+      behaviorChanged: false,
+      changes: [],
+      instructionsDiff: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = { loadDiff: vi.fn().mockResolvedValue(diff()) };
+    TestBed.configureTestingModule({
+      providers: [{ provide: AdminMarketplaceService, useValue: mockService }],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  function render(): ComponentFixture<ReviewDiffComponent> {
+    const fixture = TestBed.createComponent(ReviewDiffComponent);
+    fixture.componentRef.setInput('agentId', 'ast-001');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  async function expand(fixture: ComponentFixture<ReviewDiffComponent>): Promise<void> {
+    const button = (fixture.nativeElement as HTMLElement).querySelector('button')!;
+    button.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function text(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('does not fetch anything until it is expanded', () => {
+    render();
+    expect(mockService.loadDiff).not.toHaveBeenCalled();
+  });
+
+  it('fetches on the first expand and shows what changed', async () => {
+    mockService.loadDiff.mockResolvedValue(
+      diff({ behaviorChanged: true, changes: [{ field: 'instructions', behavior: true }] }),
+    );
+    const fixture = render();
+    await expand(fixture);
+
+    expect(mockService.loadDiff).toHaveBeenCalledWith('ast-001');
+    expect(text(fixture)).toContain('Instructions');
+  });
+
+  it('does not re-fetch when collapsed and expanded again', async () => {
+    const fixture = render();
+    await expand(fixture);
+    await expand(fixture); // collapse
+    await expand(fixture); // re-expand
+
+    // The pending version is immutable, so a second request could only return the same
+    // bytes — and a reviewer comparing two rows should not pay for it twice.
+    expect(mockService.loadDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it('names a first submission rather than reporting no changes', async () => {
+    mockService.loadDiff.mockResolvedValue(
+      diff({ firstSubmission: true, publishedVersion: undefined, behaviorChanged: true }),
+    );
+    const fixture = render();
+    await expand(fixture);
+
+    expect(text(fixture)).toContain('First submission');
+    expect(text(fixture)).not.toContain('Identical to the published version');
+  });
+
+  it('says so plainly when a resubmission changed nothing', async () => {
+    const fixture = render();
+    await expand(fixture);
+    expect(text(fixture)).toContain('Identical to the published version 2');
+  });
+
+  it('styles a behavior change differently from a presentation one', async () => {
+    // The asymmetry is the whole point: a tagline fix should be approvable at a glance and
+    // an instruction rewrite should not. If these ever render alike, that is gone.
+    mockService.loadDiff.mockResolvedValue(
+      diff({
+        behaviorChanged: true,
+        changes: [
+          { field: 'instructions', behavior: true },
+          { field: 'tagline', behavior: false },
+        ],
+      }),
+    );
+    const fixture = render();
+    await expand(fixture);
+
+    const items = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('li'),
+    ) as HTMLElement[];
+    const behavior = items.find((li) => li.textContent?.trim() === 'Instructions')!;
+    const presentation = items.find((li) => li.textContent?.trim() === 'Tagline')!;
+
+    expect(behavior.className).not.toBe(presentation.className);
+    expect(behavior.className).toContain('amber');
+    expect(presentation.className).not.toContain('amber');
+  });
+
+  it('renders the instructions diff with added and removed lines distinguished', async () => {
+    mockService.loadDiff.mockResolvedValue(
+      diff({
+        behaviorChanged: true,
+        changes: [{ field: 'instructions', behavior: true }],
+        instructionsDiff: ['--- approved', '+++ submitted', '-Be concise.', '+Be thorough.'],
+      }),
+    );
+    const fixture = render();
+    await expand(fixture);
+
+    const spans = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('pre span'),
+    ) as HTMLElement[];
+    const removed = spans.find((s) => s.textContent?.includes('-Be concise.'))!;
+    const added = spans.find((s) => s.textContent?.includes('+Be thorough.'))!;
+
+    expect(removed.className).toContain('rose');
+    expect(added.className).toContain('emerald');
+  });
+
+  it('degrades to a message the reviewer can act on when the fetch fails', async () => {
+    mockService.loadDiff.mockRejectedValue(new Error('boom'));
+    const fixture = render();
+    await expand(fixture);
+
+    // Never a blank panel: the reviewer still has to decide, so tell them the diff is
+    // missing and that the agent itself is still reviewable.
+    expect(text(fixture)).toContain('Could not load what changed');
+  });
+
+  it('marks the toggle as expanded for assistive technology', async () => {
+    const fixture = render();
+    const button = (fixture.nativeElement as HTMLElement).querySelector('button')!;
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    await expand(fixture);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-controls')).toBe('review-diff-ast-001');
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.ts
@@ -1,0 +1,167 @@
+import { ChangeDetectionStrategy, Component, inject, input, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown, heroChevronRight } from '@ng-icons/heroicons/outline';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AgentVersionDiff, VersionFieldChange } from '../models/marketplace.model';
+
+/**
+ * "What changed since I approved this?" — the reviewer's actual question (§6.1).
+ *
+ * Before this, a submission arrived in the queue with no reference to what it replaces, so
+ * a typo fix and a full instruction rewrite looked identical and both got the same careful
+ * read. The point is asymmetry: make the cheap approval cheap without making the expensive
+ * one easy to miss.
+ *
+ * **Collapsed by default, loaded on expand.** The queue is a list of decisions; fetching a
+ * diff for every row up front would pull every pending Agent's full instructions down to
+ * render a badge nobody has opened. The one thing shown *before* expanding is whether
+ * behavior changed, because that is what decides whether the row needs opening at all —
+ * and it rides the queue payload rather than this request.
+ */
+@Component({
+  selector: 'app-review-diff',
+  imports: [NgIcon],
+  providers: [provideIcons({ heroChevronDown, heroChevronRight })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="mt-2">
+      <button
+        type="button"
+        (click)="toggle()"
+        [attr.aria-expanded]="expanded()"
+        [attr.aria-controls]="panelId()"
+        class="inline-flex items-center gap-1 rounded-2xl text-sm/6 font-medium text-blue-700 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400"
+      >
+        <ng-icon
+          [name]="expanded() ? 'heroChevronDown' : 'heroChevronRight'"
+          class="size-4"
+          aria-hidden="true"
+        />
+        {{ expanded() ? 'Hide changes' : 'What changed' }}
+      </button>
+
+      @if (expanded()) {
+        <div [id]="panelId()" class="mt-2 text-sm/6">
+          @if (loading()) {
+            <p class="text-gray-500 dark:text-gray-400">Loading changes…</p>
+          } @else if (error(); as message) {
+            <p class="text-rose-700 dark:text-rose-400">{{ message }}</p>
+          } @else if (diff(); as d) {
+            @if (d.firstSubmission) {
+              <!-- Not "nothing changed" — there is simply nothing to compare against, and
+                   the reviewer is reading the whole submission rather than a delta. -->
+              <p class="text-gray-600 dark:text-gray-400">
+                First submission — nothing is published yet, so there is nothing to compare
+                against.
+              </p>
+            } @else if (d.changes.length === 0) {
+              <p class="text-gray-600 dark:text-gray-400">
+                Identical to the published version {{ d.publishedVersion }}.
+              </p>
+            } @else {
+              <p class="text-gray-600 dark:text-gray-400">
+                Version {{ d.pendingVersion }} against published
+                {{ d.publishedVersion }}
+              </p>
+
+              <ul class="mt-2 flex flex-wrap gap-1.5">
+                @for (change of d.changes; track change.field) {
+                  <li
+                    class="rounded-2xl px-2 py-0.5 text-xs font-medium"
+                    [class]="change.behavior ? behaviorClasses : presentationClasses"
+                  >
+                    {{ label(change) }}
+                  </li>
+                }
+              </ul>
+
+              @if (d.instructionsDiff.length) {
+                <!-- Monospace and horizontally scrollable: instructions are prose the author
+                     wrote with intentional line breaks, and wrapping them would invent
+                     changes that are not there. -->
+                <pre
+                  class="mt-3 overflow-x-auto rounded-2xl bg-gray-50 p-3 text-xs/5 dark:bg-gray-900"
+                ><code>@for (line of d.instructionsDiff; track $index) {<span [class]="lineClasses(line)">{{ line }}
+</span>}</code></pre>
+              }
+            }
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class ReviewDiffComponent {
+  private readonly service = inject(AdminMarketplaceService);
+
+  readonly agentId = input.required<string>();
+
+  protected readonly expanded = signal(false);
+  protected readonly loading = signal(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly diff = signal<AgentVersionDiff | null>(null);
+
+  /** Behavior reads as attention; presentation reads as information. */
+  protected readonly behaviorClasses =
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300';
+  protected readonly presentationClasses =
+    'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
+
+  private readonly fieldLabels: Record<string, string> = {
+    instructions: 'Instructions',
+    bindings: 'Tools & skills',
+    modelConfig: 'Model',
+    name: 'Name',
+    description: 'Description',
+    tagline: 'Tagline',
+    starters: 'Starters',
+    emoji: 'Emoji',
+    iconKey: 'Icon',
+    category: 'Category',
+    publisherId: 'Publisher',
+  };
+
+  protected panelId(): string {
+    return `review-diff-${this.agentId()}`;
+  }
+
+  protected label(change: VersionFieldChange): string {
+    return this.fieldLabels[change.field] ?? change.field;
+  }
+
+  /** Colour the +/- lines; the `@@` hunk headers and context stay neutral. */
+  protected lineClasses(line: string): string {
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      return 'text-gray-500 dark:text-gray-400';
+    }
+    if (line.startsWith('+')) {
+      return 'text-emerald-700 dark:text-emerald-400';
+    }
+    if (line.startsWith('-')) {
+      return 'text-rose-700 dark:text-rose-400';
+    }
+    return 'text-gray-600 dark:text-gray-300';
+  }
+
+  protected async toggle(): Promise<void> {
+    const next = !this.expanded();
+    this.expanded.set(next);
+    // Fetched once and kept: a reviewer comparing two rows should not re-request, and the
+    // pending version cannot change under them while they read it — it is immutable.
+    if (next && !this.diff() && !this.loading()) {
+      await this.load();
+    }
+  }
+
+  private async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.diff.set(await this.service.loadDiff(this.agentId()));
+    } catch {
+      this.error.set('Could not load what changed. Try again, or review the agent directly.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -310,3 +310,48 @@ export interface AdminQueueCounts {
   pendingCount: number;
   openReportCount: number;
 }
+
+/**
+ * One field that differs between the approved snapshot and the pending one (§6.1).
+ *
+ * `before`/`after` are raw snapshot values, rendered per field by the diff component —
+ * a tagline as text, `bindings` as kinds and refs. The backend deliberately does not
+ * pre-render them into strings, which would put presentation on the wrong side of the wire.
+ */
+export interface VersionFieldChange {
+  /** Snapshot field name, camelCase as the rest of the Agent surface names it. */
+  field: string;
+  /** Value in the published version; absent on a first submission. */
+  before?: unknown;
+  after?: unknown;
+  /**
+   * Whether this changes what the Agent *does* (instructions, bindings, model) rather
+   * than how it presents. Drives the reviewer's at-a-glance triage.
+   */
+  behavior: boolean;
+}
+
+/**
+ * The pending version against the currently published one (§6.1).
+ *
+ * Answers the reviewer's real question — "what changed since I approved this?" — which the
+ * queue could not answer before: a submission arrived with no reference to what it
+ * replaces, so a typo fix and a full rewrite looked identical.
+ */
+export interface AgentVersionDiff {
+  agentId: string;
+  /** The live snapshot; absent on a first submission. */
+  publishedVersion?: number;
+  /** The snapshot under review. */
+  pendingVersion?: number;
+  /**
+   * Nothing is published yet, so there is nothing to diff against. A distinct signal
+   * rather than an empty `changes` list, which would read as "nothing changed".
+   */
+  firstSubmission: boolean;
+  /** Instructions, bindings or model differ — a careful read rather than a glance. */
+  behaviorChanged: boolean;
+  changes: VersionFieldChange[];
+  /** Unified line diff of the instructions; empty when unchanged or on a first submission. */
+  instructionsDiff: string[];
+}

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -12,6 +12,7 @@ import { heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash } from '@ng-icon
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { AdminListingRow } from '../models/marketplace.model';
 import { AgentTileComponent } from '../components/agent-tile.component';
+import { ReviewDiffComponent } from '../components/review-diff.component';
 import { reachabilityReviewerMessage } from '../../../agents/models/reachability';
 import {
   RequestChangesDialogComponent,
@@ -33,7 +34,7 @@ import { parseIso } from '../../../utils/date';
 @Component({
   selector: 'app-review-queue',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, AgentTileComponent],
+  imports: [NgIcon, AgentTileComponent, ReviewDiffComponent],
   providers: [provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash })],
   template: `
     <div class="min-h-dvh">
@@ -104,6 +105,12 @@ import { parseIso } from '../../../utils/date';
                        PRIVATE agent shelves a tile that 404s for everyone but its author,
                        and that is the one fact the reviewer cannot get from anywhere else
                        on this row. -->
+                  <!-- §6.1 — what this submission changes against what is published.
+                       Collapsed by default and fetched on expand: the queue is a list of
+                       decisions, and pre-loading a diff per row would pull every pending
+                       agent's full instructions down to render a control nobody opened. -->
+                  <app-review-diff [agentId]="row.agentId" />
+
                   @if (reachabilityWarning(row); as warning) {
                     <p
                       class="mt-1 flex items-start gap-1.5 text-sm/6 text-amber-700 dark:text-amber-400"

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
+  AgentVersionDiff,
   AdminListingRow,
   AdminQueueCounts,
   AdminReportRow,
@@ -57,6 +58,19 @@ export class AdminMarketplaceService {
   /** The Review queue: everything currently awaiting a decision. */
   async loadSubmissions(): Promise<AdminListingRow[]> {
     return this.fetchListings(`${this.baseUrl()}/submissions`);
+  }
+
+  /**
+   * What a pending submission changes against what is published (§6.1).
+   *
+   * Fetched per row on demand rather than with the queue: the queue is a list of decisions
+   * to make, and pre-loading a diff for every row would pull every pending Agent's full
+   * instructions down to render badges nobody has opened yet.
+   */
+  async loadDiff(agentId: string): Promise<AgentVersionDiff> {
+    return firstValueFrom(
+      this.http.get<AgentVersionDiff>(`${this.baseUrl()}/${agentId}/diff`),
+    );
   }
 
   /** The Listings table: every agent that has ever been submitted. */


### PR DESCRIPTION
PR-5 of the agent version-snapshots epic (§6.1). Spec: #783 · #790 · merged: #784 · #787 · #789 · #791. Independent of the open #792.

## The problem

The reviewer's actual question is **"what changed since I approved this?"** — and until now they could not see it. A submission arrived in the queue with no reference to what it replaces, so a typo fix and a full instruction rewrite looked identical, and both got the same careful read.

`GET /admin/agents/{id}/diff` returns the pending version against the published one. The review queue grows a collapsed **"What changed"** control per row.

**The asymmetry is the point.** A tagline fix reads as one grey badge you approve at a glance. An instruction rewrite reads as amber, plus a red/green line diff you actually read.

| | |
|---|---|
| `behaviorChanged` | instructions / bindings / model differ — the one line that decides careful-read vs glance |
| `changes[]` | differing fields, behavior first, with before/after values |
| `instructionsDiff` | unified line diff, `approved` → `submitted` |
| `firstSubmission` | nothing published yet — a distinct signal, not an empty list |

## Reviewer notes

**The diff is computed server-side** with `difflib`. A client-side library renders more prettily, but it means a new SPA dependency — this repo pins exactly and does not add packages casually — and a second implementation of "did this change" that can disagree with the field-level answer. One source, one answer.

**Collapsed, fetched on expand.** The queue is a list of decisions; pre-loading a diff for every row would pull every pending agent's *full instructions* down to render a control nobody opened. `test_does_not_fetch_anything_until_it_is_expanded` guards it, because that is exactly the kind of property a later template edit loses silently.

**`DIFF_FIELD_ORDER` is asserted against the snapshot field lists at import time**, and again as a test so the failure names the feature instead of arriving as an `ImportError`. The worst outcome available here is a reviewer told *"nothing changed"* about something that did — which is precisely what a field added to `AgentVersion` and forgotten in the diff would produce.

**"First submission" is never an empty change list.** They are opposite claims: one means "read all of this", the other means "approve it". A **dangling** `publishedVersion` (pointer set, snapshot gone) falls back to the same rendering — *"there is nothing live to compare against"* is true; *"the author rewrote everything"* would not be.

**Absent is not empty.** `bindings: null` means "synthesize the legacy KB binding via compat"; `[]` means "binds nothing". A laxer comparison would report no change while the agent quietly lost its knowledge base. Binding **order** counts too — it is meaningful to the resolver, so no normalization is applied.

**Record metadata is never reported.** `version` / `createdAt` / `createdBy` differ on every snapshot by construction and would bury the fields that matter.

**Whitespace-only instruction edits** are flagged as changed and produce a diff — honest rather than tidy. The stored bytes differ, and the reviewer is approving the bytes.

## Testing

Backend **5553 passed, 3 skipped** (5504 baseline + 49). SPA **1691 passed across 153 files** (1682 + 9).

`test_each_field_is_detected_on_its_own` is parametrized over the whole field set: change one field, see exactly one change — no misses, no false positives.

## Two things the tests caught in my own work

I documented `instructions_diff` as empty on a first submission and then did not implement it — it was emitting the entire prompt as added lines. The docstring had the better design (the reviewer reads the full prompt in the version view anyway), so the code changed to match.

`ng test` caught a duplicate import that `npx tsc --noEmit` had passed cleanly. Worth knowing the two are not equivalent gates in this repo.

## Not in this PR

PR-6 (publisher management admin page) — independent of the rest and landable any time. That is the last phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)