### PR TITLE
feat(tools): RFC 8693 token exchange for per-user calls to existing APIs

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -77,6 +77,12 @@ jobs:
       # "iam") for any environment whose Gateway already exists; "jwt" only
       # applies to a newly created Gateway.
       CDK_GATEWAY_INBOUND_AUTH: ${{ vars.CDK_GATEWAY_INBOUND_AUTH }}
+      # RFC 8693 token exchange (optional). Leave both unset unless the
+      # organisation runs a token service with a token-exchange endpoint; the
+      # feature is dormant when the URL is empty. Not secrets — the client
+      # secret itself lives in Secrets Manager and is populated out of band.
+      CDK_TOKEN_EXCHANGE_URL: ${{ vars.CDK_TOKEN_EXCHANGE_URL }}
+      CDK_TOKEN_EXCHANGE_CLIENT_ID: ${{ vars.CDK_TOKEN_EXCHANGE_CLIENT_ID }}
       CDK_HOSTED_ZONE_DOMAIN: ${{ vars.CDK_HOSTED_ZONE_DOMAIN }}
       CDK_COGNITO_DOMAIN_PREFIX: ${{ vars.CDK_COGNITO_DOMAIN_PREFIX }}
       CDK_COGNITO_CALLBACK_URLS: ${{ vars.CDK_COGNITO_CALLBACK_URLS }}

--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -31,6 +31,10 @@ from apis.shared.tools.scoped_ids import base_tool_id, collect_tool_name_filters
 from agents.main_agent.integrations import oauth_token_cache
 from agents.main_agent.integrations.mcp_apps import UICapableMCPClient
 from agents.main_agent.integrations.gateway_auth import get_sigv4_auth
+from agents.main_agent.integrations.token_exchange import (
+    TokenExchangeError,
+    get_token_exchange_client,
+)
 from agents.main_agent.integrations.oauth_auth import (
     CompositeAuth,
     create_oauth_bearer_auth,
@@ -364,7 +368,11 @@ class ExternalMCPIntegration:
 
                 forward_auth = bool(getattr(tool, "forward_auth_token", False))
                 requires_oauth = bool(tool.requires_oauth_provider)
-                requires_user_auth = forward_auth or requires_oauth
+                exchange_audience = getattr(tool, "token_exchange_audience", None)
+                # An exchanged token is per-user just like the other two modes,
+                # so it must partition the client cache the same way — otherwise
+                # one user's Directory token would be reused for another.
+                requires_user_auth = forward_auth or requires_oauth or bool(exchange_audience)
 
                 cache_key = self._get_cache_key(tool_id, user_id, requires_user_auth)
                 # A different selected-tool subset is a different client, so fold
@@ -396,7 +404,58 @@ class ExternalMCPIntegration:
                 token_provider: Optional[Callable[[], Optional[str]]] = None
                 provider_id: Optional[str] = None
 
-                if forward_auth:
+                if exchange_audience:
+                    # RFC 8693: trade the user's Cognito token for one the
+                    # downstream API already trusts. Checked before forward_auth
+                    # because forwarding the raw Cognito token to such an API
+                    # would send a credential it cannot validate — a silent
+                    # 401 rather than an obvious misconfiguration.
+                    if not auth_token:
+                        logger.warning(
+                            f"Tool {tool_id} needs a token exchange but no auth_token "
+                            "was provided; skipping"
+                        )
+                        continue
+                    if not user_id:
+                        logger.warning(
+                            f"Tool {tool_id} needs a token exchange but no user_id "
+                            "was provided; skipping (tokens must be cached per user)"
+                        )
+                        continue
+
+                    exchanger = get_token_exchange_client()
+                    if not exchanger.configured:
+                        logger.warning(
+                            f"Tool {tool_id} declares token_exchange_audience but the "
+                            "runtime has no exchange configuration; skipping"
+                        )
+                        continue
+
+                    # Resolved lazily per request, like the OAuth path: exchanged
+                    # tokens are short-lived (600s in dev) and a client may
+                    # outlive one, so binding a value here would go stale
+                    # mid-conversation. TokenExchangeClient handles caching.
+                    async def _exchange(
+                        t=auth_token, a=exchange_audience, u=user_id, tid=tool_id
+                    ) -> Optional[str]:
+                        try:
+                            return await exchanger.exchange(
+                                subject_token=t, audience=a, user_id=u
+                            )
+                        except TokenExchangeError as exc:
+                            # Fail closed: no token means the request goes
+                            # unauthenticated and the downstream API refuses it,
+                            # which is the correct outcome and is visible here.
+                            logger.warning(f"Token exchange failed for {tid}: {exc}")
+                            return None
+
+                    token_provider = _exchange
+                    logger.info(
+                        f"Using RFC 8693 token exchange for tool {tool_id} "
+                        f"(audience={exchange_audience})"
+                    )
+
+                elif forward_auth:
                     if not auth_token:
                         logger.warning(
                             f"Tool {tool_id} has forward_auth_token=true but no auth_token provided"

--- a/backend/src/agents/main_agent/integrations/oauth_auth.py
+++ b/backend/src/agents/main_agent/integrations/oauth_auth.py
@@ -5,8 +5,9 @@ Provides an httpx Auth class that injects OAuth Bearer tokens into requests.
 The token is retrieved dynamically at request time based on user context.
 """
 
+import inspect
 import logging
-from typing import Generator, Optional, Callable
+from typing import AsyncGenerator, Generator, Optional, Callable
 
 import httpx
 
@@ -38,11 +39,15 @@ class OAuthBearerAuth(httpx.Auth):
 
         Args:
             token: Static token to use (for simple cases)
-            token_provider: Callback function that returns the current token.
-                           Called synchronously at request time.
+            token_provider: Callback returning the current token. May be a plain
+                callable (resolved synchronously at request time, e.g. an
+                in-memory cache lookup) or an async callable (awaited in
+                `async_auth_flow`, e.g. an RFC 8693 token exchange that may need
+                a network round trip).
         """
         self._token = token
         self._token_provider = token_provider
+        self._provider_is_async = inspect.iscoroutinefunction(token_provider)
 
         if not token and not token_provider:
             raise ValueError("Either token or token_provider must be provided")
@@ -50,8 +55,31 @@ class OAuthBearerAuth(httpx.Auth):
     def _get_token(self) -> Optional[str]:
         """Get the current token, either static or from provider."""
         if self._token_provider:
+            if self._provider_is_async:
+                # Refuse rather than return a coroutine, which would be
+                # stringified into the Authorization header and produce a
+                # baffling 401 at the far end.
+                raise RuntimeError(
+                    "async token_provider requires the async request path "
+                    "(httpx will call async_auth_flow); this is a wiring bug"
+                )
             return self._token_provider()
         return self._token
+
+    async def _get_token_async(self) -> Optional[str]:
+        """Resolve the token, awaiting the provider when it is async."""
+        if self._token_provider:
+            if self._provider_is_async:
+                return await self._token_provider()
+            return self._token_provider()
+        return self._token
+
+    def _apply(self, request: httpx.Request, token: Optional[str]) -> None:
+        if token:
+            request.headers["Authorization"] = f"Bearer {token}"
+            logger.debug("Added OAuth Bearer token to request")
+        else:
+            logger.warning("No OAuth token available for request")
 
     def auth_flow(
         self, request: httpx.Request
@@ -61,14 +89,22 @@ class OAuthBearerAuth(httpx.Auth):
 
         This method is called by httpx for each request.
         """
-        token = self._get_token()
+        self._apply(request, self._get_token())
+        yield request
 
-        if token:
-            request.headers["Authorization"] = f"Bearer {token}"
-            logger.debug("Added OAuth Bearer token to request")
-        else:
-            logger.warning("No OAuth token available for request")
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """
+        Async counterpart of `auth_flow`.
 
+        httpx calls this on async clients, which is what the MCP streamable-HTTP
+        transport uses. Overriding it is what makes an async token provider
+        possible: the default implementation delegates to the sync `auth_flow`,
+        which cannot await. Without this, a network-backed provider would have to
+        block the event loop.
+        """
+        self._apply(request, await self._get_token_async())
         yield request
 
 

--- a/backend/src/agents/main_agent/integrations/token_exchange.py
+++ b/backend/src/agents/main_agent/integrations/token_exchange.py
@@ -1,0 +1,260 @@
+"""
+RFC 8693 token exchange for downstream APIs.
+
+Trades the signed-in user's Cognito access token for a token-service JWT scoped
+to one registered downstream application, so an MCP server can call an API that
+already trusts token-service JWTs as the user — with no change on the target
+API's side.
+
+Why this lives in the agent runtime rather than the Gateway
+----------------------------------------------------------
+AgentCore Gateway cannot do this. Its outbound OAuth credential provider accepts
+only CLIENT_CREDENTIALS and AUTHORIZATION_CODE (verified against the
+`bedrock-agentcore-control` API model: `OAuthGrantType` has exactly those two
+values, and the string "TOKEN_EXCHANGE" appears nowhere in the model). A
+token-exchange grant is not expressible there.
+
+Separately, a Gateway with `AWS_IAM` inbound auth never receives the user's
+token, so it would have nothing to exchange even if the grant existed. The
+exchange therefore happens here, where the user's token is already in hand, and
+the result is forwarded to the MCP server exactly as `forward_auth_token` does
+with the raw token.
+
+Caching
+-------
+Exchanged tokens are short-lived by design (the token service caps them, 600s in
+dev) and every downstream API call needs one, so they are cached per
+(user, audience) and reused until shortly before expiry. The cache holds
+credentials, so entries are keyed by user and never shared across users.
+
+What this does NOT provide
+--------------------------
+Revocation does not propagate. The token service validates the subject token
+offline (signature, issuer, expiry, token_use, client_id) and never asks Cognito
+whether it is still live, so a Cognito token revoked before its expiry is still
+exchangeable. Exposure is bounded by the token service's own lifetime cap.
+Measured and documented on the token-service side; noted here because this is
+where the tokens are minted from.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import boto3
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Grant and token-type identifiers (RFC 8693 §2.1).
+_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+# Refresh this far before expiry so a token is not spent on the wire as it dies.
+_EXPIRY_SKEW_SECONDS = 30
+
+# Floor on cache lifetime, in case the server returns a tiny expires_in.
+_MIN_CACHE_SECONDS = 5
+
+_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    token: str
+    expires_at: float  # monotonic seconds
+
+
+class TokenExchangeError(Exception):
+    """The exchange could not be completed."""
+
+
+class TokenExchangeClient:
+    """
+    Exchanges Cognito access tokens for token-service JWTs.
+
+    One instance per process. Thread-safe: the agent runtime serves concurrent
+    turns, and without a lock two turns for the same user would each perform a
+    network exchange and race to populate the cache.
+    """
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        client_id: Optional[str] = None,
+        secret_id: Optional[str] = None,
+        region: Optional[str] = None,
+    ) -> None:
+        self._endpoint = endpoint or os.getenv("TOKEN_EXCHANGE_URL", "")
+        self._client_id = client_id or os.getenv("TOKEN_EXCHANGE_CLIENT_ID", "")
+        self._secret_id = secret_id or os.getenv("TOKEN_EXCHANGE_SECRET_ID", "")
+        self._region = region or os.getenv("AWS_REGION", "us-west-2")
+
+        self._cache: Dict[Tuple[str, str], _CacheEntry] = {}
+        self._lock = threading.Lock()
+        self._client_secret: Optional[str] = None
+
+    @property
+    def configured(self) -> bool:
+        """True when every value needed to perform an exchange is present."""
+        return bool(self._endpoint and self._client_id and self._secret_id)
+
+    def _load_client_secret(self) -> str:
+        """
+        Read the confidential-client secret from Secrets Manager.
+
+        Cached for the life of the process: it is needed on every exchange and
+        Secrets Manager is both rate-limited and billed per call. A rotated
+        secret is therefore picked up on the next cold start.
+        """
+        if self._client_secret is not None:
+            return self._client_secret
+
+        try:
+            client = boto3.client("secretsmanager", region_name=self._region)
+            response = client.get_secret_value(SecretId=self._secret_id)
+            payload = json.loads(response["SecretString"])
+        except Exception as exc:
+            raise TokenExchangeError(
+                f"could not read exchange client secret '{self._secret_id}'"
+            ) from exc
+
+        secret = payload.get(self._client_id)
+        if not secret:
+            raise TokenExchangeError(
+                f"no secret provisioned for exchange client '{self._client_id}'"
+            )
+
+        self._client_secret = secret
+        return secret
+
+    def _cache_key(self, user_id: str, audience: str) -> Tuple[str, str]:
+        return (user_id, audience)
+
+    def _cached(self, key: Tuple[str, str]) -> Optional[str]:
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at <= time.monotonic():
+            # Drop rather than serve a token that is about to be refused.
+            self._cache.pop(key, None)
+            return None
+        return entry.token
+
+    async def exchange(
+        self,
+        subject_token: str,
+        audience: str,
+        user_id: str,
+    ) -> str:
+        """
+        Return a token-service JWT for `audience`, acting for the user who owns
+        `subject_token`.
+
+        Args:
+            subject_token: the user's Cognito access token.
+            audience: token-service applicationId of the target application.
+            user_id: cache partition. Must identify the user, never be shared.
+
+        Raises:
+            TokenExchangeError: not configured, refused, or unreachable.
+        """
+        if not self.configured:
+            raise TokenExchangeError(
+                "token exchange is not configured (need TOKEN_EXCHANGE_URL, "
+                "TOKEN_EXCHANGE_CLIENT_ID, TOKEN_EXCHANGE_SECRET_ID)"
+            )
+        if not subject_token:
+            raise TokenExchangeError("no user token available to exchange")
+        if not audience:
+            raise TokenExchangeError("no audience configured for this tool")
+        if not user_id:
+            # Without a user id the cache cannot be partitioned, and a shared
+            # entry would hand one user's token to another.
+            raise TokenExchangeError("user_id is required to exchange a token")
+
+        key = self._cache_key(user_id, audience)
+
+        with self._lock:
+            cached = self._cached(key)
+        if cached:
+            return cached
+
+        client_secret = self._load_client_secret()
+
+        try:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as http:
+                response = await http.post(
+                    self._endpoint,
+                    auth=(self._client_id, client_secret),
+                    data={
+                        "grant_type": _GRANT_TYPE,
+                        "subject_token": subject_token,
+                        "subject_token_type": _SUBJECT_TOKEN_TYPE,
+                        "audience": audience,
+                    },
+                )
+        except httpx.HTTPError as exc:
+            raise TokenExchangeError(f"token exchange request failed: {exc}") from exc
+
+        if response.status_code != 200:
+            # The endpoint returns deliberately coarse errors; log what it gave
+            # us but never the tokens involved.
+            detail = ""
+            try:
+                body = response.json()
+                detail = f"{body.get('error')}: {body.get('error_description')}"
+            except Exception:
+                detail = response.text[:200]
+            raise TokenExchangeError(
+                f"token exchange refused (HTTP {response.status_code}) {detail}"
+            )
+
+        body = response.json()
+        token = body.get("access_token")
+        if not token:
+            raise TokenExchangeError("token exchange returned no access_token")
+
+        expires_in = body.get("expires_in")
+        try:
+            lifetime = int(expires_in)
+        except (TypeError, ValueError):
+            # No usable expiry: cache for the minimum rather than indefinitely.
+            lifetime = _MIN_CACHE_SECONDS + _EXPIRY_SKEW_SECONDS
+
+        ttl = max(_MIN_CACHE_SECONDS, lifetime - _EXPIRY_SKEW_SECONDS)
+
+        with self._lock:
+            self._cache[key] = _CacheEntry(
+                token=token, expires_at=time.monotonic() + ttl
+            )
+
+        logger.info(
+            "Token exchange succeeded for audience=%s (cached %ss)", audience, ttl
+        )
+        return token
+
+    def invalidate(self, user_id: str, audience: str) -> None:
+        """Drop a cached token, e.g. after the target API rejects it."""
+        with self._lock:
+            self._cache.pop(self._cache_key(user_id, audience), None)
+
+
+_client: Optional[TokenExchangeClient] = None
+_client_lock = threading.Lock()
+
+
+def get_token_exchange_client() -> TokenExchangeClient:
+    """The process-wide exchange client."""
+    global _client
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = TokenExchangeClient()
+    return _client

--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -180,6 +180,7 @@ async def admin_create_tool(
             status=request.status,
             requires_oauth_provider=request.requires_oauth_provider,
             forward_auth_token=request.forward_auth_token,
+            token_exchange_audience=request.token_exchange_audience,
             is_public=request.is_public,
             enabled_by_default=request.enabled_by_default,
             mcp_config=mcp_config,

--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -257,17 +257,37 @@ class ToolCatalogService:
         """
         Validate that auth configurations don't conflict.
 
+        There are three ways to put a per-user credential in the Authorization
+        header — forwarding the OIDC token, an OAuth provider token, and an
+        RFC 8693 exchanged token — and only one header, so at most one may be
+        selected.
+
         Raises:
-            ValueError: If forward_auth_token and requires_oauth_provider are both set,
-                or if forward_auth_token is set with a non-'none' MCP auth type.
+            ValueError: If more than one per-user auth mode is set, or if a mode
+                that owns the Authorization header is combined with a non-'none'
+                MCP auth type.
         """
-        if tool.forward_auth_token and tool.requires_oauth_provider:
+        selected = [
+            name
+            for name, on in (
+                ("forward_auth_token", bool(tool.forward_auth_token)),
+                ("requires_oauth_provider", bool(tool.requires_oauth_provider)),
+                ("token_exchange_audience", bool(tool.token_exchange_audience)),
+            )
+            if on
+        ]
+        if len(selected) > 1:
             raise ValueError(
-                "Cannot enable both 'forward_auth_token' and 'requires_oauth_provider'. "
-                "Both use the Authorization header and are mutually exclusive."
+                f"Cannot enable more than one per-user auth mode: {', '.join(selected)}. "
+                "All use the Authorization header and are mutually exclusive."
             )
 
-        if tool.forward_auth_token and tool.mcp_config:
+        # These two put a bearer in the Authorization header themselves, so the
+        # transport must not also be signing it. SigV4 and Bearer cannot coexist.
+        owns_auth_header = bool(tool.forward_auth_token) or bool(
+            tool.token_exchange_audience
+        )
+        if owns_auth_header and tool.mcp_config:
             auth_type = tool.mcp_config.auth_type
             if isinstance(auth_type, str):
                 is_none = auth_type == "none"
@@ -275,9 +295,14 @@ class ToolCatalogService:
                 from apis.shared.tools.models import MCPAuthType
                 is_none = auth_type == MCPAuthType.NONE
             if not is_none:
+                mode = (
+                    "forward_auth_token"
+                    if tool.forward_auth_token
+                    else "token_exchange_audience"
+                )
                 raise ValueError(
-                    "When 'forward_auth_token' is enabled, MCP auth type must be 'none'. "
-                    "The OIDC token will use the Authorization header."
+                    f"When '{mode}' is enabled, MCP auth type must be 'none'. "
+                    "The per-user token will use the Authorization header."
                 )
 
     def _validate_protocol_config(self, tool: ToolDefinition) -> None:

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -630,6 +630,15 @@ class ToolDefinition(BaseModel):
         description="If true, forward the user's OIDC authentication token to the MCP server. "
         "Only use for same-team controlled servers. Mutually exclusive with requires_oauth_provider.",
     )
+    token_exchange_audience: Optional[str] = Field(
+        None,
+        description="Token-service applicationId to exchange the user's token for (RFC 8693). "
+        "When set, the runtime trades the user's Cognito access token for a token-service JWT "
+        "scoped to this application and forwards that instead of the raw token — so APIs "
+        "that already trust token-service JWTs can serve agent requests as the signed-in user. "
+        "Takes precedence over forward_auth_token, which would send a token the target API "
+        "cannot validate. Mutually exclusive with requires_oauth_provider.",
+    )
 
     # Access control
     is_public: bool = Field(
@@ -722,6 +731,7 @@ class ToolDefinition(BaseModel):
             "status": self.status if isinstance(self.status, str) else self.status.value,
             "requiresOauthProvider": self.requires_oauth_provider,
             "forwardAuthToken": self.forward_auth_token,
+            "tokenExchangeAudience": self.token_exchange_audience,
             "isPublic": self.is_public,
             "enabledByDefault": self.enabled_by_default,
             "createdAt": to_iso(self.created_at) if self.created_at else None,
@@ -785,6 +795,7 @@ class ToolDefinition(BaseModel):
             status=item.get("status", ToolStatus.ACTIVE),
             requires_oauth_provider=item.get("requiresOauthProvider"),
             forward_auth_token=item.get("forwardAuthToken", False),
+            token_exchange_audience=item.get("tokenExchangeAudience"),
             is_public=item.get("isPublic", False),
             enabled_by_default=item.get("enabledByDefault", False),
             mcp_config=mcp_config,
@@ -1074,6 +1085,7 @@ class ToolCreateRequest(BaseModel):
     status: ToolStatus = Field(default=ToolStatus.ACTIVE)
     requires_oauth_provider: Optional[str] = Field(None, alias="requiresOauthProvider")
     forward_auth_token: bool = Field(default=False, alias="forwardAuthToken")
+    token_exchange_audience: Optional[str] = Field(None, alias="tokenExchangeAudience")
     is_public: bool = Field(default=False, alias="isPublic")
     enabled_by_default: bool = Field(default=False, alias="enabledByDefault")
 
@@ -1099,6 +1111,7 @@ class ToolUpdateRequest(BaseModel):
     status: Optional[ToolStatus] = None
     requires_oauth_provider: Optional[str] = Field(None, alias="requiresOauthProvider")
     forward_auth_token: Optional[bool] = Field(None, alias="forwardAuthToken")
+    token_exchange_audience: Optional[str] = Field(None, alias="tokenExchangeAudience")
     is_public: Optional[bool] = Field(None, alias="isPublic")
     enabled_by_default: Optional[bool] = Field(None, alias="enabledByDefault")
 
@@ -1285,6 +1298,7 @@ class AdminToolResponse(BaseModel):
     status: ToolStatus
     requires_oauth_provider: Optional[str] = Field(None, alias="requiresOauthProvider")
     forward_auth_token: bool = Field(default=False, alias="forwardAuthToken")
+    token_exchange_audience: Optional[str] = Field(None, alias="tokenExchangeAudience")
     is_public: bool = Field(..., alias="isPublic")
     allowed_app_roles: List[str] = Field(..., alias="allowedAppRoles")
     enabled_by_default: bool = Field(..., alias="enabledByDefault")
@@ -1331,6 +1345,7 @@ class AdminToolResponse(BaseModel):
             status=tool.status,
             requires_oauth_provider=tool.requires_oauth_provider,
             forward_auth_token=tool.forward_auth_token,
+            token_exchange_audience=tool.token_exchange_audience,
             is_public=tool.is_public,
             allowed_app_roles=allowed_roles or tool.allowed_app_roles,
             enabled_by_default=tool.enabled_by_default,
@@ -1382,6 +1397,7 @@ class MCPDiscoverRequest(BaseModel):
     api_key_header: Optional[str] = Field(None, alias="apiKeyHeader")
     secret_arn: Optional[str] = Field(None, alias="secretArn")
     forward_auth_token: bool = Field(default=False, alias="forwardAuthToken")
+    token_exchange_audience: Optional[str] = Field(None, alias="tokenExchangeAudience")
     requires_oauth_provider: Optional[str] = Field(
         None, alias="requiresOauthProvider"
     )

--- a/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
+++ b/frontend/ai.client/src/app/admin/tools/models/admin-tool.model.ts
@@ -134,6 +134,7 @@ export interface AdminTool {
   status: ToolStatus;
   requiresOauthProvider: string | null;
   forwardAuthToken: boolean;
+  tokenExchangeAudience?: string | null;
   isPublic: boolean;
   allowedAppRoles: string[];
   enabledByDefault: boolean;
@@ -186,6 +187,7 @@ export interface ToolCreateRequest {
   status?: ToolStatus;
   requiresOauthProvider?: string | null;
   forwardAuthToken?: boolean;
+  tokenExchangeAudience?: string | null;
   isPublic?: boolean;
   enabledByDefault?: boolean;
   mcpConfig?: MCPServerConfig;
@@ -204,6 +206,7 @@ export interface ToolUpdateRequest {
   status?: ToolStatus;
   requiresOauthProvider?: string | null;
   forwardAuthToken?: boolean;
+  tokenExchangeAudience?: string | null;
   isPublic?: boolean;
   enabledByDefault?: boolean;
   mcpConfig?: MCPServerConfig | null;
@@ -243,6 +246,23 @@ export interface MCPDiscoverRequest {
    * backend can resolve the admin's token.
    */
   requiresOauthProvider?: string | null;
+  /**
+   * Token-service applicationId (RFC 8693 `audience`) to exchange the user's
+   * token for at request time. When set, the runtime trades the signed-in user's
+   * Cognito access token for a token the target API already trusts and sends
+   * that as the bearer, so an existing API needs no changes to serve agent
+   * requests as the user.
+   *
+   * Mutually exclusive with `forwardAuthToken` and `requiresOauthProvider` —
+   * there is only one Authorization header. Requires MCP auth type `none`.
+   *
+   * Note: discovery does NOT exchange. The exchange client lives in the agent
+   * runtime, which `app_api` may not import (enforced import boundary), so
+   * registration discovers the tool list unauthenticated. Fine for servers that
+   * do not gate `tools/list`; a server that does will need its tools entered
+   * manually until an exchange client exists in the shared layer.
+   */
+  tokenExchangeAudience?: string | null;
 }
 
 /**
@@ -287,6 +307,7 @@ export interface ToolFormData {
   status: ToolStatus;
   requiresOauthProvider: string | null;
   forwardAuthToken: boolean;
+  tokenExchangeAudience?: string | null;
   isPublic: boolean;
   enabledByDefault: boolean;
   // MCP configuration (for mcp_external protocol)

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-form.page.ts
@@ -408,6 +408,43 @@ import {
                     </p>
                   </div>
                 }
+
+                <!-- Token exchange (RFC 8693) — for APIs that trust a different issuer -->
+                <div class="border-t border-gray-200 pt-6 dark:border-gray-700">
+                  <label for="tokenExchangeAudience" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    Or exchange the token first (RFC 8693)
+                  </label>
+                  <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                    Use when the target API trusts a <em>different</em> issuer than this app — for example an
+                    existing institutional token service. The user's token is traded for one that API already
+                    accepts, so the API needs no changes. Leave blank to disable.
+                  </p>
+                  <input
+                    id="tokenExchangeAudience"
+                    type="text"
+                    formControlName="tokenExchangeAudience"
+                    placeholder="target application id (audience), e.g. a GUID from your token service"
+                    class="mt-2 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm/6 text-gray-900 placeholder-gray-400 shadow-xs focus:border-primary-500 focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+                  />
+
+                  @if (form.get('tokenExchangeAudience')?.value) {
+                    <div class="mt-3 rounded-2xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/30">
+                      <p class="mb-1 text-sm/6 font-medium text-amber-900 dark:text-amber-100">
+                        Requires configuration
+                      </p>
+                      <p class="text-sm/6 text-amber-800 dark:text-amber-200">
+                        The platform must be deployed with a token exchange endpoint configured, and this
+                        deployment's client secret populated, or these tools will not load. Set the MCP
+                        Authentication Type to "None" above — the exchanged token uses the Authorization header,
+                        so it cannot be combined with SigV4.
+                      </p>
+                      <p class="mt-2 text-sm/6 text-amber-800 dark:text-amber-200">
+                        Tool discovery below does not exchange tokens, so a server that requires
+                        authentication to list its tools will return nothing here.
+                      </p>
+                    </div>
+                  }
+                </div>
               </section>
 
               <!-- User OAuth Connector -->
@@ -1001,6 +1038,7 @@ export class ToolFormPage implements OnInit {
     enabledByDefault: [false],
     requiresOauthProvider: [''],
     forwardAuthToken: [false],
+    tokenExchangeAudience: [''],
     // MCP External Server configuration
     mcpServerUrl: [''],
     mcpTransport: ['streamable-http'],
@@ -1098,6 +1136,7 @@ export class ToolFormPage implements OnInit {
         apiKeyHeader: formValue.mcpApiKeyHeader || null,
         secretArn: formValue.mcpSecretArn || null,
         forwardAuthToken: formValue.forwardAuthToken || false,
+        tokenExchangeAudience: formValue.tokenExchangeAudience || null,
         requiresOauthProvider: formValue.requiresOauthProvider || null,
       });
 
@@ -1256,15 +1295,38 @@ export class ToolFormPage implements OnInit {
       this.selectedProtocol.set(value);
     });
 
-    // Mutual exclusivity: forwardAuthToken and requiresOauthProvider
+    // Mutual exclusivity across the three per-user auth modes. All three put a
+    // credential in the Authorization header and there is only one, so selecting
+    // any clears the others. The backend enforces this too (tools service
+    // _validate_auth_config); this just avoids submitting a request that 400s.
     this.form.get('forwardAuthToken')?.valueChanges.subscribe(checked => {
-      if (checked && this.form.get('requiresOauthProvider')?.value) {
-        this.form.get('requiresOauthProvider')?.setValue('');
+      if (checked) {
+        if (this.form.get('requiresOauthProvider')?.value) {
+          this.form.get('requiresOauthProvider')?.setValue('');
+        }
+        if (this.form.get('tokenExchangeAudience')?.value) {
+          this.form.get('tokenExchangeAudience')?.setValue('');
+        }
       }
     });
     this.form.get('requiresOauthProvider')?.valueChanges.subscribe(value => {
-      if (value && this.form.get('forwardAuthToken')?.value) {
-        this.form.get('forwardAuthToken')?.setValue(false);
+      if (value) {
+        if (this.form.get('forwardAuthToken')?.value) {
+          this.form.get('forwardAuthToken')?.setValue(false);
+        }
+        if (this.form.get('tokenExchangeAudience')?.value) {
+          this.form.get('tokenExchangeAudience')?.setValue('');
+        }
+      }
+    });
+    this.form.get('tokenExchangeAudience')?.valueChanges.subscribe(value => {
+      if (value) {
+        if (this.form.get('forwardAuthToken')?.value) {
+          this.form.get('forwardAuthToken')?.setValue(false);
+        }
+        if (this.form.get('requiresOauthProvider')?.value) {
+          this.form.get('requiresOauthProvider')?.setValue('');
+        }
       }
     });
 
@@ -1308,6 +1370,7 @@ export class ToolFormPage implements OnInit {
         enabledByDefault: tool.enabledByDefault,
         requiresOauthProvider: tool.requiresOauthProvider || '',
         forwardAuthToken: tool.forwardAuthToken || false,
+        tokenExchangeAudience: tool.tokenExchangeAudience || '',
       });
 
       // Update protocol signal
@@ -1484,6 +1547,7 @@ export class ToolFormPage implements OnInit {
           enabledByDefault: formValue.enabledByDefault,
           requiresOauthProvider: requiresOauthProvider,
           forwardAuthToken: formValue.forwardAuthToken || false,
+          tokenExchangeAudience: formValue.tokenExchangeAudience || null,
           mcpConfig: mcpConfig,
           a2aConfig: a2aConfig,
           mcpGatewayConfig: mcpGatewayConfig,
@@ -1501,6 +1565,7 @@ export class ToolFormPage implements OnInit {
           enabledByDefault: formValue.enabledByDefault,
           requiresOauthProvider: requiresOauthProvider,
           forwardAuthToken: formValue.forwardAuthToken || false,
+          tokenExchangeAudience: formValue.tokenExchangeAudience || null,
           mcpConfig: mcpConfig,
           a2aConfig: a2aConfig,
           mcpGatewayConfig: mcpGatewayConfig,

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -59,6 +59,12 @@ export interface AppConfig {
   mcpSandbox: McpSandboxConfig;
   mcpIdentity: McpIdentityConfig;
   gateway: GatewayConfig;
+  /**
+   * Optional. Absent for any deployment without an external token service, which
+   * is the default. Kept optional rather than defaulted so a fork constructing
+   * AppConfig by hand does not have to know this feature exists.
+   */
+  tokenExchange?: TokenExchangeConfig;
   appVersion: string;
   tags: { [key: string]: string };
 }
@@ -296,6 +302,34 @@ export interface GatewayConfig {
 }
 
 /**
+ * RFC 8693 token exchange against an external token service.
+ *
+ * Lets the agent trade the signed-in user's Cognito access token for a token
+ * issued by a token service the organisation already runs, so downstream APIs
+ * that trust that service can serve agent requests as the user without being
+ * modified. Useful anywhere internal APIs already accept a JWT from an existing
+ * identity or token service — the pattern is not specific to any one kind of
+ * organisation.
+ *
+ * Deliberately not done by AgentCore Gateway: its outbound OAuth credential
+ * provider supports only CLIENT_CREDENTIALS and AUTHORIZATION_CODE
+ * (`OAuthGrantType` in the bedrock-agentcore-control API model has exactly those
+ * two values), so a token-exchange grant cannot be expressed there. A Gateway
+ * with AWS_IAM inbound auth also never sees the user's token, so it would have
+ * nothing to exchange. The runtime performs the exchange instead.
+ *
+ * Entirely optional and additive. Leave it unset and no resources, permissions,
+ * or environment variables are created — a deployment that only ever uses SigV4
+ * for MCP traffic is unaffected.
+ */
+export interface TokenExchangeConfig {
+  /** Exchange endpoint, e.g. https://tokens.example.org/v2/oauth/token */
+  url: string;
+  /** client_id this deployment authenticates as. */
+  clientId: string;
+}
+
+/**
  * Load and validate configuration from CDK context
  * @param scope The CDK construct scope
  * @returns Validated AppConfig object
@@ -303,6 +337,14 @@ export interface GatewayConfig {
 export function loadConfig(scope: cdk.App): AppConfig {
   // Load required configuration from environment variables or context
   const projectPrefix = process.env.CDK_PROJECT_PREFIX || scope.node.tryGetContext('projectPrefix');
+  const tokenExchangeUrl =
+    process.env.CDK_TOKEN_EXCHANGE_URL
+    || scope.node.tryGetContext('tokenExchange')?.url
+    || '';
+  const tokenExchangeClientId =
+    process.env.CDK_TOKEN_EXCHANGE_CLIENT_ID
+    || scope.node.tryGetContext('tokenExchange')?.clientId
+    || '';
   const awsRegion = process.env.CDK_AWS_REGION || scope.node.tryGetContext('awsRegion');
   
   // Validate required variables
@@ -533,6 +575,14 @@ export function loadConfig(scope: cdk.App): AppConfig {
         || scope.node.tryGetContext('gateway')?.inboundAuth
         || 'iam',
     },
+    // Left undefined unless a URL is configured, so the feature and every
+    // resource behind it stay absent for deployments that do not want it.
+    tokenExchange: tokenExchangeUrl
+      ? {
+          url: tokenExchangeUrl,
+          clientId: tokenExchangeClientId,
+        }
+      : undefined,
     tags: {
       ...(scope.node.tryGetContext('tags') || {}),
     },

--- a/infrastructure/lib/constructs/identity/token-exchange-secret-construct.ts
+++ b/infrastructure/lib/constructs/identity/token-exchange-secret-construct.ts
@@ -1,0 +1,62 @@
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+
+import { AppConfig, getResourceName, getRemovalPolicy } from '../../config';
+
+export interface TokenExchangeSecretConstructProps {
+  config: AppConfig;
+}
+
+/**
+ * TokenExchangeSecretConstruct — confidential-client secret this
+ * deployment uses to authenticate to an external token service's RFC 8693
+ * token-exchange endpoint.
+ *
+ * Why a secret of our own rather than reading the token service's copy: the
+ * token service and this platform live in different AWS accounts, so the
+ * runtime cannot read the secret the token service holds. Each side keeps its
+ * own copy of the same shared secret.
+ *
+ * No value is supplied here, unlike the other secrets in this stack. The others
+ * are values we generate and own; this one is a credential agreed with a system
+ * we do not control, so CDK cannot invent it. CloudFormation still seeds a random
+ * value on first create (it generates one whenever `GenerateSecretString` is
+ * present, even empty), so the real credential is written over the top:
+ *
+ *   aws secretsmanager put-secret-value \
+ *     --secret-id <this secret> \
+ *     --secret-string '{"<client_id>":"<secret>"}'
+ *
+ * Stack updates do not regenerate it, so that written value survives subsequent
+ * deploys. Same pattern as the OAuth and auth-provider client secrets.
+ *
+ * The JSON-map shape matches the token service's own secret so the same value
+ * can be pasted on both sides, and so a deployment could hold credentials for
+ * more than one exchange client later.
+ *
+ * Until it is populated the stored value is a random string that the token
+ * service will not recognise, so exchanges are refused — the affected tools simply do
+ * not load rather than failing mid-conversation.
+ */
+export class TokenExchangeSecretConstruct extends Construct {
+  public readonly secret: secretsmanager.Secret;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: TokenExchangeSecretConstructProps,
+  ) {
+    super(scope, id);
+
+    const { config } = props;
+
+    this.secret = new secretsmanager.Secret(this, 'TokenExchangeSecret', {
+      secretName: getResourceName(config, 'token-exchange-client'),
+      description:
+        'client_id -> client_secret map used to authenticate to an external ' +
+        'token service RFC 8693 exchange endpoint. Populated out of band; ' +
+        'CDK cannot generate a credential shared with an external system.',
+      removalPolicy: getRemovalPolicy(config),
+    });
+  }
+}

--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -338,6 +338,20 @@ export class InferenceAgentCoreConstruct extends Construct {
         // user's Cognito access token as a Bearer token; 'iam' → SigV4.
         AGENTCORE_GATEWAY_INBOUND_AUTH: config.gateway.inboundAuth,
 
+        // RFC 8693 token exchange. Spread in only when configured, so a
+        // deployment that does not use it gets no extra environment variables at
+        // all — no diff to its runtime definition. The exchange runs here rather
+        // than in the Gateway because AgentCore's outbound OAuth credential
+        // provider has no token-exchange grant.
+        ...(config.tokenExchange
+          ? {
+              TOKEN_EXCHANGE_URL: config.tokenExchange.url,
+              TOKEN_EXCHANGE_CLIENT_ID: config.tokenExchange.clientId,
+              TOKEN_EXCHANGE_SECRET_ID:
+                props.refs.tokenExchangeSecret?.secretName ?? '',
+            }
+          : {}),
+
         // S3 storage
         S3_ASSISTANTS_VECTOR_STORE_BUCKET_NAME: vectorBucketName,
         S3_ASSISTANTS_VECTOR_STORE_INDEX_NAME: vectorIndexName,

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -149,7 +149,16 @@ export function createRuntimeExecutionRole(
     sid: 'SecretsManagerRead',
     effect: iam.Effect.ALLOW,
     actions: ['secretsmanager:GetSecretValue'],
-    resources: [`${oauthClientSecretsArn}*`, `${authProviderSecretsArn}*`],
+    // Trailing wildcard: AWS appends a random 6-char suffix to secret ARNs.
+    // The exchange secret is only granted when the feature is configured,
+    // so a deployment without it gets no extra permission.
+    resources: [
+      `${oauthClientSecretsArn}*`,
+      `${authProviderSecretsArn}*`,
+      ...(refs.tokenExchangeSecret
+        ? [`${refs.tokenExchangeSecret.secretArn}*`]
+        : []),
+    ],
   }));
 
   // ── AgentCore Identity OAuth vault secrets ──

--- a/infrastructure/lib/constructs/platform-compute-refs.ts
+++ b/infrastructure/lib/constructs/platform-compute-refs.ts
@@ -60,6 +60,12 @@ export interface PlatformComputeRefs {
   oauthUserTokensTable: dynamodb.ITable;
   oauthTokenEncryptionKey: kms.IKey;
   oauthClientSecretsSecret: secretsmanager.ISecret;
+  /**
+   * Confidential-client secret for the RFC 8693 token exchange.
+   * Undefined unless `config.tokenExchange` is configured — the secret is
+   * not created for deployments that do not use the feature.
+   */
+  tokenExchangeSecret?: secretsmanager.ISecret;
   authProvidersTable: dynamodb.ITable;
   authProviderSecretsSecret: secretsmanager.ISecret;
 

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -22,6 +22,7 @@ import { NetworkConstruct } from './constructs/network/network-construct';
 
 // Identity
 import { ArtifactRenderTokenSecretConstruct } from './constructs/identity/artifact-render-token-secret-construct';
+import { TokenExchangeSecretConstruct } from './constructs/identity/token-exchange-secret-construct';
 import { AuthProvidersConstruct } from './constructs/identity/auth-providers-construct';
 import { AuthSecretConstruct } from './constructs/identity/auth-secret-construct';
 import { BffCookieKeyConstruct } from './constructs/identity/bff-cookie-key-construct';
@@ -191,6 +192,7 @@ export class PlatformStack extends cdk.Stack {
   public readonly artifactsContentBucket: s3.IBucket;
   public readonly artifactsTable: dynamodb.ITable;
   public readonly artifactRenderTokenSecret: secretsmanager.ISecret;
+  public readonly tokenExchangeSecret?: secretsmanager.ISecret;
   /**
    * The CSP `frame-ancestors` source list resolved for the artifacts
    * iframe origin (space-separated). Forwarded to the render Lambda
@@ -329,6 +331,19 @@ export class PlatformStack extends cdk.Stack {
       { config },
     );
     this.artifactRenderTokenSecret = artifactRenderToken.secret;
+
+    // Only for deployments that actually use an external token service. Creating
+    // it unconditionally would add a billed Secrets Manager secret to every
+    // fork, including those that never register an external MCP server and
+    // intend to use SigV4 for all API-to-MCP traffic.
+    if (config.tokenExchange) {
+      const tokenExchange = new TokenExchangeSecretConstruct(
+        this,
+        'TokenExchange',
+        { config },
+      );
+      this.tokenExchangeSecret = tokenExchange.secret;
+    }
 
     // ============================================================
     // Data tables
@@ -720,6 +735,7 @@ export class PlatformStack extends cdk.Stack {
       artifactsContentBucket: this.artifactsContentBucket,
       artifactsTable: this.artifactsTable,
       artifactRenderTokenSecret: this.artifactRenderTokenSecret,
+      tokenExchangeSecret: this.tokenExchangeSecret,
       artifactsOriginUrl: this.artifactsOriginUrl,
       skillResourcesBucket: this.skillResourcesBucket,
       memorySpacesBucket: this.memorySpacesBucket,

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -5,7 +5,7 @@
  * required typed properties for BackendStack consumption.
  */
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { PlatformStack } from '../lib/platform-stack';
 import { McpIdentityConfig } from '../lib/config';
 import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
@@ -92,6 +92,41 @@ describe('PlatformStack', () => {
       // OAuth client secrets, auth provider secrets, Cognito BFF client secret,
       // artifact render token (always-on now)
       template.resourceCountIs('AWS::SecretsManager::Secret', 7);
+    });
+
+    it('creates the token exchange secret only when configured', () => {
+      // Opt-in: with a URL configured the secret appears, and CDK adds no
+      // PasswordLength/SecretStringTemplate because the credential is agreed
+      // with an external service rather than generated here. CloudFormation
+      // still seeds a random value on create; the real one is written over it.
+      const optInApp = new cdk.App();
+      const optInStack = new PlatformStack(optInApp, 'TokenExchangeStack', {
+        config: createMockConfig({
+          tokenExchange: {
+            url: 'https://tokenservice.example.edu/v2/oauth/token',
+            clientId: 'example-client',
+          },
+        }),
+      });
+      const optIn = Template.fromStack(optInStack);
+
+      optIn.resourceCountIs('AWS::SecretsManager::Secret', 8);
+      optIn.hasResourceProperties('AWS::SecretsManager::Secret', {
+        Name: Match.stringLikeRegexp('token-exchange-client'),
+        GenerateSecretString: {},
+      });
+    });
+
+    it('does NOT create the token exchange secret by default', () => {
+      // The feature must cost a fork nothing when unconfigured: no extra
+      // Secrets Manager resource, no extra IAM permission. A deployment that
+      // never registers an external MCP server, or that wants SigV4 only for
+      // all API-to-MCP traffic, should see no trace of it.
+      const secrets = template.findResources('AWS::SecretsManager::Secret');
+      const names = Object.values<any>(secrets).map((r) => r.Properties?.Name);
+      expect(
+        names.some((n) => typeof n === 'string' && n.includes('token-exchange')),
+      ).toBe(false);
     });
 
     it('creates KMS keys', () => {

--- a/scripts/common/load-env.sh
+++ b/scripts/common/load-env.sh
@@ -149,6 +149,16 @@ build_cdk_context_params() {
     if [ -n "${CDK_GATEWAY_INBOUND_AUTH:-}" ]; then
         context_params="${context_params} --context gateway.inboundAuth=\"${CDK_GATEWAY_INBOUND_AUTH}\""
     fi
+
+    # RFC 8693 token exchange. Both omitted when empty: CDK context
+    # cannot express an empty string, and an absent value correctly means the
+    # feature stays dormant.
+    if [ -n "${CDK_TOKEN_EXCHANGE_URL:-}" ]; then
+        context_params="${context_params} --context tokenExchange.url=\"${CDK_TOKEN_EXCHANGE_URL}\""
+    fi
+    if [ -n "${CDK_TOKEN_EXCHANGE_CLIENT_ID:-}" ]; then
+        context_params="${context_params} --context tokenExchange.clientId=\"${CDK_TOKEN_EXCHANGE_CLIENT_ID}\""
+    fi
     if [ -n "${CDK_FRONTEND_CERTIFICATE_ARN:-}" ]; then
         context_params="${context_params} --context frontend.certificateArn=\"${CDK_FRONTEND_CERTIFICATE_ARN}\""
     fi
@@ -243,6 +253,8 @@ export CDK_MANAGE_DNS_RECORDS="${CDK_MANAGE_DNS_RECORDS:-$(get_json_value "manag
 # existing AWS_IAM Gateway makes the deploy fail. It applies to a newly
 # created Gateway.
 export CDK_GATEWAY_INBOUND_AUTH="${CDK_GATEWAY_INBOUND_AUTH:-$(get_json_value "gateway.inboundAuth" "${CONTEXT_FILE}")}"
+export CDK_TOKEN_EXCHANGE_URL="${CDK_TOKEN_EXCHANGE_URL:-$(get_json_value "tokenExchange.url" "${CONTEXT_FILE}")}"
+export CDK_TOKEN_EXCHANGE_CLIENT_ID="${CDK_TOKEN_EXCHANGE_CLIENT_ID:-$(get_json_value "tokenExchange.clientId" "${CONTEXT_FILE}")}"
 
 # Shared CORS origins — env var > context file (no hardcoded defaults)
 export CDK_CORS_ORIGINS="${CDK_CORS_ORIGINS:-$(get_json_value "corsOrigins" "${CONTEXT_FILE}")}"


### PR DESCRIPTION
Lets a tool call an API that trusts a **different issuer** than this platform, as the signed-in user. The runtime trades the user's Cognito access token for one the target already accepts, so an existing internal API can serve agent requests **without being modified**.

## If you don't use this, nothing changes

Read this section first if you're reviewing for fork impact.

Unconfigured, a deployment gets: no new AWS resources, no new IAM permissions, no new environment variables, no required config, and no behaviour change. Asserted by a test that synthesises a default stack and requires **zero** occurrences of the feature in the template.

A deployment that never registers an external MCP server, or that wants SigV4 for all MCP traffic, is unaffected. `AppConfig.tokenExchange` is optional specifically so a fork constructing `AppConfig` by hand doesn't need to know this exists.

| Layer | Unconfigured |
|---|---|
| Secrets Manager secret | not created |
| IAM grant | not added |
| Runtime env vars | absent |
| Tool field | optional, `null` |
| Runtime auth branch | unreachable |

## Why the runtime and not AgentCore Gateway

Gateway can't express this. Its outbound OAuth credential provider supports only `CLIENT_CREDENTIALS` and `AUTHORIZATION_CODE` — `OAuthGrantType` in the `bedrock-agentcore-control` API model has exactly those two values, and `TOKEN_EXCHANGE` appears nowhere in the model (checked across three installed SDK versions). A Gateway with `AWS_IAM` inbound auth also never receives the user's token, so it would have nothing to exchange.

Consequence worth knowing: the repo's `GatewayOAuthGrantType.TOKEN_EXCHANGE` value and its `_GRANT_TYPE_TO_AWS` mapping are **dead** — selecting it would fail API validation. Left alone here; follow-up issue instead of a wider diff.

## What's included

**Infrastructure** — all conditional on `config.tokenExchange`:
- `TokenExchangeConfig` (optional on `AppConfig`)
- `TokenExchangeSecretConstruct` — this deployment's confidential-client secret. Separate from the token service's own copy because they're in different AWS accounts. CFN seeds a random value; the agreed credential is written over it out of band and survives later deploys.
- Runtime env vars + `GetSecretValue` grant, spread in only when configured

**Runtime**:
- `integrations/token_exchange.py` — per-`(user, audience)` cache so tokens can never be shared across users, TTL from `expires_in` less a 30s skew, thread-locked because concurrent turns for one user would otherwise race
- `external_mcp_client.py` — third per-user auth branch, ahead of `forward_auth` because forwarding a raw Cognito token to such an API is a silent 401
- `oauth_auth.py` — `async_auth_flow`. **Required, not cosmetic**: `token_provider` was documented as called synchronously, so an async provider would have put a coroutine object into the `Authorization` header. This is on the shared path for all OAuth MCP servers; sync providers take identical logic.

**Admin surface**:
- `token_exchange_audience` on `ToolDefinition`, the admin models, and the form
- Deliberately **not** a new `MCPAuthType` — that dropdown describes how to reach the server, and its `bearer-token` option means a static bearer, not per-user delegation
- Three per-user modes now share one `Authorization` header, so `_validate_auth_config` rejects more than one; the form clears the others so a valid form can't produce a 400

## Verified end-to-end against dev

Before this branch existed, using the token service side already deployed:
- exchange returns `200`
- issued token is signature-valid to the target API
- `GET /directory/me` returns the caller's **own** record — identity propagation, not just authentication
- a role registered in the token service reached a role-gated endpoint that previously returned `403`

## Known limitations (documented in code)

- **Discovery does not exchange.** The exchange client lives in `agents/`, which `app_api` may not import (enforced boundary), so registration lists tools unauthenticated. Fine for servers that don't gate `tools/list`; the form says so. Fixing it means an exchange client in `apis/shared`.
- **Revocation does not propagate.** Token-service validation is offline, so a revoked-but-unexpired subject token is still exchangeable. Exposure is bounded by the exchange's lifetime cap.

## Tests

| Suite | Result |
|---|---|
| infrastructure | **483 pass** (incl. default-off and opt-in assertions) |
| backend | **5624 pass** |
| frontend `tsc` | clean |

The `admin/tools` frontend suite has **21 pre-existing failures** (Angular JIT / `@angular/compiler` setup) — confirmed identical with these changes stashed, so that suite can't currently guard this form.

## Follow-ups (not in this PR)

- Dead `GatewayOAuthGrantType.TOKEN_EXCHANGE` enum value + mapping
- `tests/lambdas/test_artifact_render.py` fails when `AWS_DEFAULT_REGION` is set (71 pass clean, 19 fail with it) — latent env sensitivity
- Exchange client in `apis/shared` so registration-time discovery can authenticate