### PR TITLE
feat(docs-site): redesign landing page and add product roadmap

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
 			],
 			sidebar: [
 				{ label: 'Getting Started', items: [{ autogenerate: { directory: 'getting-started' } }] },
+				{ label: 'Roadmap', slug: 'roadmap' },
 				{ label: 'Local Development', slug: 'local-development' },
 				{ label: 'Deployment', items: [{ autogenerate: { directory: 'deployment' } }] },
 				{ label: 'Configuration', items: [{ autogenerate: { directory: 'configuration' } }] },

--- a/docs-site/src/components/ScreenshotPlaceholder.astro
+++ b/docs-site/src/components/ScreenshotPlaceholder.astro
@@ -1,0 +1,38 @@
+---
+// Screenshot placeholder — a frosted app-window frame with a labelled, dashed
+// drop zone. Used on the landing + roadmap pages wherever a real product
+// screenshot belongs. Replace by dropping an <img> (or <picture>) into the
+// window body and deleting the `.shot-placeholder` block, keeping `.shot` and
+// `.shot-bar` so the window chrome stays consistent.
+//
+// Props:
+//   label   — what to capture, shown inside the drop zone (required)
+//   title   — text in the window title bar (defaults to the label)
+//   aspect  — CSS aspect-ratio of the window body (default "16 / 10")
+//   kind    — "app" (traffic-light dots) | "browser" (dots + address pill)
+interface Props {
+	label: string;
+	title?: string;
+	aspect?: string;
+	kind?: 'app' | 'browser';
+}
+
+const { label, title = label, aspect = '16 / 10', kind = 'browser' } = Astro.props;
+---
+
+<figure class="shot" data-screenshot-placeholder={label}>
+	<div class="shot-bar">
+		<span class="shot-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+		{kind === 'browser' ? <span class="shot-address">{title}</span> : <span class="shot-title">{title}</span>}
+	</div>
+	<div class="shot-body" style={`aspect-ratio: ${aspect};`}>
+		<div class="shot-placeholder">
+			<svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+				<circle cx="12" cy="13" r="4" />
+			</svg>
+			<span class="shot-label">{label}</span>
+			<span class="shot-hint">screenshot placeholder</span>
+		</div>
+	</div>
+</figure>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,60 +1,350 @@
 ---
 title: AgentCore Public Stack
-description: The unofficial frontend for Strands and AgentCore — a production-ready, multi-agent conversational AI platform on AWS Bedrock AgentCore.
+description: The open-source, production-ready conversational AI platform for AWS Bedrock AgentCore and Strands Agents — chat, agents, tools, knowledge, and governance, deployed into an AWS account you control.
 template: splash
 hero:
   title: |
     <span class="hero-kicker">Strands · AgentCore</span>
-    AgentCore Public Stack
-  image:
-    dark: ../../assets/globe-dark.svg
-    light: ../../assets/globe-light.svg
-    alt: AgentCore Public Stack logo
-  tagline: The unofficial frontend for Strands Agents and AWS Bedrock AgentCore.
+    Own your AI platform,
+    <span class="hero-accent">on your own cloud.</span>
+  tagline: AgentCore Public Stack is the open-source, production-ready conversational AI platform for AWS Bedrock AgentCore and Strands Agents — chat, agents, tools, knowledge, and governance, deployed into an AWS account you control.
   actions:
     - text: Get started
       link: /agentcore-public-stack/getting-started/introduction/
       icon: right-arrow
       variant: primary
+    - text: See the roadmap
+      link: /agentcore-public-stack/roadmap/
+      icon: rocket
+      variant: minimal
     - text: View on GitHub
       link: https://github.com/Boise-State-Development/agentcore-public-stack
       icon: external
       variant: minimal
 ---
 
-import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import ScreenshotPlaceholder from '../../components/ScreenshotPlaceholder.astro';
 
-A production-ready, multi-agent conversational AI platform built on **AWS Bedrock AgentCore** and **Strands Agents** — streaming chat, tools, RAG, MCP Apps, artifacts, and voice, wired together and ready to deploy.
+{/* ── Hero product shot ─────────────────────────────────────────────── */}
 
-<CardGrid>
-	<LinkCard
-		title="Getting Started"
-		href="/agentcore-public-stack/getting-started/introduction/"
-		description="What the platform is, how it fits together, and how to run it locally."
+<div class="lp-hero-shot lp-reveal">
+	<ScreenshotPlaceholder
+		label="Full app — a streaming conversation with an artifact open in the side panel"
+		title="chat.your-university.edu"
+		aspect="16 / 9"
 	/>
-	<LinkCard
-		title="Local Development"
-		href="/agentcore-public-stack/local-development/"
-		description="Run the backend and SPA locally against a deployed environment."
-	/>
-	<LinkCard
-		title="Deployment"
-		href="/agentcore-public-stack/deployment/overview/"
-		description="Ship to AWS: platform stack, backend images, and the frontend."
-	/>
-	<LinkCard
-		title="Features"
-		href="/agentcore-public-stack/features/agents/"
-		description="Agents, tools, MCP Apps, RAG, artifacts, voice, and SSE streaming."
-	/>
-	<LinkCard
-		title="MCP & Integrations"
-		href="/agentcore-public-stack/integrations/mcp-overview/"
-		description="Connect MCP servers, Gateway targets, and remote A2A agents."
-	/>
-	<LinkCard
-		title="Reference"
-		href="/agentcore-public-stack/reference/sse-event-types/"
-		description="SSE event types, service boundaries, and CLI commands."
-	/>
-</CardGrid>
+</div>
+
+<div class="lp-chiprow lp-reveal" aria-label="Platform capabilities">
+	<span class="lp-chip">Streaming chat</span>
+	<span class="lp-chip">Custom agents</span>
+	<span class="lp-chip">Skills</span>
+	<span class="lp-chip">MCP&nbsp;+&nbsp;MCP Apps</span>
+	<span class="lp-chip">Knowledge bases</span>
+	<span class="lp-chip">Artifacts</span>
+	<span class="lp-chip">Voice</span>
+	<span class="lp-chip">RBAC&nbsp;+&nbsp;quotas</span>
+	<span class="lp-chip">Cost analytics</span>
+</div>
+
+{/* ── Why this exists — the vendor-independence argument ────────────── */}
+
+<section id="why" class="lp-section lp-reveal">
+	<div class="lp-manifesto">
+		<p class="lp-eyebrow"><span class="lp-eyebrow-num">✱</span> why this exists</p>
+		<h2 class="lp-h2">every vendor now agrees: <span class="lp-accent">don't get locked in.</span></h2>
+		<p class="lp-lede">
+			The AI labs are openly competing with their own biggest customers and partners, and
+			even the platform vendors now coach enterprises to keep their AI stack swappable —
+			while each one pitches its own ecosystem as the safe place to do it. We think the
+			advice is right and the conclusion goes further than any vendor will take it: the
+			only harness that's truly separate from the model is one you can read, fork, and
+			run yourself.
+		</p>
+		<blockquote class="lp-quote">
+			<p>"Keep your harness separate from the model."</p>
+			<cite>— Satya Nadella, Microsoft CEO, on making any model swappable · <a href="https://techcrunch.com/2026/07/29/microsoft-is-openly-competing-with-openai-anthropic-more-than-ever/">TechCrunch, July 2026</a></cite>
+		</blockquote>
+		<div class="lp-manifesto-grid">
+			<div class="lp-manifesto-item">
+				<h3>The harness is yours.</h3>
+				<p>The chat surface, agents, tools, and governance are open-source code deployed in your AWS account — infrastructure you control, not a subscription you rent.</p>
+			</div>
+			<div class="lp-manifesto-item">
+				<h3>Models are swappable.</h3>
+				<p>Every provider Strands Agents supports — Bedrock by default, plus Anthropic, OpenAI, Gemini, Ollama, and more — switchable per conversation and per agent. When a better or cheaper model ships, you swap it that afternoon.</p>
+			</div>
+			<div class="lp-manifesto-item">
+				<h3>Leaving costs nothing.</h3>
+				<p>No per-seat contracts, no proprietary formats, no ecosystem toll. Your data, prompts, and agents live inside a security boundary you already operate.</p>
+			</div>
+		</div>
+	</div>
+</section>
+
+{/* ── 01 · Chat ─────────────────────────────────────────────────────── */}
+
+<section id="chat" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">01</span> the conversation</p>
+	<h2 class="lp-h2">chat that ships <span class="lp-accent">finished.</span></h2>
+	<p class="lp-lede">
+		Not a demo loop — the whole conversational surface. Token-by-token streaming over SSE,
+		artifacts rendered in a docked panel, voice in and out, and context that manages itself
+		on long conversations instead of falling over.
+	</p>
+	<div class="lp-feature">
+		<ul class="lp-points">
+			<li><strong>Streaming, end to end.</strong> Tool calls, interactive tool UIs, and errors all arrive as stream events — the UI never blocks on a spinner.</li>
+			<li><strong>Artifacts.</strong> Generated documents, code, and pages open in a side panel you can keep working next to.</li>
+			<li><strong>Voice mode.</strong> Speak to the assistant and hear it answer.</li>
+			<li><strong>Automatic compaction.</strong> Older turns roll into a summary when context runs long — surfaced in the UI, never silent.</li>
+			<li><strong>Conversations that survive anything.</strong> Refresh mid-stream, switch tabs, come back tomorrow — the session picks up where it was.</li>
+		</ul>
+		<ScreenshotPlaceholder
+			label="A conversation mid-stream — tool call running, artifact panel docked on the right"
+			title="Conversation — artifact panel"
+		/>
+	</div>
+</section>
+
+{/* ── 02 · Agents ───────────────────────────────────────────────────── */}
+
+<section id="agents" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">02</span> agents</p>
+	<h2 class="lp-h2">build an agent once. <span class="lp-accent">your whole org runs it.</span></h2>
+	<p class="lp-lede">
+		Agents bundle instructions, tools, skills, and knowledge bases into something anyone can
+		use. Publish to the marketplace, and teammates pin it in one click — no setup guide,
+		no terminal.
+	</p>
+	<div class="lp-feature lp-feature--flip">
+		<ScreenshotPlaceholder
+			label="Agent marketplace — browse view with published agent cards"
+			title="Agent marketplace"
+		/>
+		<ul class="lp-points">
+			<li><strong>Marketplace.</strong> Publish an agent and control who can find it — a team, a role, or everyone.</li>
+			<li><strong>Version snapshots.</strong> Every publish is a snapshot; roll back a bad release without touching the editor.</li>
+			<li><strong>@-mentions.</strong> Pull a second agent into the middle of a conversation when you need its tools.</li>
+			<li><strong>Collaborative editing.</strong> Share an agent with viewers and editors — ownership is an access gate, not a silo.</li>
+			<li><strong>Skills.</strong> Reusable instruction packs agents load on demand, governed by the same role system as tools and models.</li>
+		</ul>
+	</div>
+</section>
+
+{/* ── 03 · Tools & MCP ──────────────────────────────────────────────── */}
+
+<section id="tools" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">03</span> tools &amp; integrations</p>
+	<h2 class="lp-h2">connect the systems <span class="lp-accent">you already run.</span></h2>
+	<p class="lp-lede">
+		Four tool protocols, one registry: direct functions, AWS SDK calls, MCP servers behind
+		AgentCore Gateway, and remote A2A agents. Admins register a server; role-based access
+		decides who gets which tools.
+	</p>
+	<div class="lp-feature">
+		<ul class="lp-points">
+			<li><strong>MCP Apps.</strong> Tools can render live, interactive UIs inline in the conversation — not just text results.</li>
+			<li><strong>OAuth built in.</strong> Tools that need user consent trigger it mid-conversation and resume where they left off.</li>
+			<li><strong>Per-tool enablement.</strong> Turn individual tools on or off within a server — expose exactly what each role needs.</li>
+			<li><strong>Gateway targets.</strong> Register Lambda-backed MCP targets from the admin console, secured with SigV4.</li>
+			<li><strong>A2A agents.</strong> Call out to remote agents running on their own AgentCore Runtimes.</li>
+		</ul>
+		<ScreenshotPlaceholder
+			label="An MCP App rendered inline in a conversation (interactive tool UI)"
+			title="MCP App — inline tool UI"
+		/>
+	</div>
+</section>
+
+{/* ── 04 · Knowledge ────────────────────────────────────────────────── */}
+
+<section id="knowledge" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">04</span> knowledge</p>
+	<h2 class="lp-h2">answers grounded in <span class="lp-accent">your documents.</span></h2>
+	<p class="lp-lede">
+		Every agent can carry its own knowledge base. Upload documents, connect sources, and
+		keep them fresh with scheduled re-sync — retrieval runs on Bedrock Knowledge Bases
+		inside your account.
+	</p>
+	<div class="lp-feature lp-feature--flip">
+		<ScreenshotPlaceholder
+			label="Knowledge base management — documents list with sync status"
+			title="Agent knowledge base"
+		/>
+		<ul class="lp-points">
+			<li><strong>Per-agent knowledge bases.</strong> Each agent retrieves from its own corpus — no cross-contamination between teams.</li>
+			<li><strong>Scheduled sync.</strong> Connected sources re-index on a schedule, so answers track the documents as they change.</li>
+			<li><strong>Citations in the stream.</strong> Retrieval results ride the same SSE stream as everything else.</li>
+			<li><strong>Export conversations.</strong> Save finished conversations out to connected storage.</li>
+		</ul>
+	</div>
+</section>
+
+{/* ── 05 · Governance ───────────────────────────────────────────────── */}
+
+<section id="governance" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">05</span> governance &amp; cost</p>
+	<h2 class="lp-h2">governed by default, <span class="lp-accent">down to the token.</span></h2>
+	<p class="lp-lede">
+		Access control and cost visibility aren't bolt-ons. Roles map to your identity provider's
+		groups and gate every model, tool, and skill — and every model call is metered, priced,
+		and attributable.
+	</p>
+	<div class="lp-feature">
+		<ul class="lp-points">
+			<li><strong>RBAC from your IdP.</strong> Roles bind to identity-provider groups, with inheritance and wildcard grants.</li>
+			<li><strong>Delegated admin.</strong> Scope admin surfaces to the people who own them — models, tools, users, costs.</li>
+			<li><strong>Usage quotas.</strong> Per-user token budgets with in-stream warnings before a cutoff, not after.</li>
+			<li><strong>Cost analytics.</strong> Per-session, per-call cost breakdowns in the admin console.</li>
+			<li><strong>Prompt-cache observability.</strong> Cache hit/miss status and prefix fingerprints on every call — see exactly which change burned money.</li>
+		</ul>
+		<ScreenshotPlaceholder
+			label="Admin cost analytics — per-session call breakdown with cache status"
+			title="Admin — cost analytics"
+		/>
+	</div>
+</section>
+
+{/* ── 06 · Deploy ───────────────────────────────────────────────────── */}
+
+<section id="deploy" class="lp-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">06</span> your infrastructure</p>
+	<h2 class="lp-h2">one stack. <span class="lp-accent">your AWS account.</span></h2>
+	<p class="lp-lede">
+		Everything deploys as a single CDK stack plus three GitHub Actions workflows. No SaaS
+		control plane, no per-seat licensing — your data never leaves the security boundary
+		you already operate.
+	</p>
+	<div class="lp-feature">
+		<div class="lp-terminal" role="img" aria-label="Deploy pipeline: one CDK stack, then backend images, then the frontend">
+			<div class="lp-terminal-bar"><span class="shot-dots" aria-hidden="true"><i></i><i></i><i></i></span>deploy — bash</div>
+			<pre class="lp-terminal-body">{`$ npx cdk deploy your-prefix-PlatformStack
+✓ PlatformStack        one stack, every AWS resource
+
+$ gh workflow run backend.yml
+✓ app-api              ECS behind the SPA
+✓ inference-api        AgentCore Runtime container
+✓ rag-ingestion        knowledge base pipeline
+✓ artifact-render      artifact rendering
+
+$ gh workflow run frontend-deploy.yml
+✓ SPA → S3 + CloudFront
+
+Deployed. Your models, your data, your bill.`}</pre>
+		</div>
+		<ul class="lp-points">
+			<li><strong>Single CDK stack.</strong> Every resource lives in one <code>PlatformStack</code> — no cross-stack ordering to babysit.</li>
+			<li><strong>Zero-downtime backend deploys.</strong> Images ship out-of-band via ECR and rolling service updates.</li>
+			<li><strong>Bring your own models.</strong> Any provider Strands Agents supports — Bedrock, Anthropic, OpenAI, Gemini, local models, and more — behind an admin-curated catalog.</li>
+			<li><strong>Consumption pricing.</strong> Pay AWS for what your people actually use — not per seat.</li>
+		</ul>
+	</div>
+</section>
+
+{/* ── Roadmap teaser ────────────────────────────────────────────────── */}
+
+<section id="roadmap-teaser" class="lp-section lp-reveal">
+	<div class="lp-band">
+		<div class="lp-band-copy">
+			<p class="lp-eyebrow"><span class="lp-eyebrow-num">→</span> where this is going</p>
+			<h2 class="lp-h2">from chat app to <span class="lp-accent">agent platform.</span></h2>
+			<p class="lp-lede">
+				Chat is the home base — the roadmap is about what runs beyond it: shared agents,
+				portable skills, scheduled work, and a governed registry of everything your org
+				has built.
+			</p>
+			<a class="lp-band-cta" href="/agentcore-public-stack/roadmap/">Explore the roadmap →</a>
+		</div>
+		<ul class="rm-legend" aria-label="Roadmap status legend">
+			<li><span class="rm-dot rm-dot--live"></span><strong>Live</strong> shipped today</li>
+			<li><span class="rm-dot rm-dot--partial"></span><strong>Partial</strong> works with limits</li>
+			<li><span class="rm-dot rm-dot--building"></span><strong>Building</strong> active work</li>
+			<li><span class="rm-dot rm-dot--next"></span><strong>Next</strong> the next horizon</li>
+			<li><span class="rm-dot rm-dot--exploring"></span><strong>Exploring</strong> a direction, not a commitment</li>
+		</ul>
+	</div>
+</section>
+
+{/* ── FAQ ───────────────────────────────────────────────────────────── */}
+
+<section class="lp-section lp-section--narrow lp-reveal">
+	<h2 class="lp-h2">frequently asked <span class="lp-accent">questions.</span></h2>
+	<div class="lp-faq">
+		<details>
+			<summary>What is the AgentCore Public Stack?</summary>
+			<p>
+				A production-ready, multi-agent conversational AI platform built on AWS Bedrock
+				AgentCore and Strands Agents — an Angular chat frontend, FastAPI backends, and a
+				CDK-defined AWS platform, developed in the open by Boise State University.
+			</p>
+		</details>
+		<details>
+			<summary>Is this an official AWS product?</summary>
+			<p>
+				No — it's the <em>unofficial</em> frontend for Strands and AgentCore: an
+				independent open-source project that builds on those AWS services and tracks
+				them closely.
+			</p>
+		</details>
+		<details>
+			<summary>Why not just buy Copilot or ChatGPT Enterprise?</summary>
+			<p>
+				Those are excellent products — rented from vendors who are increasingly
+				competing with each other, repricing as they go, and coaching you not to get
+				locked in while selling you their ecosystem. Renting the harness means renting
+				the switching costs. Owning it means model choice, pricing, and roadmap stay
+				decisions you make, not terms you accept.
+			</p>
+		</details>
+		<details>
+			<summary>Which models does it support?</summary>
+			<p>
+				The model layer is Strands Agents, so you're not tied to any one vendor's
+				catalog. Amazon Bedrock is the default provider, and Strands also supports
+				Anthropic, OpenAI, Google Gemini, Mistral, Ollama, SageMaker, LiteLLM, and
+				more — plus custom providers for anything it doesn't ship (see the
+				<a href="https://strandsagents.com/docs/user-guide/concepts/model-providers/">full
+				provider list</a>). Admins curate the catalog, users switch per conversation,
+				and role-based access controls who can use which model.
+			</p>
+		</details>
+		<details>
+			<summary>Where does my data live?</summary>
+			<p>
+				In your AWS account. Conversations, documents, and knowledge bases stay inside
+				your own security boundary, and models are used for inference only — your data
+				is never used to train third-party models.
+			</p>
+		</details>
+		<details>
+			<summary>What does it cost to run?</summary>
+			<p>
+				There's no license — you pay AWS for consumption. Built-in quotas, cost
+				analytics, and prompt-cache observability exist precisely so you can see and
+				control that spend per user and per call.
+			</p>
+		</details>
+		<details>
+			<summary>How do I deploy it?</summary>
+			<p>
+				One CDK stack for infrastructure, three GitHub Actions workflows for the
+				application. The <a href="/agentcore-public-stack/deployment/overview/">deployment
+				guide</a> walks through it end to end.
+			</p>
+		</details>
+	</div>
+</section>
+
+{/* ── Final CTA ─────────────────────────────────────────────────────── */}
+
+<section class="lp-section lp-reveal">
+	<div class="lp-final">
+		<h2 class="lp-h2">run your own. <span class="lp-accent">tonight.</span></h2>
+		<p class="lp-lede">Clone the repo, deploy the stack, and hand your whole org an AI platform you control.</p>
+		<div class="lp-final-actions">
+			<a class="lp-band-cta" href="/agentcore-public-stack/getting-started/quick-start/">Quick start →</a>
+			<a class="lp-band-cta lp-band-cta--ghost" href="https://github.com/Boise-State-Development/agentcore-public-stack">Star on GitHub</a>
+		</div>
+	</div>
+</section>

--- a/docs-site/src/content/docs/roadmap.mdx
+++ b/docs-site/src/content/docs/roadmap.mdx
@@ -1,0 +1,167 @@
+---
+title: Roadmap
+description: Where the AgentCore Public Stack is today and where it's going — from chat app to governed agent platform.
+template: splash
+prev: false
+next: false
+hero:
+  title: |
+    <span class="hero-kicker">Roadmap · Updated July 2026</span>
+    From chat app,
+    <span class="hero-accent">to agent platform.</span>
+  tagline: Chat is the home base — where people converse, run tools, and build agents today. The roadmap is about everything that runs beyond the chat window — shared agents, portable skills, scheduled work, and a governed registry of what your org has built.
+  actions:
+    - text: Get started
+      link: /agentcore-public-stack/getting-started/introduction/
+      icon: right-arrow
+      variant: primary
+    - text: Suggest a direction
+      link: https://github.com/Boise-State-Development/agentcore-public-stack/issues
+      icon: external
+      variant: minimal
+---
+
+{/* ── Legend ────────────────────────────────────────────────────────── */}
+
+<ul class="rm-legend rm-legend--page" aria-label="Roadmap status legend">
+	<li><span class="rm-dot rm-dot--live"></span><strong>Live</strong> shipped today</li>
+	<li><span class="rm-dot rm-dot--partial"></span><strong>Partial</strong> works with limits</li>
+	<li><span class="rm-dot rm-dot--building"></span><strong>Building</strong> active work</li>
+	<li><span class="rm-dot rm-dot--next"></span><strong>Next</strong> the next product horizon</li>
+	<li><span class="rm-dot rm-dot--exploring"></span><strong>Exploring</strong> a direction, not a commitment</li>
+</ul>
+
+{/* ── 01 · Conversation ─────────────────────────────────────────────── */}
+
+<section id="conversation" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">01</span> the home base</p>
+	<h2 class="lp-h2">the conversation is <span class="lp-accent">home.</span></h2>
+	<p class="lp-lede">
+		Everything starts in chat: streaming responses, tools, artifacts, and voice. The work
+		here is about making a conversation durable — something you can leave, interrupt, and
+		return to without losing anything.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>Streaming chat over SSE</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Token-by-token responses with tool calls, errors, and metadata all riding the same stream.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Artifacts panel</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Generated documents, code, and pages rendered in a docked side panel.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Voice mode</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Speak to the assistant and hear responses back.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Automatic context compaction</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Long conversations roll older turns into a summary — surfaced in the UI as it happens.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Session workspace files</h3><span class="rm-pill rm-pill--building">Building</span></div><p>Give each conversation a real file workspace the agent can read and write.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Interrupted-turn continuity</h3><span class="rm-pill rm-pill--building">Building</span></div><p>Stop or refresh mid-response and keep the partial turn as context instead of losing it.</p></div>
+	</div>
+</section>
+
+{/* ── 02 · Agents ───────────────────────────────────────────────────── */}
+
+<section id="agents" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">02</span> agents for everyone</p>
+	<h2 class="lp-h2">build once, <span class="lp-accent">share everywhere.</span></h2>
+	<p class="lp-lede">
+		Agents bundle instructions, tools, skills, and knowledge into something shareable. The
+		direction: lower the skill floor for building them, and raise the ceiling on what they
+		can be trusted to do.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>Custom agents</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Instructions, model, tools, skills, and knowledge bases — composed per agent.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Agent marketplace</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Publish agents with reach controls; teammates browse and pin in one click.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Version snapshots &amp; rollback</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Every publish is a snapshot; a bad release rolls back without touching the editor.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>@-mentions</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Pull another agent into the middle of a conversation when you need its capabilities.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Collaborative editing</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Viewer and editor sharing on agents — ownership is an access gate, not a silo.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Skill Creator</h3><span class="rm-pill rm-pill--next">Next</span></div><p>An agent that writes skills — turn a working conversation into a reusable capability.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Agent Designer</h3><span class="rm-pill rm-pill--next">Next</span></div><p>A governed design surface for composing agents from platform primitives.</p></div>
+	</div>
+</section>
+
+{/* ── 03 · Tools ────────────────────────────────────────────────────── */}
+
+<section id="tools" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">03</span> tools &amp; integrations</p>
+	<h2 class="lp-h2">every protocol, <span class="lp-accent">one registry.</span></h2>
+	<p class="lp-lede">
+		Direct functions, AWS SDK calls, MCP servers behind AgentCore Gateway, and remote A2A
+		agents — registered once, governed by roles, and increasingly able to render their own
+		interfaces inside the conversation.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>Multi-protocol tools</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Direct, AWS SDK, MCP + SigV4 via Gateway, and A2A client calls — one tool registry.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>MCP Apps</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Tools render live interactive UIs inline in chat, streaming their inputs as the model types.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>OAuth consent mid-conversation</h3><span class="rm-pill rm-pill--live">Live</span></div><p>External tools request user consent in-stream and resume the turn after sign-in.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Per-tool enablement</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Enable individual tools within a server — expose exactly what each role needs.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Admin Gateway registration</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Register Lambda-backed MCP targets from the admin console, no redeploy required.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Tool search at scale</h3><span class="rm-pill rm-pill--building">Building</span></div><p>Keep agent context small while the full tool catalog stays available on demand.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>A2A server surface</h3><span class="rm-pill rm-pill--exploring">Exploring</span></div><p>Expose platform agents to the outside world with their own AgentCards.</p></div>
+	</div>
+</section>
+
+{/* ── 04 · Knowledge ────────────────────────────────────────────────── */}
+
+<section id="knowledge" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">04</span> knowledge &amp; memory</p>
+	<h2 class="lp-h2">what your agents <span class="lp-accent">know.</span></h2>
+	<p class="lp-lede">
+		Retrieval today, memory next. Knowledge bases ground answers in documents; memory
+		spaces will let people and teams carry curated context between conversations.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>Per-agent knowledge bases</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Each agent retrieves from its own Bedrock Knowledge Base inside your account.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Scheduled knowledge sync</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Connected sources re-index on a schedule so answers track changing documents.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Conversation export</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Save conversations out to connected storage services.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Memory spaces</h3><span class="rm-pill rm-pill--building">Building</span></div><p>Bindable, shareable markdown "second brains" that agents load as context.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Export as an agent tool</h3><span class="rm-pill rm-pill--next">Next</span></div><p>Let the agent itself file results into your connected systems mid-conversation.</p></div>
+	</div>
+</section>
+
+{/* ── 05 · Governance ───────────────────────────────────────────────── */}
+
+<section id="governance" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">05</span> governance &amp; cost</p>
+	<h2 class="lp-h2">trust is a <span class="lp-accent">feature.</span></h2>
+	<p class="lp-lede">
+		Everything an agent can touch is granted by a role, and everything a model call costs
+		is measured. The work here is making that visibility effortless — for admins and for
+		the people paying the bill.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>RBAC from your identity provider</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Roles bind to IdP groups with inheritance and wildcard grants across models, tools, and skills.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Delegated admin scopes</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Scope each admin surface to the people who own it instead of one all-powerful role.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Usage quotas</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Per-user budgets with in-stream warnings before the cutoff, not after.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Cost analytics</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Per-session, per-call cost breakdowns in the admin console.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Prompt-cache observability</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Cache status and prefix fingerprints on every call — the change that burned money has a name.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Admin audit log</h3><span class="rm-pill rm-pill--building">Building</span></div><p>A durable record of who changed what across the admin surfaces.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Cache-cost dashboard</h3><span class="rm-pill rm-pill--building">Building</span></div><p>Fleet-wide cache write/read ratios and per-call anatomy, visualized.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Quota cooldown windows</h3><span class="rm-pill rm-pill--next">Next</span></div><p>Anchored usage windows and a platform-wide spend ceiling as a hard backstop.</p></div>
+	</div>
+</section>
+
+{/* ── 06 · Beyond chat ──────────────────────────────────────────────── */}
+
+<section id="beyond-chat" class="lp-section rm-section lp-reveal">
+	<p class="lp-eyebrow"><span class="lp-eyebrow-num">06</span> beyond the chat window</p>
+	<h2 class="lp-h2">systems, not just <span class="lp-accent">conversations.</span></h2>
+	<p class="lp-lede">
+		The long arc: successful agent work should become a system you can run again — on a
+		schedule, headlessly, from other surfaces — with the same identity, grants, and cost
+		controls as an interactive session.
+	</p>
+	<div class="rm-grid">
+		<div class="rm-card"><div class="rm-card-head"><h3>Single-stack CDK deploy</h3><span class="rm-pill rm-pill--live">Live</span></div><p>One <code>PlatformStack</code>, three workflows — infrastructure and app code ship independently.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>API keys for programmatic access</h3><span class="rm-pill rm-pill--live">Live</span></div><p>Call the platform from scripts and services with scoped keys.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Scheduled runs</h3><span class="rm-pill rm-pill--partial">Partial</span></div><p>Recurring agent runs exist behind a kill switch — the product surface is still to come.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Headless agent entrypoint</h3><span class="rm-pill rm-pill--exploring">Exploring</span></div><p>Run the same governed agents without a chat session attached.</p></div>
+		<div class="rm-card"><div class="rm-card-head"><h3>Capability registry</h3><span class="rm-pill rm-pill--exploring">Exploring</span></div><p>A governed catalog of every agent, skill, and tool the org has built — discovery with guardrails.</p></div>
+	</div>
+</section>
+
+{/* ── Closing ───────────────────────────────────────────────────────── */}
+
+<section class="lp-section lp-reveal">
+	<div class="lp-final">
+		<p class="lp-eyebrow lp-eyebrow--center"><span class="lp-eyebrow-num">→</span> help shape what comes next</p>
+		<h2 class="lp-h2">what should we build <span class="lp-accent">next?</span></h2>
+		<p class="lp-lede">Tell us which capability, integration, or surface would change how your org works.</p>
+		<div class="lp-final-actions">
+			<a class="lp-band-cta" href="https://github.com/Boise-State-Development/agentcore-public-stack/issues">Open an issue →</a>
+			<a class="lp-band-cta lp-band-cta--ghost" href="/agentcore-public-stack/getting-started/introduction/">Read the docs</a>
+		</div>
+	</div>
+</section>

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -653,3 +653,770 @@ site-search button[data-open-modal] kbd {
 .social-icons a svg {
 	font-size: 1.5rem; /* ~24px, up from the default 1em (~16px) */
 }
+
+/* =============================================================================
+   Landing + roadmap pages (splash template)
+   -----------------------------------------------------------------------------
+   Editorial layout in the OpenWork mold — numbered mono eyebrows, huge
+   lowercase display headlines with one accent phrase, alternating two-column
+   feature rows, app-window screenshot placeholders, and a status-pill roadmap —
+   rendered in the site's own frosted-glass Boise-blue system.
+   ========================================================================== */
+
+/* Splash pages carry long-form marketing layout — widen the content column. */
+:root[data-has-hero] {
+	--sl-content-width: 75rem;
+}
+
+/* With no hero image the copy owns the full column — let the tagline breathe. */
+:root[data-has-hero] .hero .tagline {
+	max-width: 52ch;
+}
+
+/* Hero: second headline line rendered as the accent phrase. */
+.hero .hero-accent {
+	display: block;
+	background: linear-gradient(
+		100deg,
+		var(--sl-color-accent) 0%,
+		var(--sl-color-accent-high) 55%,
+		var(--brand-orange-300) 130%
+	);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+}
+
+:root[data-theme='light'] .hero .hero-accent {
+	background: linear-gradient(100deg, var(--brand) 0%, var(--sl-color-accent) 70%, var(--brand-orange) 145%);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+	-webkit-text-fill-color: transparent;
+}
+
+/* ---------- Section shells ------------------------------------------------- */
+.lp-section {
+	margin-block: clamp(4.5rem, 10vh, 8rem) 0;
+}
+
+.lp-section--narrow {
+	max-width: 52rem;
+	margin-inline: auto;
+}
+
+/* Mono numbered eyebrow — "01 · the conversation" */
+.lp-eyebrow {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	margin: 0 0 1rem;
+	font-family: var(--sl-font-mono);
+	font-size: var(--sl-text-xs);
+	font-weight: 500;
+	letter-spacing: 0.22em;
+	text-transform: uppercase;
+	color: var(--sl-color-text-accent);
+}
+
+.lp-eyebrow--center {
+	justify-content: center;
+}
+
+.lp-eyebrow-num {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 2rem;
+	padding: 0.2rem 0.45rem;
+	border: 1px solid color-mix(in oklab, var(--brand) 38%, transparent);
+	border-radius: 0.4rem;
+	background: color-mix(in oklab, var(--brand) 14%, transparent);
+	letter-spacing: 0.06em;
+}
+
+/* Big lowercase display headline with an accent phrase. */
+.lp-h2 {
+	margin: 0 0 1.1rem !important;
+	font-family: var(--font-display);
+	font-weight: 800;
+	font-size: clamp(1.9rem, calc(1rem + 3.2vw), 3.1rem) !important;
+	line-height: 1.05;
+	letter-spacing: -0.022em;
+	color: var(--sl-color-white);
+}
+
+.lp-h2 .lp-accent {
+	background: linear-gradient(100deg, var(--sl-color-accent-high) 0%, var(--sl-color-accent) 100%);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+}
+
+:root[data-theme='light'] .lp-h2 .lp-accent {
+	background: linear-gradient(100deg, var(--brand) 0%, var(--sl-color-accent) 100%);
+	-webkit-background-clip: text;
+	background-clip: text;
+	color: transparent;
+}
+
+.lp-lede {
+	max-width: 56ch;
+	margin: 0 0 2.25rem;
+	font-size: clamp(var(--sl-text-base), calc(0.6rem + 1vw), var(--sl-text-lg));
+	font-weight: 450;
+	line-height: 1.65;
+	color: var(--sl-color-gray-2);
+}
+
+/* ---------- Manifesto — the vendor-independence argument ------------------- */
+.lp-manifesto {
+	position: relative;
+	padding: clamp(1.75rem, 4vw, 3.25rem);
+	border: 1px solid color-mix(in oklab, var(--brand) 32%, transparent);
+	border-radius: 1.25rem;
+	background:
+		radial-gradient(130% 170% at 100% 0%, color-mix(in oklab, var(--brand-orange) 9%, transparent), transparent 55%),
+		radial-gradient(120% 160% at 0% 100%, color-mix(in oklab, var(--brand) 20%, transparent), transparent 60%),
+		color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+	-webkit-backdrop-filter: blur(16px) saturate(150%);
+	backdrop-filter: blur(16px) saturate(150%);
+}
+
+.lp-manifesto .lp-lede {
+	max-width: 68ch;
+}
+
+.lp-quote {
+	max-width: 46rem;
+	margin: 2rem 0 2.5rem;
+	padding: 1.4rem 1.75rem 1.3rem;
+	border: 0;
+	border-inline-start: 3px solid var(--brand-orange);
+	border-radius: 0 0.9rem 0.9rem 0;
+	background: color-mix(in oklab, var(--brand-orange) 7%, transparent);
+}
+
+.lp-quote p {
+	margin: 0 0 0.6rem !important;
+	font-family: var(--font-display);
+	font-size: clamp(1.15rem, calc(0.8rem + 1.2vw), 1.6rem);
+	font-weight: 700;
+	line-height: 1.3;
+	letter-spacing: -0.015em;
+	color: var(--sl-color-white);
+}
+
+.lp-quote cite {
+	font-style: normal;
+	font-family: var(--sl-font-mono);
+	font-size: var(--sl-text-xs);
+	letter-spacing: 0.02em;
+	color: var(--sl-color-gray-3);
+}
+
+.lp-quote cite a {
+	color: var(--sl-color-text-accent);
+}
+
+.lp-manifesto-grid {
+	display: grid;
+	gap: 1rem;
+}
+
+@media (min-width: 62rem) {
+	.lp-manifesto-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+.lp-manifesto-item {
+	padding: 1.15rem 1.3rem;
+	border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+	border-radius: 1rem;
+	background: color-mix(in oklab, var(--sl-color-bg) 45%, transparent);
+}
+
+.lp-manifesto-item h3 {
+	margin: 0 0 0.45rem !important;
+	font-family: var(--font-display);
+	font-size: var(--sl-text-base) !important;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	color: var(--sl-color-white);
+}
+
+.lp-manifesto-item p {
+	margin: 0 !important;
+	font-size: var(--sl-text-sm);
+	line-height: 1.6;
+	color: var(--sl-color-gray-2);
+}
+
+:root[data-theme='light'] .lp-manifesto {
+	background:
+		radial-gradient(130% 170% at 100% 0%, color-mix(in oklab, var(--brand-orange) 7%, transparent), transparent 55%),
+		radial-gradient(120% 160% at 0% 100%, color-mix(in oklab, var(--brand) 10%, transparent), transparent 60%),
+		color-mix(in oklab, white 62%, transparent);
+}
+
+:root[data-theme='light'] .lp-manifesto-item {
+	background: color-mix(in oklab, white 55%, transparent);
+}
+
+/* ---------- Two-column feature rows ---------------------------------------- */
+.lp-feature {
+	display: grid;
+	gap: clamp(1.5rem, 4vw, 3.5rem);
+	align-items: center;
+}
+
+@media (min-width: 62rem) {
+	.lp-feature {
+		grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+	}
+	/* Flipped rows put the visual first in source AND on screen — alternation. */
+	.lp-feature--flip {
+		grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+	}
+}
+
+.lp-points {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.lp-points li {
+	position: relative;
+	margin: 0 !important;
+	padding-inline-start: 1.6rem;
+	font-size: var(--sl-text-sm);
+	line-height: 1.6;
+	color: var(--sl-color-gray-2);
+}
+
+.lp-points li::before {
+	content: '';
+	position: absolute;
+	inset-inline-start: 0;
+	top: 0.45em;
+	width: 0.55rem;
+	height: 0.55rem;
+	border-radius: 0.16rem;
+	background: linear-gradient(135deg, var(--sl-color-accent), var(--brand-600));
+	box-shadow: 0 0 10px color-mix(in oklab, var(--sl-color-accent) 55%, transparent);
+}
+
+.lp-points li strong {
+	color: var(--sl-color-white);
+	font-weight: 600;
+}
+
+/* ---------- Capability chips (under the hero shot) ------------------------- */
+.lp-chiprow {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 0.6rem;
+	margin-top: 1.75rem;
+}
+
+.lp-chip {
+	padding: 0.4rem 0.9rem;
+	font-family: var(--sl-font-mono);
+	font-size: var(--sl-text-xs);
+	letter-spacing: 0.04em;
+	color: var(--sl-color-gray-2);
+	border: 1px solid color-mix(in oklab, var(--brand) 28%, transparent);
+	border-radius: 999px;
+	background: color-mix(in oklab, var(--sl-color-bg) 45%, transparent);
+	-webkit-backdrop-filter: blur(10px);
+	backdrop-filter: blur(10px);
+}
+
+/* ---------- App-window screenshot placeholder ------------------------------ */
+.lp-hero-shot {
+	max-width: 62rem;
+	margin: clamp(2rem, 6vh, 4rem) auto 0;
+}
+
+.shot {
+	margin: 0;
+	border: 1px solid color-mix(in oklab, var(--brand) 30%, transparent);
+	border-radius: 1rem;
+	overflow: hidden;
+	background: color-mix(in oklab, var(--sl-color-bg) 60%, transparent);
+	-webkit-backdrop-filter: blur(16px) saturate(150%);
+	backdrop-filter: blur(16px) saturate(150%);
+	box-shadow:
+		0 1px 0 0 color-mix(in oklab, white 10%, transparent) inset,
+		0 30px 80px -30px color-mix(in oklab, var(--brand-800) 90%, transparent);
+}
+
+.shot-bar {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.6rem 0.9rem;
+	border-bottom: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+	background: color-mix(in oklab, var(--sl-color-bg) 40%, transparent);
+}
+
+.shot-dots {
+	display: inline-flex;
+	gap: 0.38rem;
+	flex: none;
+}
+
+.shot-dots i {
+	width: 0.62rem;
+	height: 0.62rem;
+	border-radius: 999px;
+	background: color-mix(in oklab, var(--brand) 35%, transparent);
+}
+
+.shot-dots i:first-child {
+	background: color-mix(in oklab, var(--brand-orange) 75%, transparent);
+}
+
+.shot-address,
+.shot-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-family: var(--sl-font-mono);
+	font-size: var(--sl-text-xs);
+	color: var(--sl-color-gray-3);
+}
+
+.shot-address {
+	flex: 1;
+	max-width: 26rem;
+	margin-inline: auto;
+	padding: 0.22rem 0.9rem;
+	text-align: center;
+	border: 1px solid color-mix(in oklab, var(--brand) 20%, transparent);
+	border-radius: 999px;
+	background: color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+}
+
+.shot-body {
+	position: relative;
+	display: grid;
+	place-items: center;
+	/* Faint graph paper inside the window so the empty state still feels designed. */
+	background-image:
+		linear-gradient(to right, color-mix(in oklab, var(--brand-300) 7%, transparent) 1px, transparent 1px),
+		linear-gradient(to bottom, color-mix(in oklab, var(--brand-300) 7%, transparent) 1px, transparent 1px);
+	background-size: 32px 32px;
+}
+
+.shot-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.55rem;
+	max-width: 34ch;
+	margin: 1rem;
+	padding: 1.4rem 1.7rem;
+	text-align: center;
+	color: var(--sl-color-gray-3);
+	border: 1.5px dashed color-mix(in oklab, var(--brand) 45%, transparent);
+	border-radius: 0.8rem;
+	background: color-mix(in oklab, var(--brand) 7%, transparent);
+}
+
+.shot-label {
+	font-size: var(--sl-text-sm);
+	font-weight: 500;
+	line-height: 1.45;
+	color: var(--sl-color-gray-2);
+}
+
+.shot-hint {
+	font-family: var(--sl-font-mono);
+	font-size: 0.68rem;
+	letter-spacing: 0.18em;
+	text-transform: uppercase;
+	color: var(--sl-color-text-accent);
+}
+
+:root[data-theme='light'] .shot {
+	background: color-mix(in oklab, white 65%, transparent);
+	box-shadow:
+		0 1px 0 0 color-mix(in oklab, white 70%, transparent) inset,
+		0 30px 80px -34px color-mix(in oklab, var(--brand) 45%, transparent);
+}
+
+/* ---------- Terminal mockup ------------------------------------------------ */
+.lp-terminal {
+	border: 1px solid color-mix(in oklab, var(--brand) 32%, transparent);
+	border-radius: 1rem;
+	overflow: hidden;
+	background: color-mix(in oklab, hsl(222 44% 4%) 88%, var(--brand));
+	box-shadow: 0 30px 80px -30px color-mix(in oklab, var(--brand-800) 90%, transparent);
+}
+
+.lp-terminal-bar {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.6rem 0.9rem;
+	font-family: var(--sl-font-mono);
+	font-size: var(--sl-text-xs);
+	color: hsl(222 20% 60%);
+	border-bottom: 1px solid color-mix(in oklab, var(--brand) 26%, transparent);
+}
+
+.lp-terminal-body {
+	margin: 0;
+	padding: 1.1rem 1.25rem 1.3rem;
+	font-family: var(--sl-font-mono);
+	font-size: 0.78rem;
+	line-height: 1.75;
+	color: hsl(220 30% 86%);
+	background: transparent;
+	border: 0;
+	overflow-x: auto;
+	white-space: pre;
+}
+
+/* ---------- Roadmap status pills & legend ---------------------------------- */
+:root {
+	--status-live: #22c47a;
+	--status-partial: #a78bfa;
+	--status-building: #4d8dff;
+	--status-next: var(--brand-orange);
+	--status-exploring: #94a3b8;
+}
+
+.rm-legend {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	margin: 0;
+	padding: 1.4rem 1.6rem;
+	border: 1px solid color-mix(in oklab, var(--brand) 26%, transparent);
+	border-radius: 1rem;
+	background: color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+	-webkit-backdrop-filter: blur(14px);
+	backdrop-filter: blur(14px);
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-gray-3);
+}
+
+.rm-legend li {
+	display: flex;
+	align-items: baseline;
+	gap: 0.55rem;
+	margin: 0 !important;
+}
+
+.rm-legend strong {
+	color: var(--sl-color-white);
+	font-weight: 600;
+}
+
+/* Roadmap page variant: a horizontal band under the hero. */
+.rm-legend--page {
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: center;
+	column-gap: 1.6rem;
+	max-width: fit-content;
+	margin: clamp(1.5rem, 4vh, 2.5rem) auto 0;
+}
+
+.rm-dot {
+	flex: none;
+	width: 0.55rem;
+	height: 0.55rem;
+	border-radius: 999px;
+	align-self: center;
+}
+
+.rm-dot--live { background: var(--status-live); box-shadow: 0 0 8px color-mix(in oklab, var(--status-live) 70%, transparent); }
+.rm-dot--partial { background: var(--status-partial); box-shadow: 0 0 8px color-mix(in oklab, var(--status-partial) 70%, transparent); }
+.rm-dot--building { background: var(--status-building); box-shadow: 0 0 8px color-mix(in oklab, var(--status-building) 70%, transparent); }
+.rm-dot--next { background: var(--status-next); box-shadow: 0 0 8px color-mix(in oklab, var(--status-next) 70%, transparent); }
+.rm-dot--exploring { background: var(--status-exploring); }
+
+.rm-pill {
+	flex: none;
+	padding: 0.18rem 0.6rem;
+	font-family: var(--sl-font-mono);
+	font-size: 0.66rem;
+	font-weight: 500;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	border-radius: 999px;
+	border: 1px solid;
+}
+
+.rm-pill--live { color: var(--status-live); border-color: color-mix(in oklab, var(--status-live) 45%, transparent); background: color-mix(in oklab, var(--status-live) 12%, transparent); }
+.rm-pill--partial { color: var(--status-partial); border-color: color-mix(in oklab, var(--status-partial) 45%, transparent); background: color-mix(in oklab, var(--status-partial) 12%, transparent); }
+.rm-pill--building { color: var(--status-building); border-color: color-mix(in oklab, var(--status-building) 45%, transparent); background: color-mix(in oklab, var(--status-building) 12%, transparent); }
+.rm-pill--next { color: var(--status-next); border-color: color-mix(in oklab, var(--status-next) 45%, transparent); background: color-mix(in oklab, var(--status-next) 12%, transparent); }
+.rm-pill--exploring { color: var(--status-exploring); border-color: color-mix(in oklab, var(--status-exploring) 45%, transparent); background: color-mix(in oklab, var(--status-exploring) 12%, transparent); }
+
+:root[data-theme='light'] .rm-pill--live { color: #0c7a4b; }
+:root[data-theme='light'] .rm-pill--partial { color: #6d4fd8; }
+:root[data-theme='light'] .rm-pill--building { color: var(--brand); }
+:root[data-theme='light'] .rm-pill--next { color: #b23607; }
+:root[data-theme='light'] .rm-pill--exploring { color: #56657a; }
+
+/* ---------- Roadmap card grid ---------------------------------------------- */
+.rm-section {
+	padding-top: clamp(2.5rem, 6vh, 4rem);
+	border-top: 1px solid color-mix(in oklab, var(--brand) 18%, transparent);
+}
+
+.rm-grid {
+	display: grid;
+	gap: 1rem;
+	margin-top: 0.5rem;
+}
+
+@media (min-width: 48rem) {
+	.rm-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (min-width: 72rem) {
+	.rm-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+.rm-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	padding: 1.15rem 1.3rem;
+	border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+	border-radius: 1rem;
+	background: color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+	-webkit-backdrop-filter: blur(14px) saturate(150%);
+	backdrop-filter: blur(14px) saturate(150%);
+	box-shadow:
+		0 1px 0 0 color-mix(in oklab, white 8%, transparent) inset,
+		0 18px 40px -28px color-mix(in oklab, var(--brand-800) 80%, transparent);
+	transition:
+		transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+		border-color 0.25s ease;
+}
+
+.rm-card:hover {
+	transform: translateY(-3px);
+	border-color: color-mix(in oklab, var(--brand) 42%, transparent);
+}
+
+:root[data-theme='light'] .rm-card {
+	background: color-mix(in oklab, white 62%, transparent);
+}
+
+.rm-card-head {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 0.75rem;
+}
+
+.rm-card h3 {
+	margin: 0 !important;
+	font-family: var(--font-display);
+	font-size: var(--sl-text-base) !important;
+	font-weight: 700;
+	line-height: 1.25;
+	letter-spacing: -0.01em;
+	color: var(--sl-color-white);
+}
+
+.rm-card p {
+	margin: 0 !important;
+	font-size: var(--sl-text-sm);
+	line-height: 1.55;
+	color: var(--sl-color-gray-3);
+}
+
+/* ---------- Roadmap teaser band + final CTA -------------------------------- */
+.lp-band {
+	display: grid;
+	gap: 2rem;
+	align-items: center;
+	padding: clamp(1.75rem, 4vw, 3rem);
+	border: 1px solid color-mix(in oklab, var(--brand) 30%, transparent);
+	border-radius: 1.25rem;
+	background:
+		radial-gradient(120% 160% at 0% 0%, color-mix(in oklab, var(--brand) 22%, transparent), transparent 60%),
+		color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+	-webkit-backdrop-filter: blur(16px) saturate(150%);
+	backdrop-filter: blur(16px) saturate(150%);
+}
+
+@media (min-width: 62rem) {
+	.lp-band {
+		grid-template-columns: minmax(0, 7fr) minmax(0, 4fr);
+	}
+}
+
+.lp-band-copy .lp-lede {
+	margin-bottom: 1.5rem;
+}
+
+.lp-band-cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.7rem 1.35rem;
+	font-weight: 600;
+	font-size: var(--sl-text-sm);
+	color: white !important;
+	text-decoration: none;
+	border-radius: 999px;
+	background: linear-gradient(180deg, var(--sl-color-accent) 0%, var(--brand) 100%);
+	border: 1px solid color-mix(in oklab, var(--sl-color-accent-high) 45%, transparent);
+	box-shadow: 0 10px 30px -10px color-mix(in oklab, var(--brand) 75%, transparent);
+	transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lp-band-cta:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 16px 40px -12px color-mix(in oklab, var(--brand) 85%, transparent);
+}
+
+.lp-band-cta--ghost {
+	color: var(--sl-color-white) !important;
+	background: color-mix(in oklab, var(--sl-color-bg) 40%, transparent);
+	border: 1px solid color-mix(in oklab, var(--brand) 32%, transparent);
+	box-shadow: none;
+	-webkit-backdrop-filter: blur(10px);
+	backdrop-filter: blur(10px);
+}
+
+.lp-band-cta--ghost:hover {
+	background: color-mix(in oklab, var(--brand) 14%, transparent);
+	box-shadow: none;
+}
+
+.lp-final {
+	padding: clamp(2rem, 6vh, 3.5rem) 1rem clamp(1rem, 4vh, 2rem);
+	text-align: center;
+}
+
+.lp-final .lp-lede {
+	margin-inline: auto;
+}
+
+.lp-final-actions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 0.8rem;
+}
+
+/* ---------- FAQ ------------------------------------------------------------ */
+.lp-faq {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	margin-top: 2rem;
+}
+
+.lp-faq details {
+	border: 1px solid color-mix(in oklab, var(--brand) 24%, transparent);
+	border-radius: 0.9rem;
+	background: color-mix(in oklab, var(--sl-color-bg) 55%, transparent);
+	-webkit-backdrop-filter: blur(14px);
+	backdrop-filter: blur(14px);
+	transition: border-color 0.2s ease;
+}
+
+.lp-faq details[open] {
+	border-color: color-mix(in oklab, var(--brand) 45%, transparent);
+}
+
+.lp-faq summary {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 1rem 1.25rem;
+	cursor: pointer;
+	list-style: none;
+	text-align: start;
+	font-family: var(--font-display);
+	font-weight: 600;
+	font-size: var(--sl-text-base);
+	color: var(--sl-color-white);
+}
+
+.lp-faq summary::-webkit-details-marker {
+	display: none;
+}
+
+/* Starlight's markdown styles inject their own caret + centring on
+   details/summary — strip them so the FAQ rows read as clean flex rows. */
+.lp-faq summary::marker {
+	content: '';
+}
+
+.lp-faq summary::before,
+.lp-faq summary > svg,
+.lp-faq summary .caret {
+	display: none !important;
+}
+
+.lp-faq summary::after {
+	content: '+';
+	flex: none;
+	font-family: var(--sl-font-mono);
+	font-size: 1.1rem;
+	color: var(--sl-color-text-accent);
+	transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.lp-faq details[open] summary::after {
+	transform: rotate(45deg);
+}
+
+.lp-faq details p {
+	margin: 0 !important;
+	padding: 0 1.25rem 1.15rem;
+	font-size: var(--sl-text-sm);
+	line-height: 1.65;
+	color: var(--sl-color-gray-2);
+}
+
+:root[data-theme='light'] .lp-faq details {
+	background: color-mix(in oklab, white 62%, transparent);
+}
+
+/* ---------- Scroll reveal (progressive enhancement) ------------------------ */
+@supports (animation-timeline: view()) {
+	@media (prefers-reduced-motion: no-preference) {
+		.lp-reveal {
+			animation: lp-fade-up both;
+			animation-timeline: view();
+			animation-range: entry 0% entry 32%;
+		}
+	}
+}
+
+@keyframes lp-fade-up {
+	from {
+		opacity: 0.15;
+		transform: translateY(26px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}


### PR DESCRIPTION
## Summary

Redesigns the docs-site landing page and adds a `/roadmap` page, emulating the [OpenWork](https://openworklabs.com/) content architecture (numbered editorial sections, app-window product shots, status-pill roadmap) while keeping our existing frosted-glass Boise-blue identity. All copy is grounded in shipped features.

### Landing page (`/`)
- Hero: "Own your AI platform, on your own cloud." with a full-app screenshot placeholder and capability chips
- **`#why` manifesto section** — the vendor-independence argument, anchored on Satya Nadella's "keep your harness separate from the model" line ([TechCrunch, July 2026](https://techcrunch.com/2026/07/29/microsoft-is-openly-competing-with-openai-anthropic-more-than-ever/)): the only harness truly separate from the model is one you can read, fork, and run yourself
- Six numbered feature sections: chat, agents/marketplace, tools & MCP, knowledge, governance & cost, and deploy (with a terminal mock of the real `PlatformStack` → `backend.yml` → `frontend-deploy.yml` pipeline)
- Roadmap teaser band, FAQ (including "Why not just buy Copilot or ChatGPT Enterprise?"), final CTA
- Model-support copy reflects Strands Agents providers (Bedrock default, plus Anthropic, OpenAI, Gemini, Ollama, and more — [full list](https://strandsagents.com/docs/user-guide/concepts/model-providers/)), not Bedrock-only

### Roadmap page (`/roadmap`)
- "From chat app, to agent platform." with a Live / Partial / Building / Next / Exploring legend
- Six themed sections of status cards reflecting actual project state (e.g. session workspace files and admin audit log = Building; quota cooldown windows and Skill Creator = Next; A2A server surface and capability registry = Exploring; scheduled runs = Partial)
- Added to the sidebar; `prev`/`next` pagination disabled on the splash template

### Screenshot placeholders
Eight `ScreenshotPlaceholder` window frames describe exactly what to capture (find them via `data-screenshot-placeholder`). Real screenshots to follow in a later PR — drop an `<img>` into `.shot-body` and delete the `.shot-placeholder` block.

## Test plan
- [x] `npm run build` passes (52 pages)
- [x] Verified dark + light themes and mobile (375px) layouts in the browser
- [ ] Replace screenshot placeholders with real captures (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)