### PR TITLE
fix(tools): normalise token_exchange_audience so whitespace cannot silently disable delegated identity

### DIFF
--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -423,6 +423,7 @@ class ToolCatalogService:
             for k in (
                 "forward_auth_token",
                 "requires_oauth_provider",
+                "token_exchange_audience",
                 "mcp_config",
                 "protocol",
                 "mcp_gateway_config",
@@ -432,10 +433,20 @@ class ToolCatalogService:
             await self.repository.get_tool(tool_id) if needs_existing else None
         )
 
-        # Pre-validate auth config if relevant fields are being updated
+        # Pre-validate auth config if relevant fields are being updated.
+        #
+        # token_exchange_audience belongs here as much as the other two: all
+        # three compete for the Authorization header. Omitting it let an edit
+        # add an audience to a tool that already forwarded the OIDC token, or
+        # combine one with a non-'none' MCP auth type — rules create enforces
+        # and update silently did not. The runtime happens to prefer the
+        # exchanged token, so the result was a broken tool rather than a leaked
+        # credential, but a validation rule that holds on one path and not the
+        # other is worse than no rule.
         if existing and (
             "forward_auth_token" in updates
             or "requires_oauth_provider" in updates
+            or "token_exchange_audience" in updates
             or "mcp_config" in updates
         ):
             # Build a preview of the updated tool for validation
@@ -446,6 +457,9 @@ class ToolCatalogService:
                 protocol=existing.protocol,
                 forward_auth_token=updates.get("forward_auth_token", existing.forward_auth_token),
                 requires_oauth_provider=updates.get("requires_oauth_provider", existing.requires_oauth_provider),
+                token_exchange_audience=updates.get(
+                    "token_exchange_audience", existing.token_exchange_audience
+                ),
                 mcp_config=updates.get("mcp_config", existing.mcp_config),
             )
             self._validate_auth_config(preview)

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from apis.shared.timestamps import from_iso, to_iso
 
 
@@ -639,6 +639,26 @@ class ToolDefinition(BaseModel):
         "Takes precedence over forward_auth_token, which would send a token the target API "
         "cannot validate. Mutually exclusive with requires_oauth_provider.",
     )
+
+    @field_validator("token_exchange_audience", mode="before")
+    @classmethod
+    def _clean_token_exchange_audience(cls, v: object) -> object:
+        """
+        Strip surrounding whitespace and treat blank as unset.
+
+        A pasted audience arrived with a leading space, which made the token
+        service refuse every exchange: it compares the audience against its
+        allowlist with an ordinal comparison, so " <guid>" != "<guid>". The tool
+        still appeared to work because the endpoint it called happened to allow
+        anonymous access — the request simply went unauthenticated. Silent
+        downgrade from delegated identity to anonymous is the worst possible
+        failure mode for this feature, so the value is normalised on the way in
+        rather than trusted.
+        """
+        if isinstance(v, str):
+            v = v.strip()
+            return v or None
+        return v
 
     # Access control
     is_public: bool = Field(

--- a/backend/tests/apis/app_api/tools/test_update_auth_mode_validation.py
+++ b/backend/tests/apis/app_api/tools/test_update_auth_mode_validation.py
@@ -1,0 +1,138 @@
+"""
+Auth-mode validation must hold on the UPDATE path, not just on create.
+
+`_validate_auth_config` enforces two rules: at most one per-user auth mode
+(forward_auth_token / requires_oauth_provider / token_exchange_audience — all
+three compete for the single Authorization header), and MCP auth type 'none' when
+a mode owns that header.
+
+Create ran those checks. Update did not consider token_exchange_audience at all,
+so editing a tool to add an audience skipped validation entirely — a rule that
+held on one path and not the other. The runtime happens to prefer the exchanged
+token, so the result was a broken tool rather than a leaked credential, but the
+inconsistency is the bug.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.app_api.tools.service import ToolCatalogService
+from apis.shared.tools.models import (
+    MCPAuthType,
+    MCPServerConfig,
+    ToolDefinition,
+    ToolProtocol,
+)
+
+
+def _admin():
+    return MagicMock(user_id="admin1", email="admin@example.com")
+
+
+def _tool(**overrides) -> ToolDefinition:
+    base = dict(
+        tool_id="campus_directory",
+        display_name="Directory",
+        description="d",
+        category="utility",
+        protocol=ToolProtocol.MCP_EXTERNAL,
+    )
+    base.update(overrides)
+    return ToolDefinition(**base)
+
+
+def _service(existing: ToolDefinition) -> ToolCatalogService:
+    svc = ToolCatalogService.__new__(ToolCatalogService)
+    svc.repository = MagicMock()
+    svc.repository.get_tool = AsyncMock(return_value=existing)
+    svc.repository.update_tool = AsyncMock(return_value=existing)
+    return svc
+
+
+class TestUpdateEnforcesAuthModeExclusivity:
+    @pytest.mark.asyncio
+    async def test_adding_audience_to_a_forwarding_tool_is_rejected(self):
+        existing = _tool(forward_auth_token=True)
+        svc = _service(existing)
+
+        with pytest.raises(ValueError) as exc:
+            await svc.update_tool(
+                "campus_directory",
+                {"token_exchange_audience": "cc5aa8a0-guid"},
+                _admin(),
+            )
+        assert "more than one per-user auth mode" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_adding_audience_to_an_oauth_tool_is_rejected(self):
+        existing = _tool(requires_oauth_provider="google_workspace")
+        svc = _service(existing)
+
+        with pytest.raises(ValueError):
+            await svc.update_tool(
+                "campus_directory",
+                {"token_exchange_audience": "cc5aa8a0-guid"},
+                _admin(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_adding_forwarding_to_an_exchange_tool_is_rejected(self):
+        # The mirror case: the conflict must be caught whichever side is edited.
+        existing = _tool(token_exchange_audience="cc5aa8a0-guid")
+        svc = _service(existing)
+
+        with pytest.raises(ValueError):
+            await svc.update_tool(
+                "campus_directory", {"forward_auth_token": True}, _admin()
+            )
+
+    @pytest.mark.asyncio
+    async def test_audience_requires_mcp_auth_type_none(self):
+        # SigV4 and Bearer both want the Authorization header; the exchanged
+        # token would win and the request would reach an IAM-expecting endpoint
+        # unsigned.
+        existing = _tool(
+            mcp_config=MCPServerConfig(
+                server_url="https://x.lambda-url.us-west-2.on.aws/mcp",
+                auth_type=MCPAuthType.AWS_IAM,
+            )
+        )
+        svc = _service(existing)
+
+        with pytest.raises(ValueError) as exc:
+            await svc.update_tool(
+                "campus_directory",
+                {"token_exchange_audience": "cc5aa8a0-guid"},
+                _admin(),
+            )
+        assert "must be 'none'" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_valid_audience_update_is_allowed(self):
+        existing = _tool(
+            mcp_config=MCPServerConfig(
+                server_url="https://x.lambda-url.us-west-2.on.aws/mcp",
+                auth_type=MCPAuthType.NONE,
+            )
+        )
+        svc = _service(existing)
+
+        await svc.update_tool(
+            "campus_directory",
+            {"token_exchange_audience": "cc5aa8a0-guid"},
+            _admin(),
+        )
+        svc.repository.update_tool.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clearing_the_audience_is_allowed(self):
+        # Removing a mode must never be blocked — otherwise a misconfigured tool
+        # could not be repaired.
+        existing = _tool(token_exchange_audience="cc5aa8a0-guid")
+        svc = _service(existing)
+
+        await svc.update_tool(
+            "campus_directory", {"token_exchange_audience": None}, _admin()
+        )
+        svc.repository.update_tool.assert_awaited()

--- a/backend/tests/apis/shared/tools/test_token_exchange_audience.py
+++ b/backend/tests/apis/shared/tools/test_token_exchange_audience.py
@@ -1,0 +1,76 @@
+"""
+Normalisation of `token_exchange_audience`.
+
+Regression test for a real failure. A pasted audience reached DynamoDB with a
+leading space:
+
+    ' cc5aa8a0-90f7-427a-bf9d-60678a980215'   (37 chars, not 36)
+
+The token service compares the requested audience against its per-client
+allowlist with an ordinal comparison, so the space made every exchange fail with
+"audience is not permitted for this client".
+
+What made it dangerous rather than merely broken: the tool still appeared to
+work. The endpoint it called allowed anonymous access, so the request went
+through unauthenticated and returned plausible data. A silent downgrade from
+delegated user identity to anonymous is the worst failure mode this feature can
+have — nothing in the user-visible output indicates the user's identity was
+dropped.
+"""
+
+import pytest
+
+from apis.shared.tools.models import ToolDefinition, ToolProtocol
+
+
+def _tool(**kwargs) -> ToolDefinition:
+    return ToolDefinition(
+        tool_id="t",
+        display_name="T",
+        description="d",
+        category="utility",
+        protocol=ToolProtocol.MCP_EXTERNAL,
+        **kwargs,
+    )
+
+
+class TestTokenExchangeAudienceNormalisation:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            " cc5aa8a0-90f7-427a-bf9d-60678a980215",
+            "cc5aa8a0-90f7-427a-bf9d-60678a980215 ",
+            "  cc5aa8a0-90f7-427a-bf9d-60678a980215  ",
+            "\tcc5aa8a0-90f7-427a-bf9d-60678a980215\n",
+        ],
+    )
+    def test_surrounding_whitespace_is_stripped(self, raw: str) -> None:
+        assert (
+            _tool(token_exchange_audience=raw).token_exchange_audience
+            == "cc5aa8a0-90f7-427a-bf9d-60678a980215"
+        )
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\t", "\n"])
+    def test_blank_becomes_none_not_empty_string(self, raw: str) -> None:
+        # An empty string must not read as "exchange configured": that would send
+        # an empty audience and fail at the token service instead of simply
+        # leaving the feature off.
+        assert _tool(token_exchange_audience=raw).token_exchange_audience is None
+
+    def test_absent_stays_none(self) -> None:
+        assert _tool().token_exchange_audience is None
+
+    def test_valid_value_is_untouched(self) -> None:
+        aud = "cc5aa8a0-90f7-427a-bf9d-60678a980215"
+        assert _tool(token_exchange_audience=aud).token_exchange_audience == aud
+
+    def test_round_trips_through_dynamodb_shape(self) -> None:
+        # The stored form is what the runtime reads back, so normalisation has to
+        # survive persistence rather than only existing in memory.
+        tool = _tool(token_exchange_audience="  spaced-guid  ")
+        item = tool.to_dynamo_item()
+        assert item["tokenExchangeAudience"] == "spaced-guid"
+        assert (
+            ToolDefinition.from_dynamo_item(item).token_exchange_audience
+            == "spaced-guid"
+        )


### PR DESCRIPTION
Two hardening fixes for `token_exchange_audience`, both the same shape: a mistake that leaves a tool **silently not working** instead of failing where it was made.

## 1. Whitespace silently disabled delegated identity

A pasted audience reached DynamoDB with a leading space:

```
' cc5aa8a0-90f7-427a-bf9d-60678a980215'   <- 37 chars, not 36
```

The token service compares against its per-client allowlist with an ordinal comparison, so it refused **every** exchange: `audience is not permitted for this client`.

**The tool still appeared to work.** The endpoint it called (`GET /directory/search`) allows anonymous access, so the request went through unauthenticated and returned plausible data. Eight refusals in the token service log; nothing wrong in the agent's answer.

Fix: a `before` validator that strips surrounding whitespace and maps blank to `None`. Blank matters as much as the strip — an empty string reads as "exchange configured" and would send an empty audience, failing at the token service rather than leaving the feature off.

## 2. Update skipped the validation that create enforced

`_validate_auth_config` enforces at most one per-user auth mode (`forward_auth_token` / `requires_oauth_provider` / `token_exchange_audience` — all three compete for the single Authorization header), and MCP auth type `none` when a mode owns that header.

`update_tool` never considered `token_exchange_audience`: absent from `needs_existing`, from the condition that triggers pre-validation, and from the preview passed to the validator. So **creating** a tool with an audience was checked and **editing** one to add an audience was not. Reachable through the admin UI.

Not a credential leak, and worth being precise about why: at runtime the exchange branch is evaluated before `forward_auth`, so the exchanged token wins and the raw Cognito token is never sent; with `aws-iam`, bearer takes precedence over SigV4 and the request reaches an IAM-expecting endpoint unsigned. Both are a broken tool, not a disclosed secret.

The bug is the inconsistency — a rule that holds on create and not update is worse than no rule, because the UI implies the config was checked.

## Tests

17 total. The update-path tests were **confirmed to fail without the fix** — 4 of 6 do (`DID NOT RAISE`), including the mirror case where `forward_auth_token` is added to a tool that already has an audience, showing the gap ran both directions. The 2 that pass either way are the positive cases: a valid audience update, and clearing an audience (which must never be blocked, or a misconfigured tool could not be repaired).

Whitespace tests cover leading/trailing/tab/newline, blank and whitespace-only becoming `None`, absent staying `None`, a valid value untouched, and survival through the DynamoDB round trip — normalisation has to hold in the stored form, since that is what the runtime reads back.

Backend suite: **5641 passed**.

## Two notes for whoever hits this next

1. **Fixing the stored value alone was not enough in dev.** The runtime caches MCP clients keyed on the tool's `updatedAt`, and the token-provider closure captures the audience at client construction — so a corrected record is ignored until the version changes.
2. **No agent-visible Directory tool required authentication**, which is why #1 hid. mcp-servers#24 (`directory_me`) and #25 (`directory_pending`) fix that: neither can succeed without a real user token, so a broken exchange now fails loudly.
