### PR TITLE
fix(marketplace): keep rollback reversible, and tell the reviewer why a diff is missing

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -1158,6 +1158,29 @@ def _reachability(assistant: Assistant) -> str:
     return "owner_only"
 
 
+def _latest_version(listing: AgentListing) -> Optional[int]:
+    """The highest snapshot number this listing has, without reading the version partition.
+
+    Answers one question for the Listings table: *does more than one version exist?* — which
+    is what the rollback affordance actually depends on. ``published_version`` alone cannot
+    answer it, because a rollback moves that pointer **down**: a listing serving ``v1`` with
+    ``v2``–``v5`` behind it is indistinguishable from one that has only ever had ``v1``, and
+    the table hid the only route back to the newer snapshots (see
+    ``canRollBack``). Rolling forward is the same pointer move as rolling back, so the entry
+    point cannot be gated on the direction.
+
+    ``submitted_version`` is the high-water mark that survives a rollback: both counters only
+    ever move *up* when a snapshot is cut, so ``max`` of the two is ≥ 2 exactly when a second
+    version exists. It can *understate* the true highest — an admin presentation edit cuts a
+    version and bumps only ``published_version``, so a later rollback leaves the max one
+    short — which is harmless here, because no caller asks for the number itself, only
+    whether it is above one. Anything that needs the real list already calls
+    ``list_agent_versions``.
+    """
+    highest = max(listing.published_version or 0, listing.submitted_version or 0)
+    return highest or None
+
+
 def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> AdminListingRow:
     listing = assistant.listing
     if listing is None:  # callers filter; belt-and-braces rather than a stripped assert
@@ -1184,6 +1207,7 @@ def _to_row(assistant: Assistant, publisher: Optional[PublisherProfile]) -> Admi
         reviewed_at=listing.reviewed_at,
         review_note=listing.review_note,
         updated_at=assistant.updated_at,
+        latest_version=_latest_version(listing),
         published_version=listing.published_version,
         reachability=_reachability(assistant),
         admin_edits=listing.admin_edits,

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -1009,6 +1009,17 @@ class AdminListingRow(BaseModel):
     reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
     review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
     updated_at: str = Field(..., alias="updatedAt", description="ISO 8601 of the last write to the Agent record")
+    latest_version: Optional[int] = Field(
+        None,
+        alias="latestVersion",
+        description=(
+            "The highest snapshot number this Agent has, which for 1-based sequential "
+            "versions is also how many exist. Present so the Listings table can tell "
+            "'serving v1' apart from 'only ever had v1' — the rollback affordance depends "
+            "on whether *another* version exists, not on which one is currently live, and "
+            "after a rollback to v1 those two readings disagree. Derived, never stored."
+        ),
+    )
     published_version: Optional[int] = Field(
         None,
         alias="publishedVersion",

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -662,6 +662,44 @@ class TestListingsRowReportsTheLiveVersion:
 
         assert "drift" not in resp.json()["listings"][0]
 
+    def test_the_row_also_reports_how_many_versions_exist(self, app):
+        """``latestVersion`` is the high-water mark, ``publishedVersion`` is the pointer."""
+        assistant = _make_assistant(
+            listing=_listing("published", publishedVersion=3, submittedVersion=3)
+        )
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            resp = TestClient(app).get("/admin/agents/listings")
+
+        assert resp.json()["listings"][0]["latestVersion"] == 3
+
+    def test_a_rolled_back_row_still_reports_the_versions_above_it(self, app):
+        """⚠️ The distinction the rollback affordance depends on.
+
+        A rollback moves ``published_version`` **down**, so a listing serving ``v1`` with
+        ``v2``–``v5`` behind it looked identical to one that had only ever had ``v1``. The
+        Listings table hid its rollback control on that reading and stranded the rollback
+        with no way to undo it. ``submitted_version`` survives the pointer moving down.
+        """
+        assistant = _make_assistant(
+            listing=_listing("published", publishedVersion=1, submittedVersion=5)
+        )
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            row = TestClient(app).get("/admin/agents/listings").json()["listings"][0]
+
+        assert row["publishedVersion"] == 1
+        assert row["latestVersion"] == 5
+
+    def test_a_pre_snapshot_listing_reports_no_version_at_all(self, app):
+        """Absent, not ``0`` — the caller's question is "is there a second one?"."""
+        assistant = _make_assistant(listing=_listing("published", submittedVersion=None))
+        by_state, publishers = _listing_rows(assistant)
+        with by_state, publishers:
+            row = TestClient(app).get("/admin/agents/listings").json()["listings"][0]
+
+        assert row.get("latestVersion") is None
+
 
 class TestWithdrawalDecision:
     """§5.1 — withdrawal is a request an admin acts on, in the existing queue."""

--- a/docs/specs/agent-version-snapshots.md
+++ b/docs/specs/agent-version-snapshots.md
@@ -370,6 +370,16 @@ version attributed to the admin.
   way a takedown's does, because an admin changing what users run is not something the
   author should have to discover; and it **cuts no version** — rolling back is a pointer
   move over immutable records, so rolling forward again is the same operation.
+
+  ⚠️ **That last property has to reach the UI, and at first it did not.** The Listings page
+  gated its control on `publishedVersion > 1`, which reads "are we serving above the first
+  version?" — the same answer as "does a second version exist?" right up until someone rolls
+  back, and the opposite one afterwards. A listing rolled back to `v1` still had every later
+  snapshot intact and the endpoint would happily repoint at one, but the only entry point was
+  hidden: the rollback could not be undone from the UI. The row now carries `latestVersion`
+  (the high-water mark, which survives the pointer moving down) and the control, its label
+  and the dialog's copy are all direction-neutral, because half of this feature's uses are
+  the second half of an earlier use.
 - **Transaction vs fail-closed ordering.** Publishing and delisting are now two writes on
   two items (§3.3), and the "an unpublished agent cannot be in the store" invariant is held
   by call order rather than by atomicity. Ordering is enforced in one place

--- a/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.spec.ts
@@ -162,6 +162,29 @@ describe('ReviewDiffComponent', () => {
     expect(text(fixture)).toContain('Could not load what changed');
   });
 
+  it('shows the server’s own explanation instead of the generic failure', async () => {
+    // The pre-snapshot case: retrying can never work, and "could not load" invites exactly
+    // that. The backend names the real cause and what to do about it — the reviewer has to
+    // see *that*, not a transport-shaped message about a data condition.
+    mockService.loadDiff.mockRejectedValue({
+      error: { detail: 'This submission predates version snapshots, so there is nothing to compare.' },
+    });
+    const fixture = render();
+    await expand(fixture);
+
+    expect(text(fixture)).toContain('predates version snapshots');
+    expect(text(fixture)).not.toContain('Could not load what changed');
+  });
+
+  it('falls back to the generic failure when the error carries no detail', async () => {
+    // A real transport failure has no `detail`, and "try again" is the right advice there.
+    mockService.loadDiff.mockRejectedValue({ error: { detail: '   ' } });
+    const fixture = render();
+    await expand(fixture);
+
+    expect(text(fixture)).toContain('Could not load what changed');
+  });
+
   it('marks the toggle as expanded for assistive technology', async () => {
     const fixture = render();
     const button = (fixture.nativeElement as HTMLElement).querySelector('button')!;

--- a/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-diff.component.ts
@@ -153,13 +153,31 @@ export class ReviewDiffComponent {
     }
   }
 
+  /**
+   * Load the diff, preferring the server's own explanation over a generic one.
+   *
+   * ⚠️ **The reason a diff is missing is usually the useful part.** This used to discard the
+   * response entirely and always say "could not load", which reads as a transient failure —
+   * so a reviewer looking at a submission that simply *predates* version snapshots was told
+   * to try again, and trying again could never work. The backend distinguishes those cases
+   * deliberately (it names the pre-snapshot one and tells the author to resubmit); throwing
+   * that away at the boundary put the reviewer back where the collapsed message left them.
+   *
+   * The generic line stays as the fallback for the case it was written for: a real transport
+   * failure, where there is no `detail` and retrying is exactly the right advice.
+   */
   private async load(): Promise<void> {
     this.loading.set(true);
     this.error.set(null);
     try {
       this.diff.set(await this.service.loadDiff(this.agentId()));
-    } catch {
-      this.error.set('Could not load what changed. Try again, or review the agent directly.');
+    } catch (err) {
+      const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+      this.error.set(
+        typeof detail === 'string' && detail.trim()
+          ? detail
+          : 'Could not load what changed. Try again, or review the agent directly.',
+      );
     } finally {
       this.loading.set(false);
     }

--- a/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.spec.ts
@@ -73,12 +73,22 @@ describe('RollbackDialogComponent', () => {
     expect(component.selectable().map((v) => v.version)).toEqual([2, 1]);
   });
 
-  it('says so plainly when there is nothing to roll back to', async () => {
+  it('says so plainly when there is nothing else to switch to', async () => {
     const component = build([version(3, true)]);
     await component.ngOnInit();
 
     expect(component.selectable()).toEqual([]);
     expect(component.canSubmit()).toBe(false);
+  });
+
+  it('offers later versions too, so a rollback can be undone', async () => {
+    // Serving v1 with v2–v3 still on the shelf: nothing was deleted, so the picker's job is
+    // "everything that is not live", not "everything below the live one". Filtering by
+    // direction would make the sequel to every rollback unreachable.
+    const component = build([version(3), version(2), version(1, true)]);
+    await component.ngOnInit();
+
+    expect(component.selectable().map((v) => v.version)).toEqual([3, 2]);
   });
 
   it('will not submit without a reason', async () => {

--- a/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/rollback-dialog.component.ts
@@ -13,16 +13,22 @@ export interface RollbackDialogData {
 export type RollbackDialogResult = { version: number; reason: string } | undefined;
 
 /**
- * Repoint a published listing at an earlier snapshot (§8).
+ * Repoint a published listing at a different snapshot (§8).
  *
  * **Versions are loaded here rather than with the Listings table.** The table is a list of
  * listings; a version history is a per-agent question that only matters once someone has
- * decided to roll one back, and fetching every agent's history to render a page of rows
- * would be the same mistake the review diff avoids.
+ * decided to change one, and fetching every agent's history to render a page of rows would
+ * be the same mistake the review diff avoids.
  *
- * The currently-published version is shown but not selectable — "roll back to what is
- * already live" is not a decision, and the backend refuses it anyway. Offering it would
- * make the picker's most obvious entry the one that errors.
+ * The currently-published version is shown but not selectable — "publish what is already
+ * live" is not a decision, and the backend refuses it anyway. Offering it would make the
+ * picker's most obvious entry the one that errors.
+ *
+ * ⚠️ **The copy is direction-neutral on purpose.** A rollback lowers the published pointer
+ * but deletes nothing, so the newer snapshots are still there and putting one back is this
+ * same dialog — the picker lists whatever is not live, above or below. Wording it as "roll
+ * back to an earlier version" described the majority case and mislabelled the sequel to
+ * every rollback, which is the one an admin reaches for under time pressure.
  */
 @Component({
   selector: 'app-rollback-dialog',
@@ -53,12 +59,12 @@ export type RollbackDialogResult = { version: number; reason: string } | undefin
         <div class="flex items-start justify-between gap-3 px-6 pt-5">
           <div class="min-w-0">
             <h2 id="rollback-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
-              Roll back to an earlier version
+              Publish a different version
             </h2>
             <p id="rollback-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
               The store serves the version you pick, and everyone who opens
               <span class="font-medium">{{ data.listing.name }}</span> runs it from the next
-              turn. Nothing is deleted — the current version stays available to roll forward
+              turn. Nothing is deleted — the version live now stays available to switch back
               to, and {{ data.listing.ownerName }}'s draft is untouched.
             </p>
           </div>
@@ -79,8 +85,8 @@ export type RollbackDialogResult = { version: number; reason: string } | undefin
             <p role="alert" class="text-sm/6 text-rose-700 dark:text-rose-400">{{ error() }}</p>
           } @else if (selectable().length === 0) {
             <p class="text-sm/6 text-gray-600 dark:text-gray-400">
-              This agent has only ever had one approved version, so there is nothing to roll
-              back to.
+              This agent has only ever had one approved version, so there is nothing else to
+              switch to.
             </p>
           } @else {
             <label
@@ -110,7 +116,7 @@ export type RollbackDialogResult = { version: number; reason: string } | undefin
               for="rollback-reason"
               class="mt-4 block text-sm/6 font-medium text-gray-900 dark:text-white"
             >
-              Why are you rolling back?
+              Why are you changing the published version?
             </label>
             <textarea
               id="rollback-reason"

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -112,6 +112,16 @@ export interface AdminListingRow {
   publishedVersion?: number;
 
   /**
+   * The highest snapshot this agent has — for 1-based sequential versions, also how many.
+   *
+   * Distinct from `publishedVersion` because a rollback moves that pointer *down*: a listing
+   * serving `v1` with `v2`–`v5` behind it looks identical to one that has only ever had
+   * `v1`, and gating the rollback affordance on the latter reading hides the only way back
+   * to the newer snapshots.
+   */
+  latestVersion?: number;
+
+  /**
    * Who can open this agent if it is shelved, derived from `visibility` server-side.
    * `everyone` = PUBLIC; the other two mean the store tile will 404 for most users.
    * Advisory — the reviewer is told, never blocked.

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.spec.ts
@@ -124,6 +124,7 @@ describe('MarketplaceListingsPage — rollback', () => {
       category: 'Administration',
       state: 'published',
       publishedVersion: 3,
+      latestVersion: 3,
       usageCount: 12,
       updatedAt: '2026-07-22T00:00:00Z',
       reachability: 'everyone',
@@ -170,27 +171,38 @@ describe('MarketplaceListingsPage — rollback', () => {
 
   afterEach(() => TestBed.resetTestingModule());
 
-  it('offers rollback on a published listing that has history behind it', async () => {
-    const fixture = await render([row({ publishedVersion: 3 })]);
-    expect(button(fixture, 'Roll back')).toBeTruthy();
+  it('offers the control on a published listing that has more than one version', async () => {
+    const fixture = await render([row({ publishedVersion: 3, latestVersion: 3 })]);
+    expect(button(fixture, 'Change version')).toBeTruthy();
   });
 
-  it('hides rollback on v1 — there is nothing behind the first version', async () => {
-    // A control whose dialog can only say "nothing to roll back to" is worse than no control.
-    const fixture = await render([row({ publishedVersion: 1 })]);
-    expect(button(fixture, 'Roll back')).toBeFalsy();
+  it('hides it when the agent has only ever had one version', async () => {
+    // A control whose dialog can only say "nothing else to switch to" is worse than none.
+    const fixture = await render([row({ publishedVersion: 1, latestVersion: 1 })]);
+    expect(button(fixture, 'Change version')).toBeFalsy();
     // The other published action is unaffected.
     expect(button(fixture, 'Take down')).toBeTruthy();
   });
 
-  it('hides rollback on a listing that is not published', async () => {
-    const fixture = await render([row({ state: 'in_review', publishedVersion: undefined })]);
-    expect(button(fixture, 'Roll back')).toBeFalsy();
+  it('keeps offering it after a rollback to v1, so the rollback can be undone', async () => {
+    // ⚠️ The regression this exists for. Gating on `publishedVersion > 1` hid the control in
+    // the one state that most needs it: v2–v5 are still there, repointing at one is the same
+    // operation in the other direction, and the endpoint accepts it — but the UI had removed
+    // the only way to ask. A rollback you cannot undo is a worse rollback.
+    const fixture = await render([row({ publishedVersion: 1, latestVersion: 5 })]);
+    expect(button(fixture, 'Change version')).toBeTruthy();
+  });
+
+  it('hides it on a listing that is not published', async () => {
+    const fixture = await render([
+      row({ state: 'in_review', publishedVersion: undefined, latestVersion: 4 }),
+    ]);
+    expect(button(fixture, 'Change version')).toBeFalsy();
   });
 
   it('sends the chosen version and reason', async () => {
     const fixture = await render([row()]);
-    button(fixture, 'Roll back')!.click();
+    button(fixture, 'Change version')!.click();
     await fixture.whenStable();
 
     expect(mockService.rollback).toHaveBeenCalledWith('ast-001', {
@@ -204,7 +216,7 @@ describe('MarketplaceListingsPage — rollback', () => {
   it('does nothing when the dialog is dismissed', async () => {
     mockDialog.open.mockReturnValue({ closed: of(undefined) });
     const fixture = await render([row()]);
-    button(fixture, 'Roll back')!.click();
+    button(fixture, 'Change version')!.click();
     await fixture.whenStable();
 
     expect(mockService.rollback).not.toHaveBeenCalled();
@@ -215,7 +227,7 @@ describe('MarketplaceListingsPage — rollback', () => {
       error: { detail: 'Version 2 of this agent does not exist.' },
     });
     const fixture = await render([row()]);
-    button(fixture, 'Roll back')!.click();
+    button(fixture, 'Change version')!.click();
     await fixture.whenStable();
     fixture.detectChanges();
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -223,9 +223,14 @@ import {
                           >
                             Request changes
                           </button>
-                          <!-- Only once there is something to roll back *to*. A control that
+                          <!-- Only once there is a second version to switch to. A control that
                                opens a dialog whose only honest content is "there is nothing
-                               here" is worse than an absent one. -->
+                               here" is worse than an absent one.
+
+                               Labelled for the operation, not one direction of it: after a
+                               rollback the same control is how an admin puts the newer
+                               version back, and "Roll back" would name the opposite of what
+                               it then does. -->
                           @if (canRollBack(row)) {
                             <button
                               type="button"
@@ -233,7 +238,7 @@ import {
                               (click)="rollback(row)"
                               class="rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                             >
-                              Roll back
+                              Change version
                             </button>
                           }
                           <button
@@ -334,14 +339,23 @@ export class MarketplaceListingsPage implements OnInit {
   }
 
   /**
-   * Whether an earlier snapshot exists to roll back to.
+   * Whether another snapshot exists to switch to.
    *
-   * Inferred from the version number rather than by fetching the history: `v1` is by
-   * definition the first, so there is nothing behind it. Anything above `v1` *may* have a
-   * predecessor — the dialog loads the real list and says so honestly if it does not.
+   * ⚠️ Asked as "does a second version exist?", not "are we serving above `v1`?". Those read
+   * the same until someone rolls back, and then they diverge in the one state where the
+   * control matters most: a listing rolled back to `v1` still has every later version
+   * sitting there, and repointing at one is the *same operation* in the other direction —
+   * which is exactly what the dialog promises ("the current version stays available to roll
+   * forward to"). Gating on `publishedVersion > 1` hid the button precisely then, stranding
+   * the rollback with no way to undo it from the UI even though the endpoint accepts it.
+   *
+   * `latestVersion` is the high-water mark and survives the pointer moving down, so it
+   * answers the question the affordance is really asking. Still inferred rather than fetched
+   * — a page of rows must not fetch every agent's history — and the dialog loads the real
+   * list and says so honestly in the edge the inference cannot see.
    */
   canRollBack(row: AdminListingRow): boolean {
-    return (row.publishedVersion ?? 0) > 1;
+    return (row.latestVersion ?? 0) > 1;
   }
 
   /**


### PR DESCRIPTION
Two gaps found validating #800 end-to-end against dev (localhost SPA → local app-api → dev-ai data). Both are in the UI layer of features #800 got right at the API.

## Rollback could not be undone from the UI

#800 shipped rollback with the property that makes it safe to reach for: **no version is cut**, so the snapshot you rolled off is still there and putting it back is the same pointer move. The dialog said exactly that — "the current version stays available to roll forward to". The Listings page then hid the only control that could do it.

`canRollBack` asked `publishedVersion > 1`. That reads *"are we serving above the first version?"*, which gives the same answer as *"does a second version exist?"* right up until someone rolls back — and the opposite one afterwards. A listing rolled back to `v1` with `v2`–`v5` intact was indistinguishable from one that had only ever had `v1`, so the button vanished in the one state that most needs it.

The endpoint accepts the forward move; I confirmed it against dev by calling it directly. The UI simply had no way to ask. **A rollback you cannot undo is a worse rollback**, and it degrades the property the feature was built on.

The row now carries `latestVersion`, derived as `max(publishedVersion, submittedVersion)`:

- Both counters only ever move **up** when a snapshot is cut, and `submittedVersion` survives the pointer moving down — so the max is ≥ 2 exactly when a second version exists.
- It can *understate* the true highest (an admin presentation edit bumps only `publishedVersion`, so a later rollback leaves it one short). Harmless: nothing reads the number itself, only whether it is above one.
- No extra read. A page of rows must not fetch every agent's history, and anything needing the real list already calls `list_agent_versions`.

Copy follows the behaviour rather than the majority case. "Roll back" named the *opposite* of what the control does on the sequel to every rollback, so the button is **"Change version"**, the dialog **"Publish a different version"**, and the reason prompt asks why you are changing the published version. The picker was already right — it offers everything not currently live, in either direction.

## The improved diff message never reached the reviewer

#800 taught the diff endpoint to name the real cause when a submission predates version snapshots, instead of claiming there was nothing awaiting review. `ReviewDiffComponent.load` caught with a bare `catch` and replaced every failure with "Could not load what changed. Try again, or review the agent directly."

So the reviewer was told to retry, and **retrying could never work** — the row is old, not broken. The backend's text even names the fix ("ask the author to resubmit — that captures one on the way in"), and the UI discarded it at the boundary.

`detail` is now preferred when the server sent one. The generic line stays as the fallback for the case it was written for: a real transport failure, where there is no `detail` and "try again" is exactly the right advice.

## Verification

Driven through the browser against dev data, with DynamoDB checked at each step.

- **Roll forward, end to end:** built a two-version agent, rolled back to `v1` — the control now stays, the picker offers `v2`, and publishing it moved `publishedVersion` to 2 with the GSI5 key back on `VERSION#00000002`. Still correctly absent on a pre-snapshot published listing and on a genuinely single-version one.
- **Review diff:** the pre-snapshot `in_review` row now renders "This submission predates version snapshots… Ask the author to resubmit" inline, instead of the generic failure.
- **5620 backend tests, 1729 frontend tests, all passing** — 7 of them new, including one pinning the exact regression (`keeps offering it after a rollback to v1, so the rollback can be undone`).

All test agents created during validation were deleted; dev is back to zero leftover version and indexed rows.

## Also in this PR

The §8 entry in `docs/specs/agent-version-snapshots.md` now records why the affordance cannot be gated on the published pointer — half of this feature's uses are the second half of an earlier use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)