### PR TITLE
feat(marketplace): version rollback, and close the withdrawal origin gap

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -20,6 +20,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from apis.app_api.agent_designer.services.listing_service import (
     ListingError,
     list_admin_listings,
+    list_agent_versions,
+    rollback_listing,
     patch_listing_presentation,
     review_listing,
     decide_withdrawal,
@@ -54,6 +56,7 @@ from apis.shared.assistants.models import (
     AgentCategoryUpdateRequest,
     AgentListing,
     AgentVersionDiffResponse,
+    AgentVersionsResponse,
     PublisherCreateRequest,
     PublisherEligibilityRequest,
     PublisherEligibilityResponse,
@@ -62,6 +65,7 @@ from apis.shared.assistants.models import (
     PublisherUpdateRequest,
     ResolveReportRequest,
     ReviewListingRequest,
+    RollbackListingRequest,
     StoreFrontUpdateRequest,
     TakedownRequest,
     WithdrawalDecisionRequest,
@@ -225,9 +229,10 @@ async def decide_agent_withdrawal(
     have different inputs, different notes and opposite defaults. One endpoint with four
     decision values would make an accidental unpublication a one-character mistake.
 
-    ``grant`` → ``private`` and off the shelf. ``decline`` → back to ``published``, which
-    restores nothing because the listing never stopped being live while the request was
-    pending — that is the point of leaving the store index alone in ``withdrawal_requested``.
+    ``grant`` → ``private`` and off the shelf. ``decline`` → back to whatever state the
+    request came from (``withdrawal_from``), which restores nothing because the listing never
+    stopped being live while the request was pending — that is the point of leaving the store
+    index alone in ``withdrawal_requested``.
     """
     try:
         return await decide_withdrawal(
@@ -238,6 +243,50 @@ async def decide_agent_withdrawal(
     except Exception as e:
         logger.error(f"Error deciding agent withdrawal: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to decide withdrawal: {str(e)}")
+
+
+@router.get("/{agent_id}/versions", response_model=AgentVersionsResponse)
+async def list_agent_version_history(
+    agent_id: str, admin: User = Depends(require_marketplace_admin),
+):
+    """Every snapshot this Agent has, newest first — the rollback picker's source (§8).
+
+    Admin-only, like the diff and for the same reason: version *names* are harmless but this
+    is the history of an Agent's approvals, and the surface that reads it is the one that can
+    change what the store serves.
+    """
+    try:
+        versions, published = await list_agent_versions(agent_id)
+        return AgentVersionsResponse(versions=versions, published_version=published)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error listing agent versions: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to list versions: {str(e)}")
+
+
+@router.post("/{agent_id}/rollback", response_model=AgentListing)
+async def rollback_agent_listing(
+    agent_id: str,
+    request: RollbackListingRequest,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """Repoint a published listing at an earlier snapshot (§8).
+
+    The answer to "the approved version turned out to be wrong". Separate from ``/review``
+    because it is not a review decision — no version is cut, nothing moves through the queue,
+    and the listing stays ``published`` throughout. It only changes *which* approved artifact
+    the store serves, which is why it can only act on a listing that is already published.
+    """
+    try:
+        return await rollback_listing(
+            agent_id, admin, version=request.version, reason=request.reason
+        )
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error rolling back agent listing: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to roll back listing: {str(e)}")
 
 
 @router.patch("/{agent_id}/listing", response_model=AgentListing)

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -39,6 +39,7 @@ from apis.shared.assistants.listing import (
     assert_transition,
     gsi5_keys,
     is_listed,
+    is_on_shelf,
 )
 from apis.shared.assistants.listing_repository import list_by_state, write_listing
 from apis.shared.assistants.version_diff import (
@@ -49,6 +50,7 @@ from apis.shared.assistants.version_diff import (
 from apis.shared.assistants.version_repository import (
     create_version,
     get_version,
+    list_versions,
     set_version_index,
 )
 from apis.shared.assistants.versions import snapshot_of
@@ -58,6 +60,7 @@ from apis.shared.assistants.models import (
     AdminListingRow,
     AgentListing,
     AgentVersionDiffResponse,
+    AgentVersionSummary,
     Assistant,
     VersionFieldChange,
     PublisherProfile,
@@ -457,18 +460,36 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
     if not assistant.listing:
         raise ListingError("This agent has no marketplace listing.", status_code=404)
 
+    current = assistant.listing.state
+
+    # ⚠️ Refuse a second request explicitly, before choosing a target.
+    #
+    # This used to fall out of the transition table — ``withdrawal_requested`` does not
+    # self-loop — but that only held while the target was picked from the *state*. Picking it
+    # from ``is_on_shelf`` means a pending request whose pointer is missing resolves to
+    # ``private``, and ``private`` is an author target, so the author would walk the grant
+    # edge themselves. Granting a withdrawal is the admin's decision (§5.1); an author who
+    # could do it by asking twice would have the unilateral delisting this state prevents.
+    if current == "withdrawal_requested":
+        raise ListingError(
+            "You have already asked for this listing to be pulled. An admin decides next; "
+            "it stays in the store until they do.",
+            status_code=400,
+        )
+
     # A live listing can only be *requested* down; anything else goes straight to private.
     #
-    # ⚠️ Known gap, left deliberately rather than patched here: a listing that was published
-    # and then sent back for changes is still serving (``review_listing`` does not
-    # unpublish), but its state is ``changes_requested``, so this reads it as not-live and
-    # the author goes straight to ``private`` — pulling something users can currently see
-    # without an admin deciding. Closing it needs a product call, not a predicate swap: the
-    # transition table cannot allow ``changes_requested → withdrawal_requested`` without
-    # also opening a route to ``published`` for a listing that was never approved (see
-    # ``ALLOWED_TRANSITIONS``), and it is unclear what declining such a request should
-    # restore the listing to.
-    target = "withdrawal_requested" if is_listed(assistant.listing.state) else "private"
+    # Asked as ``is_on_shelf``, not ``is_listed``: the state name alone gets this wrong for a
+    # listing that was published and then sent back for changes. That one is still serving
+    # (``review_listing`` deliberately does not unpublish) while sitting in
+    # ``changes_requested``, and reading it as not-live let the author pull something users
+    # could currently see with no admin deciding — the unilateral delisting §5.1 exists to
+    # prevent, reached through the one state nobody thought to check.
+    target = (
+        "withdrawal_requested"
+        if is_on_shelf(current, assistant.listing.published_version)
+        else "private"
+    )
 
     try:
         assert_transition(assistant.listing.state, target)
@@ -486,10 +507,19 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
         # which is exactly what this state exists to prevent. A declined request then needs
         # no repair, because nothing was undone.
         listing = assistant.listing.model_copy(
-            update={"state": target, "withdrawal_requested_at": now}
+            update={
+                "state": target,
+                "withdrawal_requested_at": now,
+                # Where to put it back if the admin says no. Recorded here rather than
+                # inferred at decision time because by then the origin is gone.
+                "withdrawal_from": current,
+            }
         )
         await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
-        logger.info(f"🙋 Agent {agent_id} withdrawal requested by its owner {user.user_id}")
+        logger.info(
+            f"🙋 Agent {agent_id} withdrawal requested by its owner {user.user_id} "
+            f"(from {current})"
+        )
         return listing
 
     # Pre-publication withdrawal: nothing is on the shelf, so this is immediate. The
@@ -506,10 +536,18 @@ async def decide_withdrawal(
 ) -> AgentListing:
     """Admin grants or declines an author's withdrawal request (§5.1).
 
-    ``grant`` takes the listing to ``private`` and off the shelf. ``decline`` returns it to
-    ``published`` and changes nothing else — the listing never stopped being live, so there
-    is no key to restore and no version to re-promote. That asymmetry is the payoff of
+    ``grant`` takes the listing to ``private`` and off the shelf. ``decline`` puts it back
+    where it came from and changes nothing else — the listing never stopped being live, so
+    there is no key to restore and no version to re-promote. That asymmetry is the payoff of
     leaving the index alone while the request was pending.
+
+    ⚠️ **"Where it came from", not "``published``".** Two states can be on the shelf and so
+    reach ``withdrawal_requested``: ``published``, and a ``changes_requested`` listing that
+    was published before the admin sent it back. Declining the second one into ``published``
+    would silently drop the outstanding change request *and* make ``withdrawal_requested →
+    published`` reachable by a listing that was never approved — the one thing
+    ``ALLOWED_TRANSITIONS`` is arranged to prevent. ``withdrawal_from`` is read here, and
+    falls back to ``published`` only for requests recorded before that field existed.
 
     A declining admin should say why, since the author asked for something and is not
     getting it; ``note`` renders on their card exactly as a request-changes reason does.
@@ -523,7 +561,7 @@ async def decide_withdrawal(
             status_code=400,
         )
 
-    target = "private" if decision == "grant" else "published"
+    target = "private" if decision == "grant" else (assistant.listing.withdrawal_from or "published")
     try:
         assert_transition(assistant.listing.state, target)
     except ListingTransitionError as e:
@@ -535,6 +573,10 @@ async def decide_withdrawal(
         "reviewed_at": now,
         "reviewed_by": admin.user_id,
         "review_note": note or None,
+        # The request is answered; the origin pointer has done its job. ``withdrawal_requested_at``
+        # deliberately stays — the author's card says what happened and when, and a request
+        # that vanished on decline would read as though it was never made.
+        "withdrawal_from": None,
     }
     if target == "private":
         changes["published_version"] = None
@@ -712,6 +754,105 @@ async def review_listing(
     return listing
 
 
+async def list_agent_versions(agent_id: str) -> Tuple[List[AgentVersionSummary], Optional[int]]:
+    """Every snapshot this Agent has, newest first, plus which one is live.
+
+    Backs the rollback picker. Summaries rather than whole versions: the picker needs to say
+    *which* version and when it was cut, and shipping every snapshot's full ``instructions``
+    to render a dropdown would send the entire approval history of an Agent down the wire to
+    draw a list of numbers.
+    """
+    assistant = await _load_any(agent_id)
+    published = assistant.listing.published_version if assistant.listing else None
+    versions = await list_versions(agent_id)
+    summaries = [
+        AgentVersionSummary(
+            version=v.version,
+            name=v.name,
+            tagline=v.tagline,
+            created_at=v.created_at,
+            created_by=v.created_by,
+            is_published=v.version == published,
+        )
+        for v in sorted(versions, key=lambda v: v.version or 0, reverse=True)
+        if v.version is not None
+    ]
+    return summaries, published
+
+
+async def rollback_listing(
+    agent_id: str, admin: User, *, version: int, reason: str
+) -> AgentListing:
+    """Repoint a published listing at an earlier snapshot (§8).
+
+    The answer to "the approved version turned out to be wrong", and nearly free because
+    versions are immutable and numbered: the old snapshot is still sitting there intact, so
+    a rollback is a pointer move plus an index move — no new version is cut, and nothing
+    about the author's draft changes.
+
+    **Only from ``published``.** A rollback is not a way *into* the store — an Agent that is
+    private, in review or taken down has no live listing to roll back, and letting this
+    endpoint publish one would be a second door past review. ``assert_transition`` is not
+    consulted because the state does not change; the explicit check below is the gate.
+
+    **A reason is required and reaches the author**, exactly as takedown and request-changes
+    do. An admin replacing what users run is a decision the author has to be able to see,
+    and the alternative — a silent pointer move — leaves them looking at a store tile that
+    no longer matches the version they last had approved, with nothing to explain it.
+
+    Ordering is ``_publish_version``'s: new key first, then clear the superseded one, so a
+    half-failed rollback shows the Agent twice rather than not at all.
+    """
+    assistant = await _load_any(agent_id)
+    if not assistant.listing:
+        raise ListingError("This agent has no marketplace listing.", status_code=404)
+
+    listing_now = assistant.listing
+    if listing_now.state != "published":
+        raise ListingError(
+            f"Only a published listing can be rolled back; this one is '{listing_now.state}'.",
+            status_code=400,
+        )
+    if not (reason or "").strip():
+        raise ListingError(
+            "A rollback needs a reason — it renders on the author's card, and replacing what "
+            "users run without saying why leaves them unable to tell what happened.",
+            status_code=400,
+        )
+
+    current = listing_now.published_version
+    if version == current:
+        raise ListingError(
+            f"Version {version} is already the published one.", status_code=400
+        )
+    if await get_version(agent_id, version) is None:
+        raise ListingError(f"Version {version} of this agent does not exist.", status_code=404)
+
+    now = _now()
+    listing = listing_now.model_copy(
+        update={
+            "published_version": version,
+            "reviewed_at": now,
+            "reviewed_by": admin.user_id,
+            "review_note": reason,
+        }
+    )
+    await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+
+    # Record first, then move the key — the publish ordering. A key pointing at a version the
+    # listing does not claim is the failure the sparse index exists to prevent.
+    await _publish_version(
+        agent_id,
+        version,
+        category=listing.category,
+        agent_created_at=assistant.created_at,
+        superseding=current,
+    )
+
+    logger.info(f"⏪ Agent {agent_id} rolled back {current} → {version} by {admin.user_id}")
+    return listing
+
+
 async def takedown_listing(agent_id: str, admin: User, reason: str) -> AgentListing:
     """Delist a published Agent, clearing its directory key (D2).
 
@@ -873,10 +1014,22 @@ async def diff_pending_version(agent_id: str) -> AgentVersionDiffResponse:
     if not listing:
         raise ListingError("This agent has no marketplace listing.", status_code=404)
 
-    pending_number = listing.submitted_version
-    if pending_number is None or listing.state not in PENDING_DECISION_STATES:
+    # Two different causes, and collapsing them told the reviewer the wrong one. A listing
+    # sitting in ``in_review`` *does* have something awaiting review — if it also has no
+    # ``submittedVersion`` it predates snapshots, which is a fact about the record's age and
+    # not about the queue. Saying "nothing awaiting review" about a row the admin is looking
+    # at in the review queue reads as a bug in the queue.
+    if listing.state not in PENDING_DECISION_STATES:
         raise ListingError(
             "This agent has nothing awaiting review, so there is no diff to show.",
+            status_code=400,
+        )
+
+    pending_number = listing.submitted_version
+    if pending_number is None:
+        raise ListingError(
+            "This submission predates version snapshots, so there is nothing to compare. "
+            "Ask the author to resubmit — that captures one on the way in.",
             status_code=400,
         )
 

--- a/backend/src/apis/app_api/agent_designer/services/store_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/store_service.py
@@ -35,6 +35,7 @@ from apis.shared.assistants.models import (
 from apis.shared.assistants.publishers import list_publishers
 from apis.shared.assistants.storefront import get_featured_ids
 from apis.shared.assistants.version_repository import batch_get_versions
+from apis.shared.assistants.versions import VERSION_SK_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +79,41 @@ def to_listing_response(
     )
 
 
-def _project(items: list, publishers: dict, *, category: str) -> List[AgentListingResponse]:
-    responses = []
+def _project_with_keys(
+    items: list, publishers: dict, *, category: str
+) -> List[Tuple[str, AgentListingResponse]]:
+    """``(GSI5_SK, response)`` for each row that renders.
+
+    ⚠️ **Pairs, not two parallel lists.** ``browse_all`` needs each response's sort key, and
+    it used to get it by ``zip``-ing the raw items against the projected responses — which is
+    only correct while *nothing is ever skipped*. Any dropped row shifts every later response
+    onto the previous row's key, so the merge silently sorts the shelf wrong. That was
+    latent; the stale-index skip below makes it reachable with real data, so the pairing is
+    built here where the drop happens instead of being reconstructed by position afterwards.
+    """
+    projected: List[Tuple[str, AgentListingResponse]] = []
     for item in items:
+        # ⚠️ Skip anything that is not a version row *before* trying to parse one.
+        #
+        # The index moved onto the ``VERSION#`` row in PR-2, but listings published before
+        # that still carry GSI5 keys on their ``METADATA`` item, so this query returns Agent
+        # rows too. They cannot validate as an ``AgentVersion`` (no ``agentId``), and the
+        # generic handler below logged a full pydantic traceback for each one, on every store
+        # browse — an error-shaped log line for a data condition that is merely old.
+        #
+        # Such a listing is invisible in the store either way: it has no version row to
+        # render. The fix for *that* is to clear the stale keys off the Agent row; this
+        # keeps the read path quiet in the meantime and correct forever, since a
+        # non-``VERSION#`` key in this index is never something the shelf should render.
+        sort_key = str(item.get("SK", ""))
+        if not sort_key.startswith(VERSION_SK_PREFIX):
+            logger.info(
+                "Skipping stale store index row %s/%s — the directory key belongs on the "
+                "published version, not the Agent",
+                item.get("PK"),
+                sort_key,
+            )
+            continue
         try:
             version = AgentVersion.model_validate(
                 {k: v for k, v in item.items() if k not in ("PK", "SK")}
@@ -88,10 +121,17 @@ def _project(items: list, publishers: dict, *, category: str) -> List[AgentListi
         except Exception:
             logger.warning("Skipping unparseable store row", exc_info=True)
             continue
-        projected = to_listing_response(version, publishers, category=category)
-        if projected:
-            responses.append(projected)
-    return responses
+        response = to_listing_response(version, publishers, category=category)
+        if response:
+            projected.append((str(item.get("GSI5_SK", "")), response))
+    return projected
+
+
+def _project(items: list, publishers: dict, *, category: str) -> List[AgentListingResponse]:
+    """The shelf rows, for callers that already know which partition they queried."""
+    return [
+        response for _key, response in _project_with_keys(items, publishers, category=category)
+    ]
 
 
 async def browse_category(
@@ -124,17 +164,17 @@ async def browse_all(*, limit: int = 50) -> List[AgentListingResponse]:
 
     publishers = {p.id: p for p in await list_publishers()}
 
+    # Sort on ``GSI5_SK``, not on the row's ``createdAt``. These are version rows now, so
+    # ``createdAt`` is when the *snapshot* was cut — merging on it would order the store by
+    # most-recently-approved and let a re-approved five-year-old Agent surface above a
+    # genuinely new one. ``GSI5_SK`` is ``CREATED#{agent createdAt}``, which is the ordering
+    # the per-category shelves already use, so merging on it keeps browse-all consistent
+    # with browse-category. ``_project_with_keys`` pairs the two so a skipped row cannot
+    # slide every later response onto the wrong key.
     merged: List[Tuple[str, AgentListingResponse]] = []
     for category in categories:
         items, _ = await query_store(category.id, limit=limit)
-        for item, response in zip(items, _project(items, publishers, category=category.id)):
-            # Sort on ``GSI5_SK``, not on the row's ``createdAt``. These are version rows
-            # now, so ``createdAt`` is when the *snapshot* was cut — merging on it would
-            # order the store by most-recently-approved and let a re-approved five-year-old
-            # Agent surface above a genuinely new one. ``GSI5_SK`` is ``CREATED#{agent
-            # createdAt}``, which is the ordering the per-category shelves already use, so
-            # merging on it is what keeps browse-all consistent with browse-category.
-            merged.append((str(item.get("GSI5_SK", "")), response))
+        merged.extend(_project_with_keys(items, publishers, category=category.id))
 
     # Newest-first across the merged set, matching the per-category ordering.
     merged.sort(key=lambda pair: pair[0], reverse=True)

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -70,8 +70,10 @@ LISTING_STATES: Tuple[str, ...] = (
 #   published         → changes_requested  admin requests changes on a live listing
 #   taken_down        → changes_requested  admin annotates an already-delisted listing
 #   in_review         → private            author withdraws a pending submission
-#   changes_requested → private            author withdraws
+#   changes_requested → private            author withdraws one that was never live
 #   published         → withdrawal_requested author ASKS to pull a live listing
+#   changes_requested → withdrawal_requested author ASKS to pull one that is *still* live
+#   withdrawal_requested → changes_requested admin declines; it goes back where it came from
 #   withdrawal_requested → private          admin grants the withdrawal
 #   withdrawal_requested → published        admin declines; the listing stays live
 #   withdrawal_requested → taken_down       admin pulls it outright instead
@@ -89,21 +91,26 @@ LISTING_STATES: Tuple[str, ...] = (
 # and withdrawing a *pending* submission (``in_review``/``changes_requested`` → ``private``).
 #
 # ⚠️ ``changes_requested`` covers two different listings — one that was never published, and
-# one that *was* and is still serving while the author revises it (``review_listing`` does
-# not unpublish). Only the first should be able to walk ``→ private`` alone, but this table
-# cannot tell them apart, and adding ``changes_requested → withdrawal_requested`` to fix it
-# would open ``in_review → changes_requested → withdrawal_requested → published`` — a route
-# to ``published`` for something never approved, which is the one property
-# ``test_approval_is_the_only_door_into_the_store`` exists to hold. Left alone deliberately;
-# see the note on ``is_on_shelf``.
+# one that *was* and is still serving while the author revises it (``review_listing``
+# deliberately does not unpublish). Only the first may walk ``→ private`` alone; the second
+# has to go through a request, which is why this row carries both exits and
+# ``withdraw_listing`` picks between them with ``is_on_shelf`` rather than by state name.
+#
+# The reason that is safe — and it is the whole reason ``AgentListing.withdrawal_from``
+# exists — is that declining a withdrawal returns the listing to the state it came *from*,
+# not to a hardcoded ``published``. So ``in_review → changes_requested →
+# withdrawal_requested → published`` is not reachable: a listing that entered
+# ``withdrawal_requested`` from ``changes_requested`` can only go back to
+# ``changes_requested``. Approval remains the only door into the store, and
+# ``test_approval_is_the_only_door_into_the_store`` asserts exactly that.
 ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     None: {"in_review"},
     "private": {"in_review"},
     "in_review": {"published", "changes_requested", "private"},
-    "changes_requested": {"in_review", "private"},
+    "changes_requested": {"in_review", "private", "withdrawal_requested"},
     "published": {"taken_down", "changes_requested", "withdrawal_requested"},
     "taken_down": {"in_review", "changes_requested"},
-    "withdrawal_requested": {"private", "published", "taken_down"},
+    "withdrawal_requested": {"private", "published", "changes_requested", "taken_down"},
 }
 
 # States an author may drive. Everything else is the reviewer's (``require_admin``).

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -166,6 +166,22 @@ class AgentListing(BaseModel):
             "when — a request that vanishes on decline reads as though it was never made."
         ),
     )
+    withdrawal_from: Optional[ListingState] = Field(
+        None,
+        alias="withdrawalFrom",
+        description=(
+            "The state a pending withdrawal request came *from*, so declining it restores "
+            "exactly that rather than assuming ``published``.\n\n"
+            "Two states can be on the shelf and therefore reach ``withdrawal_requested``: "
+            "``published``, and a ``changes_requested`` listing that was published before the "
+            "admin sent it back (``review_listing`` deliberately does not unpublish). Without "
+            "this field, declining the second one would land it in ``published`` and silently "
+            "discard the outstanding change request — and, worse, it would make "
+            "``withdrawal_requested → published`` reachable from a listing that had never been "
+            "approved. Recording the origin is what keeps ``ALLOWED_TRANSITIONS`` provably "
+            "free of a second door into the store."
+        ),
+    )
     submitted_version: Optional[int] = Field(
         None,
         alias="submittedVersion",
@@ -789,6 +805,58 @@ class VersionFieldChange(BaseModel):
         description=(
             "Whether this field changes what the Agent *does* (instructions, bindings, "
             "model) rather than how it presents. Drives the reviewer's at-a-glance triage."
+        ),
+    )
+
+
+class AgentVersionSummary(BaseModel):
+    """One snapshot, described just enough to pick it out of a list (§8 rollback).
+
+    Deliberately not an ``AgentVersion``: the rollback picker renders a number, a name and a
+    date, and sending the full snapshot would put every past version's ``instructions`` on
+    the wire to draw a dropdown — the whole approval history of an Agent, to an admin who
+    asked which versions exist.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: int = Field(..., description="Version number, 1-based")
+    name: Optional[str] = Field(None, description="Name as of this snapshot")
+    tagline: Optional[str] = Field(None, description="Tagline as of this snapshot")
+    created_at: Optional[str] = Field(
+        None, alias="createdAt", description="ISO 8601 when the snapshot was cut"
+    )
+    created_by: Optional[str] = Field(
+        None, alias="createdBy", description="Who cut it — the author, or an admin for a D13 edit"
+    )
+    is_published: bool = Field(
+        False, alias="isPublished", description="Whether this is the snapshot the store serves"
+    )
+
+
+class AgentVersionsResponse(BaseModel):
+    """Every snapshot an Agent has, newest first, plus which one is live."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    versions: List[AgentVersionSummary] = Field(default_factory=list)
+    published_version: Optional[int] = Field(
+        None, alias="publishedVersion", description="The number the listing currently serves"
+    )
+
+
+class RollbackListingRequest(BaseModel):
+    """Repoint a published listing at an earlier snapshot (§8)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: int = Field(..., description="The snapshot to make live")
+    reason: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Why — rendered on the author's card. Required for the same reason takedown's is: "
+            "an admin changing what users run is something the author must be able to see."
         ),
     )
 

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -974,3 +974,150 @@ class TestWithdrawalRequestIsLegibleInTheQueue:
             resp = TestClient(app).get("/admin/agents/listings")
 
         assert resp.json()["listings"][0].get("withdrawalRequestedAt") is None
+
+
+class TestWithdrawalRemembersWhereItCameFrom:
+    """§5.1 — declining returns the listing to its origin, not to a hardcoded ``published``.
+
+    Two states can be on the shelf and so reach ``withdrawal_requested``: ``published``, and
+    a ``changes_requested`` listing that was published before the admin sent it back
+    (``review_listing`` deliberately does not unpublish). Declining the second into
+    ``published`` would discard the outstanding change request *and* make
+    ``withdrawal_requested → published`` reachable by something never approved.
+    """
+
+    def test_declining_returns_a_listing_to_the_state_it_came_from(self, app, _no_writes):
+        listing = _listing(
+            "withdrawal_requested", publishedVersion=2, withdrawalFrom="changes_requested"
+        )
+        with _loaded(_make_assistant(listing=listing)):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal",
+                json={"decision": "decline", "note": "Keeping it up."},
+            )
+
+        assert resp.status_code == 200
+        written = _no_writes.call_args.args[1]
+        assert written.state == "changes_requested"
+        assert written.published_version == 2
+        # The pointer has done its job; leaving it set would re-decline into a stale origin.
+        assert written.withdrawal_from is None
+
+    def test_declining_an_ordinary_request_still_lands_in_published(self, app, _no_writes):
+        listing = _listing(
+            "withdrawal_requested", publishedVersion=2, withdrawalFrom="published"
+        )
+        with _loaded(_make_assistant(listing=listing)):
+            TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal",
+                json={"decision": "decline", "note": "Still needed."},
+            )
+
+        assert _no_writes.call_args.args[1].state == "published"
+
+    def test_a_request_recorded_before_the_field_existed_falls_back_to_published(
+        self, app, _no_writes
+    ):
+        """Pre-existing pending requests carry no origin; ``published`` is the old behaviour."""
+        listing = _listing("withdrawal_requested", publishedVersion=2)
+        with _loaded(_make_assistant(listing=listing)):
+            TestClient(app).post(
+                "/admin/agents/ast-001/withdrawal",
+                json={"decision": "decline", "note": "Still needed."},
+            )
+
+        assert _no_writes.call_args.args[1].state == "published"
+
+    def test_granting_still_goes_private_and_off_the_shelf(self, app, _no_writes):
+        listing = _listing(
+            "withdrawal_requested", publishedVersion=2, withdrawalFrom="changes_requested"
+        )
+        index = _no_writes.set_version_index
+        with _loaded(_make_assistant(listing=listing)):
+            TestClient(app).post("/admin/agents/ast-001/withdrawal", json={"decision": "grant"})
+
+        written = _no_writes.call_args.args[1]
+        assert written.state == "private"
+        assert written.published_version is None
+        assert index.await_args.args[1:] == (2, None)
+
+
+class TestRollback:
+    """§8 — repoint a published listing at an earlier snapshot."""
+
+    def _versions(self, *numbers):
+        return patch(
+            f"{SERVICE_MODULE}.get_version",
+            new_callable=AsyncMock,
+            side_effect=lambda _a, n: (
+                SimpleNamespace(version=n) if n in numbers else None
+            ),
+        )
+
+    def test_rollback_repoints_the_listing_and_moves_the_key(self, app, _no_writes):
+        index = _no_writes.set_version_index
+        listing = _listing("published", publishedVersion=5, submittedVersion=5)
+        with _loaded(_make_assistant(listing=listing)), self._versions(2, 5):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/rollback",
+                json={"version": 2, "reason": "v5 broke citations."},
+            )
+
+        assert resp.status_code == 200
+        written = _no_writes.call_args.args[1]
+        assert written.published_version == 2
+        assert written.state == "published"
+        # The reason reaches the author, like a takedown's does.
+        assert written.review_note == "v5 broke citations."
+        # New key first, then clear the superseded one — ``_publish_version``'s ordering, so
+        # a half-failed rollback shows the Agent twice rather than not at all.
+        assert [(c.args[1], c.args[2] is None) for c in index.await_args_list] == [
+            (2, False),
+            (5, True),
+        ]
+
+    def test_rollback_needs_a_reason(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=5))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/rollback", json={"version": 2, "reason": "   "}
+            )
+
+        assert resp.status_code == 400
+        assert "reason" in resp.json()["detail"]
+        _no_writes.assert_not_awaited()
+
+    def test_rollback_refuses_a_version_that_does_not_exist(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=5))), \
+                self._versions(5):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/rollback", json={"version": 99, "reason": "nope"}
+            )
+
+        assert resp.status_code == 404
+        _no_writes.assert_not_awaited()
+
+    def test_rollback_refuses_the_version_already_live(self, app, _no_writes):
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=5))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/rollback", json={"version": 5, "reason": "again"}
+            )
+
+        assert resp.status_code == 400
+        assert "already the published one" in resp.json()["detail"]
+        _no_writes.assert_not_awaited()
+
+    @pytest.mark.parametrize("state", ["private", "in_review", "changes_requested", "taken_down"])
+    def test_rollback_is_not_a_door_into_the_store(self, app, _no_writes, state):
+        """Only a *published* listing can be rolled back.
+
+        Otherwise this endpoint would publish an Agent without going through review — the
+        one thing the state machine is arranged to prevent.
+        """
+        with _loaded(_make_assistant(listing=_listing(state, publishedVersion=None))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/rollback", json={"version": 2, "reason": "no"}
+            )
+
+        assert resp.status_code == 400
+        assert state in resp.json()["detail"]
+        _no_writes.assert_not_awaited()

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -761,3 +761,36 @@ class TestSubmissionCutsTheSnapshot:
         assert written.published_version == 2, "a resubmission must not unpublish"
         assert written.submitted_version == 1
         _no_writes.set_version_index.assert_not_awaited()
+
+
+class TestAnAuthorCannotGrantTheirOwnWithdrawal:
+    """§5.1's core rule, guarded where it can actually be walked.
+
+    ``withdrawal_requested → private`` is a legal edge — it is how an admin *grants* a
+    withdrawal — and ``private`` is an author target. So the only thing keeping an author off
+    it is that ``withdraw_listing`` never chooses ``private`` as the target for a pending
+    request. That used to be implied by the transition table; once the target came from
+    ``is_on_shelf`` instead of the state name, a pending request with no published pointer
+    resolved to ``private`` and the author granted their own withdrawal.
+    """
+
+    @pytest.mark.parametrize("published_version", [3, None])
+    def test_asking_twice_is_refused_however_the_pointer_looks(
+        self, app, make_user, _no_writes, published_version
+    ):
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="withdrawal_requested",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=published_version,
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 400
+        assert "already asked" in resp.json()["detail"]
+        # The decisive assertion: nothing was written, so the listing did not go private.
+        _no_writes.assert_not_awaited()

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -97,11 +97,33 @@ def test_approval_is_the_only_door_into_the_store():
     publishable = {s for s in ALLOWED_TRANSITIONS if "published" in ALLOWED_TRANSITIONS[s]}
     # ``withdrawal_requested`` is the one addition, and it is not a door *into* the store:
     # the listing never left, so declining a withdrawal is a refusal to unpublish rather
-    # than a new publication. Nothing unreviewed can reach ``published`` through it — you
-    # can only get to ``withdrawal_requested`` from ``published`` in the first place.
+    # than a new publication.
     assert publishable == {"in_review", "withdrawal_requested"}
-    assert ALLOWED_TRANSITIONS["withdrawal_requested"] <= {"private", "published", "taken_down"}
-    assert {s for s, t in ALLOWED_TRANSITIONS.items() if "withdrawal_requested" in t} == {"published"}
+    assert ALLOWED_TRANSITIONS["withdrawal_requested"] <= {
+        "private",
+        "published",
+        "changes_requested",
+        "taken_down",
+    }
+
+    # The property that keeps the paragraph above true now that *two* states can reach
+    # ``withdrawal_requested``: a request can only be declined back into a state that could
+    # have sent it there. So `in_review → changes_requested → withdrawal_requested →
+    # published` is not walkable — a listing that entered from ``changes_requested`` returns
+    # to ``changes_requested``, and only one that was genuinely ``published`` returns to
+    # ``published``.
+    #
+    # ⚠️ The table permits both exits; what picks the right one is
+    # ``AgentListing.withdrawal_from``, read by ``decide_withdrawal``. If that field ever
+    # stops being recorded on the way in, this invariant is no longer enforced by anything —
+    # ``test_declining_returns_a_listing_to_the_state_it_came_from`` is the other half.
+    entrants = {s for s, t in ALLOWED_TRANSITIONS.items() if "withdrawal_requested" in t}
+    assert entrants == {"published", "changes_requested"}
+    decline_targets = ALLOWED_TRANSITIONS["withdrawal_requested"] - {"private", "taken_down"}
+    assert decline_targets == entrants, (
+        "A declined withdrawal must be able to land exactly where requests come from — no "
+        "more (that would be a new door into the store) and no less (that would strand one)."
+    )
 
 
 def test_private_cannot_jump_straight_to_published():

--- a/backend/tests/shared/test_agent_store.py
+++ b/backend/tests/shared/test_agent_store.py
@@ -106,6 +106,60 @@ async def _publish(agent_id: str, category: str, created_at: str, publisher_id="
     await publish_agent_version(agent_id, category, created_at, publisher_id=publisher_id)
 
 
+# ── legacy rows left in the index ────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_a_legacy_agent_row_left_in_the_index_is_skipped_quietly(table, caplog):
+    """PR-2 moved the directory key onto the version row; older listings kept theirs.
+
+    Those Agent rows come back from the same query and cannot be an ``AgentVersion``, so
+    the generic handler logged a full pydantic traceback for each one on *every* store
+    browse. The listing is invisible either way — it has no snapshot to render — so the
+    read path skips it by sort key instead of failing to parse it.
+    """
+    _seed_agent(
+        table,
+        "ast-legacy",
+        created_at="2026-07-01T00:00:00Z",
+        name="Published Before Snapshots",
+        GSI5_PK="LISTED#Administration",
+        GSI5_SK="CREATED#2026-07-01T00:00:00Z",
+    )
+
+    with caplog.at_level("WARNING"):
+        listings, _ = await browse_category("Administration")
+
+    assert listings == []
+    assert "Skipping unparseable store row" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_skipped_row_does_not_shift_the_browse_all_ordering(table):
+    """The pairing bug the skip would otherwise expose.
+
+    ``browse_all`` sorts on each row's ``GSI5_SK``. It used to get those by zipping the raw
+    items against the projected responses, which is only correct while nothing is skipped —
+    one dropped row slides every later response onto the previous row's key.
+    """
+    await ensure_seeded()
+    _seed_agent(
+        table,
+        "ast-legacy",
+        created_at="2026-07-09T00:00:00Z",
+        name="Legacy",
+        GSI5_PK="LISTED#Administration",
+        GSI5_SK="CREATED#2026-07-09T00:00:00Z",
+    )
+    _seed_agent(table, "ast-old", created_at="2026-07-01T00:00:00Z", name="Older")
+    await _publish("ast-old", "Administration", "2026-07-01T00:00:00Z")
+    _seed_agent(table, "ast-new", created_at="2026-07-20T00:00:00Z", name="Newer")
+    await _publish("ast-new", "Teaching", "2026-07-20T00:00:00Z")
+
+    listings = await browse_all()
+
+    # Newest-first by *Agent* creation, with the legacy row absent rather than misplaced.
+    assert [row.name for row in listings] == ["Newer", "Older"]
+
+
 # ── the structural guarantee ─────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_browse_returns_published_agents(table):

--- a/docs/specs/agent-version-snapshots.md
+++ b/docs/specs/agent-version-snapshots.md
@@ -1,8 +1,9 @@
 # Agent Version Snapshots — Immutable Approved Listings
 
-**Status:** Partially implemented — PR-1 (#784) and PR-2 (#787) merged; PR-3 (#789) open
+**Status:** **Complete.** PR-1 (#784) · PR-2 (#787) · PR-3 (#789) · PR-4 (#791) · PR-5 (#793) ·
+PR-6 (#795), plus #792 (orphan version rows), #799 (E2E fix pass) and the §8 rollback.
 **Author:** (drafted with Claude)
-**Date:** 2026-07-29 · revised 2026-07-29 against what shipped
+**Date:** 2026-07-29 · revised 2026-07-30 against what shipped
 **Targets branch:** `develop`
 **Supersedes:** the post-approval *drift detection* portion of `agent-marketplace.md` (D14)
 
@@ -327,7 +328,9 @@ finished backend, not a design problem. It needs the `admin.marketplace` scope
 | **PR-3** | Invocation resolution: published version for everyone but the owner, draft for the owner. ~~version in the agent cache key~~ (see §4.2 — deliberately not implemented). The one seam at `chat/routes.py`. | #789 |
 | **PR-4** | Lifecycle: `withdrawal_requested` state, delete refusal, admin queue entry for withdrawal requests. | |
 | **PR-5** | Review diff view (pending vs published). | |
-| **PR-6** | Publisher management admin page — independent of the rest; can land any time. | |
+| **PR-6** | Publisher management admin page — independent of the rest; can land any time. | ✅ #795 |
+| **follow-up** | E2E fix pass: detail read serves the snapshot, withdrawal decisions reachable, review diff reachable, publisher delete guarded. | ✅ #799 |
+| **§8** | Admin rollback to a prior version. | ✅ |
 
 PR-2 and PR-3 must ship in the same release: PR-2 alone makes the store show
 snapshots while pinned users still run the draft, which is the confusing half-state.
@@ -346,15 +349,27 @@ version attributed to the admin.
 
 ## 8. Open items
 
-- **Version retention.** Every resubmission cuts a version. Unbounded growth is
-  probably fine at this scale (a few hundred agents, a handful of versions each), but
-  worth a decision rather than a discovery. DynamoDB TTL on superseded versions older
-  than N months is the cheap answer — except versions referenced by an audit record
-  should survive.
-- **Does an admin need to roll back to a prior version?** Falls out nearly free once
-  versions are immutable and numbered (repoint `publishedVersion`), and it is the
-  obvious answer to "the approved version turned out to be wrong." Not in the phasing
-  above; say if it should be.
+- ~~**Version retention.**~~ **DECIDED 2026-07-30: deliberately unbounded.** Every
+  resubmission cuts a version and nothing removes one. At this scale — a few hundred
+  agents, a handful of versions each, a snapshot being a few KB — the storage is
+  immaterial, and the alternatives all cost more than they save. A TTL on superseded
+  versions is cheap to run but deletes invisibly and cannot exempt a version an audit or
+  takedown record points at; a keep-last-N prune is predictable but silently destroys the
+  older half of a listing's approval history, which is the thing the epic exists to make
+  durable. **Rollback (below) shipped and made this stronger, not weaker**: an old version
+  is no longer inert history, it is something an admin can put back on the shelf, so
+  deleting one now costs a recovery path. Revisit if a single Agent ever accumulates
+  enough versions to make the partition read slow — that is the symptom worth acting on,
+  not the row count.
+- ~~**Does an admin need to roll back to a prior version?**~~ **SHIPPED 2026-07-30.**
+  `GET /admin/agents/{id}/versions` + `POST /admin/agents/{id}/rollback`, with a picker on
+  the admin Listings page. Repoints `publishedVersion` and moves the GSI5 key through
+  `_publish_version`, so it inherits the new-key-first ordering. Three constraints worth
+  keeping: it acts **only on a `published` listing** (otherwise it is a second door into
+  the store, past review); it **requires a reason**, which lands on the author's card the
+  way a takedown's does, because an admin changing what users run is not something the
+  author should have to discover; and it **cuts no version** — rolling back is a pointer
+  move over immutable records, so rolling forward again is the same operation.
 - **Transaction vs fail-closed ordering.** Publishing and delisting are now two writes on
   two items (§3.3), and the "an unpublished agent cannot be in the store" invariant is held
   by call order rather than by atomicity. Ordering is enforced in one place

--- a/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+import { RollbackDialogComponent } from './rollback-dialog.component';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminListingRow, AgentVersionSummary } from '../models/marketplace.model';
+
+/**
+ * The rollback picker (§8).
+ *
+ * Two rules worth pinning, because getting either wrong makes the dialog offer a choice the
+ * backend then refuses: the currently-published version is never selectable, and a reason is
+ * mandatory — it is what the author sees when the thing they wrote gets replaced.
+ */
+describe('RollbackDialogComponent', () => {
+  let closed: unknown;
+  let mockService: { loadVersions: ReturnType<typeof vi.fn> };
+
+  const listing = {
+    agentId: 'ast-001',
+    name: 'Policy Lookup',
+    ownerName: 'Ada Author',
+    category: 'Administration',
+    state: 'published',
+    publishedVersion: 3,
+    usageCount: 0,
+    updatedAt: '2026-07-22T00:00:00Z',
+    reachability: 'everyone',
+    adminEdits: [],
+  } as AdminListingRow;
+
+  function version(n: number, isPublished = false): AgentVersionSummary {
+    return {
+      version: n,
+      name: `Policy Lookup v${n}`,
+      createdAt: '2026-07-0' + n + 'T00:00:00Z',
+      isPublished,
+    };
+  }
+
+  function build(versions: AgentVersionSummary[]): RollbackDialogComponent {
+    closed = 'not-closed';
+    mockService = { loadVersions: vi.fn().mockResolvedValue({ versions, publishedVersion: 3 }) };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DialogRef,
+          useValue: {
+            close: (v: unknown) => {
+              closed = v;
+            },
+          },
+        },
+        { provide: DIALOG_DATA, useValue: { listing } },
+        { provide: AdminMarketplaceService, useValue: mockService },
+      ],
+    });
+    return TestBed.createComponent(RollbackDialogComponent).componentInstance;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  beforeEach(() => {
+    closed = 'not-closed';
+  });
+
+  it('offers every version except the one already live', async () => {
+    const component = build([version(3, true), version(2), version(1)]);
+    await component.ngOnInit();
+
+    expect(component.selectable().map((v) => v.version)).toEqual([2, 1]);
+  });
+
+  it('says so plainly when there is nothing to roll back to', async () => {
+    const component = build([version(3, true)]);
+    await component.ngOnInit();
+
+    expect(component.selectable()).toEqual([]);
+    expect(component.canSubmit()).toBe(false);
+  });
+
+  it('will not submit without a reason', async () => {
+    // The author is about to have what they wrote replaced; a silent pointer move leaves
+    // them with a store tile that no longer matches their last approval and no explanation.
+    const component = build([version(3, true), version(2)]);
+    await component.ngOnInit();
+    component.version.set(2);
+
+    expect(component.canSubmit()).toBe(false);
+    component.reason.set('   ');
+    expect(component.canSubmit()).toBe(false);
+    component.reason.set('v3 broke citations.');
+    expect(component.canSubmit()).toBe(true);
+  });
+
+  it('closes with the version and trimmed reason', async () => {
+    const component = build([version(3, true), version(2)]);
+    await component.ngOnInit();
+    component.version.set(2);
+    component.reason.set('  v3 broke citations.  ');
+    component.onSubmit();
+
+    expect(closed).toEqual({ version: 2, reason: 'v3 broke citations.' });
+  });
+
+  it('closes with undefined on cancel, which the caller reads as "do nothing"', async () => {
+    const component = build([version(3, true), version(2)]);
+    await component.ngOnInit();
+    component.onCancel();
+
+    expect(closed).toBeUndefined();
+  });
+
+  it('surfaces a load failure instead of rendering an empty picker', async () => {
+    const component = build([]);
+    mockService.loadVersions.mockRejectedValue({ error: { detail: 'Agent not found.' } });
+    await component.ngOnInit();
+
+    expect(component.error()).toBe('Agent not found.');
+    expect(component.loading()).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.ts
@@ -1,0 +1,198 @@
+import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminListingRow, AgentVersionSummary } from '../models/marketplace.model';
+
+export interface RollbackDialogData {
+  listing: AdminListingRow;
+}
+
+/** The chosen version and reason, or undefined if cancelled. */
+export type RollbackDialogResult = { version: number; reason: string } | undefined;
+
+/**
+ * Repoint a published listing at an earlier snapshot (§8).
+ *
+ * **Versions are loaded here rather than with the Listings table.** The table is a list of
+ * listings; a version history is a per-agent question that only matters once someone has
+ * decided to roll one back, and fetching every agent's history to render a page of rows
+ * would be the same mistake the review diff avoids.
+ *
+ * The currently-published version is shown but not selectable — "roll back to what is
+ * already live" is not a decision, and the backend refuses it anyway. Offering it would
+ * make the picker's most obvious entry the one that errors.
+ */
+@Component({
+  selector: 'app-rollback-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+      (click)="onCancel()"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rollback-title"
+        aria-describedby="rollback-description"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="min-w-0">
+            <h2 id="rollback-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Roll back to an earlier version
+            </h2>
+            <p id="rollback-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              The store serves the version you pick, and everyone who opens
+              <span class="font-medium">{{ data.listing.name }}</span> runs it from the next
+              turn. Nothing is deleted — the current version stays available to roll forward
+              to, and {{ data.listing.ownerName }}'s draft is untouched.
+            </p>
+          </div>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          @if (loading()) {
+            <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading versions…</p>
+          } @else if (error()) {
+            <p role="alert" class="text-sm/6 text-rose-700 dark:text-rose-400">{{ error() }}</p>
+          } @else if (selectable().length === 0) {
+            <p class="text-sm/6 text-gray-600 dark:text-gray-400">
+              This agent has only ever had one approved version, so there is nothing to roll
+              back to.
+            </p>
+          } @else {
+            <label
+              for="rollback-version"
+              class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+            >
+              Version to publish
+            </label>
+            <select
+              id="rollback-version"
+              [value]="version()"
+              (change)="onVersionChange($event)"
+              class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+            >
+              <option value="" disabled>Choose a version…</option>
+              @for (v of selectable(); track v.version) {
+                <option [value]="v.version">
+                  v{{ v.version }}{{ v.name ? ' — ' + v.name : '' }}
+                </option>
+              }
+            </select>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              Currently serving v{{ data.listing.publishedVersion }}.
+            </p>
+
+            <label
+              for="rollback-reason"
+              class="mt-4 block text-sm/6 font-medium text-gray-900 dark:text-white"
+            >
+              Why are you rolling back?
+            </label>
+            <textarea
+              id="rollback-reason"
+              rows="3"
+              [value]="reason()"
+              (input)="onReasonInput($event)"
+              placeholder="Be specific — this is the whole message the author receives."
+              class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
+            ></textarea>
+          }
+        </div>
+
+        <div
+          class="flex justify-end gap-2 border-t border-gray-200 px-6 py-4 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            [disabled]="!canSubmit()"
+            (click)="onSubmit()"
+            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Publish this version
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class RollbackDialogComponent implements OnInit {
+  private dialogRef = inject<DialogRef<RollbackDialogResult>>(DialogRef);
+  private service = inject(AdminMarketplaceService);
+  readonly data = inject<RollbackDialogData>(DIALOG_DATA);
+
+  readonly versions = signal<AgentVersionSummary[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly version = signal<number | ''>('');
+  readonly reason = signal('');
+
+  /** Everything except the one already live — see the class docstring. */
+  readonly selectable = computed(() => this.versions().filter((v) => !v.isPublished));
+  readonly canSubmit = computed(() => this.version() !== '' && !!this.reason().trim());
+
+  async ngOnInit(): Promise<void> {
+    try {
+      const response = await this.service.loadVersions(this.data.listing.agentId);
+      this.versions.set(response.versions ?? []);
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(
+        typeof detail === 'string' ? detail : 'Could not load this agent’s versions.',
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  onVersionChange(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    this.version.set(value ? Number(value) : '');
+  }
+
+  onReasonInput(event: Event): void {
+    this.reason.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onSubmit(): void {
+    const version = this.version();
+    const reason = this.reason().trim();
+    if (version !== '' && reason) {
+      this.dialogRef.close({ version, reason });
+    }
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -151,6 +151,38 @@ export interface WithdrawalDecisionRequest {
 }
 
 /**
+ * One snapshot in an Agent's history, described just enough to pick out of a list.
+ *
+ * Deliberately not the whole version: the picker renders a number, a name and a date, and
+ * shipping every past snapshot's `instructions` to draw a dropdown would put an Agent's
+ * entire approval history on the wire.
+ */
+export interface AgentVersionSummary {
+  version: number;
+  name?: string;
+  tagline?: string;
+  createdAt?: string;
+  createdBy?: string;
+  isPublished: boolean;
+}
+
+export interface AgentVersionsResponse {
+  versions: AgentVersionSummary[];
+  publishedVersion?: number;
+}
+
+/**
+ * Repoint a published listing at an earlier snapshot (§8).
+ *
+ * `reason` is required and reaches the author's card, exactly as a takedown's does — an
+ * admin changing what users run is something the author has to be able to see.
+ */
+export interface RollbackListingRequest {
+  version: number;
+  reason: string;
+}
+
+/**
  * Presentation-only patch. The backend refuses behavior fields (`instructions`,
  * `bindings`, `modelConfig`, `starters`, `visibility`) with a 422 — an admin editing
  * behavior would own something they did not write and cannot test.

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Dialog } from '@angular/cdk/dialog';
 import { signal } from '@angular/core';
+import { of } from 'rxjs';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { MarketplaceListingsPage } from './listings.page';
 import { AdminListingRow } from '../models/marketplace.model';
@@ -101,5 +102,123 @@ describe('MarketplaceListingsPage — published-version marker', () => {
     // wrong. This one means the system is working, and amber would misreport that.
     const fixture = await renderWith([row({ publishedVersion: 3 })]);
     expect(versionBadge(fixture, 'v3')!.className).not.toContain('amber');
+  });
+});
+
+/**
+ * Rollback (§8).
+ *
+ * Repointing a published listing at an earlier snapshot. Not a review decision — nothing is
+ * cut, nothing queues, the listing stays published — so it lives beside "Take down" rather
+ * than in the review queue.
+ */
+describe('MarketplaceListingsPage — rollback', () => {
+  let mockService: any;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  function row(overrides: Partial<AdminListingRow> = {}): AdminListingRow {
+    return {
+      agentId: 'ast-001',
+      name: 'Policy Lookup',
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      state: 'published',
+      publishedVersion: 3,
+      usageCount: 12,
+      updatedAt: '2026-07-22T00:00:00Z',
+      reachability: 'everyone',
+      adminEdits: [],
+      ...overrides,
+    };
+  }
+
+  async function render(rows: AdminListingRow[]) {
+    mockService.loadListings.mockResolvedValue(rows);
+    const fixture = TestBed.createComponent(MarketplaceListingsPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function button(fixture: ComponentFixture<unknown>, label: string) {
+    return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === label,
+    );
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: signal<string | null>(null),
+      loadListings: vi.fn().mockResolvedValue([]),
+      takedown: vi.fn().mockResolvedValue(undefined),
+      review: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      loadVersions: vi.fn().mockResolvedValue({ versions: [], publishedVersion: 3 }),
+    };
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ closed: of({ version: 2, reason: 'v3 broke citations.' }) }),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: mockDialog },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('offers rollback on a published listing that has history behind it', async () => {
+    const fixture = await render([row({ publishedVersion: 3 })]);
+    expect(button(fixture, 'Roll back')).toBeTruthy();
+  });
+
+  it('hides rollback on v1 — there is nothing behind the first version', async () => {
+    // A control whose dialog can only say "nothing to roll back to" is worse than no control.
+    const fixture = await render([row({ publishedVersion: 1 })]);
+    expect(button(fixture, 'Roll back')).toBeFalsy();
+    // The other published action is unaffected.
+    expect(button(fixture, 'Take down')).toBeTruthy();
+  });
+
+  it('hides rollback on a listing that is not published', async () => {
+    const fixture = await render([row({ state: 'in_review', publishedVersion: undefined })]);
+    expect(button(fixture, 'Roll back')).toBeFalsy();
+  });
+
+  it('sends the chosen version and reason', async () => {
+    const fixture = await render([row()]);
+    button(fixture, 'Roll back')!.click();
+    await fixture.whenStable();
+
+    expect(mockService.rollback).toHaveBeenCalledWith('ast-001', {
+      version: 2,
+      reason: 'v3 broke citations.',
+    });
+    // Not a review decision — it must not travel through that endpoint.
+    expect(mockService.review).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the dialog is dismissed', async () => {
+    mockDialog.open.mockReturnValue({ closed: of(undefined) });
+    const fixture = await render([row()]);
+    button(fixture, 'Roll back')!.click();
+    await fixture.whenStable();
+
+    expect(mockService.rollback).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server's refusal", async () => {
+    mockService.rollback.mockRejectedValue({
+      error: { detail: 'Version 2 of this agent does not exist.' },
+    });
+    const fixture = await render([row()]);
+    button(fixture, 'Roll back')!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('does not exist');
   });
 });

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -31,6 +31,11 @@ import {
   RequestChangesDialogData,
   RequestChangesDialogResult,
 } from '../components/request-changes-dialog.component';
+import {
+  RollbackDialogComponent,
+  RollbackDialogData,
+  RollbackDialogResult,
+} from '../components/rollback-dialog.component';
 
 /**
  * Listings — every agent that has ever been submitted (D10).
@@ -218,6 +223,19 @@ import {
                           >
                             Request changes
                           </button>
+                          <!-- Only once there is something to roll back *to*. A control that
+                               opens a dialog whose only honest content is "there is nothing
+                               here" is worse than an absent one. -->
+                          @if (canRollBack(row)) {
+                            <button
+                              type="button"
+                              [disabled]="busyId() === row.agentId"
+                              (click)="rollback(row)"
+                              class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                            >
+                              Roll back
+                            </button>
+                          }
                           <button
                             type="button"
                             [disabled]="busyId() === row.agentId"
@@ -310,6 +328,45 @@ export class MarketplaceListingsPage implements OnInit {
     } catch (err) {
       const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
       this.error.set(typeof detail === 'string' ? detail : 'Failed to record the decision.');
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+
+  /**
+   * Whether an earlier snapshot exists to roll back to.
+   *
+   * Inferred from the version number rather than by fetching the history: `v1` is by
+   * definition the first, so there is nothing behind it. Anything above `v1` *may* have a
+   * predecessor — the dialog loads the real list and says so honestly if it does not.
+   */
+  canRollBack(row: AdminListingRow): boolean {
+    return (row.publishedVersion ?? 0) > 1;
+  }
+
+  /**
+   * Repoint a published listing at an earlier snapshot (§8).
+   *
+   * Not a review decision — nothing is cut, nothing queues, and the listing stays published.
+   * It changes only which approved artifact the store serves, which is why it sits beside
+   * "Take down" rather than in the review queue.
+   */
+  async rollback(row: AdminListingRow): Promise<void> {
+    const ref = this.dialog.open<RollbackDialogResult, RollbackDialogData>(
+      RollbackDialogComponent,
+      { data: { listing: row } },
+    );
+    const choice = await firstValueFrom(ref.closed);
+    if (!choice) return;
+
+    this.busyId.set(row.agentId);
+    this.error.set(null);
+    try {
+      await this.service.rollback(row.agentId, choice);
+      await this.reload();
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(typeof detail === 'string' ? detail : 'Failed to roll back the listing.');
     } finally {
       this.busyId.set(null);
     }

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -4,6 +4,8 @@ import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import {
   AgentVersionDiff,
+  AgentVersionsResponse,
+  RollbackListingRequest,
   PublisherCreateRequest,
   PublisherEligibilityResponse,
   PublisherUpdateRequest,
@@ -113,6 +115,24 @@ export class AdminMarketplaceService {
    */
   async decideWithdrawal(agentId: string, request: WithdrawalDecisionRequest): Promise<void> {
     await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/withdrawal`, request));
+  }
+
+  /** Every snapshot this agent has, newest first — the rollback picker's source (§8). */
+  async loadVersions(agentId: string): Promise<AgentVersionsResponse> {
+    return firstValueFrom(
+      this.http.get<AgentVersionsResponse>(`${this.baseUrl()}/${agentId}/versions`),
+    );
+  }
+
+  /**
+   * Repoint a published listing at an earlier snapshot (§8).
+   *
+   * Not a review decision: no version is cut, nothing enters the queue, and the listing
+   * stays published throughout. It only changes *which* approved artifact the store serves,
+   * which is why the backend refuses it on anything that is not already published.
+   */
+  async rollback(agentId: string, request: RollbackListingRequest): Promise<void> {
+    await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/rollback`, request));
   }
 
   /**

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
@@ -120,3 +120,69 @@ describe('SubmitListingDialogComponent — going public', () => {
     });
   });
 });
+
+/**
+ * Category preselection on a resubmission.
+ *
+ * The shelf an Agent already sits on is the answer nine times out of ten, and an author
+ * resubmitting a Teaching listing should not have to notice that the picker quietly offered
+ * them Administration instead — that silently moves a live listing to a different shelf.
+ */
+describe('SubmitListingDialogComponent — category preselection', () => {
+  function build(
+    data: Record<string, unknown>,
+    categories = [
+      { id: 'Administration', label: 'Administration' },
+      { id: 'Teaching', label: 'Teaching' },
+    ],
+  ): SubmitListingDialogComponent {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DialogRef, useValue: { close: () => undefined } },
+        {
+          provide: DIALOG_DATA,
+          useValue: { agentId: 'ast-001', agentName: 'Policy Lookup', ...data },
+        },
+        {
+          provide: AgentListingService,
+          useValue: {
+            loadCategories: async () => categories,
+            preflight: async (): Promise<ListingPreflight> => ({
+              agentId: 'ast-001',
+              exposedSkills: [],
+              blockReason: null,
+              requiresPublic: false,
+              reachability: 'everyone',
+            }),
+            submit: async () => ({ listing: { state: 'in_review' } }),
+          },
+        },
+      ],
+    });
+    return TestBed.createComponent(SubmitListingDialogComponent).componentInstance;
+  }
+
+  it("keeps the listing's current shelf on a resubmission", async () => {
+    const component = build({ listing: { state: 'private', category: 'Teaching' } });
+    await component.ngOnInit();
+
+    expect(component.category()).toBe('Teaching');
+  });
+
+  it('leaves a first submission unselected rather than guessing', async () => {
+    // An author who never chose a shelf must choose one — defaulting to whichever category
+    // sorts first would file new listings under it by accident.
+    const component = build({});
+    await component.ngOnInit();
+
+    expect(component.category()).toBe('');
+  });
+
+  it('clears a shelf that has since been closed to new listings', async () => {
+    const component = build({ listing: { state: 'private', category: 'Retired' } });
+    await component.ngOnInit();
+
+    expect(component.category()).toBe('');
+  });
+});


### PR DESCRIPTION
Finishes the version-snapshots epic. The two §8 open items get decisions, and the behavioural gap #799 deliberately left open gets closed now that the product call behind it is made.

## An author can no longer pull a live listing alone

A listing that was published and then sent back for changes keeps serving — `review_listing` deliberately does not unpublish — but sits in `changes_requested`. `withdraw_listing` asked `is_listed`, which answers by **state name**, so it read that listing as not-live and took it straight to `private`: the unilateral delisting §5.1 exists to prevent, reached through the one state nobody thought to check.

#799 documented this instead of fixing it, because the transition table could not allow `changes_requested → withdrawal_requested` without also opening `in_review → changes_requested → withdrawal_requested → published` — a route to published for something never approved.

`AgentListing.withdrawalFrom` is what makes the edge safe: **a declined withdrawal returns to the state it came *from***, so a request that entered from `changes_requested` can only go back there. Approval stays the only door into the store, and `test_approval_is_the_only_door_into_the_store` now asserts that structurally rather than by enumeration — the decline targets must equal the set of states that can enter.

> ⚠️ Moving that decision onto `is_on_shelf` opened a hole the existing suite caught, and it is the most interesting thing in this PR. `withdrawal_requested → private` is a legal edge — it is how an admin **grants** a withdrawal — and `private` is an author target. So a pending request with no published pointer resolved to `private` and the author granted their own withdrawal. `withdraw_listing` now refuses a second request explicitly rather than relying on the table to imply it, with a test at both pointer states.

## Rollback (§8)

`GET /admin/agents/{id}/versions` + `POST /admin/agents/{id}/rollback`, with a picker on the admin Listings page. Reuses `_publish_version`, so it inherits the new-key-first ordering.

Three constraints worth keeping:

- **Only from `published`** — otherwise this endpoint is a second door into the store, past review.
- **A reason is required** and lands on the author's card, exactly as a takedown's does. An admin replacing what users run is not something the author should have to discover.
- **No version is cut.** It is a pointer move over immutable records, so rolling forward again is the same operation.

The picker excludes the version already live (the backend refuses it anyway, so offering it would make the most obvious entry the one that errors), and the button only renders above `v1`.

## Retention: deliberately unbounded

At a few hundred agents with a handful of KB-sized snapshots each the storage is immaterial, and every alternative costs more than it saves — a TTL deletes invisibly and cannot exempt a version an audit or takedown record points at; a keep-last-N prune destroys the older half of a listing's approval history, which is the thing the epic exists to make durable. Rollback makes this **stronger, not weaker**: an old version is no longer inert history, so deleting one now costs a recovery path. Revisit if one Agent ever accumulates enough versions to make the partition read slow — that is the symptom worth acting on, not the row count.

## Also fixed

- **The store read logged a pydantic traceback per legacy row, per browse.** Listings published before PR-2 still carry GSI5 keys on their `METADATA` item, so the query returns Agent rows that cannot be an `AgentVersion`. Skipped by sort key now. (The one such row in dev has had its stale keys cleared.)
- **A latent ordering bug that skip exposed:** `browse_all` paired raw items to projected responses *positionally*, so any dropped row slid every later response onto the previous row's sort key. `_project_with_keys` builds the pairing where the drop happens.
- **The review diff** no longer tells a reviewer looking at an in-review row that there is "nothing awaiting review" when the real cause is a pre-snapshot submission.

## Not changed

The resubmit dialog's category default. #799 reported it as resetting to the first option; **it does not** — `ngOnInit` preselects the listing's category and clears it only when that shelf has closed to new listings. I could not reproduce it and the component is correct; three regression tests now pin behaviour that was previously untested.

## Verification

Driven through the browser on a second local stack, with DynamoDB checked at each step:

- rollback v3 → v1: pointer moved, GSI5 key moved off v3 onto v1, reason recorded, state stayed `published`, no version cut — and both the store tile and non-owner invocation followed to v1
- live `changes_requested` listing: author withdraw becomes a **request** recording `withdrawalFrom=changes_requested`; decline restores `changes_requested` (not `published`); a second request refuses; grant goes `private` and clears the pointer
- legacy row: one info line, no traceback, no `ValidationError`

**5588 backend tests, 1725 frontend tests, all passing** — 20 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)