### PR TITLE
feat(spa): scope the assistants explainer to production, answer the legacy site, and promote the marketplace

### DIFF
--- a/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/categories.page.ts
@@ -38,7 +38,7 @@ import { AgentCategory } from '../models/marketplace.model';
         <div class="mb-6">
           <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Categories</h1>
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-            The shelves of the store, in browse order. Empty categories hide themselves on
+            How the store is grouped, in browse order. Empty categories hide themselves on
             Discover, so it is safe to add one before anything is published into it.
           </p>
         </div>

--- a/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/default-pins.page.ts
@@ -168,7 +168,7 @@ interface StagedPin {
               </span>
               Members cannot remove a locked agent — it is in their sidebar for good. Lock
               the ones that genuinely must be there and leave the rest removable, or Pinned
-              stops being the user's own shelf.
+              stops being the user's own list.
             }
             @if (lockedElsewhere()) {
               <span [class]="lockWarning() ? 'mt-2 block' : ''">
@@ -176,7 +176,7 @@ interface StagedPin {
                 other {{ lockedElsewhereRoles() === 1 ? 'role locks' : 'roles lock' }}
                 {{ lockedElsewhere() }} more.
                 A member who matches several roles gets the union of all of them, and a
-                lock from any one role wins — so the shelf an individual ends up with can
+                lock from any one role wins — so the set an individual ends up with can
                 be larger than any single role's list.
               </span>
             }
@@ -385,7 +385,7 @@ interface StagedPin {
             </h2>
             <p class="mb-3 text-sm/6 text-gray-600 dark:text-gray-400">
               Everything that has been submitted to the store. Seeding an agent that is not
-              published still works — it is a pin, not a shelf slot — but members can only
+              published still works — it is a pin, not a listing — but members can only
               open one they could reach on their own.
             </p>
 

--- a/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/publishers.page.ts
@@ -55,7 +55,7 @@ import {
         <div class="mb-6">
           <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Publishers</h1>
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-            Who a listing is attributed to on the shelf — the Registrar, Communications &
+            Who a listing is attributed to in Discover — the Registrar, Communications &
             Marketing, the university itself. An agent built by one person can still speak
             as the office that owns it.
           </p>

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
@@ -846,8 +846,8 @@ export class ShareAgentDialogComponent {
         // recalls nothing, because an author who thinks withdrawal revokes access decides
         // worse than one who knows it does not.
         message: published
-          ? `An admin reviews this before "${name}" comes off the shelf, so it stays in ` +
-            'the store until they decide. Even once it does come down, nothing is ' +
+          ? `An admin reviews this before "${name}" comes down from Discover, so it stays ` +
+            'published until they decide. Even once it does come down, nothing is ' +
             'recalled: anyone who already added it keeps it, conversations underway keep ' +
             'running, and it stays reachable by direct link.'
           : `"${name}" is pulled from the review queue. You can submit it again at any time.`,

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -17,7 +17,7 @@ export interface SubmitListingDialogData {
   agentName: string;
   /** Present on a resubmission; its category preselects the picker. */
   listing?: AgentListingBlock;
-  /** The current shelf subtitle, if the Agent already has one. */
+  /** The current listing subtitle, if the Agent already has one. */
   tagline?: string;
   /** Only used to prefill an absent tagline — see `deriveTagline` (#749). */
   description?: string;
@@ -142,7 +142,7 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
                 Category
               </label>
               <p class="text-xs/5 text-gray-500 dark:text-gray-400">
-                Which shelf it sits on. A reviewer may move it.
+                Where it appears in Discover. An admin may move it.
               </p>
               <select
                 id="listing-category"
@@ -166,14 +166,14 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
             <!--
               Tagline (D4). Prefilled from the description's first clause for the many
               Agents that predate the field — the author edits rather than invents, and
-              sees what the shelf will say at the one moment they are looking at it.
+              sees what the listing will say at the one moment they are looking at it.
             -->
             <div class="mt-5">
               <label for="listing-tagline" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
                 Tagline
               </label>
               <p class="text-xs/5 text-gray-500 dark:text-gray-400">
-                The one line under the name on the shelf. We started it from your
+                The one line under the name in Discover. We started it from your
                 description — make it read like a subtitle.
               </p>
               <input
@@ -191,7 +191,7 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
 
             <div class="mt-5">
               <label for="listing-note" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                Note to the reviewer <span class="font-normal text-gray-500 dark:text-gray-400">(optional)</span>
+                Note to the admin <span class="font-normal text-gray-500 dark:text-gray-400">(optional)</span>
               </label>
               <textarea
                 id="listing-note"
@@ -229,8 +229,8 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
 
             <p class="mt-5 text-xs/5 text-gray-500 dark:text-gray-400">
               You'll be credited as the publisher. An admin may reattribute the listing to a
-              department or the university at approval — that changes the name on the shelf and
-              nothing about who can run it.
+              department or the university at approval — that changes the name shown with it in
+              Discover and nothing about who can run it.
             </p>
 
             @if (error(); as message) {
@@ -313,11 +313,11 @@ export class SubmitListingDialogComponent implements OnInit {
         'available to everyone at Boise State.',
   );
 
-  /** A resubmission is answering a reviewer; a first submission is introducing itself. */
+  /** A resubmission is answering an admin; a first submission is introducing itself. */
   readonly notePlaceholder = computed(() =>
     this.isResubmission()
       ? 'What you changed since the last review.'
-      : 'Anything the reviewer should know — who it is for, what it draws on.',
+      : 'Anything the admin should know — who it is for, what it draws on.',
   );
 
   async ngOnInit(): Promise<void> {

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.css
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.css
@@ -122,13 +122,16 @@
     animation: reveal-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
   }
 
-  /* `nth-child`, not `nth-of-type`: the five panels are a <header> followed by four
-     <section>s, and per-type counting would restart the sequence at the first one. */
+  /* `nth-child`, not `nth-of-type`: the six panels are a <header> followed by five
+     <section>s, and per-type counting would restart the sequence at the first one.
+     Keep a delay for every panel — an unlisted `.reveal` gets `animation-delay: 0`,
+     which lands it ahead of the ones above it and breaks the sequence. */
   .reveal:nth-child(1) { animation-delay: 0ms; }
   .reveal:nth-child(2) { animation-delay: 90ms; }
   .reveal:nth-child(3) { animation-delay: 160ms; }
   .reveal:nth-child(4) { animation-delay: 220ms; }
   .reveal:nth-child(5) { animation-delay: 270ms; }
+  .reveal:nth-child(6) { animation-delay: 310ms; }
 }
 
 @keyframes reveal-rise {

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.html
@@ -15,9 +15,31 @@
         </h1>
 
         <p class="mt-5 max-w-xl text-base/7 text-gray-600 dark:text-gray-300">
-          Nothing was lost and nothing was switched off. Everything you built is waiting for
-          you under <strong class="font-semibold text-gray-900 dark:text-white">Agents</strong>,
-          exactly as you left it — under the name the rest of the field uses for it.
+          Nothing was lost and nothing was switched off. If you had built assistants on
+          <em class="not-italic font-semibold text-gray-900 dark:text-white">this latest version</em>,
+          everything is waiting for you under
+          <strong class="font-semibold text-gray-900 dark:text-white">Agents</strong>, exactly as
+          you left it — under a more industry-aligned name.
+        </p>
+        <!-- The legacy half, in one paragraph. It sits in the hero rather than in a section
+             of its own because the whole message is two facts — where they are, and that
+             moving them is manual. Anything longer turns a short answer into a project.
+
+             The link *reads* as the bare host the reader knows and *goes* to their own
+             list (`?segment=my`), so the sentence stays plain while the click still lands
+             somewhere useful. -->
+        <p class="mt-3 max-w-xl text-base/7 text-gray-600 dark:text-gray-300">
+          If you built assistants on the
+          <strong class="font-semibold text-gray-900 dark:text-white">previous version</strong> of
+          boisestate.ai, they are still available at
+          <a
+            [href]="legacyAssistantsUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="rounded font-semibold text-primary-600 underline underline-offset-2 hover:text-primary-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-primary-300 dark:hover:text-primary-200"
+            >legacy.boisestate.ai</a
+          >. We apologize, but legacy assistants were incompatible with our new version and
+          will need to be migrated by hand.
         </p>
 
         <div class="mt-8 flex flex-wrap items-center gap-3">
@@ -44,8 +66,13 @@
     </header>
 
     <!-- ── Reassurance ───────────────────────────────────────────────────────
-         First section on the page because it is the first question: the rename
-         is only interesting once you know your work survived it. -->
+         First section on the page: the rename is only interesting once you know
+         your work survived it.
+
+         Every claim in here is scoped to assistants built on this site — "here",
+         "on this site", and the heading itself — because for a legacy assistant
+         none of it is true. The hero says so once; this must not quietly take it
+         back three paragraphs later. -->
     <section class="reveal mt-14" aria-labelledby="kept-heading">
       <div class="flex items-center gap-3">
         <span
@@ -55,13 +82,13 @@
           <ng-icon name="heroShieldCheck" class="size-5" />
         </span>
         <h2 id="kept-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
-          Your assistants are safe. They became agents.
+          The assistants you built here are safe. They became agents.
         </h2>
       </div>
 
       <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-        Every one of them is under Agents right now, with the same name you gave it. There is
-        nothing to move, re-create or set up again.
+        Every one you made on this site is under Agents right now, with the same name you gave
+        it. There is nothing to move, re-create or set up again.
       </p>
 
       <ul class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -168,9 +195,8 @@
         What that opens up
       </h2>
       <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-        An agent is not just yours to chat with. You can share one with everyone, use one
-        somebody else built, and call on one in the middle of a conversation. All of this
-        works today.
+        An agent is not just yours to chat with. You can use one somebody else built, and call
+        on one in the middle of a conversation. Both work today.
       </p>
 
       <div class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -189,16 +215,102 @@
       </div>
     </section>
 
+    <!-- ── The marketplace ───────────────────────────────────────────────────
+         The one section that asks the reader for something rather than
+         explaining something to them, so it comes last before the close.
+
+         Review is presented as what it is — an admin reads it before anyone
+         else can — rather than softened into "a quick check". Someone deciding
+         whether to spend an afternoon on an agent deserves to know a human
+         stands between them and publication, and stating it plainly reads as a
+         quality bar. Hedging it reads as a gate you might fail. -->
+    <section class="reveal mt-16" aria-labelledby="store-heading">
+      <div class="flex items-center gap-3">
+        <span
+          class="inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-300"
+          aria-hidden="true"
+        >
+          <ng-icon name="heroSquares2x2" class="size-5" />
+        </span>
+        <h2 id="store-heading" class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
+          Put yours in the marketplace
+        </h2>
+      </div>
+
+      <p class="mt-3 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        Discover is where they all live: agents built here, by people here, that anyone can
+        find and use. If you have built something that works, it probably solves a problem you
+        are not the only one having — and putting it up is how the person three offices over
+        stops rebuilding it.
+      </p>
+
+      <ol class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        @for (step of marketplaceSteps; track step.title; let i = $index) {
+          <li class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <div class="flex items-center gap-3">
+              <span
+                class="inline-flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-300"
+                aria-hidden="true"
+              >
+                <ng-icon [name]="step.icon" class="size-5" />
+              </span>
+              <span class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                Step {{ i + 1 }}
+              </span>
+            </div>
+            <h3 class="mt-4 text-base/7 font-semibold text-gray-900 dark:text-white">{{ step.title }}</h3>
+            <p class="mt-1.5 text-sm/6 text-gray-600 dark:text-gray-400">{{ step.body }}</p>
+          </li>
+        }
+      </ol>
+
+      <div class="mt-6 flex flex-wrap items-center gap-3">
+        <a
+          routerLink="/agents/discover"
+          class="group inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition-all duration-200 hover:bg-primary-600 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 active:scale-[0.98] dark:focus-visible:ring-offset-gray-800"
+        >
+          <ng-icon name="heroSquares2x2" class="size-4" aria-hidden="true" />
+          Browse the marketplace
+          <ng-icon
+            name="heroArrowRight"
+            class="size-4 transition-transform duration-200 group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </a>
+        <a
+          routerLink="/agents"
+          class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm/6 font-semibold text-gray-700 transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 dark:focus-visible:ring-offset-gray-800"
+        >
+          Submit one of mine
+        </a>
+      </div>
+
+      <p class="mt-6 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        There is no bar to clear beyond being useful and being yours. We are genuinely excited
+        to see what you build.
+      </p>
+    </section>
+
     <!-- ── Close ─────────────────────────────────────────────────────────────
          One door out, and the bookmark promise repeated where someone who
          skimmed the page will still catch it. -->
     <section class="reveal mt-16 mb-8 rounded-3xl border border-gray-200 bg-gray-50 px-6 py-10 text-center sm:px-12 dark:border-gray-700 dark:bg-gray-800/60">
       <h2 class="text-xl/7 font-bold tracking-tight text-gray-900 sm:text-2xl/8 dark:text-white">
-        Everything you had is under Agents
+        Everything you built here is under Agents
       </h2>
       <p class="mx-auto mt-3 max-w-xl text-sm/6 text-gray-600 dark:text-gray-400">
         Open it and you will find every one of them, working as before. The only new thing to
         learn is what you can add to them.
+      </p>
+      <p class="mx-auto mt-3 max-w-xl text-sm/6 text-gray-600 dark:text-gray-400">
+        Looking for something you made on the older site? It is still at
+        <a
+          [href]="legacyAssistantsUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="rounded font-semibold text-primary-600 underline underline-offset-2 hover:text-primary-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-primary-300 dark:hover:text-primary-200"
+          >legacy.boisestate.ai</a
+        >, and you can set it up again here whenever you are ready.
       </p>
 
       <div class="mt-7 flex flex-wrap items-center justify-center gap-3">

--- a/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
+++ b/frontend/ai.client/src/app/agents/migration/agents-migration.page.ts
@@ -10,6 +10,7 @@ import {
   heroCpuChip,
   heroDocumentText,
   heroLink,
+  heroPaperAirplane,
   heroPuzzlePiece,
   heroShieldCheck,
   heroSparkles,
@@ -66,6 +67,34 @@ interface OpensUp {
  * Everything claimed here is a surface that ships today. If a capability is removed or
  * gated, the claim on this page goes with it — an explainer that oversells is worse than
  * the redirect it replaced. (This is why scheduled runs are not mentioned; see `opensUp`.)
+ *
+ * ## Two audiences, and why the second one gets two sentences
+ *
+ * "Assistants are now Agents" is only the *whole* truth for people who built on this
+ * version of the site. There is a second group — everyone who built an assistant on the
+ * **previous** boisestate.ai, now parked at `legacy.boisestate.ai` — for whom "nothing was
+ * lost, it is all under Agents" is flatly wrong: that generation of assistant is not
+ * compatible with this one, none of it came across, and re-creating it here is manual work.
+ *
+ * They are answered in the hero, in one paragraph: where their assistants are, and that
+ * moving them is by hand. That is the entire answer, and it was deliberately cut back to
+ * it — an earlier draft gave them a section with two comparison cards and a four-step
+ * procedure, which turned a short piece of bad news into something that read like a
+ * project. Someone who has to rebuild an assistant does not need it explained twice; they
+ * need the link and the honest sentence.
+ *
+ * What the hero cannot do is carry the qualifier through the rest of the page, so every
+ * unqualified "everything you built is here" below it is scoped to *this* version instead
+ * ("here", "on this site"). A reassurance a reader cannot trust is worth less than no
+ * reassurance: the person who follows "nothing to do" and finds an empty list stops
+ * believing the rest of the page, including the parts that are true for them.
+ *
+ * The one place precision beats brevity is the link — it *reads* as `legacy.boisestate.ai`
+ * and *points* at `?segment=my`, so the sentence stays plain while the click still lands on
+ * their own list rather than a home page they have to search from.
+ *
+ * ⚠️ This whole page is host-gated (production apex + localhost; see
+ * `shared/utils/legacy-migration-host.ts`) and comes out with the legacy site.
  */
 @Component({
   selector: 'app-agents-migration',
@@ -83,6 +112,7 @@ interface OpensUp {
       heroCpuChip,
       heroDocumentText,
       heroLink,
+      heroPaperAirplane,
       heroPuzzlePiece,
       heroShieldCheck,
       heroSparkles,
@@ -94,12 +124,23 @@ interface OpensUp {
 })
 export class AgentsMigrationPage {
   /**
+   * Deep link to the reader's **own** assistants on the previous site, not its home page.
+   * `?segment=my` is the legacy list's "mine" tab. Someone sent to a landing page has to
+   * re-find their work before they can start copying it, and that re-finding is where
+   * people give up.
+   */
+  readonly legacyAssistantsUrl = 'https://legacy.boisestate.ai/assistants?segment=my';
+
+  /**
    * What came across untouched. One line each — this section answers a worry, and a worry
    * is answered by a short concrete list, not by an explanation of the mechanism.
+   *
+   * ⚠️ Scoped to assistants built **in this version**. See the class doc: unqualified here
+   * is a lie to the legacy half of the audience.
    */
   readonly carriedOver: readonly { label: string; detail: string; icon: string }[] = [
     {
-      label: 'Every assistant you built',
+      label: 'Every assistant you built here',
       detail: 'The same name, the same instructions, the same opening questions.',
       icon: 'heroSparkles',
     },
@@ -177,14 +218,12 @@ export class AgentsMigrationPage {
    * A "Run on a schedule" card sat here and has been pulled: scheduled runs work, but they
    * have no navigation of their own yet, so the card promised a feature with nowhere to go.
    * Put it back (with `heroClock`) when that surface is rolled out.
+   *
+   * A "Share it with everyone" card was also pulled — not because it was untrue, but because
+   * the marketplace outgrew a card. It has its own section below, since "how do I get one
+   * published" is a procedure and a card can only tease it.
    */
   readonly opensUp: readonly OpensUp[] = [
-    {
-      title: 'Share it with everyone',
-      body:
-        'Put an agent up for review and it appears in Discover, where anyone here can find it and use it — instead of you sending a link to one person at a time.',
-      icon: 'heroSquares2x2',
-    },
     {
       title: 'Keep the ones you like',
       body:
@@ -196,6 +235,56 @@ export class AgentsMigrationPage {
       body:
         'Type @ in any conversation to hand what you are working on to a different agent, then carry on. Nothing to close, nothing to start over.',
       icon: 'heroChatBubbleLeftRight',
+    },
+  ];
+
+  /**
+   * How an agent gets published. Three steps because there are three, and each one names
+   * who acts — you, an admin, everyone — since the question underneath "how do I publish" is
+   * really "who decides, and when does it stop being mine to change".
+   *
+   * The decider is named as **an admin**, not "someone" or "a person". Anonymous review
+   * ("someone reads it") makes an accountable process sound like a committee behind a
+   * curtain; "an admin" is a role the reader already knows exists here, so the same sentence
+   * reads as governance rather than as a mystery.
+   *
+   * No "shelf" either, in any of the three. It is the marketplace metaphor talking, and it
+   * only makes sense to someone already picturing a store — the reader who needs this list
+   * most is the one who is not. The literal words the UI uses (a **category** you choose,
+   * **Discover** where it lands) cost nothing and need no decoding. The author-facing
+   * surfaces this page hands off to were brought in step: the submit dialog's Category and
+   * Tagline hints, its "Note to the admin", and the withdrawal confirmation in
+   * `share-agent-dialog`. **Shelf survives in code** — `CategoryShelf`, the `shelves` signal,
+   * the internal comments — because that is the domain model's name, not copy a user reads.
+   * ⚠️ Still on the admin side: `categories.page.ts`, `publishers.page.ts` and the
+   * reachability warning in `models/reachability.ts` say it to reviewers.
+   *
+   * ⚠️ Every claim here is asserted against the shipped flow, not the intent:
+   * `submit-listing-dialog.component.ts` for what the author fills in (category, tagline,
+   * optional note, and the public checkbox), `LISTING_STATE_LABELS` in `store.model.ts` for
+   * the vocabulary an admin's decision comes back in, and `PUBLISHED_VERSION_TOOLTIP` in
+   * the admin marketplace model for the snapshot rule in step 3. If the review flow changes,
+   * this list changes with it — the fastest way to make a governed process feel arbitrary is
+   * to describe it inaccurately.
+   */
+  readonly marketplaceSteps: readonly { title: string; body: string; icon: string }[] = [
+    {
+      title: 'You submit it',
+      body:
+        'Choose the category it belongs in, write the one line that sits under its name, and add a note to the admin if there is something they should know. Agents start private, so you confirm you are making this one public.',
+      icon: 'heroPaperAirplane',
+    },
+    {
+      title: 'An admin reviews it',
+      body:
+        'An admin reads it before anyone else can. They publish it, or come back asking for changes — either way you see the decision, and their reasoning, on your own agent.',
+      icon: 'heroShieldCheck',
+    },
+    {
+      title: 'It goes live in Discover',
+      body:
+        'Published, it appears in Discover for everyone here to find, use and pin. What they run is the approved version, so you can keep working on yours — your next version goes live when it is approved too.',
+      icon: 'heroSquares2x2',
     },
   ];
 }

--- a/frontend/ai.client/src/app/agents/models/reachability.ts
+++ b/frontend/ai.client/src/app/agents/models/reachability.ts
@@ -40,7 +40,7 @@ export function reachabilityIsLimited(value: ListingReachability): boolean {
  */
 export function reachabilityReviewerMessage(value: ListingReachability): string | null {
   if (value === 'owner_only') {
-    return "Private — only the author can open this. Approving it shelves a tile nobody else can use.";
+    return 'Private — only the author can open this. Approving it publishes a tile nobody else can use.';
   }
   if (value === 'shared_only') {
     return 'Shared — only people it is shared with can open it. Everyone else will get an error.';

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './auth/auth.guard';
 import { adminGuard } from './auth/admin.guard';
 import { firstBootGuard } from './auth/first-boot.guard';
+import { legacyMigrationHostGuard } from './shared/utils/legacy-migration-host';
 
 export const routes: Routes = [
     {
@@ -64,9 +65,14 @@ export const routes: Routes = [
         // assistants go — entirely unanswered. So it renders the explainer instead, which
         // says what changed, that nothing was lost, and what the Agent surface adds. Every
         // path out of it lands on `/agents`.
+        //
+        // ⚠️ TEMPORARY host gate: the explainer only renders on the production apex, where
+        // people arriving off the previous version of the site have that question. Everywhere
+        // else `legacyMigrationHostGuard` restores the old silent redirect onto `/agents`.
+        // See `shared/utils/legacy-migration-host.ts`.
         path: 'assistants',
         loadComponent: () => import('./agents/migration/agents-migration.page').then(m => m.AgentsMigrationPage),
-        canActivate: [authGuard],
+        canActivate: [authGuard, legacyMigrationHostGuard],
         pathMatch: 'full',
     },
     {

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -68,7 +68,14 @@
                 know, and a greyed-out entry with a past-tense badge reads as deactivated
                 rather than as a door. Retire it, and the "New" badge below, once the
                 rename has landed with users.
+
+                ⚠️ TEMPORARY host gate (`showAssistantsSignpost`): production apex only, the
+                same gate the `/assistants` route carries, because the page now also answers
+                "where did my assistants from the *previous site* go?" — a question only
+                people arriving off legacy.boisestate.ai have. See
+                `shared/utils/legacy-migration-host.ts`.
             -->
+            @if (showAssistantsSignpost) {
             <a
                 routerLink="/assistants"
                 routerLinkActive="bg-gray-200/80 dark:bg-white/10"
@@ -81,6 +88,7 @@
                 </div>
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
             </a>
+            }
 
             <a
                 routerLink="/agents"

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -9,6 +9,7 @@ import { SessionService as BffSessionService } from '../../auth/session.service'
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
+import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 
 describe('Sidenav', () => {
   let mockRouter: any;
@@ -175,9 +176,17 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
 
   let mockUserService: any;
   let mockAgentService: any;
+  /**
+   * ⚠️ TEMPORARY, with the Assistants signpost it gates. Defaults to `true` — the interesting
+   * assertions below are about the signpost's *content* and its coupling to `showAgents()`,
+   * and every one of them would pass vacuously on a host where the entry is absent outright.
+   * The host gate itself gets its own test rather than silently suppressing the others.
+   */
+  let onLegacyMigrationHost: boolean;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
+    onLegacyMigrationHost = true;
     mockUserService = {
       hasAnyRole: vi.fn().mockReturnValue(false),
       currentUser: signal({ user_id: 'u1', email: 'u1@example.com' }),
@@ -213,6 +222,9 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
           useValue: { accessible$: signal<boolean | null>(false), loadSpaces: vi.fn().mockResolvedValue(undefined) },
         },
         { provide: AgentService, useValue: mockAgentService },
+        // `useFactory`, not `useValue`: resolution happens at render time, so a test can
+        // flip the flag after `configureTestingModule` and before `renderSidenav()`.
+        { provide: LEGACY_MIGRATION_HOST, useFactory: () => onLegacyMigrationHost },
       ],
     });
   });
@@ -294,6 +306,21 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
     mockAgentService.accessible$.set(false);
     const fixture = await renderSidenav();
     expect(assistantsNavLink(fixture)).toBeNull();
+  });
+
+  it('hides the Assistants signpost off the production apex', async () => {
+    // ⚠️ TEMPORARY, with the signpost. The explainer now also answers "where did the
+    // assistants I built on the *previous site* go?", which is a question only production
+    // has — on dev or beta the entry would point at an explanation of a site that reader is
+    // not on. (`localhost` is allowed, but as a bench, not an audience.) Paired with
+    // `legacyMigrationHostGuard` on the route, so the URL cannot be reached by hand where
+    // the nav entry is hidden.
+    onLegacyMigrationHost = false;
+    const fixture = await renderSidenav();
+
+    expect(assistantsNavLink(fixture)).toBeNull();
+    // The Agents entry is untouched by the host gate — it is a different feature.
+    expect(agentsNavLink(fixture)).toBeDefined();
   });
 
   it('badges Agents as New, not as Preview — unfamiliar is not unstable', async () => {

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -9,6 +9,7 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
 import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
+import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 
 @Component({
   selector: 'app-sidenav',
@@ -64,6 +65,16 @@ export class Sidenav {
    * hides it so it doesn't flash in before disappearing.
    */
   readonly showAgents = computed(() => this.agentService.accessible$() === true);
+
+  /**
+   * Whether to show the "Assistants" signpost. ⚠️ TEMPORARY, and deliberately *not* a
+   * signal: the host cannot change without a full page load, so this is a constant for the
+   * lifetime of the app instance. Scoped to the production apex because that is the only
+   * place the question it answers ("where did the assistants I built on the old site go?")
+   * gets asked — see `shared/utils/legacy-migration-host.ts`. The `/assistants` route is
+   * gated on the same host, so the two never disagree.
+   */
+  protected readonly showAssistantsSignpost = inject(LEGACY_MIGRATION_HOST);
 
   constructor() {
     // Kick off the accessibility probes once the user is authenticated —

--- a/frontend/ai.client/src/app/shared/utils/legacy-migration-host.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/legacy-migration-host.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { Router, provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import {
+  LEGACY_MIGRATION_HOST,
+  isLegacyMigrationHost,
+  legacyMigrationHostGuard,
+} from './legacy-migration-host';
+
+/**
+ * ⚠️ TEMPORARY, with the surface it gates — delete this file together with
+ * `legacy-migration-host.ts`, the `/assistants` route and `agents/migration/`.
+ *
+ * The `/assistants` explainer is scoped to the production apex because the question it now
+ * answers ("where did the assistants I built on the previous site go?") only exists there.
+ * Two things must agree for that to hold: the sidenav entry (asserted in `sidenav.spec.ts`)
+ * and the route guard. A nav entry that hides while the URL still renders is not a scope,
+ * it is a hidden page — so the guard's redirect is asserted here rather than assumed.
+ */
+describe('legacy migration host gate', () => {
+  describe('isLegacyMigrationHost', () => {
+    it('accepts the production apex, with or without www', () => {
+      expect(isLegacyMigrationHost('boisestate.ai')).toBe(true);
+      expect(isLegacyMigrationHost('www.boisestate.ai')).toBe(true);
+    });
+
+    it('is case-insensitive, because hostnames are', () => {
+      expect(isLegacyMigrationHost('BoiseState.AI')).toBe(true);
+    });
+
+    it('rejects the deployed non-production environments', () => {
+      // Exact match, not a suffix test: `dev.` and `beta.` are inside the same domain and
+      // a naive `endsWith('boisestate.ai')` would let both through.
+      expect(isLegacyMigrationHost('dev.boisestate.ai')).toBe(false);
+      expect(isLegacyMigrationHost('beta.boisestate.ai')).toBe(false);
+    });
+
+    it('accepts localhost so the copy can be read in place while it is worked on', () => {
+      // Not an audience — the bench. Deliberately separate from the case above so that
+      // deleting it never reads as "and dev/beta too".
+      expect(isLegacyMigrationHost('localhost')).toBe(true);
+    });
+
+    it('rejects a lookalike host that merely ends in the apex', () => {
+      expect(isLegacyMigrationHost('notboisestate.ai')).toBe(false);
+      expect(isLegacyMigrationHost('boisestate.ai.example.com')).toBe(false);
+    });
+
+    it('treats a missing hostname as off-host', () => {
+      expect(isLegacyMigrationHost(undefined)).toBe(false);
+      expect(isLegacyMigrationHost('')).toBe(false);
+    });
+  });
+
+  describe('legacyMigrationHostGuard', () => {
+    @Component({ template: '' })
+    class BlankComponent {}
+
+    function configure(onHost: boolean) {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([
+            {
+              path: 'assistants',
+              component: BlankComponent,
+              canActivate: [legacyMigrationHostGuard],
+              pathMatch: 'full',
+            },
+            { path: 'agents', component: BlankComponent },
+          ]),
+          provideLocationMocks(),
+          { provide: LEGACY_MIGRATION_HOST, useValue: onHost },
+        ],
+      });
+      return TestBed.inject(Router);
+    }
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+    });
+
+    it('lets the explainer render on the production apex', async () => {
+      const router = configure(true);
+      await router.navigateByUrl('/assistants');
+      expect(router.url).toBe('/assistants');
+    });
+
+    it('restores the silent redirect onto /agents everywhere else', async () => {
+      // Not a blocked navigation: off-host, `/assistants` is just an old alias, and
+      // returning `false` would strand the user on a dead URL instead.
+      const router = configure(false);
+      await router.navigateByUrl('/assistants');
+      expect(router.url).toBe('/agents');
+    });
+  });
+});

--- a/frontend/ai.client/src/app/shared/utils/legacy-migration-host.ts
+++ b/frontend/ai.client/src/app/shared/utils/legacy-migration-host.ts
@@ -1,0 +1,64 @@
+import { DOCUMENT } from '@angular/common';
+import { InjectionToken, inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+/**
+ * ⚠️ TEMPORARY — the Assistants signpost is scoped to the production apex.
+ *
+ * `/assistants` and its sidenav entry exist for one audience: people arriving at the
+ * production site who built assistants in the **previous** version of boisestate.ai (now
+ * parked at `legacy.boisestate.ai`) and want to know where those went. Nobody else has that
+ * question, so the deployed environments that are not production do not get the page —
+ * neither `dev.boisestate.ai` nor `beta.boisestate.ai`.
+ *
+ * `localhost` is on the list for the opposite reason: it is not an audience, it is the bench.
+ * Copy is the entire substance of this page, and copy that cannot be read in place gets
+ * reviewed by imagination — so anyone working on it can see it without editing the gate,
+ * which is also how a "just for a second" local edit stops ending up in a commit.
+ *
+ * This is a client-side courtesy gate, not a security boundary: the page is copy and two
+ * outbound links, and anyone who flips it back on in devtools has learned nothing they could
+ * not read here. It is scoping, not access control.
+ *
+ * The whole thing — this file, the sidenav entry, the route, `agents/migration/` — comes out
+ * when the legacy site is retired.
+ *
+ * **To preview on another host**, override `LEGACY_MIGRATION_HOST` in the app providers, or
+ * add that host below; do not commit either.
+ */
+export const LEGACY_MIGRATION_HOSTS: readonly string[] = [
+  'boisestate.ai',
+  'www.boisestate.ai',
+  // Local development only. Reachable from nowhere else, so it costs the gate nothing.
+  'localhost',
+];
+
+/** Whether `hostname` is a host the Assistants signpost should appear on. */
+export function isLegacyMigrationHost(hostname: string | null | undefined): boolean {
+  if (!hostname) return false;
+  return LEGACY_MIGRATION_HOSTS.includes(hostname.toLowerCase());
+}
+
+/**
+ * Whether this page load is on a host that shows the Assistants signpost.
+ *
+ * A token rather than a bare `window.location` read at each call site, for two reasons: it
+ * resolves once (the host cannot change without a full page load, so re-deriving it is
+ * noise), and it gives specs a seam — override the token instead of trying to fake
+ * `document.location`, which cannot be done without breaking the real `Document` the
+ * TestBed needs for rendering.
+ */
+export const LEGACY_MIGRATION_HOST = new InjectionToken<boolean>('LEGACY_MIGRATION_HOST', {
+  providedIn: 'root',
+  factory: () => isLegacyMigrationHost(inject(DOCUMENT).location?.hostname),
+});
+
+/**
+ * Route guard for `/assistants`. Off-host this behaves exactly as the route did before the
+ * explainer existed: a silent redirect onto `/agents`. That is the right answer here — off
+ * the apex there is no legacy site to explain, so the URL is only an old alias.
+ */
+export const legacyMigrationHostGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  return inject(LEGACY_MIGRATION_HOST) || router.parseUrl('/agents');
+};


### PR DESCRIPTION
## What

Three things, on the `/assistants` explainer and the marketplace surfaces it hands off to.

### 1. The legacy site now gets an answer

The page said *"nothing was lost — everything you built is under Agents."* That is only true for people who built on **this** version of the site. Anyone who built an assistant on the previous boisestate.ai — now parked at `legacy.boisestate.ai` — gets nothing back from that sentence: that generation of assistant is not compatible with this one, none of it came across, and re-creating it here is manual work.

The hero now answers both audiences, and every unqualified *"everything you built is here"* below it is scoped to this version (*"here"*, *"on this site"*). A reassurance a reader cannot trust is worth less than no reassurance — someone who follows "nothing to do" and finds an empty list stops believing the parts of the page that **are** true for them.

The legacy half is two sentences in the hero rather than a section of its own: where their assistants are, and that moving them is by hand. The link reads as `legacy.boisestate.ai` and points at `?segment=my`, so the sentence stays plain while the click lands on their own list rather than a home page they'd have to search from.

### 2. ⚠️ The page is host-gated — TEMPORARY

The explainer and its sidenav entry now render only on the production apex (`boisestate.ai` / `www.boisestate.ai`), plus `localhost` as a bench so the copy can be read in place while it is worked on. **Not on `dev.` or `beta.`** — off the apex there is no legacy site to explain.

Two enforcement points that cannot disagree:
- `legacyMigrationHostGuard` on the route restores the old silent redirect onto `/agents`
- the sidenav entry hides

A nav entry that hides while the URL still renders is not a scope, it is a hidden page. This is **scoping, not access control** — the page is copy and two outbound links. All of it (`legacy-migration-host.ts`, the route, `agents/migration/`, the nav entry) comes out when the legacy site is retired; every piece is commented to say so.

### 3. Marketplace promotion

A three-step section that names who acts at each stage — **you submit → an admin reviews → it goes live in Discover** — including the published-snapshot rule, so an author knows when it stops being theirs to change. Two CTAs (Browse the marketplace / Submit one of mine) and a closing line that we're excited to see what people build.

Review is stated plainly rather than softened into "a quick check": someone deciding whether to spend an afternoon on an agent should know a human stands between them and publication. Stated plainly it reads as a quality bar; hedged, it reads as a gate you might fail.

Every governance claim is asserted against the shipped flow, not the intent — `submit-listing-dialog.component.ts` for what the author fills in, `LISTING_STATE_LABELS` for the decision vocabulary, `PUBLISHED_VERSION_TOOLTIP` for the snapshot rule. The fastest way to make a governed process feel arbitrary is to describe it inaccurately.

### 4. Vocabulary: no more "shelf", no more anonymous "reviewer"

"Shelf" only parses for someone already picturing a store, and the reader who most needs these hints is the one who is not. "A reviewer" makes an accountable process sound like a committee behind a curtain. Replaced across **every user-visible instance**, both audiences:

| Surface | Was | Now |
|---|---|---|
| Submit dialog — Category | "Which **shelf** it sits on. A **reviewer** may move it." | "Where it appears in **Discover**. An **admin** may move it." |
| Submit dialog — Tagline | "under the name **on the shelf**" | "under the name **in Discover**" |
| Submit dialog — Note | "Note to the **reviewer**" | "Note to the **admin**" |
| Share dialog — withdrawal | "comes **off the shelf**, so it stays in the store" | "comes **down from Discover**, so it stays published" |
| Review queue warning | "Approving it **shelves** a tile…" | "Approving it **publishes** a tile…" |
| Admin → Categories | "The **shelves of the store**, in browse order" | "**How the store is grouped**, in browse order" |
| Admin → Publishers | "attributed to **on the shelf**" | "attributed to **in Discover**" |
| Admin → Default pins | "the user's own **shelf**" / "not a **shelf slot**" | "the user's own **list**" / "not a **listing**" |

`shelf` **survives in code** — `CategoryShelf`, the `shelves` signal, `visibleShelves`, internal comments — because that is the domain model's name, not copy a user reads.

## Testing

- `npx tsc --noEmit` clean
- `npx ng test` — **1761/1761 pass** (158 files), including a new `legacy-migration-host.spec.ts` covering the guard's redirect in both directions and lookalike-host rejection (`notboisestate.ai`, `beta.boisestate.ai`), plus an off-apex sidenav case
- Verified live on `localhost:4200`: the page renders, the gate closes correctly when localhost is removed from the allowlist (`/assistants` → `/agents`, nav entry gone, Agents entry unaffected), all legacy links resolve to the right URL, and the submit + withdrawal dialogs and all three admin pages show the new copy with zero `shel(f|ves)` matches in rendered text. No console errors. No listing state was changed — both dialogs were cancelled out of.

## Reviewer note

Because of the host gate, **this will not be visible on dev after merge** — `/assistants` will just redirect to `/agents` there. To see it, add your host to `LEGACY_MIGRATION_HOSTS` locally, or run it on `localhost:4200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)