### PR TITLE
fix(api-keys): resolve the key owner's real roles for RBAC

### DIFF
--- a/backend/src/apis/app_api/chat/converse_routes.py
+++ b/backend/src/apis/app_api/chat/converse_routes.py
@@ -19,6 +19,11 @@ before any Bedrock invocation occurs. Requests for models the caller's
 role does not permit are rejected with HTTP 403. Only Bedrock-provider
 models are supported — non-Bedrock catalog models (e.g. provider ``mantle``)
 are rejected by Bedrock with HTTP 400.
+
+Because an API key stores no roles of its own, the caller's roles are read
+back from the Users table per request (``_build_user_from_api_key``) so this
+surface resolves the *same* grants as the cookie-session path. Any new check
+added here must take that hydrated ``User`` — never a synthesized one.
 """
 
 import json
@@ -33,6 +38,7 @@ from fastapi import APIRouter, Header, HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from apis.shared.auth.models import User
+from apis.shared.users import UserRepository
 from apis.shared import quota as shared_quota
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.costs.calculator import CostCalculator
@@ -80,13 +86,57 @@ async def _validate_api_key(api_key: str):
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _build_user_from_api_key(validated_key) -> User:
-    """Construct a minimal User from a ValidatedApiKey for quota checking."""
+_user_repository: Optional[UserRepository] = None
+
+
+def get_user_repository() -> Optional[UserRepository]:
+    """Module-level UserRepository, or None when no Users table is configured."""
+    global _user_repository
+    if _user_repository is None:
+        repo = UserRepository()
+        if repo.enabled:
+            _user_repository = repo
+    return _user_repository
+
+
+async def _build_user_from_api_key(validated_key) -> User:
+    """Resolve the key owner's real identity for quota and RBAC checks.
+
+    An API key stores only ``key_id``/``user_id``/``name`` — never roles — so
+    the caller's roles have to be read back from the Users table, the same
+    record the cookie-session path enriches from (``_enrich_user_from_store``
+    in ``apis.shared.auth.dependencies``). That record holds the IdP roles
+    parsed from the Entra ID token at BFF callback, which is exactly the
+    shape ``AppRoleService.resolve_user_permissions`` expects.
+
+    This previously passed a hardcoded ``roles=["user"]`` placeholder. No
+    AppRole maps the JWT role ``user``, so permission resolution matched
+    nothing and fell back to the ``default`` role — which grants no models —
+    and *every* api-converse request 403'd regardless of the owner's actual
+    grants.
+
+    Fails closed: a key whose owner has no profile row (deprovisioned, or
+    never synced) gets 401 rather than silently degrading to ``default``.
+    """
+    repo = get_user_repository()
+    profile = await repo.get_user(validated_key.user_id) if repo else None
+
+    if profile is None:
+        logger.warning(
+            "API key %s references user %s with no profile row; refusing request",
+            validated_key.key_id,
+            validated_key.user_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired API key",
+        )
+
     return User(
-        email=f"{validated_key.user_id}@api-key",
+        email=profile.email or f"{validated_key.user_id}@api-key",
         user_id=validated_key.user_id,
-        name=validated_key.name,
-        roles=["user"],
+        name=profile.name or validated_key.name,
+        roles=profile.roles or [],
     )
 
 async def _record_cost(
@@ -513,7 +563,7 @@ async def api_converse(
         raise HTTPException(status_code=400, detail="messages array must not be empty")
 
     # 2.5 Build User and synthetic session_id for quota / cost accounting
-    user = _build_user_from_api_key(validated_key)
+    user = await _build_user_from_api_key(validated_key)
     session_id = f"api-converse-{validated_key.key_id}"
 
     # 2.6 Quota check (fail-open: errors are logged but don't block the request)

--- a/backend/src/apis/shared/rbac/cache.py
+++ b/backend/src/apis/shared/rbac/cache.py
@@ -2,14 +2,36 @@
 
 import os
 import asyncio
+import hashlib
 import logging
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, Sequence
 from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 
 from .models import AppRole, UserEffectivePermissions
 
 logger = logging.getLogger(__name__)
+
+
+def roles_fingerprint(roles: Optional[Sequence[str]]) -> str:
+    """Stable short digest of a caller's JWT roles.
+
+    Part of the user-permissions cache key. ``resolve_user_permissions``
+    derives its result *purely* from ``user.roles``, so the cache key has to
+    cover the roles too — keying on ``user_id`` alone lets two requests that
+    carry the same subject but different roles read each other's entries.
+
+    That is not hypothetical: the API-key path and the cookie-session path
+    build a ``User`` for the *same* ``user_id``, and an API-key request whose
+    role hydration produced a different list would otherwise serve (and
+    poison) the SPA session's permissions for the whole 5-minute TTL.
+
+    Sorted before hashing because permission resolution unions across roles
+    and is therefore order-independent — ``["Staff", "OFFICE365"]`` and
+    ``["OFFICE365", "Staff"]`` must not occupy two entries.
+    """
+    normalized = "\x00".join(sorted(roles or []))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass
@@ -71,11 +93,15 @@ class AppRoleCache:
     # User Permissions Cache
     # =========================================================================
 
+    @staticmethod
+    def _user_key(user_id: str, fingerprint: str) -> str:
+        return f"user:{user_id}:{fingerprint}"
+
     async def get_user_permissions(
-        self, user_id: str
+        self, user_id: str, fingerprint: str
     ) -> Optional[UserEffectivePermissions]:
-        """Get cached user permissions."""
-        entry = self._user_cache.get(f"user:{user_id}")
+        """Get cached user permissions for this user *and* role set."""
+        entry = self._user_cache.get(self._user_key(user_id, fingerprint))
         if entry and not entry.is_expired:
             return entry.value
         return None
@@ -83,12 +109,13 @@ class AppRoleCache:
     async def set_user_permissions(
         self,
         user_id: str,
+        fingerprint: str,
         permissions: UserEffectivePermissions,
         ttl: Optional[timedelta] = None,
     ):
-        """Cache user permissions."""
+        """Cache user permissions under this user *and* role set."""
         ttl = ttl or self.DEFAULT_USER_TTL
-        self._user_cache[f"user:{user_id}"] = CacheEntry(
+        self._user_cache[self._user_key(user_id, fingerprint)] = CacheEntry(
             value=permissions, expires_at=datetime.now(timezone.utc) + ttl
         )
 
@@ -135,11 +162,15 @@ class AppRoleCache:
     # =========================================================================
 
     async def invalidate_user(self, user_id: str):
-        """Invalidate cache for a specific user."""
-        key = f"user:{user_id}"
-        if key in self._user_cache:
+        """Invalidate every cached role-set entry for a specific user."""
+        prefix = f"user:{user_id}:"
+        stale = [k for k in self._user_cache if k.startswith(prefix)]
+        for key in stale:
             del self._user_cache[key]
-            logger.debug(f"Invalidated user cache: {user_id}")
+        if stale:
+            logger.debug(
+                f"Invalidated user cache: {user_id} ({len(stale)} role-set entries)"
+            )
 
     async def invalidate_role(self, role_id: str):
         """Invalidate cache for a specific role and all affected users."""

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -8,7 +8,7 @@ from apis.shared.tools.scoped_ids import base_tool_id
 
 from .models import AppRole, UserEffectivePermissions
 from .repository import AppRoleRepository
-from .cache import AppRoleCache, get_app_role_cache
+from .cache import AppRoleCache, get_app_role_cache, roles_fingerprint
 from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
@@ -70,8 +70,11 @@ class AppRoleService:
         Returns:
             UserEffectivePermissions with merged permissions
         """
-        # Step 1: Check cache
-        cached = await self.cache.get_user_permissions(user.user_id)
+        # Step 1: Check cache. Keyed on the role set as well as the subject —
+        # two callers can share a user_id but carry different roles (see
+        # ``roles_fingerprint``), and they must not read each other's entry.
+        fingerprint = roles_fingerprint(user.roles)
+        cached = await self.cache.get_user_permissions(user.user_id, fingerprint)
         if cached:
             logger.debug(f"Cache hit for user permissions: {user.user_id}")
             return cached
@@ -111,7 +114,7 @@ class AppRoleService:
         permissions = self._merge_permissions(user.user_id, matching_roles)
 
         # Step 5: Cache and return
-        await self.cache.set_user_permissions(user.user_id, permissions)
+        await self.cache.set_user_permissions(user.user_id, fingerprint, permissions)
 
         logger.debug(
             f"Resolved permissions for {user.name}: "

--- a/backend/tests/rbac/test_app_role_cache.py
+++ b/backend/tests/rbac/test_app_role_cache.py
@@ -86,8 +86,8 @@ def cache() -> AppRoleCache:
 async def test_cache_hit_before_ttl(cache: AppRoleCache):
     """Cached user permissions are returned when TTL has not expired (Req 7.2)."""
     perms = _make_permissions("alice")
-    await cache.set_user_permissions("alice", perms, ttl=timedelta(minutes=10))
-    result = await cache.get_user_permissions("alice")
+    await cache.set_user_permissions("alice", "fp", perms, ttl=timedelta(minutes=10))
+    result = await cache.get_user_permissions("alice", "fp")
     assert result is not None
     assert result.user_id == "alice"
     assert result.tools == ["tool_1"]
@@ -119,10 +119,10 @@ async def test_jwt_mapping_cache_hit_before_ttl(cache: AppRoleCache):
 async def test_cache_miss_after_ttl(cache: AppRoleCache):
     """Expired user permissions return None (Req 7.3)."""
     perms = _make_permissions("bob")
-    await cache.set_user_permissions("bob", perms, ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("bob", "fp", perms, ttl=timedelta(minutes=10))
     # Simulate time passing beyond TTL
-    _expire_entry(cache, "user", "user:bob")
-    result = await cache.get_user_permissions("bob")
+    _expire_entry(cache, "user", "user:bob:fp")
+    result = await cache.get_user_permissions("bob", "fp")
     assert result is None
 
 
@@ -154,16 +154,16 @@ async def test_invalidate_role_clears_role_and_user_caches(cache: AppRoleCache):
     """invalidate_role removes the role entry and clears ALL user caches (Req 7.4)."""
     role = _make_role("editor")
     await cache.set_role(role, ttl=timedelta(minutes=10))
-    await cache.set_user_permissions("alice", _make_permissions("alice"), ttl=timedelta(minutes=10))
-    await cache.set_user_permissions("bob", _make_permissions("bob"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("alice", "fp", _make_permissions("alice"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("bob", "fp", _make_permissions("bob"), ttl=timedelta(minutes=10))
     # JWT mapping should NOT be affected
     await cache.set_jwt_mapping("Admin", ["admin_role"], ttl=timedelta(minutes=10))
 
     await cache.invalidate_role("editor")
 
     assert await cache.get_role("editor") is None
-    assert await cache.get_user_permissions("alice") is None
-    assert await cache.get_user_permissions("bob") is None
+    assert await cache.get_user_permissions("alice", "fp") is None
+    assert await cache.get_user_permissions("bob", "fp") is None
     # JWT mapping untouched
     assert await cache.get_jwt_mapping("Admin") == ["admin_role"]
 
@@ -176,7 +176,7 @@ async def test_invalidate_role_clears_role_and_user_caches(cache: AppRoleCache):
 async def test_invalidate_jwt_mapping_clears_mapping_and_user_caches(cache: AppRoleCache):
     """invalidate_jwt_mapping removes the mapping and clears ALL user caches (Req 7.5)."""
     await cache.set_jwt_mapping("Editor", ["editor_role"], ttl=timedelta(minutes=10))
-    await cache.set_user_permissions("alice", _make_permissions("alice"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("alice", "fp", _make_permissions("alice"), ttl=timedelta(minutes=10))
     # Role cache should NOT be affected
     role = _make_role("admin")
     await cache.set_role(role, ttl=timedelta(minutes=10))
@@ -184,7 +184,7 @@ async def test_invalidate_jwt_mapping_clears_mapping_and_user_caches(cache: AppR
     await cache.invalidate_jwt_mapping("Editor")
 
     assert await cache.get_jwt_mapping("Editor") is None
-    assert await cache.get_user_permissions("alice") is None
+    assert await cache.get_user_permissions("alice", "fp") is None
     # Role cache untouched
     assert await cache.get_role("admin") is not None
 
@@ -196,13 +196,13 @@ async def test_invalidate_jwt_mapping_clears_mapping_and_user_caches(cache: AppR
 @pytest.mark.asyncio
 async def test_invalidate_all_clears_everything(cache: AppRoleCache):
     """invalidate_all clears user, role, and JWT mapping caches (Req 7.6)."""
-    await cache.set_user_permissions("alice", _make_permissions("alice"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("alice", "fp", _make_permissions("alice"), ttl=timedelta(minutes=10))
     await cache.set_role(_make_role("editor"), ttl=timedelta(minutes=10))
     await cache.set_jwt_mapping("Admin", ["admin_role"], ttl=timedelta(minutes=10))
 
     await cache.invalidate_all()
 
-    assert await cache.get_user_permissions("alice") is None
+    assert await cache.get_user_permissions("alice", "fp") is None
     assert await cache.get_role("editor") is None
     assert await cache.get_jwt_mapping("Admin") is None
 
@@ -215,24 +215,24 @@ async def test_invalidate_all_clears_everything(cache: AppRoleCache):
 async def test_cleanup_expired_removes_only_expired(cache: AppRoleCache):
     """cleanup_expired removes expired entries but keeps valid ones (Req 7.7)."""
     # Valid entries (long TTL)
-    await cache.set_user_permissions("alice", _make_permissions("alice"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("alice", "fp", _make_permissions("alice"), ttl=timedelta(minutes=10))
     await cache.set_role(_make_role("editor"), ttl=timedelta(minutes=10))
     await cache.set_jwt_mapping("Admin", ["admin_role"], ttl=timedelta(minutes=10))
 
     # Entries that will be expired
-    await cache.set_user_permissions("expired_user", _make_permissions("expired_user"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("expired_user", "fp", _make_permissions("expired_user"), ttl=timedelta(minutes=10))
     await cache.set_role(_make_role("expired_role"), ttl=timedelta(minutes=10))
     await cache.set_jwt_mapping("ExpiredMapping", ["x"], ttl=timedelta(minutes=10))
 
     # Force-expire only the second batch
-    _expire_entry(cache, "user", "user:expired_user")
+    _expire_entry(cache, "user", "user:expired_user:fp")
     _expire_entry(cache, "role", "role:expired_role")
     _expire_entry(cache, "jwt_mapping", "jwt:ExpiredMapping")
 
     await cache.cleanup_expired()
 
     # Valid entries still present
-    assert await cache.get_user_permissions("alice") is not None
+    assert await cache.get_user_permissions("alice", "fp") is not None
     assert await cache.get_role("editor") is not None
     assert await cache.get_jwt_mapping("Admin") == ["admin_role"]
 
@@ -251,9 +251,9 @@ async def test_cleanup_expired_removes_only_expired(cache: AppRoleCache):
 async def test_get_stats_accuracy(cache: AppRoleCache):
     """get_stats returns accurate total and expired counts per layer (Req 7.8)."""
     # Add 2 user entries: 1 valid, 1 will be expired
-    await cache.set_user_permissions("alice", _make_permissions("alice"), ttl=timedelta(minutes=10))
-    await cache.set_user_permissions("bob", _make_permissions("bob"), ttl=timedelta(minutes=10))
-    _expire_entry(cache, "user", "user:bob")
+    await cache.set_user_permissions("alice", "fp", _make_permissions("alice"), ttl=timedelta(minutes=10))
+    await cache.set_user_permissions("bob", "fp", _make_permissions("bob"), ttl=timedelta(minutes=10))
+    _expire_entry(cache, "user", "user:bob:fp")
 
     # Add 2 role entries: 1 valid, 1 will be expired
     await cache.set_role(_make_role("editor"), ttl=timedelta(minutes=10))

--- a/backend/tests/routes/conftest.py
+++ b/backend/tests/routes/conftest.py
@@ -53,6 +53,42 @@ def _stub_ensure_session_metadata_exists(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Auto-stub the api-converse profile lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def stub_api_key_user_profile(monkeypatch):
+    """Give /chat/api-converse a Users-table profile to hydrate roles from.
+
+    The handler reads the key owner's real roles per request and fails closed
+    when no profile row exists (an API key stores no roles of its own). Route
+    tests that only patch ``_validate_api_key`` would otherwise all 401.
+
+    Tests exercising hydration itself — the fail-closed path, or which roles
+    reach RBAC — should re-patch ``converse_routes.get_user_repository``
+    directly rather than rely on this default.
+    """
+    from apis.shared.users import UserProfile
+
+    profile = UserProfile(
+        userId="user-001",
+        email="test@example.com",
+        name="Test User",
+        roles=["Staff"],
+        emailDomain="example.com",
+        createdAt="2026-01-01T00:00:00Z",
+        lastLoginAt="2026-01-01T00:00:00Z",
+    )
+    repo = AsyncMock()
+    repo.get_user = AsyncMock(return_value=profile)
+    monkeypatch.setattr(
+        "apis.app_api.chat.converse_routes.get_user_repository",
+        lambda: repo,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Requirement 1.3: User factory fixture
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/routes/test_api_converse_role_hydration.py
+++ b/backend/tests/routes/test_api_converse_role_hydration.py
@@ -1,0 +1,177 @@
+"""Regression tests: /chat/api-converse resolves the key owner's REAL roles.
+
+An API key record stores only ``key_id``/``user_id``/``name`` — never roles.
+The handler previously synthesized ``roles=["user"]``, a JWT role no AppRole
+maps, so permission resolution matched nothing, fell back to the ``default``
+role (which grants no models in prod), and every request 403'd regardless of
+the owner's actual grants.
+
+These tests pin the contract: the roles handed to RBAC come from the Users
+table row, and a key with no profile row is refused rather than silently
+degraded to ``default``.
+"""
+
+import os
+
+os.environ.setdefault("AWS_REGION", "us-east-1")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.users import UserProfile
+
+
+def _make_validated_key():
+    key = MagicMock()
+    key.user_id = "user-001"
+    key.key_id = "key-001"
+    key.name = "Model Traning"
+    return key
+
+
+def _make_profile(roles):
+    return UserProfile(
+        userId="user-001",
+        email="ravitejaseera@example.edu",
+        name="Ravi Teja Seera",
+        roles=roles,
+        emailDomain="example.edu",
+        createdAt="2026-01-01T00:00:00Z",
+        lastLoginAt="2026-01-01T00:00:00Z",
+    )
+
+
+def _make_repo(profile):
+    repo = AsyncMock()
+    repo.get_user = AsyncMock(return_value=profile)
+    return repo
+
+
+def _make_app_role_service(can_access=True):
+    svc = MagicMock()
+    svc.can_access_model = AsyncMock(return_value=can_access)
+    return svc
+
+
+def _post(app_role_svc, repo):
+    """Drive one api-converse request, returning (response, patched svc)."""
+    from apis.app_api.chat.converse_routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    limiter = MagicMock()
+    limiter.check_rate_limit = AsyncMock(return_value=True)
+
+    bedrock = MagicMock()
+    bedrock.converse.return_value = {
+        "output": {"message": {"content": [{"text": "ok"}]}},
+        "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+        "stopReason": "end_turn",
+    }
+
+    with patch(
+        "apis.app_api.chat.converse_routes._validate_api_key",
+        new_callable=AsyncMock,
+        return_value=_make_validated_key(),
+    ), patch(
+        "apis.app_api.chat.converse_routes.get_user_repository",
+        return_value=repo,
+    ), patch(
+        "apis.app_api.chat.converse_routes.get_app_role_service",
+        return_value=app_role_svc,
+    ), patch(
+        "apis.app_api.chat.converse_routes._get_bedrock_client",
+        return_value=bedrock,
+    ), patch(
+        "apis.app_api.chat.converse_routes._record_cost",
+        new_callable=AsyncMock,
+    ), patch(
+        "apis.shared.rate_limit.get_rate_limiter",
+        return_value=limiter,
+    ), patch(
+        "apis.shared.quota.is_quota_enforcement_enabled",
+        return_value=False,
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        return client.post(
+            "/chat/api-converse",
+            headers={"X-API-Key": "test-api-key-123"},
+            json={
+                "model_id": "global.anthropic.claude-sonnet-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+
+class TestRolesComeFromTheUsersTable:
+    def test_stored_roles_are_passed_to_rbac(self):
+        """The User handed to can_access_model carries the stored IdP roles."""
+        svc = _make_app_role_service(can_access=True)
+        repo = _make_repo(_make_profile(["Staff", "OFFICE365"]))
+
+        resp = _post(svc, repo)
+
+        assert resp.status_code == 200
+        svc.can_access_model.assert_awaited_once()
+        user_arg = svc.can_access_model.await_args.args[0]
+        assert user_arg.roles == ["Staff", "OFFICE365"]
+
+    def test_placeholder_role_is_never_synthesized(self):
+        """Guards the exact regression: roles=["user"] reaching RBAC."""
+        svc = _make_app_role_service(can_access=True)
+        repo = _make_repo(_make_profile(["Staff"]))
+
+        _post(svc, repo)
+
+        user_arg = svc.can_access_model.await_args.args[0]
+        assert "user" not in user_arg.roles
+
+    def test_profile_identity_replaces_synthetic_email(self):
+        """Email/name come from the profile, not f"{user_id}@api-key"."""
+        svc = _make_app_role_service(can_access=True)
+        repo = _make_repo(_make_profile(["Staff"]))
+
+        _post(svc, repo)
+
+        user_arg = svc.can_access_model.await_args.args[0]
+        assert user_arg.email == "ravitejaseera@example.edu"
+        assert user_arg.name == "Ravi Teja Seera"
+        assert user_arg.user_id == "user-001"
+
+    def test_repo_is_queried_by_the_keys_user_id(self):
+        svc = _make_app_role_service(can_access=True)
+        repo = _make_repo(_make_profile(["Staff"]))
+
+        _post(svc, repo)
+
+        repo.get_user.assert_awaited_once_with("user-001")
+
+
+class TestFailsClosed:
+    def test_missing_profile_returns_401_not_default_role(self):
+        """A key whose owner has no profile row is refused outright.
+
+        Falling through to ``default`` would be the old bug in reverse:
+        a silent, wrong-permissions request instead of a clear failure.
+        """
+        svc = _make_app_role_service(can_access=True)
+        repo = _make_repo(None)
+
+        resp = _post(svc, repo)
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid or expired API key"
+        svc.can_access_model.assert_not_called()
+
+    def test_unconfigured_repository_returns_401(self):
+        """No Users table configured → refuse, don't degrade."""
+        svc = _make_app_role_service(can_access=True)
+
+        resp = _post(svc, None)
+
+        assert resp.status_code == 401
+        svc.can_access_model.assert_not_called()

--- a/backend/tests/shared/test_rbac_cache_service.py
+++ b/backend/tests/shared/test_rbac_cache_service.py
@@ -14,18 +14,18 @@ class TestAppRoleCache:
     @pytest.mark.asyncio
     async def test_user_permissions_set_get(self):
         perms = MagicMock()
-        await self.cache.set_user_permissions("u1", perms)
-        assert await self.cache.get_user_permissions("u1") is perms
+        await self.cache.set_user_permissions("u1", "fp", perms)
+        assert await self.cache.get_user_permissions("u1", "fp") is perms
 
     @pytest.mark.asyncio
     async def test_user_permissions_miss(self):
-        assert await self.cache.get_user_permissions("nope") is None
+        assert await self.cache.get_user_permissions("nope", "fp") is None
 
     @pytest.mark.asyncio
     async def test_user_permissions_expired(self):
         perms = MagicMock()
-        await self.cache.set_user_permissions("u1", perms, ttl=timedelta(seconds=-1))
-        assert await self.cache.get_user_permissions("u1") is None
+        await self.cache.set_user_permissions("u1", "fp", perms, ttl=timedelta(seconds=-1))
+        assert await self.cache.get_user_permissions("u1", "fp") is None
 
     @pytest.mark.asyncio
     async def test_role_set_get(self):
@@ -62,9 +62,9 @@ class TestAppRoleCache:
     @pytest.mark.asyncio
     async def test_invalidate_user(self):
         perms = MagicMock()
-        await self.cache.set_user_permissions("u1", perms)
+        await self.cache.set_user_permissions("u1", "fp", perms)
         await self.cache.invalidate_user("u1")
-        assert await self.cache.get_user_permissions("u1") is None
+        assert await self.cache.get_user_permissions("u1", "fp") is None
 
     @pytest.mark.asyncio
     async def test_invalidate_user_nonexistent(self):
@@ -75,28 +75,28 @@ class TestAppRoleCache:
         role = MagicMock(); role.role_id = "admin"
         perms = MagicMock()
         await self.cache.set_role(role)
-        await self.cache.set_user_permissions("u1", perms)
+        await self.cache.set_user_permissions("u1", "fp", perms)
         await self.cache.invalidate_role("admin")
         assert await self.cache.get_role("admin") is None
-        assert await self.cache.get_user_permissions("u1") is None  # user cache cleared
+        assert await self.cache.get_user_permissions("u1", "fp") is None  # user cache cleared
 
     @pytest.mark.asyncio
     async def test_invalidate_jwt_mapping(self):
         await self.cache.set_jwt_mapping("viewer", ["r1"])
         perms = MagicMock()
-        await self.cache.set_user_permissions("u1", perms)
+        await self.cache.set_user_permissions("u1", "fp", perms)
         await self.cache.invalidate_jwt_mapping("viewer")
         assert await self.cache.get_jwt_mapping("viewer") is None
-        assert await self.cache.get_user_permissions("u1") is None
+        assert await self.cache.get_user_permissions("u1", "fp") is None
 
     @pytest.mark.asyncio
     async def test_invalidate_all(self):
         role = MagicMock(); role.role_id = "admin"
-        await self.cache.set_user_permissions("u1", MagicMock())
+        await self.cache.set_user_permissions("u1", "fp", MagicMock())
         await self.cache.set_role(role)
         await self.cache.set_jwt_mapping("v", ["r1"])
         await self.cache.invalidate_all()
-        assert await self.cache.get_user_permissions("u1") is None
+        assert await self.cache.get_user_permissions("u1", "fp") is None
         assert await self.cache.get_role("admin") is None
         assert await self.cache.get_jwt_mapping("v") is None
 
@@ -110,7 +110,7 @@ class TestAppRoleCache:
         role = MagicMock(); role.role_id = "old"
         await self.cache.set_role(role, ttl=timedelta(seconds=-1))
         await self.cache.set_jwt_mapping("old", ["r1"], ttl=timedelta(seconds=-1))
-        await self.cache.set_user_permissions("old", MagicMock(), ttl=timedelta(seconds=-1))
+        await self.cache.set_user_permissions("old", "fp", MagicMock(), ttl=timedelta(seconds=-1))
         await self.cache.cleanup_expired()
         assert self.cache.get_stats()["roleCacheSize"] == 0
         assert self.cache.get_stats()["jwtMappingCacheSize"] == 0
@@ -170,10 +170,42 @@ class TestAppRoleService:
             user_id="u1", app_roles=["r1"], tools=["*"], models=["*"],
             resolved_at="now", quota_tier=None,
         )
-        await self.cache.set_user_permissions("u1", perms)
-        result = await self.svc.resolve_user_permissions(self._make_user())
+        from apis.shared.rbac.cache import roles_fingerprint
+        user = self._make_user()
+        # Seed under the same role-set key the service will compute.
+        await self.cache.set_user_permissions(
+            "u1", roles_fingerprint(user.roles), perms
+        )
+        result = await self.svc.resolve_user_permissions(user)
         assert result is perms
         self.repo.get_roles_for_jwt_role.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolve_user_permissions_not_shared_across_role_sets(self):
+        """Same user_id, different roles → no cache crossover.
+
+        Regression guard for the API-key path, which builds a User for the
+        same subject as the cookie session; a shared key let one poison the
+        other's grants for the whole TTL.
+        """
+        from apis.shared.rbac.cache import roles_fingerprint
+        from apis.shared.rbac.models import UserEffectivePermissions
+        stale = UserEffectivePermissions(
+            user_id="u1", app_roles=["default"], tools=[], models=[],
+            resolved_at="now", quota_tier=None,
+        )
+        placeholder = self._make_user(roles=["user"])
+        await self.cache.set_user_permissions(
+            "u1", roles_fingerprint(placeholder.roles), stale
+        )
+
+        self.repo.get_roles_for_jwt_role.return_value = ["r1"]
+        self.repo.get_role.return_value = self._make_role()
+        real = self._make_user(roles=["Staff"])
+        result = await self.svc.resolve_user_permissions(real)
+
+        assert result is not stale
+        assert "*" in result.models
 
     @pytest.mark.asyncio
     async def test_resolve_user_permissions_from_db(self):


### PR DESCRIPTION
## Problem

A Staff user reported that every model was inaccessible via their API key, despite the web UI working fine for the same account.

`/chat/api-converse` built its `User` with a hardcoded placeholder:

```python
roles=["user"],   # converse_routes.py:89
```

No AppRole maps the JWT role `user`, so `resolve_user_permissions` matched nothing, fell back to the `default` role — which has `grantedModels: []` in prod — and **every** api-converse request 403'd with `Access denied to model: <id>`, regardless of the caller's actual grants.

The docstring said "for quota checking", which is probably the original scope; the RBAC check at `converse_routes.py:547` was added later against the same synthetic object.

Verified against prod for the reporting user — the data was never the problem:

| Check | Value |
|---|---|
| `users` record roles | `["Staff", "OFFICE365", "VPN-General Entra Sync"]` ✅ |
| `ROLE#staff.jwtRoleMappings` | `["Staff"]` ✅ |
| `ROLE#staff.grantedModels` | all 5 managed models ✅ |
| `ROLE#default.grantedModels` | `[]` ← what they were evaluated against |

## Fix

`_build_user_from_api_key` is now async and reads the owner's profile from the Users table — the same record the cookie-session path enriches from (`_enrich_user_from_store`), holding the IdP roles parsed from the Entra ID token at BFF callback. Email and name come from the profile too, so quota tier and cost attribution stop being charged against a synthetic `{user_id}@api-key` identity.

**Fails closed**: a key whose owner has no profile row gets 401 rather than silently degrading to `default`. Prod app-api already has `DYNAMODB_USERS_TABLE_NAME` set and `dynamodb:GetItem` on that table, so this path won't fire spuriously — no infra change, `backend.yml` alone deploys it.

## Second bug: cross-path cache collision

`resolve_user_permissions` derives its result purely from `user.roles` but cached under `user:{user_id}` alone. The API-key and cookie paths build a `User` for the **same subject with different roles**, so they shared one entry — whichever resolved first served the other for the whole 5-minute TTL.

That made the original bug intermittent (an API-key request landing on a task that had just served the SPA would succeed), and in the other direction let an API-key request strip a live SPA session's models, tools, and quota tier.

The key is now `user:{user_id}:{roles_fingerprint}` — roles sorted before hashing, since resolution unions across roles and is order-independent. `invalidate_user` prefix-deletes every role-set entry.

## Tests

- New `test_api_converse_role_hydration.py` — 6 tests: stored roles reach RBAC, `"user"` is never synthesized, profile identity replaces the synthetic email, and both fail-closed paths.
- New `test_resolve_user_permissions_not_shared_across_role_sets` guarding the cache crossover.
- Autouse fixture in `tests/routes/conftest.py` supplying a default profile — 21 existing api-converse tests only patched `_validate_api_key`.
- Updated cache-level tests for the new signature.

Full backend suite: **5,560 passed, 3 skipped, 0 failures.**

## Deliberately out of scope

- **No deprovisioning check.** `UserStatus.INACTIVE`/`SUSPENDED` are write-only enum members — nothing in the codebase ever sets them, and 0 of 826 prod users are non-active. A status gate here would be a no-op that *looks* like an offboarding control. The real gap (an API key is a bearer credential that outlives account disablement) is filed separately.
- **The two `can_access_model` implementations still diverge.** The API-key path uses `rbac/service.py`'s, which ignores legacy `availableToRoles` and `model.enabled`. Inert today — all 5 prod models are enabled with empty `availableToRoles` — so converging it is tech debt, not a live bug. Filed separately rather than folded into a security fix that should stay easy to review and revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)