### PR TITLE
fix(admin): show which roles carry delegated admin power

### DIFF
--- a/frontend/ai.client/src/app/admin/roles/pages/role-list.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/roles/pages/role-list.page.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * The roles list surfaces delegated admin power.
+ *
+ * The list card previously showed JWT mappings and tool grants but nothing
+ * about admin scopes, so a system admin scanning the page could not tell which
+ * roles carry admin power without opening each edit form. That cuts against the
+ * spec's own invariant that granting a scope is a `system_admin`-only act worth
+ * watching (`docs/specs/granular-admin-permissions.md` §3 I2).
+ *
+ * The subtle case these tests pin down: `system_admin` holds every scope
+ * *implicitly* and therefore carries an empty `grantedAdminScopes`. Rendering
+ * that as "no admin access" would be exactly backwards.
+ */
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { RoleListPage } from './role-list.page';
+import { AppRolesService } from '../services/app-roles.service';
+import { ToolsService } from '../../tools/services/tools.service';
+import { AppRole } from '../models/app-role.model';
+import { AdminScopeListResponse } from '../../admin-scope.model';
+
+function role(overrides: Partial<AppRole> = {}): AppRole {
+  return {
+    roleId: 'analyst',
+    displayName: 'Analyst',
+    description: '',
+    jwtRoleMappings: [],
+    inheritsFrom: [],
+    grantedTools: [],
+    grantedModels: [],
+    grantedSkills: [],
+    grantedAdminScopes: [],
+    priority: 0,
+    enabled: true,
+    isSystemRole: false,
+    ...overrides,
+  } as AppRole;
+}
+
+const REGISTRY: AdminScopeListResponse = {
+  total: 2,
+  scopes: [
+    {
+      id: 'admin.costs',
+      label: 'Cost Analytics',
+      group: 'Usage & Spend',
+      description: '',
+      delegable: true,
+    },
+    {
+      id: 'admin.users',
+      label: 'Users',
+      group: 'Identity & Access',
+      description: '',
+      delegable: true,
+    },
+  ],
+};
+
+class StubAppRolesService {
+  readonly rolesResource = { isLoading: () => false, value: () => undefined };
+  getRoles(): AppRole[] {
+    return [];
+  }
+  async fetchAdminScopes(): Promise<AdminScopeListResponse> {
+    return REGISTRY;
+  }
+}
+
+class StubToolsService {
+  getToolById() {
+    return undefined;
+  }
+}
+
+describe('RoleListPage — delegated admin visibility', () => {
+  let page: RoleListPage;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AppRolesService, useClass: StubAppRolesService },
+        { provide: ToolsService, useClass: StubToolsService },
+      ],
+    });
+    page = TestBed.createComponent(RoleListPage).componentInstance;
+    // The registry load is fired from the constructor; let it settle so the
+    // label lookups below resolve to real labels rather than raw ids.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('shows no badge for a role with no admin scopes', () => {
+    expect(page.adminAccessBadge(role())).toBeNull();
+  });
+
+  it('badges system_admin as full admin despite an empty scope list', () => {
+    const badge = page.adminAccessBadge(
+      role({ roleId: 'system_admin', isSystemRole: true, grantedAdminScopes: [] })
+    );
+    expect(badge?.label).toBe('Full Admin');
+  });
+
+  it('badges a delegated role and counts its scopes', () => {
+    const badge = page.adminAccessBadge(
+      role({ grantedAdminScopes: ['admin.costs', 'admin.users'] })
+    );
+    expect(badge?.label).toBe('Admin Access · 2');
+  });
+
+  it('drops the count for a single scope', () => {
+    const badge = page.adminAccessBadge(
+      role({ grantedAdminScopes: ['admin.costs'] })
+    );
+    expect(badge?.label).toBe('Admin Access');
+  });
+
+  it('names the granted areas in the badge tooltip', () => {
+    const badge = page.adminAccessBadge(
+      role({ grantedAdminScopes: ['admin.costs', 'admin.users'] })
+    );
+    expect(badge?.title).toBe('Delegated admin areas: Cost Analytics, Users');
+  });
+
+  it('resolves scope ids to registry labels', () => {
+    expect(page.getAdminScopeLabel('admin.costs')).toBe('Cost Analytics');
+  });
+
+  it('falls back to the raw id for a scope missing from the registry', () => {
+    expect(page.getAdminScopeLabel('admin.not_in_registry')).toBe(
+      'admin.not_in_registry'
+    );
+  });
+});

--- a/frontend/ai.client/src/app/admin/roles/pages/role-list.page.ts
+++ b/frontend/ai.client/src/app/admin/roles/pages/role-list.page.ts
@@ -18,6 +18,7 @@ import {
   heroArrowPath,
   heroChevronRight,
   heroArrowLeft,
+  heroKey,
 } from '@ng-icons/heroicons/outline';
 import { AppRolesService } from '../services/app-roles.service';
 import { AppRole } from '../models/app-role.model';
@@ -38,6 +39,7 @@ import { ToolsService } from '../../tools/services/tools.service';
       heroArrowPath,
       heroChevronRight,
       heroArrowLeft,
+      heroKey,
     }),
   ],
   host: {
@@ -153,6 +155,15 @@ import { ToolsService } from '../../tools/services/tools.service';
                         System
                       </span>
                     }
+                    @if (adminAccessBadge(role); as badge) {
+                      <span
+                        class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-xs bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
+                        [title]="badge.title"
+                      >
+                        <ng-icon name="heroKey" class="size-3" />
+                        {{ badge.label }}
+                      </span>
+                    }
                     @if (!role.enabled) {
                       <span class="px-2 py-0.5 text-xs font-medium rounded-xs bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400">
                         Disabled
@@ -169,7 +180,7 @@ import { ToolsService } from '../../tools/services/tools.service';
                   }
 
                   <!-- Role Details Grid -->
-                  <div class="grid grid-cols-1 gap-3 sm:grid-cols-3 text-sm">
+                  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
                     <!-- JWT Mappings -->
                     <div>
                       <span class="font-medium text-gray-700 dark:text-gray-300">JWT Roles:</span>
@@ -211,6 +222,31 @@ import { ToolsService } from '../../tools/services/tools.service';
                                 +{{ role.grantedTools.length - 2 }} more
                               </span>
                             }
+                          }
+                        } @else {
+                          <span class="text-gray-400 dark:text-gray-500">None</span>
+                        }
+                      </div>
+                    </div>
+
+                    <!-- Admin Access -->
+                    <div>
+                      <span class="font-medium text-gray-700 dark:text-gray-300">Admin Access:</span>
+                      <div class="mt-1 flex flex-wrap gap-1">
+                        @if (role.isSystemRole && role.roleId === 'system_admin') {
+                          <span class="px-1.5 py-0.5 text-xs rounded-xs bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+                            All Areas
+                          </span>
+                        } @else if (role.grantedAdminScopes.length > 0) {
+                          @for (scope of role.grantedAdminScopes.slice(0, 2); track scope) {
+                            <span class="px-1.5 py-0.5 text-xs rounded-xs bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+                              {{ getAdminScopeLabel(scope) }}
+                            </span>
+                          }
+                          @if (role.grantedAdminScopes.length > 2) {
+                            <span class="px-1.5 py-0.5 text-xs rounded-xs bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400">
+                              +{{ role.grantedAdminScopes.length - 2 }} more
+                            </span>
                           }
                         } @else {
                           <span class="text-gray-400 dark:text-gray-500">None</span>
@@ -295,10 +331,34 @@ export class RoleListPage {
 
   readonly rolesResource = this.appRolesService.rolesResource;
 
+  constructor() {
+    void this.loadAdminScopeLabels();
+  }
+
+  private async loadAdminScopeLabels(): Promise<void> {
+    try {
+      const response = await this.appRolesService.fetchAdminScopes();
+      this.adminScopeLabels.set(
+        new Map(response.scopes.map(s => [s.id, s.label]))
+      );
+    } catch {
+      // Non-fatal — `getAdminScopeLabel` falls back to the raw id.
+    }
+  }
+
   // Local state
   searchQuery = signal('');
   enabledFilter = signal('');
   syncing = signal<string | null>(null);
+
+  /**
+   * Scope id → human label, from `GET /admin/roles/admin-scopes`.
+   *
+   * Best-effort: if the registry fetch fails the cards fall back to raw scope
+   * ids, which still answers "does this role carry admin power?" — the question
+   * the badge exists for.
+   */
+  private readonly adminScopeLabels = signal<Map<string, string>>(new Map());
 
   // Computed
   readonly roles = computed(() => this.appRolesService.getRoles());
@@ -347,6 +407,39 @@ export class RoleListPage {
   getToolDisplayName(toolId: string): string {
     const tool = this.toolsService.getToolById(toolId);
     return tool?.name ?? toolId;
+  }
+
+  getAdminScopeLabel(scopeId: string): string {
+    return this.adminScopeLabels().get(scopeId) ?? scopeId;
+  }
+
+  /**
+   * The amber badge on the role title — the point of this feature is that a
+   * system admin can see *at a glance* which roles carry admin power, without
+   * opening each role's edit form.
+   *
+   * `system_admin` is special-cased: it holds every scope implicitly and so
+   * carries an empty `grantedAdminScopes`. Reading that as "no admin access"
+   * would be exactly backwards.
+   */
+  adminAccessBadge(role: AppRole): { label: string; title: string } | null {
+    if (role.roleId === 'system_admin') {
+      return {
+        label: 'Full Admin',
+        title: 'Holds every admin scope implicitly.',
+      };
+    }
+    const count = role.grantedAdminScopes.length;
+    if (count === 0) {
+      return null;
+    }
+    const names = role.grantedAdminScopes
+      .map(s => this.getAdminScopeLabel(s))
+      .join(', ');
+    return {
+      label: count === 1 ? 'Admin Access' : `Admin Access · ${count}`,
+      title: `Delegated admin areas: ${names}`,
+    };
   }
 
   async deleteRole(role: AppRole): Promise<void> {


### PR DESCRIPTION
## What

The roles list rendered JWT mappings and tool grants on each card but nothing about admin scopes. A system admin scanning the page could not tell which roles carry admin power without opening each role's edit form.

That cuts against the invariant the delegated-admin feature rests on — [granting a scope is a `system_admin`-only act](../blob/develop/docs/specs/granular-admin-permissions.md) (§3, I2), and one worth being able to watch.

Found while end-to-end testing PR-1..4 of the delegated admin scopes epic.

## How

- Amber **Admin Access · N** badge on the role title, with the granted areas named in the tooltip.
- An **Admin Access** cell in the details grid (grid goes 3 → 4 columns at `lg`), showing up to two labels plus "+N more", matching the existing Tools cell.
- Labels resolve from `GET /admin/roles/admin-scopes`. The fetch is best-effort — on failure the cards fall back to raw scope ids, which still answers "does this role carry admin power?", the question the badge exists for.

## The one subtle case

`system_admin` holds every scope **implicitly** and therefore carries an *empty* `grantedAdminScopes`. Rendering that as "no admin access" would be exactly backwards, so it is special-cased to **Full Admin** / **All Areas**.

## Verification

Browser-verified against dev data:

- `system_admin` → "Full Admin" badge, "All Areas"
- `default` → no badge, "None"
- a throwaway 3-scope role → "Admin Access · 3", "Cost Analytics, Quotas, +1 more"

The probe role was deleted afterwards; the dev `app-roles` table is confirmed back to `system_admin` + `default` only.

7 new unit tests in `role-list.page.spec.ts` cover the badge logic including the `system_admin` case and the registry-label fallback. Full SPA suite: 1745 passed.