### PR TITLE
feat(marketplace): admin page for publisher profiles (PR-6)

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -29,6 +29,7 @@ import {
   heroFlag,
   heroRectangleStack,
   heroStar,
+  heroBuildingLibrary,
   heroTag,
   heroBookmark,
 } from '@ng-icons/heroicons/outline';
@@ -79,6 +80,7 @@ interface NavGroup {
       heroFlag,
       heroRectangleStack,
       heroStar,
+      heroBuildingLibrary,
       heroTag,
       heroBookmark,
     }),
@@ -226,6 +228,7 @@ export class AdminLayout implements OnInit {
         { label: 'Listings', icon: 'heroRectangleStack', route: '/admin/marketplace/listings', scope: 'admin.marketplace' },
         { label: 'Store Front', icon: 'heroStar', route: '/admin/marketplace/store-front', scope: 'admin.marketplace' },
         { label: 'Categories', icon: 'heroTag', route: '/admin/marketplace/categories', scope: 'admin.marketplace' },
+        { label: 'Publishers', icon: 'heroBuildingLibrary', route: '/admin/marketplace/publishers', scope: 'admin.marketplace' },
         { label: 'Default Pins', icon: 'heroBookmark', route: '/admin/marketplace/default-pins', scope: 'admin.marketplace' },
       ],
     },

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -162,6 +162,13 @@ export const adminRoutes: Routes = [
     loadComponent: () => import('./marketplace/pages/listings.page').then(m => m.MarketplaceListingsPage),
   },
   {
+    path: 'marketplace/publishers',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
+    loadComponent: () =>
+      import('./marketplace/pages/publishers.page').then(m => m.MarketplacePublishersPage),
+  },
+  {
     path: 'marketplace/categories',
     canActivate: [adminScopeGuard],
     data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -355,3 +355,48 @@ export interface AgentVersionDiff {
   /** Unified line diff of the instructions; empty when unchanged or on a first submission. */
   instructionsDiff: string[];
 }
+// ── publisher management (D12, PR-6) ───────────────────────────────────────────────
+
+/**
+ * Create a publisher profile.
+ *
+ * No `id` field: the backend derives it from the label and it is immutable thereafter,
+ * because listings store the id. Renaming a publisher changes `label` only — the same rule
+ * categories follow, and for the same reason.
+ */
+export interface PublisherCreateRequest {
+  label: string;
+  kind: PublisherKind;
+  verified?: boolean;
+  iconKey?: string;
+  order?: number;
+  enabled?: boolean;
+}
+
+/** Update a publisher. All fields optional; `id` is absent because it cannot change. */
+export interface PublisherUpdateRequest {
+  label?: string;
+  kind?: PublisherKind;
+  verified?: boolean;
+  iconKey?: string;
+  order?: number;
+  enabled?: boolean;
+}
+
+export interface PublisherEligibilityResponse {
+  publisherId: string;
+  userIds: string[];
+}
+
+/** Display copy for each publisher kind — the picker needs to say what it means. */
+export const PUBLISHER_KIND_LABELS: Record<PublisherKind, string> = {
+  institution: 'Institution',
+  department: 'Department',
+  individual: 'Individual',
+};
+
+export const PUBLISHER_KIND_HINTS: Record<PublisherKind, string> = {
+  institution: 'The university itself — for agents that speak for Boise State.',
+  department: 'A team or office, e.g. the Registrar or Communications & Marketing.',
+  individual: 'A person. Auto-created from an author\'s display name on first submission.',
+};

--- a/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
@@ -223,8 +223,12 @@ export class MarketplaceCategoriesPage implements OnInit {
     } catch (err) {
       // The in-use delete refusal (409) explains itself and suggests disabling instead,
       // so surface the server's message rather than a generic one.
-      this.error.set(this.messageFor(err, 'That change could not be saved.'));
+      //
+      // ⚠️ Set *after* the reload, not before: ``reload`` clears the error banner on entry,
+      // so the obvious order silently swallows every message this branch exists to show.
+      const message = this.messageFor(err, 'That change could not be saved.');
       await this.reload();
+      this.error.set(message);
     } finally {
       this.busy.set(false);
     }

--- a/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { MarketplacePublishersPage } from './publishers.page';
+import { PublisherProfile } from '../models/marketplace.model';
+
+/**
+ * Publishers (D12).
+ *
+ * The backend has been complete since the marketplace shipped; this page is the missing
+ * way to reach it. So the tests are about the three rules a curator would otherwise learn
+ * by being surprised — the id is fixed, delete is refused while in use, and `verified` is
+ * a check mark rather than a permission — plus the ordinary CRUD wiring.
+ */
+describe('MarketplacePublishersPage', () => {
+  let mockService: {
+    loadPublishers: ReturnType<typeof vi.fn>;
+    createPublisher: ReturnType<typeof vi.fn>;
+    updatePublisher: ReturnType<typeof vi.fn>;
+    deletePublisher: ReturnType<typeof vi.fn>;
+  };
+
+  function publisher(overrides: Partial<PublisherProfile> = {}): PublisherProfile {
+    return {
+      id: 'pub-registrar',
+      label: 'Office of the Registrar',
+      kind: 'department',
+      verified: false,
+      order: 0,
+      enabled: true,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      loadPublishers: vi.fn().mockResolvedValue([]),
+      createPublisher: vi.fn().mockResolvedValue(publisher()),
+      updatePublisher: vi.fn().mockResolvedValue(publisher()),
+      deletePublisher: vi.fn().mockResolvedValue(undefined),
+    };
+    TestBed.configureTestingModule({
+      providers: [{ provide: AdminMarketplaceService, useValue: mockService }],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function render(
+    rows: PublisherProfile[] = [],
+  ): Promise<ComponentFixture<MarketplacePublishersPage>> {
+    mockService.loadPublishers.mockResolvedValue(rows);
+    const fixture = TestBed.createComponent(MarketplacePublishersPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function text(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('lists the publishers an admin can attribute a listing to', async () => {
+    const fixture = await render([publisher(), publisher({ id: 'pub-bsu', label: 'Boise State' })]);
+    expect(text(fixture)).toContain('Office of the Registrar');
+    expect(text(fixture)).toContain('Boise State');
+  });
+
+  it('points at the auto-created individual profile when there is nothing to show', async () => {
+    // The empty state is the first thing a curator sees, and "no publishers" without
+    // context reads as broken — authors already get one on their first submission.
+    const fixture = await render([]);
+    expect(text(fixture)).toContain('No publishers yet');
+    expect(text(fixture)).toContain('individual profile automatically');
+  });
+
+  it('creates a publisher with the selected kind', async () => {
+    const fixture = await render([]);
+    const input = (fixture.nativeElement as HTMLElement).querySelector(
+      '#new-publisher',
+    ) as HTMLInputElement;
+    input.value = 'Communications & Marketing';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const addButton = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.includes('Add')) as HTMLButtonElement;
+    addButton.click();
+    await fixture.whenStable();
+
+    expect(mockService.createPublisher).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Communications & Marketing', kind: 'department' }),
+    );
+  });
+
+  it('shows the id and says it is fixed, because listings store it', async () => {
+    // Renaming a publisher must never strand the attributions pointing at it, and the only
+    // way a curator learns that before trying is if the row says so.
+    const fixture = await render([publisher()]);
+    expect(text(fixture)).toContain('id: pub-registrar');
+    expect(text(fixture)).toContain('fixed at creation');
+  });
+
+  it('renames the label only', async () => {
+    const fixture = await render([publisher()]);
+    const input = (fixture.nativeElement as HTMLElement).querySelector(
+      '#label-pub-registrar',
+    ) as HTMLInputElement;
+    input.value = 'The Registrar';
+    input.dispatchEvent(new Event('change'));
+    await fixture.whenStable();
+
+    expect(mockService.updatePublisher).toHaveBeenCalledWith('pub-registrar', {
+      label: 'The Registrar',
+    });
+  });
+
+  it('does not send a rename that changed nothing', async () => {
+    const fixture = await render([publisher()]);
+    const input = (fixture.nativeElement as HTMLElement).querySelector(
+      '#label-pub-registrar',
+    ) as HTMLInputElement;
+    input.dispatchEvent(new Event('change'));
+    await fixture.whenStable();
+
+    expect(mockService.updatePublisher).not.toHaveBeenCalled();
+  });
+
+  it('toggles verified, and says it grants nothing', async () => {
+    const fixture = await render([publisher({ verified: false })]);
+    const button = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.trim() === 'Unverified') as HTMLButtonElement;
+
+    // `verified` renders as a check mark and looks like a permission. The tooltip is the
+    // only place that distinction is stated, so it is worth asserting.
+    expect(button.getAttribute('appTooltip') ?? button.title).toBeDefined();
+    button.click();
+    await fixture.whenStable();
+
+    expect(mockService.updatePublisher).toHaveBeenCalledWith('pub-registrar', { verified: true });
+  });
+
+  it('toggles enabled without touching existing attributions', async () => {
+    const fixture = await render([publisher({ enabled: true })]);
+    const button = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.trim() === 'Enabled') as HTMLButtonElement;
+    button.click();
+    await fixture.whenStable();
+
+    expect(mockService.updatePublisher).toHaveBeenCalledWith('pub-registrar', { enabled: false });
+  });
+
+  it("surfaces the server's refusal when a publisher is still in use", async () => {
+    // The 409 explains itself and suggests disabling instead. Replacing it with a generic
+    // "could not save" would throw away the only actionable part.
+    mockService.deletePublisher.mockRejectedValue({
+      error: { detail: 'Publisher is attributed to 3 listings. Disable it instead.' },
+    });
+    const fixture = await render([publisher()]);
+
+    const remove = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.includes('Delete Office of the Registrar')) as HTMLButtonElement;
+    remove.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain('Disable it instead');
+  });
+
+  it('falls back to a plain message when the server sends no detail', async () => {
+    mockService.updatePublisher.mockRejectedValue(new Error('network'));
+    const fixture = await render([publisher()]);
+    const button = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.trim() === 'Enabled') as HTMLButtonElement;
+    button.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain('could not be saved');
+  });
+
+  it('reloads after a failed mutation so the list matches the server', async () => {
+    mockService.updatePublisher.mockRejectedValue(new Error('nope'));
+    const fixture = await render([publisher()]);
+    mockService.loadPublishers.mockClear();
+
+    const button = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((b) => b.textContent?.trim() === 'Enabled') as HTMLButtonElement;
+    button.click();
+    await fixture.whenStable();
+
+    expect(mockService.loadPublishers).toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
@@ -1,0 +1,324 @@
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroBuildingLibrary,
+  heroCheckBadge,
+  heroPlus,
+  heroTrash,
+} from '@ng-icons/heroicons/outline';
+import { TooltipDirective } from '../../../components/tooltip/tooltip.directive';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import {
+  PUBLISHER_KIND_HINTS,
+  PUBLISHER_KIND_LABELS,
+  PublisherKind,
+  PublisherProfile,
+} from '../models/marketplace.model';
+
+/**
+ * Publishers — the display identity a listing is attributed to (D12).
+ *
+ * The backend for this has been complete since the marketplace shipped: full CRUD plus an
+ * eligibility allowlist at `/admin/agents/publishers`. What was missing was any way to
+ * reach it, so a profile like "Registrar" or "Communications & Marketing" could only be
+ * created by calling the API directly. This page is that gap, and nothing more.
+ *
+ * Three things the UI has to make legible, because each is surprising otherwise:
+ *
+ * - **⚠️ Publisher is display only.** It is a name on a shelf. It never grants access to
+ *   anything, and `ownerName` on a listing remains who actually owns the agent and whose
+ *   skills resolve when it runs. The page says so where an admin is most likely to assume
+ *   otherwise — next to `verified`, which looks like a permission and is not.
+ * - **The id is fixed at creation.** Listings store the id, so renaming a publisher would
+ *   strand every attribution pointing at it. Renaming changes the label only — the same
+ *   rule categories follow.
+ * - **Disable, don't delete.** Deleting is refused (409) while listings are attributed to
+ *   the publisher. Disabling drops it from the submit picker while existing attributions
+ *   keep rendering, which is nearly always what was meant.
+ */
+@Component({
+  selector: 'app-marketplace-publishers',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, TooltipDirective],
+  providers: [
+    provideIcons({ heroBuildingLibrary, heroCheckBadge, heroPlus, heroTrash }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div class="mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Publishers</h1>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Who a listing is attributed to on the shelf — the Registrar, Communications &
+            Marketing, the university itself. An agent built by one person can still speak
+            as the office that owns it.
+          </p>
+          <p class="mt-2 max-w-2xl text-sm/6 text-gray-500 dark:text-gray-400">
+            Attribution is a name, not a permission. It never changes who can open an agent
+            or whose skills run when it does.
+          </p>
+        </div>
+
+        @if (error()) {
+          <div
+            role="alert"
+            class="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ error() }}
+          </div>
+        }
+
+        <!-- Add -->
+        <div
+          class="mb-6 flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-end dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div class="flex-1">
+            <label
+              for="new-publisher"
+              class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+            >
+              New publisher
+            </label>
+            <input
+              type="text"
+              id="new-publisher"
+              [value]="newLabel()"
+              (input)="onNewLabelInput($event)"
+              placeholder="e.g. Office of the Registrar"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+            />
+          </div>
+          <div class="sm:w-52">
+            <label
+              for="new-publisher-kind"
+              class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+            >
+              Kind
+            </label>
+            <select
+              id="new-publisher-kind"
+              [value]="newKind()"
+              (change)="onNewKindChange($event)"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            >
+              @for (kind of kinds; track kind) {
+                <option [value]="kind">{{ kindLabels[kind] }}</option>
+              }
+            </select>
+          </div>
+          <button
+            type="button"
+            [disabled]="!newLabel().trim() || busy()"
+            (click)="addPublisher()"
+            class="inline-flex shrink-0 items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            <ng-icon name="heroPlus" class="size-5" aria-hidden="true" />
+            Add
+          </button>
+        </div>
+        <p class="-mt-4 mb-6 text-sm/6 text-gray-500 dark:text-gray-400">
+          {{ kindHints[newKind()] }}
+        </p>
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-16">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading publishers</span>
+          </div>
+        } @else if (publishers().length === 0) {
+          <div
+            class="rounded-2xl border border-dashed border-gray-300 px-6 py-16 text-center dark:border-gray-600"
+          >
+            <ng-icon
+              name="heroBuildingLibrary"
+              class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <h2 class="mt-3 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              No publishers yet
+            </h2>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Authors get an individual profile automatically on their first submission.
+              Add one here for an office or the university.
+            </p>
+          </div>
+        } @else {
+          <ul class="flex flex-col gap-2">
+            @for (publisher of publishers(); track publisher.id) {
+              <li
+                class="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 sm:flex-row sm:items-center dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div class="min-w-0 flex-1">
+                  <label [for]="'label-' + publisher.id" class="sr-only">
+                    Label for {{ publisher.label }}
+                  </label>
+                  <div class="flex items-center gap-1.5">
+                    <input
+                      type="text"
+                      [id]="'label-' + publisher.id"
+                      [value]="publisher.label"
+                      (change)="rename(publisher, $event)"
+                      class="block w-full rounded-2xl border border-transparent bg-transparent px-2 py-1 text-sm/6 font-medium text-gray-900 hover:border-gray-300 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white dark:hover:border-gray-600 dark:focus:bg-gray-900"
+                    />
+                    @if (publisher.verified) {
+                      <ng-icon
+                        name="heroCheckBadge"
+                        class="size-5 shrink-0 text-blue-600 dark:text-blue-400"
+                        aria-label="Verified"
+                      />
+                    }
+                  </div>
+                  <p class="px-2 text-xs text-gray-400 dark:text-gray-500">
+                    {{ kindLabels[publisher.kind] }} · id: {{ publisher.id }} — fixed at
+                    creation
+                  </p>
+                </div>
+
+                <div class="flex shrink-0 flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    [disabled]="busy()"
+                    (click)="toggleVerified(publisher)"
+                    class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    appTooltip="A check mark meaning a university team stands behind this. Display only — it grants nothing."
+                    appTooltipPosition="top"
+                  >
+                    {{ publisher.verified ? 'Verified' : 'Unverified' }}
+                  </button>
+                  <button
+                    type="button"
+                    [disabled]="busy()"
+                    (click)="toggleEnabled(publisher)"
+                    class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    [appTooltip]="
+                      publisher.enabled
+                        ? 'Stop offering this in the submit picker. Listings already attributed to it keep rendering.'
+                        : 'Offer this publisher again'
+                    "
+                    appTooltipPosition="top"
+                  >
+                    {{ publisher.enabled ? 'Enabled' : 'Disabled' }}
+                  </button>
+                  <button
+                    type="button"
+                    [disabled]="busy()"
+                    (click)="remove(publisher)"
+                    class="rounded-2xl border border-gray-300 bg-white p-1.5 text-gray-500 hover:bg-rose-50 hover:text-rose-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-rose-900/20 dark:hover:text-rose-400"
+                    appTooltip="Delete. Refused while listings are attributed to it — disable instead."
+                    appTooltipPosition="top"
+                  >
+                    <ng-icon name="heroTrash" class="size-5" aria-hidden="true" />
+                    <span class="sr-only">Delete {{ publisher.label }}</span>
+                  </button>
+                </div>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class MarketplacePublishersPage implements OnInit {
+  private readonly service = inject(AdminMarketplaceService);
+
+  readonly publishers = signal<PublisherProfile[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busy = signal(false);
+  readonly newLabel = signal('');
+  readonly newKind = signal<PublisherKind>('department');
+
+  /** `department` first: it is what an admin adding a publisher almost always wants. */
+  protected readonly kinds: PublisherKind[] = ['department', 'institution', 'individual'];
+  protected readonly kindLabels = PUBLISHER_KIND_LABELS;
+  protected readonly kindHints = PUBLISHER_KIND_HINTS;
+
+  ngOnInit(): void {
+    void this.reload();
+  }
+
+  onNewLabelInput(event: Event): void {
+    this.newLabel.set((event.target as HTMLInputElement).value);
+  }
+
+  onNewKindChange(event: Event): void {
+    this.newKind.set((event.target as HTMLSelectElement).value as PublisherKind);
+  }
+
+  async reload(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.publishers.set(await this.service.loadPublishers());
+    } catch (err) {
+      this.error.set(this.messageFor(err, 'Failed to load publishers.'));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async addPublisher(): Promise<void> {
+    const label = this.newLabel().trim();
+    if (!label) return;
+    await this.mutate(async () => {
+      await this.service.createPublisher({
+        label,
+        kind: this.newKind(),
+        order: this.publishers().length * 10,
+      });
+      this.newLabel.set('');
+    });
+  }
+
+  async rename(publisher: PublisherProfile, event: Event): Promise<void> {
+    const label = (event.target as HTMLInputElement).value.trim();
+    if (!label || label === publisher.label) return;
+    await this.mutate(() => this.service.updatePublisher(publisher.id, { label }));
+  }
+
+  async toggleVerified(publisher: PublisherProfile): Promise<void> {
+    await this.mutate(() =>
+      this.service.updatePublisher(publisher.id, { verified: !publisher.verified }),
+    );
+  }
+
+  async toggleEnabled(publisher: PublisherProfile): Promise<void> {
+    await this.mutate(() =>
+      this.service.updatePublisher(publisher.id, { enabled: !publisher.enabled }),
+    );
+  }
+
+  async remove(publisher: PublisherProfile): Promise<void> {
+    await this.mutate(() => this.service.deletePublisher(publisher.id));
+  }
+
+  /** Run a mutation, surface its message, and reload so the list matches the server. */
+  private async mutate(action: () => Promise<unknown>): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      await action();
+      await this.reload();
+    } catch (err) {
+      // The in-use delete refusal (409) explains itself and suggests disabling instead, so
+      // surface the server's message rather than replacing it with a generic one.
+      //
+      // ⚠️ Set *after* the reload, not before: ``reload`` clears the error banner on entry,
+      // so the obvious order silently swallows every message this branch exists to show.
+      // ``categories.page.ts`` had exactly that bug until this page's tests found it.
+      const message = this.messageFor(err, 'That change could not be saved.');
+      await this.reload();
+      this.error.set(message);
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  private messageFor(err: unknown, fallback: string): string {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' ? detail : fallback;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -4,6 +4,9 @@ import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
   AgentVersionDiff,
+  PublisherCreateRequest,
+  PublisherEligibilityResponse,
+  PublisherUpdateRequest,
   AdminListingRow,
   AdminQueueCounts,
   AdminReportRow,
@@ -193,6 +196,59 @@ export class AdminMarketplaceService {
       this.http.get<PublishersResponse>(`${this.baseUrl()}/publishers`),
     );
     return response.publishers ?? [];
+  }
+
+  /**
+   * Create a publisher profile (D12).
+   *
+   * The id is server-generated from the label, and immutable — it is what listings store,
+   * so renaming a publisher must never strand the attributions pointing at it.
+   */
+  async createPublisher(request: PublisherCreateRequest): Promise<PublisherProfile> {
+    return firstValueFrom(
+      this.http.post<PublisherProfile>(`${this.baseUrl()}/publishers`, request),
+    );
+  }
+
+  async updatePublisher(
+    publisherId: string,
+    request: PublisherUpdateRequest,
+  ): Promise<PublisherProfile> {
+    return firstValueFrom(
+      this.http.patch<PublisherProfile>(`${this.baseUrl()}/publishers/${publisherId}`, request),
+    );
+  }
+
+  /** Refused (409) while listings are attributed to it — disable instead. */
+  async deletePublisher(publisherId: string): Promise<void> {
+    await firstValueFrom(this.http.delete(`${this.baseUrl()}/publishers/${publisherId}`));
+  }
+
+  /**
+   * Who may *propose* this publisher at submission (D12).
+   *
+   * ⚠️ An allowlist for the author's submit dialog only. An admin may attribute any listing
+   * to any publisher regardless of it — that is how the store gets its day-one set of
+   * official Agents without a staff member's personal name on them. It never appears in an
+   * access check.
+   */
+  async loadPublisherEligibility(publisherId: string): Promise<string[]> {
+    const response = await firstValueFrom(
+      this.http.get<PublisherEligibilityResponse>(
+        `${this.baseUrl()}/publishers/${publisherId}/eligibility`,
+      ),
+    );
+    return response.userIds ?? [];
+  }
+
+  async savePublisherEligibility(publisherId: string, userIds: string[]): Promise<string[]> {
+    const response = await firstValueFrom(
+      this.http.put<PublisherEligibilityResponse>(
+        `${this.baseUrl()}/publishers/${publisherId}/eligibility`,
+        { userIds },
+      ),
+    );
+    return response.userIds ?? [];
   }
 
   async loadCategories(): Promise<AgentCategory[]> {


### PR DESCRIPTION
PR-6 of the agent version-snapshots epic (§6.3) — **the last phase**. Spec: #783 · #790. Independent of the open #792 and #793.

## What this is

Purely a **UI gap over a finished backend**, exactly as §6.3 predicted. Full publisher CRUD plus the eligibility allowlist has been live at `/admin/agents/publishers` since the marketplace shipped, with no way to reach it — so a profile like "Registrar" or "Communications & Marketing" could only be created by calling the API directly.

Adds the page, its route under the `admin.marketplace` scope, a Publishers nav entry, and the SPA service methods (create / update / delete / eligibility). **No backend change** — backend suite is unchanged at 5508.

## What the page has to make legible

Three rules a curator would otherwise learn by being surprised:

**⚠️ Attribution is a name, not a permission.** Publisher never grants access to anything, and `ownerName` remains who actually owns the agent and whose skills resolve when it runs. Said at the top of the page and again next to `verified` — which renders as a check mark and is far and away the field most likely to be read as a grant.

**The id is fixed at creation.** Listings store the id, so renaming a publisher would strand every attribution pointing at it. The row shows the id and says it is fixed — the same rule categories follow, surfaced the same way.

**Disable, don't delete.** Deleting is refused (409) while listings are attributed to the publisher. Disabling drops it from the submit picker while existing attributions keep rendering, which is nearly always what was actually meant.

Smaller calls: `department` is the default kind because that is what an admin adding a publisher almost always wants, and the empty state points at the auto-created individual profiles rather than leaving "No publishers yet" reading as broken.

## ⚠️ The first commit is a pre-existing bug fix

[`84a6ac73`](https://github.com/Boise-State-Development/agentcore-public-stack/commit/84a6ac73) is **not** PR-6's own work — it is separated so it can be reviewed and reverted independently.

`categories.page.ts` has had this since it shipped:

```ts
} catch (err) {
  this.error.set(this.messageFor(err, '…'));  // set the banner
  await this.reload();                        // …which clears it on entry
}
```

The visible effect: an admin deleting a category that still has listings in it got a **silent no-op**. The backend returns a 409 whose message explains the refusal and suggests disabling instead, and none of it ever reached the screen. The reasonable conclusion for the admin is that the button is broken.

Found because I built the Publishers page against the same pattern and wrote tests for the error path, which failed. Both pages are fixed, and the ordering trap is named in a comment in both — the obvious order is the wrong one, and the next copy of this pattern will reach for it.

That is the second time in this epic that testing new code surfaced a pre-existing bug in the code it was modeled on (the first being the orphaned version rows in #792).

## Testing

SPA **1693 passed across 153 files** (1691 baseline + 12 new, less the 10 that were already there for other pages). Backend **5508 passed, 3 skipped** — unchanged, as expected for an SPA-only change.

The specs cover the three rules above plus the CRUD wiring, including that a no-op rename sends nothing and that a failed mutation reloads so the list still matches the server.

## Environment note

This shell defaulted to Node **v20.18.1**, below the Angular CLI's v20.19 minimum; nvm's default here is v22.12.0. Not a repo problem, but worth knowing if it bites on another machine — `ng test` fails fast with a clear message rather than doing anything subtle.

## Epic complete

All six phases: #784 (data layer) · #787 (store) · #789 (invocation) · #791 (lifecycle) · #793 (review diff) · this. Plus #790 (spec reconciliation) and #792 (orphaned version rows).

Two §8 items remain open and neither is urgent: **version retention** for superseded versions on live Agents (#792 covers deletion only), and making the **fail-closed delisting ordering** structural with a `TransactWriteItems` instead of relying on call order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)