### PR TITLE
fix(marketplace): close four version-snapshot gaps found in E2E testing

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -76,6 +76,7 @@ from apis.shared.assistants.publishers import (
     get_publisher,
     list_eligibility,
     list_publishers,
+    publisher_in_use,
     put_publisher,
     set_eligibility,
 )
@@ -588,15 +589,32 @@ async def update_publisher_profile(
 async def delete_publisher_profile(
     publisher_id: str, admin: User = Depends(require_marketplace_admin)
 ):
-    """Delete a publisher profile and its eligibility items.
+    """Delete a publisher profile, but only while nothing is attributed to it.
 
-    Listings already attributed to it keep the id; the admin Listings table renders them
-    without a resolved publisher so the gap is visible and can be reassigned. Deleting an
-    attribution must never change who can run an Agent (D12).
+    Same rule and same wording as categories: a referenced profile cannot be deleted,
+    because listings store the *id* and would be left pointing at nothing. The admin
+    Listings table renders those as "Unattributed", and there is no surface for putting the
+    attribution back — so the delete is not a visible gap to repair, it is silent data loss
+    across every listing that named it, live ones included.
+
+    Disable instead. That drops it from the submit picker while existing attributions keep
+    rendering, which is nearly always what was meant.
+
+    Deleting an attribution never changes who can run an Agent — publisher is display only
+    (D12). This guard is about not stranding the display, not about access.
     """
     try:
         if not await get_publisher(publisher_id):
             raise HTTPException(status_code=404, detail=f"Publisher not found: {publisher_id}")
+        if await publisher_in_use(publisher_id):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Listings are still attributed to this publisher. Disable it instead — "
+                    "that removes it from the submit picker while the listings already "
+                    "credited to it keep rendering."
+                ),
+            )
         await delete_publisher(publisher_id)
     except HTTPException:
         raise

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -60,6 +60,10 @@ from apis.shared.assistants.models import (
     UpdateAssistantRequest,
     UpdateSharePermissionRequest,
 )
+from apis.shared.assistants.version_resolution import (
+    AgentVersionUnavailableError,
+    resolve_display_agent,
+)
 from apis.shared.assistants.service import (
     assistant_exists,
     create_assistant,
@@ -358,11 +362,16 @@ async def list_bindable_endpoint(
 async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require_agents_enabled)):
     """Retrieve an Agent by id with visibility-based access control.
 
-    This is the marketplace **detail read** (Phase 3). Two things beyond Phase 1:
+    This is the marketplace **detail read** (Phase 3). Three things beyond Phase 1:
 
     * ``instructions`` is gated to owner/editor — see ``INSTRUCTIONS_PERMISSIONS``.
     * ``capabilities`` + ``modelLabel`` are resolved, so the detail page can say what the
       Agent reaches by *name* rather than making the SPA dereference binding refs.
+    * A published Agent is served from its **approved snapshot** to everyone who cannot edit
+      it (§4). This is the page a store user reads before deciding to open something, so it
+      has to describe the configuration that will actually run — otherwise the author's
+      unreviewed draft supplies the name, the summary and, through ``bindings``, the
+      capability list, while invocation quietly runs the approved version instead.
 
     Capability resolution is best-effort: it is presentation, and a catalog hiccup should
     not turn a readable Agent into a 500. The list route does not resolve them at all.
@@ -375,6 +384,24 @@ async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require
         )
         if not assistant:
             raise HTTPException(status_code=403, detail="Access denied: you do not have permission to access this agent")
+
+        # Snapshot before anything reads ``assistant``, so ``capabilities`` and the listing
+        # display below resolve against the same configuration the response describes.
+        # ``can_edit`` is the instructions gate: whoever may edit the draft must be shown the
+        # draft, because this endpoint is also what loads the Agent Designer's form.
+        try:
+            assistant, _ = await resolve_display_agent(
+                assistant, can_edit=permission in INSTRUCTIONS_PERMISSIONS
+            )
+        except AgentVersionUnavailableError as unavailable:
+            logger.error(f"Published version unavailable for detail read: {unavailable}")
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "This agent's published version could not be loaded. Please try again, "
+                    "or contact an administrator if it persists."
+                ),
+            ) from unavailable
 
         response = _agent_response(assistant, permission=permission)
         try:

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -458,6 +458,16 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
         raise ListingError("This agent has no marketplace listing.", status_code=404)
 
     # A live listing can only be *requested* down; anything else goes straight to private.
+    #
+    # ⚠️ Known gap, left deliberately rather than patched here: a listing that was published
+    # and then sent back for changes is still serving (``review_listing`` does not
+    # unpublish), but its state is ``changes_requested``, so this reads it as not-live and
+    # the author goes straight to ``private`` — pulling something users can currently see
+    # without an admin deciding. Closing it needs a product call, not a predicate swap: the
+    # transition table cannot allow ``changes_requested → withdrawal_requested`` without
+    # also opening a route to ``published`` for a listing that was never approved (see
+    # ``ALLOWED_TRANSITIONS``), and it is unclear what declining such a request should
+    # restore the listing to.
     target = "withdrawal_requested" if is_listed(assistant.listing.state) else "private"
 
     try:
@@ -1012,6 +1022,12 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         state=listing.state,
         usage_count=assistant.usage_count,
         submitted_at=listing.submitted_at,
+        # Only while one is actually pending: the stamp survives the decision on the stored
+        # listing, and a resolved request rendering as "withdrawal requested 3 days ago"
+        # would put a decided listing back in front of an admin as if it still needed one.
+        withdrawal_requested_at=(
+            listing.withdrawal_requested_at if listing.state == "withdrawal_requested" else None
+        ),
         reviewed_at=listing.reviewed_at,
         review_note=listing.review_note,
         updated_at=assistant.updated_at,

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 
 from apis.shared.assistants.categories import ensure_seeded, list_categories
 from apis.shared.assistants.icons import icon_url
-from apis.shared.assistants.listing import is_listed
+from apis.shared.assistants.listing import is_on_shelf
 from apis.shared.assistants.listing_repository import batch_get_agents, query_store
 from apis.shared.assistants.models import (
     AgentCategory,
@@ -182,7 +182,11 @@ async def resolve_featured(
             unavailable.append(agent_id)
             continue
         listing = assistant.listing
-        if not listing or not is_listed(listing.state) or listing.published_version is None:
+        # ``is_on_shelf``, not ``is_listed``: the featured row must agree with browse about
+        # what is in the store. A published listing an admin sent back for changes keeps
+        # serving, and asking by state alone would drop it from the featured row while the
+        # category shelf still carried it — the same Agent present and absent on one page.
+        if not listing or not is_on_shelf(listing.state, listing.published_version):
             unavailable.append(agent_id)
             continue
         published.append((agent_id, listing.published_version))

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -87,6 +87,15 @@ LISTING_STATES: Tuple[str, ...] = (
 # Withdrawal is now a request an admin acts on (see §5.1 of the version-snapshots spec).
 # The edges an author still owns alone are the pre-publication ones: ``private → in_review``
 # and withdrawing a *pending* submission (``in_review``/``changes_requested`` → ``private``).
+#
+# ⚠️ ``changes_requested`` covers two different listings — one that was never published, and
+# one that *was* and is still serving while the author revises it (``review_listing`` does
+# not unpublish). Only the first should be able to walk ``→ private`` alone, but this table
+# cannot tell them apart, and adding ``changes_requested → withdrawal_requested`` to fix it
+# would open ``in_review → changes_requested → withdrawal_requested → published`` — a route
+# to ``published`` for something never approved, which is the one property
+# ``test_approval_is_the_only_door_into_the_store`` exists to hold. Left alone deliberately;
+# see the note on ``is_on_shelf``.
 ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     None: {"in_review"},
     "private": {"in_review"},
@@ -203,11 +212,46 @@ def is_published(state: Optional[str]) -> bool:
 def is_listed(state: Optional[str]) -> bool:
     """Whether a listing state means "live in the store" (see ``LISTED_STATES``).
 
-    This is the predicate almost everything wants: the store index, the featured row, and
-    "does an admin edit need to cut a new version". It is true for ``withdrawal_requested``
-    as well as ``published``, because a requested withdrawal is not a granted one.
+    True for ``withdrawal_requested`` as well as ``published``, because a requested
+    withdrawal is not a granted one.
+
+    ⚠️ **State-only, and therefore incomplete for "is this on the shelf right now?"** — use
+    ``is_on_shelf`` for that. ``changes_requested`` is not in ``LISTED_STATES``, but a
+    *published* listing that an admin sends back for changes deliberately keeps serving its
+    approved version (``review_listing`` does not unpublish; a takedown is the operation
+    that pulls something down). Such a listing is in ``changes_requested`` **and** in the
+    store, so this predicate answers ``False`` about an Agent users can still see.
+
+    Kept as-is rather than widened because two callers genuinely want the state alone:
+    ``gsi5_keys``, which derives the index key at the moment of promotion, and the D13
+    "does an admin edit need a new version" test.
     """
     return state in LISTED_STATES
+
+
+def is_on_shelf(state: Optional[str], published_version: Optional[int]) -> bool:
+    """Whether this listing is in the store *right now* — the fact, not the state name.
+
+    ``published_version`` is the record of which snapshot carries the sparse index key, and
+    every path that takes an Agent off the shelf clears it in the same breath as the key
+    (``takedown_listing``, a granted withdrawal, a pre-publication withdraw). So the pointer
+    being set is the same statement as "a version of this is queryable in the store" — which
+    is the physics ``version_repository.set_version_index`` describes, asked as a question.
+
+    Prefer this over ``is_listed`` anywhere the answer changes what a *user* can do. The
+    case that forced it: an admin requesting changes on a live listing leaves it serving,
+    but moves it to ``changes_requested``. Asked by state alone, ``withdraw_listing`` then
+    reads that listing as not-live and sends the author straight to ``private`` — pulling a
+    listing users can currently see, with no admin ever deciding. That is exactly the
+    unilateral delisting ``withdrawal_requested`` exists to prevent, reached through the one
+    state nobody thought to check.
+
+    ``state`` is still consulted so a cleared-but-stale pointer cannot resurrect something:
+    ``private`` and ``taken_down`` are never on the shelf whatever the pointer says.
+    """
+    if state in ("private", "taken_down", None):
+        return False
+    return published_version is not None
 
 
 def gsi5_keys(state: Optional[str], category: Optional[str], created_at: str) -> Optional[Dict[str, str]]:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -928,6 +928,16 @@ class AdminListingRow(BaseModel):
     state: ListingState = Field(..., description="Publication state")
     usage_count: int = Field(0, alias="usageCount", description="Chats — admin reporting only, never shelf furniture (D4)")
     submitted_at: Optional[str] = Field(None, alias="submittedAt", description="ISO 8601 submission timestamp")
+    withdrawal_requested_at: Optional[str] = Field(
+        None,
+        alias="withdrawalRequestedAt",
+        description=(
+            "ISO 8601 timestamp of a pending withdrawal request. The queue shows submissions "
+            "and withdrawal requests together (§5.1), and without this the two are "
+            "indistinguishable: a request would read as 'submitted <the original date>' and "
+            "an admin would answer the wrong question about it."
+        ),
+    )
     reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
     review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 of the last write to the Agent record")

--- a/backend/src/apis/shared/assistants/publishers.py
+++ b/backend/src/apis/shared/assistants/publishers.py
@@ -99,8 +99,32 @@ async def put_publisher(profile: PublisherProfile) -> PublisherProfile:
     return profile
 
 
+async def publisher_in_use(publisher_id: str) -> bool:
+    """Whether any agent's listing is still attributed to this publisher.
+
+    Guards delete, mirroring ``categories.category_in_use`` — same shape, same reason, and
+    a scan is right here for the same reason it is there: a human clicking a button, and
+    the alternative is a stranded reference nothing can render.
+
+    Listings store the publisher *id*, so deleting a profile that is still referenced does
+    not fail loudly — it silently unattributes every listing pointing at it, including live
+    published ones, which then render as "Unattributed" with no admin surface to repair
+    them. Disabling is the operation that was almost always meant.
+    """
+    from .listing_repository import list_by_state
+
+    return any(
+        (item.get("listing") or {}).get("publisherId") == publisher_id
+        for item in await list_by_state()
+    )
+
+
 async def delete_publisher(publisher_id: str) -> None:
-    """Delete a publisher profile and every eligibility item pointing at it."""
+    """Delete a publisher profile and every eligibility item pointing at it.
+
+    Callers must check ``publisher_in_use`` first; this does not re-check, so that the
+    refusal reads as one HTTP concern in the route rather than an exception type here.
+    """
     table = _table()
     table.delete_item(Key={"PK": _PARTITION, "SK": f"PUB#{publisher_id}"})
     for user_id in await list_eligibility(publisher_id):

--- a/backend/src/apis/shared/assistants/version_resolution.py
+++ b/backend/src/apis/shared/assistants/version_resolution.py
@@ -1,4 +1,4 @@
-"""Which Agent configuration a caller actually runs (version-snapshots §4).
+"""Which Agent configuration a caller actually runs, and which one they are shown (§4).
 
 One question, one answer, one place. ``resolve_invocation_agent`` takes the live Agent
 record an access check has already admitted, and returns the ``Assistant`` this caller
@@ -9,6 +9,11 @@ should run:
 | Anyone who pinned it or opened it from the store | The published snapshot |
 | The **owner**                                 | Their own draft          |
 | Anyone, when nothing is published              | The live record          |
+
+``resolve_display_agent`` answers the same question for the marketplace **detail read**,
+and differs on exactly one row: editors see the draft too. The two are kept side by side
+here rather than merged, because the reason they differ is easy to lose and expensive to
+get wrong in either direction — see that function's docstring.
 
 This is deliberately *not* in ``versions.py`` (pure, no I/O) or in
 ``version_repository.py`` (persistence). Deciding which version a person runs is policy,
@@ -76,8 +81,13 @@ async def resolve_invocation_agent(
     """Return ``(assistant_to_run, version_number)`` for this caller.
 
     ``version_number`` is ``None`` when the live record is what runs — either because the
-    caller owns it, or because nothing is published. Callers thread it into the agent cache
-    key so a promotion cannot be served from a warm agent (§4.2).
+    caller owns it, or because nothing is published. It is returned for logging and for the
+    SPA to label what ran; it is deliberately **not** threaded into the agent cache key. The
+    key is built from construction *values*, all of which a version already changes, so the
+    number buys no discrimination — and adding it breaks resume, because the paused-turn
+    snapshot does not carry it. ``chat/routes.py`` carries the full reasoning at the
+    ``resolved_version`` declaration; §4.2 of the spec records why the original design note
+    saying the opposite was reverted.
 
     Raises ``AgentVersionUnavailableError`` if a published version is named but missing.
     """
@@ -102,4 +112,46 @@ async def resolve_invocation_agent(
         raise AgentVersionUnavailableError(assistant.assistant_id, published)
 
     logger.info(f"📌 Agent {assistant.assistant_id} running published version {published}")
+    return apply_version(assistant, version), published
+
+
+async def resolve_display_agent(
+    assistant: Assistant, *, can_edit: bool
+) -> Tuple[Assistant, Optional[int]]:
+    """Return ``(assistant_to_show, version_number)`` for the marketplace **detail read**.
+
+    The same question ``resolve_invocation_agent`` answers, for the page rather than the
+    turn — and it has to be answered, because the detail read is where a store user decides
+    whether to open an Agent. Serving the author's draft there means the page describes an
+    unreviewed configuration while invocation runs the approved one: a different name, a
+    different summary, and — since ``capabilities`` is resolved from ``bindings`` — a list
+    of tools the published Agent does not actually have.
+
+    **One row differs from invocation, deliberately: editors see the draft.** For a turn the
+    line is owner-only, because an editor *running* the unpublished result would turn a
+    share grant into a way around review. For a read the opposite is required — the Agent
+    Designer loads this same endpoint, so handing an editor the published snapshot would
+    populate the edit form with the approved copy and their next save would silently revert
+    the owner's draft. ``can_edit`` is therefore the ``INSTRUCTIONS_PERMISSIONS`` set the
+    route already computes: the people trusted with the system prompt are exactly the people
+    who must see the draft.
+
+    Passed as a bool rather than the permission string so this module keeps knowing nothing
+    about the route's vocabulary.
+
+    Raises ``AgentVersionUnavailableError`` if a published version is named but missing —
+    the same refusal as invocation, for the same reason. Such an Agent has no store tile
+    either (the index is sparse on the version row), so this is only reachable by direct
+    link, and answering it with unreviewed content is the one thing worth avoiding.
+    """
+    listing = assistant.listing
+    published = listing.published_version if listing else None
+
+    if published is None or can_edit:
+        return assistant, None
+
+    version = await get_version(assistant.assistant_id, published)
+    if version is None:
+        raise AgentVersionUnavailableError(assistant.assistant_id, published)
+
     return apply_version(assistant, version), published

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -888,3 +888,89 @@ class TestReviewDiff:
         with _loaded(_make_assistant(listing=None)):
             resp = TestClient(app).get("/admin/agents/ast-001/diff")
         assert resp.status_code == 404
+
+
+class TestPublisherDeleteIsGuarded:
+    """Delete is refused while listings still name the publisher.
+
+    The page told admins this rule long before it existed: ``publishers.page.ts`` documents
+    "deleting is refused (409) while listings are attributed", and its error handling was
+    already written to pass the server's message straight through. Nothing enforced it, so
+    deleting an in-use profile silently unattributed every listing that named it — including
+    published ones, which then render as "Unattributed" with no surface for putting the
+    credit back. The id is fixed at creation, so it is not recoverable by recreating it.
+    """
+
+    def test_delete_is_refused_while_a_listing_is_attributed(self, app):
+        with patch(
+            f"{ADMIN_MODULE}.get_publisher",
+            new_callable=AsyncMock,
+            return_value=PublisherProfile.model_validate(
+                {"id": "pub-registrar", "label": "Registrar", "kind": "department"}
+            ),
+        ), patch(
+            f"{ADMIN_MODULE}.publisher_in_use", new_callable=AsyncMock, return_value=True
+        ), patch(
+            f"{ADMIN_MODULE}.delete_publisher", new_callable=AsyncMock
+        ) as delete:
+            resp = TestClient(app).delete("/admin/agents/publishers/pub-registrar")
+
+        assert resp.status_code == 409
+        # Names the alternative rather than only refusing — disabling is what was meant.
+        assert "Disable it instead" in resp.json()["detail"]
+        delete.assert_not_awaited()
+
+    def test_delete_proceeds_when_nothing_is_attributed(self, app):
+        with patch(
+            f"{ADMIN_MODULE}.get_publisher",
+            new_callable=AsyncMock,
+            return_value=PublisherProfile.model_validate(
+                {"id": "pub-registrar", "label": "Registrar", "kind": "department"}
+            ),
+        ), patch(
+            f"{ADMIN_MODULE}.publisher_in_use", new_callable=AsyncMock, return_value=False
+        ), patch(
+            f"{ADMIN_MODULE}.delete_publisher", new_callable=AsyncMock
+        ) as delete:
+            resp = TestClient(app).delete("/admin/agents/publishers/pub-registrar")
+
+        assert resp.status_code == 204
+        delete.assert_awaited_once_with("pub-registrar")
+
+
+class TestWithdrawalRequestIsLegibleInTheQueue:
+    """The row has to say it is a withdrawal, or the admin answers the wrong question.
+
+    Submissions and withdrawal requests share one queue (§5.1). Without a timestamp that
+    only a request carries, the row renders "submitted <the original date>" and reads as an
+    ordinary submission — which is how the SPA came to offer Approve on it.
+    """
+
+    def test_a_pending_request_carries_its_own_timestamp(self, app):
+        listing = _listing(
+            "withdrawal_requested",
+            publishedVersion=2,
+            withdrawalRequestedAt="2026-07-30T00:00:00Z",
+        )
+        assistant = _make_assistant(listing=listing)
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"][0]["withdrawalRequestedAt"] == "2026-07-30T00:00:00Z"
+
+    def test_a_resolved_request_does_not_keep_advertising_itself(self, app):
+        """The stamp survives the decision on the stored listing; the row must not.
+
+        A granted or declined request that still rendered "withdrawal requested 3 days ago"
+        would put a decided listing back in front of an admin as if it needed deciding.
+        """
+        listing = _listing(
+            "published", publishedVersion=2, withdrawalRequestedAt="2026-07-30T00:00:00Z"
+        )
+        assistant = _make_assistant(listing=listing)
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"][0].get("withdrawalRequestedAt") is None

--- a/backend/tests/routes/test_agent_detail.py
+++ b/backend/tests/routes/test_agent_detail.py
@@ -327,3 +327,123 @@ class TestApprovedInstructionsHashIsGated:
         resp = _get_agent(app, "viewer", agent=self._published())
 
         assert "deadbeef" not in resp.text
+
+
+# ── the detail read serves the approved snapshot (§4) ────────────────────────────────
+class TestDetailReadServesTheSnapshot:
+    """The store detail page must describe the Agent that will actually run.
+
+    Before this, ``GET /agents/{id}`` served the live record to everyone. A published Agent
+    whose author kept editing therefore had a store tile rendered from the approved snapshot
+    and a detail page rendered from the unreviewed draft — different name, different summary,
+    and ``capabilities`` resolved from the draft's bindings, so the page could advertise a
+    tool the published version does not have. Invocation ran the snapshot regardless, which
+    is what made it a lie rather than a preview.
+    """
+
+    def _published(self, **overrides):
+        listing = {
+            "state": "published",
+            "category": "Administration",
+            "publisherId": "pub-registrar",
+            "submittedVersion": 1,
+            "publishedVersion": 1,
+        }
+        listing.update(overrides.pop("listing", {}))
+        return _make_assistant(listing=listing, **overrides)
+
+    def _version(self):
+        from apis.shared.assistants.models import AgentVersion
+
+        return AgentVersion.model_validate(
+            {
+                "agentId": "ast-001",
+                "version": 1,
+                "name": "Approved Name",
+                "description": "Approved summary",
+                "instructions": "APPROVED PROMPT",
+                "tagline": "Approved tagline",
+                "bindings": [{"kind": "tool", "ref": "calculator"}],
+                "category": "Administration",
+                "publisherId": "pub-registrar",
+            }
+        )
+
+    def _get(self, app, permission, version):
+        with patch(
+            f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True
+        ), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check",
+            new_callable=AsyncMock,
+            return_value=(self._published(name="DRAFT NAME"), permission),
+        ), patch(
+            "apis.shared.assistants.version_resolution.get_version",
+            new_callable=AsyncMock,
+            return_value=version,
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_capabilities",
+            new_callable=AsyncMock,
+            return_value=([], None),
+        ):
+            return TestClient(app).get("/agents/ast-001")
+
+    def test_a_viewer_sees_the_approved_snapshot_not_the_draft(self, app, make_user, _flags_on):
+        mock_auth_user(app, make_user())
+        resp = self._get(app, "viewer", self._version())
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert body["name"] == "Approved Name"
+        assert body["description"] == "Approved summary"
+        assert body["tagline"] == "Approved tagline"
+        # The snapshot's bindings, which is what `capabilities` is resolved from.
+        assert body["bindings"] == [{"kind": "tool", "ref": "calculator", "config": {}}]
+
+    @pytest.mark.parametrize("permission", ["owner", "editor"])
+    def test_whoever_may_edit_still_gets_the_draft(self, app, make_user, _flags_on, permission):
+        """⚠️ Editors too, unlike invocation.
+
+        The Agent Designer loads its form from this endpoint. Serving an editor the approved
+        snapshot would populate the form with someone else's published copy, and their next
+        save would silently revert the owner's draft. Invocation is owner-only for the
+        opposite reason — an editor *running* the draft would bypass review.
+        """
+        mock_auth_user(app, make_user())
+        resp = self._get(app, permission, self._version())
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert body["name"] == "DRAFT NAME"
+        assert body["instructions"] == "SECRET SYSTEM PROMPT"
+
+    def test_an_unpublished_agent_is_unaffected(self, app, make_user, _flags_on):
+        """The common case, and the one that must not change."""
+        mock_auth_user(app, make_user())
+        with patch(
+            f"{ROUTES_MODULE}.assistant_exists", new_callable=AsyncMock, return_value=True
+        ), patch(
+            f"{ROUTES_MODULE}.get_assistant_with_access_check",
+            new_callable=AsyncMock,
+            return_value=(_make_assistant(name="DRAFT NAME"), "viewer"),
+        ), patch(
+            f"{ROUTES_MODULE}.resolve_capabilities",
+            new_callable=AsyncMock,
+            return_value=([], None),
+        ):
+            resp = TestClient(app).get("/agents/ast-001")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "DRAFT NAME"
+
+    def test_a_missing_snapshot_refuses_rather_than_falling_back(self, app, make_user, _flags_on):
+        """Same refusal as invocation, for the same reason.
+
+        Degrading to the draft would show unreviewed content precisely when something is
+        already wrong — and such an Agent has no store tile either, since the index is
+        sparse on the version row, so this is only reachable by direct link.
+        """
+        mock_auth_user(app, make_user())
+        resp = self._get(app, "viewer", None)
+
+        assert resp.status_code == 503
+        assert "published version could not be loaded" in resp.json()["detail"]

--- a/frontend/ai.client/src/app/admin/marketplace/components/withdrawal-decision-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/withdrawal-decision-dialog.component.ts
@@ -1,0 +1,157 @@
+import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { AdminListingRow } from '../models/marketplace.model';
+
+export interface WithdrawalDecisionDialogData {
+  listing: AdminListingRow;
+  decision: 'grant' | 'decline';
+}
+
+/** The note, or undefined if cancelled. An empty string is a valid note-less grant. */
+export type WithdrawalDecisionDialogResult = string | undefined;
+
+/**
+ * Confirms an admin's answer to a withdrawal request (§5.1).
+ *
+ * **Why a dialog at all, when Approve on a submission has none.** The two decisions are not
+ * symmetric. Approving a submission puts something new on a shelf and is trivially undone
+ * by a takedown; granting a withdrawal takes a live listing away from everyone who pinned
+ * it, and the author is the only person who asked for it. The consequence deserves a
+ * sentence naming it before the click lands.
+ *
+ * **A note is required to decline and optional to grant.** Declining refuses something the
+ * author asked for, so they are owed a reason — the same rule request-changes follows, for
+ * the same reason. Granting gives them what they wanted, so silence is a fine answer.
+ */
+@Component({
+  selector: 'app-withdrawal-decision-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="withdrawal-decision-title"
+        aria-describedby="withdrawal-decision-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2
+              id="withdrawal-decision-title"
+              class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+            >
+              {{ isGrant() ? 'Grant this withdrawal?' : 'Decline this withdrawal?' }}
+            </h2>
+            <p
+              id="withdrawal-decision-description"
+              class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400"
+            >
+              @if (isGrant()) {
+                <span class="font-medium">{{ data.listing.name }}</span> leaves the store and
+                becomes private. It revokes nothing retroactively: anyone who already pinned
+                it keeps it, conversations underway keep running, and it stays reachable by
+                direct link. {{ data.listing.ownerName }} can submit it again later.
+              } @else {
+                <span class="font-medium">{{ data.listing.name }}</span> stays in the store.
+                It never came down while the request was pending, so nothing is restored —
+                your note tells {{ data.listing.ownerName }} why it is staying.
+              }
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <label
+            for="withdrawal-note"
+            class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            {{ isGrant() ? 'Note to the author (optional)' : 'Why is it staying up?' }}
+          </label>
+          <textarea
+            id="withdrawal-note"
+            rows="3"
+            [value]="note()"
+            (input)="onNoteInput($event)"
+            [attr.placeholder]="
+              isGrant()
+                ? 'Anything they should know — otherwise leave this blank.'
+                : 'Be specific — this is the whole message the author receives.'
+            "
+            class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+          ></textarea>
+        </div>
+
+        <div
+          class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            [disabled]="!canSubmit()"
+            (click)="onSubmit()"
+            [class]="
+              isGrant()
+                ? 'rounded-2xl bg-rose-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-rose-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50'
+                : 'rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600'
+            "
+          >
+            {{ isGrant() ? 'Take it down' : 'Keep it published' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class WithdrawalDecisionDialogComponent {
+  private dialogRef = inject<DialogRef<WithdrawalDecisionDialogResult>>(DialogRef);
+  readonly data = inject<WithdrawalDecisionDialogData>(DIALOG_DATA);
+
+  readonly note = signal('');
+  readonly isGrant = computed(() => this.data.decision === 'grant');
+  readonly canSubmit = computed(() => this.isGrant() || !!this.note().trim());
+
+  onNoteInput(event: Event): void {
+    this.note.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onSubmit(): void {
+    if (this.canSubmit()) {
+      this.dialogRef.close(this.note().trim());
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -90,6 +90,15 @@ export interface AdminListingRow {
   state: ListingState;
   usageCount: number;
   submittedAt?: string;
+  /**
+   * Set only while a withdrawal request is pending.
+   *
+   * The queue shows submissions and withdrawal requests together (§5.1), and this is what
+   * tells them apart. Without it a request renders as "submitted <the original date>" and
+   * reads as an ordinary submission — so the admin answers "should this be published?"
+   * about a listing whose author asked to take it down.
+   */
+  withdrawalRequestedAt?: string;
   reviewedAt?: string;
   reviewNote?: string;
   updatedAt: string;
@@ -126,6 +135,19 @@ export interface ReviewListingRequest {
 
 export interface TakedownRequest {
   reason: string;
+}
+
+/**
+ * An admin's answer to an author's request to pull a live listing (§5.1).
+ *
+ * `grant`/`decline`, never `approve`/`reject`: "approve" means "publish this" everywhere
+ * else on this surface, and approving a *withdrawal* reads dangerously like approving the
+ * listing. Its own endpoint for the same reason — one endpoint with four decision values
+ * would make an accidental unpublication a one-character mistake.
+ */
+export interface WithdrawalDecisionRequest {
+  decision: 'grant' | 'decline';
+  note?: string;
 }
 
 /**

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -26,6 +26,11 @@ import {
   TakedownDialogData,
   TakedownDialogResult,
 } from '../components/takedown-dialog.component';
+import {
+  RequestChangesDialogComponent,
+  RequestChangesDialogData,
+  RequestChangesDialogResult,
+} from '../components/request-changes-dialog.component';
 
 /**
  * Listings — every agent that has ever been submitted (D10).
@@ -199,14 +204,29 @@ import {
                     </td>
                     <td class="px-4 py-3 text-right">
                       @if (row.state === 'published') {
-                        <button
-                          type="button"
-                          [disabled]="busyId() === row.agentId"
-                          (click)="takedown(row)"
-                          class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-rose-700 hover:bg-rose-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-rose-400 dark:hover:bg-gray-700"
-                        >
-                          Take down
-                        </button>
+                        <div class="flex justify-end gap-2">
+                          <!-- The gentler half of the pair, and the only route to a
+                               resubmission that still has a published version to diff
+                               against: every other way back (take down, granted withdrawal)
+                               clears the published-version pointer first, so the review
+                               diff has nothing to compare against without this. -->
+                          <button
+                            type="button"
+                            [disabled]="busyId() === row.agentId"
+                            (click)="requestChanges(row)"
+                            class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                          >
+                            Request changes
+                          </button>
+                          <button
+                            type="button"
+                            [disabled]="busyId() === row.agentId"
+                            (click)="takedown(row)"
+                            class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-rose-700 hover:bg-rose-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-rose-400 dark:hover:bg-gray-700"
+                          >
+                            Take down
+                          </button>
+                        </div>
                       }
                     </td>
                   </tr>
@@ -260,6 +280,38 @@ export class MarketplaceListingsPage implements OnInit {
       this.error.set(this.service.error() ?? 'Failed to load listings.');
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  /**
+   * Send a *live* listing back to its author with a note, without taking it down.
+   *
+   * The listing keeps serving its approved version while the author revises — this is
+   * feedback, not a delisting, and `takedown` is the button for the other intent.
+   *
+   * It is also the only transition that leaves `publishedVersion` intact, which makes it
+   * the only way a resubmission ever arrives with something to diff against. Without this
+   * control the review diff renders "first submission" on every submission an agent ever
+   * makes, however many versions it has.
+   */
+  async requestChanges(row: AdminListingRow): Promise<void> {
+    const ref = this.dialog.open<RequestChangesDialogResult, RequestChangesDialogData>(
+      RequestChangesDialogComponent,
+      { data: { listing: row } },
+    );
+    const note = await firstValueFrom(ref.closed);
+    if (!note) return;
+
+    this.busyId.set(row.agentId);
+    this.error.set(null);
+    try {
+      await this.service.review(row.agentId, { decision: 'request_changes', note });
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(typeof detail === 'string' ? detail : 'Failed to record the decision.');
+    } finally {
+      this.busyId.set(null);
     }
   }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { MarketplacePublishersPage } from './publishers.page';
 import { PublisherProfile } from '../models/marketplace.model';
@@ -19,6 +21,8 @@ describe('MarketplacePublishersPage', () => {
     updatePublisher: ReturnType<typeof vi.fn>;
     deletePublisher: ReturnType<typeof vi.fn>;
   };
+  /** Delete is confirmed; default to "confirmed" so the other tests read unchanged. */
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
 
   function publisher(overrides: Partial<PublisherProfile> = {}): PublisherProfile {
     return {
@@ -40,8 +44,12 @@ describe('MarketplacePublishersPage', () => {
       updatePublisher: vi.fn().mockResolvedValue(publisher()),
       deletePublisher: vi.fn().mockResolvedValue(undefined),
     };
+    mockDialog = { open: vi.fn().mockReturnValue({ closed: of(true) }) };
     TestBed.configureTestingModule({
-      providers: [{ provide: AdminMarketplaceService, useValue: mockService }],
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: mockDialog },
+      ],
     });
   });
 
@@ -60,6 +68,12 @@ describe('MarketplacePublishersPage', () => {
 
   function text(fixture: ComponentFixture<unknown>): string {
     return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  function deleteButton(fixture: ComponentFixture<unknown>): HTMLButtonElement {
+    return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Delete Office of the Registrar'),
+    ) as HTMLButtonElement;
   }
 
   it('lists the publishers an admin can attribute a listing to', async () => {
@@ -155,6 +169,26 @@ describe('MarketplacePublishersPage', () => {
     expect(mockService.updatePublisher).toHaveBeenCalledWith('pub-registrar', { enabled: false });
   });
 
+  it('confirms before deleting a publisher', async () => {
+    // The one control on this page that cannot be undone by clicking it again: the id is
+    // fixed at creation, so a mistaken delete cannot be put back.
+    const fixture = await render([publisher()]);
+    deleteButton(fixture).click();
+    await fixture.whenStable();
+
+    expect(mockDialog.open).toHaveBeenCalled();
+    expect(mockService.deletePublisher).toHaveBeenCalledWith('pub-registrar');
+  });
+
+  it('does not delete when the confirmation is dismissed', async () => {
+    mockDialog.open.mockReturnValue({ closed: of(undefined) });
+    const fixture = await render([publisher()]);
+    deleteButton(fixture).click();
+    await fixture.whenStable();
+
+    expect(mockService.deletePublisher).not.toHaveBeenCalled();
+  });
+
   it("surfaces the server's refusal when a publisher is still in use", async () => {
     // The 409 explains itself and suggests disabling instead. Replacing it with a generic
     // "could not save" would throw away the only actionable part.
@@ -163,10 +197,7 @@ describe('MarketplacePublishersPage', () => {
     });
     const fixture = await render([publisher()]);
 
-    const remove = Array.from(
-      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
-    ).find((b) => b.textContent?.includes('Delete Office of the Registrar')) as HTMLButtonElement;
-    remove.click();
+    deleteButton(fixture).click();
     await fixture.whenStable();
     fixture.detectChanges();
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
@@ -1,5 +1,11 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../../../components/confirmation-dialog/confirmation-dialog.component';
 import {
   heroBuildingLibrary,
   heroCheckBadge,
@@ -223,6 +229,7 @@ import {
 })
 export class MarketplacePublishersPage implements OnInit {
   private readonly service = inject(AdminMarketplaceService);
+  private readonly dialog = inject(Dialog);
 
   readonly publishers = signal<PublisherProfile[]>([]);
   readonly loading = signal(true);
@@ -291,7 +298,33 @@ export class MarketplacePublishersPage implements OnInit {
     );
   }
 
+  /**
+   * Delete a publisher profile, behind a confirmation.
+   *
+   * Confirmed because it is irreversible and the id is not recoverable: the id is fixed at
+   * creation, so a profile deleted by mistake cannot be recreated as the same one, and
+   * every listing that named it stays unattributed. Every other control on this page is a
+   * toggle or a rename that can be undone by doing it again; this one cannot.
+   *
+   * The server refuses (409) while listings are still attributed, and that message names
+   * disabling as the alternative — so the dialog does not repeat it here.
+   */
   async remove(publisher: PublisherProfile): Promise<void> {
+    const ref = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data: {
+        title: 'Delete this publisher?',
+        message:
+          `"${publisher.label}" is removed for good — its id is fixed at creation, so it ` +
+          'cannot be recreated as the same profile. Listings can only be deleted when ' +
+          'nothing is attributed to them; if you want it out of the submit picker while ' +
+          'existing credits keep rendering, disable it instead.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      } satisfies ConfirmationDialogData,
+    });
+    if (!(await firstValueFrom(ref.closed))) return;
+
     await this.mutate(() => this.service.deletePublisher(publisher.id));
   }
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
@@ -5,6 +5,7 @@ import { signal } from '@angular/core';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { ReviewQueuePage } from './review-queue.page';
 import { AdminListingRow } from '../models/marketplace.model';
+import { of } from 'rxjs';
 import { ListingReachability } from '../../../agents/models/reachability';
 
 /**
@@ -91,5 +92,129 @@ describe('ReviewQueuePage — reachability warning', () => {
     const approveBtn = Array.from(approve).find((b) => b.textContent?.includes('Approve'));
     expect(approveBtn).toBeTruthy();
     expect(approveBtn!.hasAttribute('disabled')).toBe(false);
+  });
+});
+
+/**
+ * Withdrawal requests in the review queue (§5.1).
+ *
+ * They share the queue with submissions, and before this they shared its *controls* too —
+ * so an author asking for their listing to come down was answered with Approve/Request
+ * changes. "Approve" then routed to `review`, which walks `withdrawal_requested →
+ * published`: the request was silently declined and the admin was told nothing.
+ *
+ * These assert the row is legible as a different question and that it reaches the endpoint
+ * built for it.
+ */
+describe('ReviewQueuePage — withdrawal requests', () => {
+  let mockService: any;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  function withdrawalRow(overrides: Partial<AdminListingRow> = {}): AdminListingRow {
+    return {
+      agentId: 'ast-002',
+      name: 'Policy Lookup',
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      state: 'withdrawal_requested',
+      usageCount: 4,
+      submittedAt: '2026-07-01T00:00:00Z',
+      withdrawalRequestedAt: '2026-07-22T00:00:00Z',
+      updatedAt: '2026-07-22T00:00:00Z',
+      reachability: 'everyone',
+      adminEdits: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: signal<string | null>(null),
+      loadSubmissions: vi.fn().mockResolvedValue([withdrawalRow()]),
+      review: vi.fn().mockResolvedValue(undefined),
+      decideWithdrawal: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDialog = { open: vi.fn().mockReturnValue({ closed: of('') }) };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: mockDialog },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function render(): Promise<ComponentFixture<ReviewQueuePage>> {
+    const fixture = TestBed.createComponent(ReviewQueuePage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function button(fixture: ComponentFixture<unknown>, label: string): HTMLButtonElement {
+    return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button')).find(
+      (b) => b.textContent?.includes(label),
+    ) as HTMLButtonElement;
+  }
+
+  it('labels the row as a withdrawal request rather than a submission', async () => {
+    const fixture = await render();
+    const rendered = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(rendered).toContain('Withdrawal requested');
+    expect(rendered).toMatch(/asked to pull it/i);
+    // The submission framing must be gone, or the admin answers the wrong question.
+    expect(rendered).not.toMatch(/· submitted/i);
+  });
+
+  it('offers grant and decline, never the submission verbs', async () => {
+    const fixture = await render();
+    expect(button(fixture, 'Take it down')).toBeTruthy();
+    expect(button(fixture, 'Keep published')).toBeTruthy();
+    expect(button(fixture, 'Approve')).toBeFalsy();
+    expect(button(fixture, 'Request changes')).toBeFalsy();
+  });
+
+  it('grants through the withdrawal endpoint, not through review', async () => {
+    const fixture = await render();
+    button(fixture, 'Take it down').click();
+    await fixture.whenStable();
+
+    expect(mockService.decideWithdrawal).toHaveBeenCalledWith('ast-002', {
+      decision: 'grant',
+      note: undefined,
+    });
+    // The bug this replaced: `review` with `approve` re-published over the request.
+    expect(mockService.review).not.toHaveBeenCalled();
+  });
+
+  it('declines with the admin note attached', async () => {
+    mockDialog.open.mockReturnValue({ closed: of('Still needed for fall registration.') });
+    const fixture = await render();
+    button(fixture, 'Keep published').click();
+    await fixture.whenStable();
+
+    expect(mockService.decideWithdrawal).toHaveBeenCalledWith('ast-002', {
+      decision: 'decline',
+      note: 'Still needed for fall registration.',
+    });
+  });
+
+  it('does nothing when the confirmation is dismissed', async () => {
+    mockDialog.open.mockReturnValue({ closed: of(undefined) });
+    const fixture = await render();
+    button(fixture, 'Take it down').click();
+    await fixture.whenStable();
+
+    expect(mockService.decideWithdrawal).not.toHaveBeenCalled();
+  });
+
+  it('tells the admin the listing is still live while they decide', async () => {
+    // The one fact that makes the decision make sense: a request is not a removal, so
+    // declining restores nothing and granting is what actually takes it down.
+    const fixture = await render();
+    expect((fixture.nativeElement as HTMLElement).textContent).toMatch(/still live in the store/i);
   });
 });

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -19,6 +19,11 @@ import {
   RequestChangesDialogData,
   RequestChangesDialogResult,
 } from '../components/request-changes-dialog.component';
+import {
+  WithdrawalDecisionDialogComponent,
+  WithdrawalDecisionDialogData,
+  WithdrawalDecisionDialogResult,
+} from '../components/withdrawal-decision-dialog.component';
 import { parseIso } from '../../../utils/date';
 
 /**
@@ -44,6 +49,10 @@ import { parseIso } from '../../../utils/date';
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Every submission lands here. Approving publishes it to the store immediately;
             requesting changes returns it to the author with your note attached to their card.
+          </p>
+          <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+            Authors asking to pull a live listing land here too. Those stay published until
+            you decide.
           </p>
         </div>
 
@@ -88,16 +97,36 @@ import { parseIso } from '../../../utils/date';
                 <app-agent-tile [agentId]="row.agentId" [iconUrl]="row.iconUrl" [emoji]="row.emoji" />
 
                 <div class="min-w-0 flex-1">
-                  <h2 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
-                    {{ row.name }}
+                  <h2 class="flex items-center gap-2 text-sm/6 font-semibold text-gray-900 dark:text-white">
+                    <span class="truncate">{{ row.name }}</span>
+                    <!-- The two things in this queue want opposite answers, and without a
+                         label they render identically. A withdrawal request said "take this
+                         down"; answering it with the submission verbs re-publishes over the
+                         author's request without ever saying so. -->
+                    @if (isWithdrawal(row)) {
+                      <span
+                        class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs/5 font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                        >Withdrawal requested</span
+                      >
+                    }
                   </h2>
                   <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
-                    {{ row.ownerName }} · {{ row.category }} · submitted
-                    {{ relativeTime(row.submittedAt) }}
+                    @if (isWithdrawal(row)) {
+                      {{ row.ownerName }} · {{ row.category }} · asked to pull it
+                      {{ relativeTime(row.withdrawalRequestedAt) }}
+                    } @else {
+                      {{ row.ownerName }} · {{ row.category }} · submitted
+                      {{ relativeTime(row.submittedAt) }}
+                    }
                   </p>
                   @if (row.tagline) {
                     <p class="truncate text-sm/6 text-gray-500 dark:text-gray-400">
                       {{ row.tagline }}
+                    </p>
+                  }
+                  @if (isWithdrawal(row)) {
+                    <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                      Still live in the store while you decide — a request is not a removal.
                     </p>
                   }
 
@@ -108,8 +137,14 @@ import { parseIso } from '../../../utils/date';
                   <!-- §6.1 — what this submission changes against what is published.
                        Collapsed by default and fetched on expand: the queue is a list of
                        decisions, and pre-loading a diff per row would pull every pending
-                       agent's full instructions down to render a control nobody opened. -->
-                  <app-review-diff [agentId]="row.agentId" />
+                       agent's full instructions down to render a control nobody opened.
+
+                       Not shown on a withdrawal request: nothing changed, and the pending
+                       version *is* the published one, so it would offer a reviewer a
+                       guaranteed-empty diff next to a decision about taking it down. -->
+                  @if (!isWithdrawal(row)) {
+                    <app-review-diff [agentId]="row.agentId" />
+                  }
 
                   @if (reachabilityWarning(row); as warning) {
                     <p
@@ -126,24 +161,45 @@ import { parseIso } from '../../../utils/date';
                 </div>
 
                 <div class="flex shrink-0 gap-2">
-                  <button
-                    type="button"
-                    [disabled]="busyId() === row.agentId"
-                    (click)="requestChanges(row)"
-                    class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                  >
-                    <ng-icon name="heroArrowUturnLeft" class="size-4" aria-hidden="true" />
-                    Request changes
-                  </button>
-                  <button
-                    type="button"
-                    [disabled]="busyId() === row.agentId"
-                    (click)="approve(row)"
-                    class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
-                  >
-                    <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
-                    Approve
-                  </button>
+                  @if (isWithdrawal(row)) {
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.agentId"
+                      (click)="decideWithdrawal(row, 'decline')"
+                      class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      <ng-icon name="heroArrowUturnLeft" class="size-4" aria-hidden="true" />
+                      Keep published
+                    </button>
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.agentId"
+                      (click)="decideWithdrawal(row, 'grant')"
+                      class="inline-flex items-center gap-1.5 rounded-2xl bg-rose-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-rose-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <ng-icon name="heroEyeSlash" class="size-4" aria-hidden="true" />
+                      Take it down
+                    </button>
+                  } @else {
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.agentId"
+                      (click)="requestChanges(row)"
+                      class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      <ng-icon name="heroArrowUturnLeft" class="size-4" aria-hidden="true" />
+                      Request changes
+                    </button>
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.agentId"
+                      (click)="approve(row)"
+                      class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                    >
+                      <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+                      Approve
+                    </button>
+                  }
                 </div>
               </li>
             }
@@ -178,8 +234,50 @@ export class ReviewQueuePage implements OnInit {
     }
   }
 
+  /**
+   * Whether this row is an author asking to pull a live listing rather than a submission.
+   *
+   * Keyed on `state`, not on the timestamp: the timestamp is what the row *renders*, and a
+   * row that lost it would silently fall back to the submission verbs — which is the exact
+   * failure this predicate exists to prevent.
+   */
+  isWithdrawal(row: AdminListingRow): boolean {
+    return row.state === 'withdrawal_requested';
+  }
+
   async approve(row: AdminListingRow): Promise<void> {
     await this.decide(row, { decision: 'approve' });
+  }
+
+  /**
+   * Grant or decline a withdrawal request.
+   *
+   * A separate endpoint from `review`, deliberately — see `decideWithdrawal` on the
+   * service. Routing this through `approve` is what the queue used to do by omission, and
+   * it silently re-published listings whose authors had asked for them to come down.
+   */
+  async decideWithdrawal(row: AdminListingRow, decision: 'grant' | 'decline'): Promise<void> {
+    const ref = this.dialog.open<
+      WithdrawalDecisionDialogResult,
+      WithdrawalDecisionDialogData
+    >(WithdrawalDecisionDialogComponent, { data: { listing: row, decision } });
+    // `undefined` is cancel; `''` is a deliberate note-less grant, so compare explicitly.
+    const note = await firstValueFrom(ref.closed);
+    if (note === undefined) return;
+
+    this.busyId.set(row.agentId);
+    this.error.set(null);
+    try {
+      await this.service.decideWithdrawal(row.agentId, { decision, note: note || undefined });
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(
+        typeof detail === 'string' ? detail : 'Failed to record the withdrawal decision.',
+      );
+    } finally {
+      this.busyId.set(null);
+    }
   }
 
   async requestChanges(row: AdminListingRow): Promise<void> {

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -21,6 +21,7 @@ import {
   ReviewListingRequest,
   RoleAgentPinsResponse,
   RoleAgentPinsUpdateRequest,
+  WithdrawalDecisionRequest,
 } from '../models/marketplace.model';
 
 interface PublishersResponse {
@@ -100,6 +101,18 @@ export class AdminMarketplaceService {
   /** Approve a submission, or return it to the author with a reason. */
   async review(agentId: string, request: ReviewListingRequest): Promise<void> {
     await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/review`, request));
+  }
+
+  /**
+   * Grant or decline an author's request to pull a live listing (§5.1).
+   *
+   * Deliberately not folded into `review`. That call answers "may this go into the store?";
+   * this one answers "may this come out?", and the two have opposite defaults — a
+   * withdrawal request routed through `review` with `approve` reads as agreeing with the
+   * author while actually re-publishing over their request.
+   */
+  async decideWithdrawal(agentId: string, request: WithdrawalDecisionRequest): Promise<void> {
+    await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/withdrawal`, request));
   }
 
   /**

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -222,7 +222,7 @@
                       {{ submitLabel(agent) }}
                     </button>
                   }
-                  @if (isOwner(agent) && isPublished(agent)) {
+                  @if (isOwner(agent) && isInStore(agent)) {
                     <button
                       type="button"
                       (click)="onViewInStore(agent)"
@@ -318,7 +318,7 @@
                       {{ submitLabel(agent) }}
                     </button>
                   }
-                  @if (isOwner(agent) && isPublished(agent)) {
+                  @if (isOwner(agent) && isInStore(agent)) {
                     <button
                       type="button"
                       (click)="onViewInStore(agent)"

--- a/frontend/ai.client/src/app/agents/agents.page.ts
+++ b/frontend/ai.client/src/app/agents/agents.page.ts
@@ -210,10 +210,18 @@ export class AgentsPage implements OnInit {
     return state === 'in_review' || state === 'changes_requested' || state === 'published';
   }
 
+  /**
+   * "Request withdrawal" on a live listing, not "Unpublish" (§5.1).
+   *
+   * The author no longer owns that edge — `published → private` left the machine, and the
+   * click now creates a request an admin acts on. Labelling it "Unpublish" promised an
+   * outcome the button cannot deliver: the listing stays in the store until the admin
+   * decides, so the author walked away believing it was gone.
+   */
   withdrawLabel(agent: Agent): string {
     switch (this.listingState(agent)) {
       case 'published':
-        return 'Unpublish';
+        return 'Request withdrawal';
       case 'in_review':
         return 'Withdraw submission';
       default:
@@ -223,6 +231,19 @@ export class AgentsPage implements OnInit {
 
   isPublished(agent: Agent): boolean {
     return this.listingState(agent) === 'published';
+  }
+
+  /**
+   * Whether the agent is in the store *now* — which "View in store" is asking, and which
+   * `isPublished` answers wrongly for one state.
+   *
+   * A pending withdrawal request leaves the listing serving (§5.1). Gating the link on
+   * `published` hid it the moment the author asked to withdraw, telling them it was
+   * already off the shelf — the same false impression the confirmation copy used to give.
+   */
+  isInStore(agent: Agent): boolean {
+    const state = this.listingState(agent);
+    return state === 'published' || state === 'withdrawal_requested';
   }
 
   onViewInStore(agent: Agent): void {
@@ -276,16 +297,20 @@ export class AgentsPage implements OnInit {
     const published = this.isPublished(agent);
     const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
       data: {
-        title: published ? 'Unpublish this agent?' : 'Withdraw this submission?',
-        // D7.3 — say plainly that this recalls nothing. An author who believes
-        // unpublishing revokes access will make a worse decision than one who knows.
+        title: published ? 'Request withdrawal?' : 'Withdraw this submission?',
+        // Two things this has to get right, and it used to get both wrong on the published
+        // path. (1) §5.1 — this is a *request*: the listing stays in the store until an
+        // admin grants it, and saying "is removed from the store" sent authors away
+        // believing it was already down. (2) D7.3 — say plainly that it recalls nothing,
+        // because an author who thinks withdrawal revokes access decides worse than one
+        // who knows it does not.
         message: published
-          ? `"${agent.name}" is removed from the store and no one new can find it there. ` +
-            'It revokes nothing retroactively: anyone who already added it keeps it, ' +
-            'conversations underway keep running, and it stays reachable by direct link. ' +
-            'You can submit it again later.'
+          ? `An admin reviews this before "${agent.name}" comes off the shelf, so it stays ` +
+            'in the store until they decide. Even once it does come down, nothing is ' +
+            'recalled: anyone who already added it keeps it, conversations underway keep ' +
+            'running, and it stays reachable by direct link.'
           : `"${agent.name}" is pulled from the review queue. You can submit it again at any time.`,
-        confirmText: published ? 'Unpublish' : 'Withdraw',
+        confirmText: published ? 'Request withdrawal' : 'Withdraw',
         cancelText: 'Cancel',
         destructive: published,
       } as ConfirmationDialogData,


### PR DESCRIPTION
End-to-end testing of the version-snapshots epic (#784, #787, #789, #790, #791, #792, #793, #795) against dev surfaced five issues. **Four were real. The fifth turned out to be deliberate behaviour and is documented rather than changed.**

## The detail page served the draft, not the snapshot

`GET /agents/{id}` had no version overlay, so a published Agent whose author kept editing had a store tile rendered from the approved snapshot and a detail page rendered from the unreviewed draft — different name, different summary, and `capabilities` resolved from the *draft's* bindings, so the page advertised tools the published version did not have. Invocation ran the snapshot regardless, which is what made it a lie rather than a preview.

`resolve_display_agent` now answers this the same way invocation does, with one deliberate difference: **editors keep seeing the draft.** The Agent Designer loads its form from this endpoint, so serving an editor the approved snapshot would populate the form with someone else's published copy and their next save would silently revert the owner's draft. Invocation stays owner-only for the opposite reason — an editor *running* the draft would bypass review.

## Withdrawal requests could not be granted

`POST /admin/agents/{id}/withdrawal` had no SPA caller. The request landed in the review queue indistinguishable from a submission, so "Request changes" 400'd on an illegal transition and **"Approve" silently *declined* it** by re-publishing, with nothing said to the admin.

The queue now labels the row, says the listing is still live while the admin decides, and offers **Take it down / Keep published** against the endpoint built for them. The author-side control said "Unpublish" and promised removal from the store — it now reads "Request withdrawal" and says an admin decides first.

## The review diff was unreachable

Every UI route to a resubmission cleared `publishedVersion` first, so `diff_pending_version` always returned `first_submission` — PR-5's "what changed since I approved this" never rendered in practice. `published → changes_requested` is the one transition that preserves the pointer, and nothing exposed it. The Listings page now does.

## Publisher delete was unguarded

`publishers.page.ts` documents a 409 refusal while listings are attributed, and its error handling was already written to surface it — but nothing enforced it. Deleting an in-use profile silently unattributed every listing naming it, live ones included, with no surface to repair them and no confirmation first. Adds `publisher_in_use` (mirroring the existing `category_in_use`) and a confirmation dialog.

## Not changed — and why

**Requesting changes on a live listing does not unpublish it.** I reported this as a bug; it is deliberate and asserted by `test_request_changes_leaves_a_live_listing_on_the_shelf` — the approved version keeps serving until one replaces it, and takedown is the operation that pulls something down. Reverted.

One consequence is left open with a note rather than patched: an author can take such a listing private alone, because `withdraw_listing` reads `changes_requested` as not-live. Closing it needs a product decision — the transition table cannot allow `changes_requested → withdrawal_requested` without also opening `in_review → changes_requested → withdrawal_requested → published`, a route to `published` for something never approved, which is the property `test_approval_is_the_only_door_into_the_store` exists to hold.

## Also

- `is_on_shelf` names the "in the store *right now*" question. `is_listed` answers by state name, and a published listing sent back for changes keeps serving — so the featured row and browse disagreed about it.
- `AdminListingRow.withdrawalRequestedAt` is what lets the queue tell a withdrawal request from a submission at all; without it the row renders "submitted &lt;the original date&gt;".
- Corrected a stale docstring in `version_resolution.py` claiming the resolved version is threaded into the agent cache key — it is deliberately not, and §4.2 records why that was reverted.

## Verification

Driven through the browser against dev-ai, with DynamoDB checked directly at each step:

- viewer detail read returns the approved snapshot and matches invocation exactly; the draft's extra tool no longer appears; owner and editor still load the draft
- withdrawal request → labelled row → decline → back to `published` with the note attached, `review` never called
- request changes on a live listing → resubmit → diff renders "Version 2 against published 1" with a behavior-flagged bindings change, `firstSubmission: false`
- publisher delete → confirmation, then 409 naming disabling as the alternative; the four attributions survive

**5570 backend tests, 1710 frontend tests, all passing** — including 8 new backend and 8 new frontend tests covering these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)