### PR TITLE
feat(marketplace): give feedback on an agent from the conversation

### DIFF
--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -718,10 +718,21 @@ async def report_agent_endpoint(
     A second report while the reporter's first is still open **updates** it rather than
     stacking (D15.4), and the response says so — without that the queue is trivially
     floodable and the count at the top of the nav stops meaning anything.
+
+    This is also the endpoint behind the feedback link at the foot of a conversation, which
+    is where most of its traffic now comes from. Two things follow from that. ``reason`` may
+    be ``suggestion`` — feedback from inside a conversation is as often "it should also do
+    X" as "it is broken". And ``sessionId`` may carry the conversation the user opted to
+    attach; it is verified against the caller before it is stored, and silently dropped
+    rather than rejected if it does not check out (see ``_attachable_session_id``).
     """
     try:
         report, replaced = await file_report(
-            agent_id, current_user, reason=request.reason, note=request.note
+            agent_id,
+            current_user,
+            reason=request.reason,
+            note=request.note,
+            session_id=request.session_id,
         )
         return SubmitReportResponse(
             agent_id=agent_id,

--- a/backend/src/apis/app_api/agent_designer/services/report_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/report_service.py
@@ -56,7 +56,12 @@ class ReportError(Exception):
 
 
 async def file_report(
-    agent_id: str, user: User, *, reason: ReportReason, note: Optional[str]
+    agent_id: str,
+    user: User,
+    *,
+    reason: ReportReason,
+    note: Optional[str],
+    session_id: Optional[str] = None,
 ) -> Tuple[AgentReport, bool]:
     """Record a user's problem report against a published Agent (D15).
 
@@ -90,7 +95,46 @@ async def file_report(
         reporter_name=_display_name(user),
         reason=reason,
         note=(note or "").strip() or None,
+        session_id=await _attachable_session_id(session_id, user),
     )
+
+
+async def _attachable_session_id(session_id: Optional[str], user: User) -> Optional[str]:
+    """The conversation reference to store, or None.
+
+    ⚠️ **The client's word is not enough here.** ``sessionId`` arrives in the request body,
+    so without this check any user could hand an admin a pointer to a conversation that is
+    not theirs — and the queue would present it as context the *reporter* consented to
+    share. So the id is kept only if the metadata read scoped to this user finds it.
+
+    A session that does not resolve is **dropped, not rejected**. The report itself is the
+    thing the user wanted to send; failing the whole submission because an optional
+    attachment did not resolve would lose the feedback to protect a nicety. Same reasoning
+    for a metadata read that errors — the reference is context, never the payload.
+    """
+    if not session_id:
+        return None
+
+    try:
+        from apis.shared.sessions.metadata import get_session_metadata
+
+        metadata = await get_session_metadata(session_id, user.user_id)
+    except Exception:
+        logger.warning(
+            f"Could not verify session {session_id} for a report by {user.user_id}; "
+            "filing the report without the conversation reference",
+            exc_info=True,
+        )
+        return None
+
+    if metadata is None:
+        logger.info(
+            f"Dropping unattachable session {session_id} from {user.user_id}'s report — "
+            "not a conversation this user owns"
+        )
+        return None
+
+    return session_id
 
 
 def _display_name(user: User) -> str:
@@ -171,6 +215,7 @@ async def _to_row(report: AgentReport) -> AdminReportRow:
         reporter_name=report.reporter_name,
         reason=report.reason,
         note=report.note,
+        session_id=report.session_id,
         state=report.state,
         created_at=report.created_at,
         resolved_at=report.resolved_at,

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -27,7 +27,14 @@ PublisherKind = Literal["institution", "department", "individual"]
 # Agent Marketplace Phase 8 (D15): problem reports. A small fixed set so the queue can be
 # sorted by severity without reading every note — ``inappropriate`` is the one that should
 # page a human rather than wait for a sweep.
-ReportReason = Literal["inaccurate", "broken", "inappropriate", "other"]
+#
+# ``suggestion`` joined the set when feedback moved out of the store's detail page and into
+# the conversation itself. It is deliberately the *same* record and the *same* queue rather
+# than a parallel "feedback" object: a user at the foot of a conversation does not know
+# whether what they hit is a defect or a missing capability, and asking them to pick the
+# right intake form would only mis-sort the ones who guess wrong. What the reason set does
+# is let the queue keep triaging by severity — see ``REPORT_REASON_SEVERITY``.
+ReportReason = Literal["inaccurate", "broken", "inappropriate", "suggestion", "other"]
 
 # Deliberately NOT a mirror of ``ListingState``: a report is a note *about* an Agent, not
 # a state *of* it. Resolving one never changes ``listing.state`` (D15.5) — if a report
@@ -68,6 +75,10 @@ REPORT_REASON_SEVERITY: Dict[str, int] = {
     "broken": 1,
     "inaccurate": 2,
     "other": 3,
+    # Last on purpose. A suggestion is the one reason that is *not* a defect, so it must
+    # never displace a complaint in the sweep — but it stays in the same queue, because an
+    # admin reading "it should also do X" is reading the most useful signal the store gets.
+    "suggestion": 4,
 }
 
 
@@ -1497,6 +1508,17 @@ class AgentReport(BaseModel):
     reporter_name: str = Field(..., alias="reporterName", description="Reporter display name, for the queue")
     reason: ReportReason = Field(..., description="Fixed-set reason, so the queue sorts by severity")
     note: Optional[str] = Field(None, description="The reporter's free text")
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionId",
+        description=(
+            "The conversation the reporter chose to attach, when they filed from the foot of "
+            "one and left the box ticked. ⚠️ Opt-in, and verified to belong to the reporter "
+            "before it is stored — see ``report_service.file_report``. Absent means the user "
+            "declined or filed from the store page, and absence is a normal state the queue "
+            "must render without implying anything was withheld."
+        ),
+    )
     state: ReportState = Field("open", description="open → resolved | dismissed (D15.5)")
     created_at: str = Field(..., alias="createdAt", description="ISO 8601; the GSI6 sort key while open")
     updated_at: Optional[str] = Field(None, alias="updatedAt", description="ISO 8601 of the last write")
@@ -1521,6 +1543,16 @@ class SubmitReportRequest(BaseModel):
     reason: ReportReason = Field(..., description="Why it is being reported")
     note: Optional[str] = Field(
         None, max_length=2000, description="What is wrong, in the reporter's words"
+    )
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionId",
+        description=(
+            "Conversation to attach for context, when the reporter opted in. Ignored unless "
+            "it is a session the *caller* owns — the server checks rather than trusting it, "
+            "since an id sent from a client is otherwise a way to hand an admin a pointer to "
+            "somebody else's conversation."
+        ),
     )
 
 
@@ -1599,6 +1631,14 @@ class AdminReportRow(BaseModel):
     reporter_name: str = Field(..., alias="reporterName", description="Reporter display name (admin-only, D15.2)")
     reason: ReportReason = Field(..., description="Fixed-set reason")
     note: Optional[str] = Field(None, description="The reporter's free text")
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionId",
+        description=(
+            "The conversation the reporter attached, if they opted in. A reference for the "
+            "admin to look up, not a transcript — nothing here reads the conversation."
+        ),
+    )
     state: ReportState = Field(..., description="open / resolved / dismissed")
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 when it was filed")
     resolved_at: Optional[str] = Field(None, alias="resolvedAt", description="ISO 8601 of the decision")

--- a/backend/src/apis/shared/assistants/reports.py
+++ b/backend/src/apis/shared/assistants/reports.py
@@ -65,7 +65,12 @@ _GSI6_ATTRS = ("GSI6_PK", "GSI6_SK")
 
 # ``state`` is a DynamoDB reserved word; ``reason`` and ``note`` are aliased alongside it
 # rather than checked one by one against the reserved list, which grows.
-_NAMES = {"#st": "state", "#reason": "reason", "#note": "note"}
+_NAMES = {
+    "#st": "state",
+    "#reason": "reason",
+    "#note": "note",
+    "#session": "sessionId",
+}
 
 
 def _now() -> str:
@@ -115,12 +120,16 @@ async def submit_report(
     reporter_name: str,
     reason: ReportReason,
     note: Optional[str],
+    session_id: Optional[str] = None,
 ) -> Tuple[AgentReport, bool]:
     """File a report, or update this reporter's already-open one (D15.4).
 
     Returns ``(report, replaced_existing)``. ``replaced_existing`` is True only when an
     *open* report was updated in place — that is the case the UI must not describe as a
     second report having been queued.
+
+    ``session_id`` is the conversation the reporter opted to attach. Like ``note`` it is
+    fully replaced on an amendment, never merged: see the REMOVE branch below for why.
 
     Three conditional writes, no read, in the order the cases actually occur:
 
@@ -146,6 +155,11 @@ async def submit_report(
     }
     if note:
         body["note"] = note
+    # ⚠️ Stored as given. Whether this session belongs to ``reporter_id`` is settled by the
+    # caller (``report_service.file_report``) before we get here — this module is storage,
+    # and a check duplicated in two places is a check that eventually disagrees with itself.
+    if session_id:
+        body["sessionId"] = session_id
 
     def _built(created_at: str) -> AgentReport:
         return AgentReport.model_validate(
@@ -186,6 +200,15 @@ async def submit_report(
     else:
         # An amended report with the text removed must not keep the old text.
         remove_parts.append("#note")
+
+    if session_id:
+        set_parts.append("#session = :session")
+        values[":session"] = session_id
+    else:
+        # Same rule, and it matters more here: unticking the box on an amendment is the
+        # user *withdrawing* the conversation they previously shared. Leaving the old
+        # reference behind would make that consent impossible to take back.
+        remove_parts.append("#session")
 
     expression = "SET " + ", ".join(set_parts)
     if remove_parts:

--- a/backend/tests/routes/test_agent_reports.py
+++ b/backend/tests/routes/test_agent_reports.py
@@ -99,19 +99,26 @@ def client(app, make_user):
 _UNSET = object()
 
 
-def _report_agent(client, *, assistant=_UNSET, body=None, submitted=None):
+def _report_agent(client, *, assistant=_UNSET, body=None, submitted=None, session=_UNSET):
     """POST the report with the storage layer stubbed at the service's own boundary.
 
     ``assistant=None`` means "the access check denies", which is why the default is a
-    sentinel rather than ``None``.
+    sentinel rather than ``None``. ``session`` is the same shape for the session-metadata
+    read behind an attached conversation: ``None`` means "not a session this caller owns",
+    and the default resolves to a stub that says they do.
     """
     resolved = _make_assistant() if assistant is _UNSET else assistant
+    resolved_session = object() if session is _UNSET else session
 
     with (
         patch(
             f"{REPORT_SERVICE}.get_assistant_with_access_check",
             AsyncMock(return_value=(resolved, "viewer") if resolved else (None, None)),
         ),
+        patch(
+            "apis.shared.sessions.metadata.get_session_metadata",
+            AsyncMock(return_value=resolved_session),
+        ) as session_read,
         patch(
             f"{REPORT_SERVICE}.submit_report",
             AsyncMock(return_value=submitted or (_report(), False)),
@@ -120,12 +127,12 @@ def _report_agent(client, *, assistant=_UNSET, body=None, submitted=None):
         response = client.post(
             f"/agents/{AGENT}/report", json=body or {"reason": "broken", "note": "It errors out"}
         )
-    return response, submit
+    return response, submit, session_read
 
 
 # ── reportable means published (D15.3) ───────────────────────────────────────────────
 def test_a_published_agent_can_be_reported(client):
-    response, submit = _report_agent(client)
+    response, submit, _ = _report_agent(client)
 
     assert response.status_code == 201
     assert submit.await_count == 1
@@ -139,14 +146,14 @@ def test_an_unpublished_agent_cannot_be_reported(client, state):
     A takedown is not available as a remedy for something that was never listed, so there
     is no useful thing the queue could do with the report either.
     """
-    response, submit = _report_agent(client, assistant=_make_assistant(listing_state=state))
+    response, submit, _ = _report_agent(client, assistant=_make_assistant(listing_state=state))
 
     assert response.status_code == 400
     assert submit.await_count == 0, "nothing may reach storage for an unpublished agent"
 
 
 def test_an_agent_that_was_never_submitted_cannot_be_reported(client):
-    response, submit = _report_agent(client, assistant=_make_assistant(listing_state=None))
+    response, submit, _ = _report_agent(client, assistant=_make_assistant(listing_state=None))
 
     assert response.status_code == 400
     assert submit.await_count == 0
@@ -154,7 +161,7 @@ def test_an_agent_that_was_never_submitted_cannot_be_reported(client):
 
 def test_an_agent_the_caller_cannot_reach_is_a_404(client):
     """The access check runs first, so reporting is not a way to probe for agents."""
-    response, submit = _report_agent(client, assistant=None)
+    response, submit, _ = _report_agent(client, assistant=None)
 
     assert response.status_code == 404
     assert submit.await_count == 0
@@ -162,22 +169,95 @@ def test_an_agent_the_caller_cannot_reach_is_a_404(client):
 
 def test_an_unknown_reason_is_refused(client):
     """The fixed set is what lets the queue sort by severity without reading every note."""
-    response, submit = _report_agent(client, body={"reason": "i-just-dont-like-it"})
+    response, submit, _ = _report_agent(client, body={"reason": "i-just-dont-like-it"})
 
     assert response.status_code == 422
     assert submit.await_count == 0
 
 
+def test_a_suggestion_is_a_reason(client):
+    """Feedback from inside a conversation is as often "it should also do X" as a defect."""
+    response, submit, _ = _report_agent(
+        client, body={"reason": "suggestion", "note": "It should also cite the handbook"}
+    )
+
+    assert response.status_code == 201
+    assert submit.await_args.kwargs["reason"] == "suggestion"
+
+
+# ── the attached conversation is opt-in, and verified (not trusted) ──────────────────
+def test_an_attached_conversation_the_caller_owns_is_stored(client):
+    response, submit, session_read = _report_agent(
+        client, body={"reason": "broken", "sessionId": "sess-123"}
+    )
+
+    assert response.status_code == 201
+    assert session_read.await_args.args == ("sess-123", "user-001")
+    assert submit.await_args.kwargs["session_id"] == "sess-123"
+
+
+def test_a_conversation_the_caller_does_not_own_is_dropped(client):
+    """⚠️ The id comes from the request body, so it is checked rather than believed.
+
+    Without this, anyone could hand an admin a pointer to somebody else's conversation and
+    the queue would present it as context the *reporter* chose to share.
+    """
+    response, submit, _ = _report_agent(
+        client, body={"reason": "broken", "sessionId": "not-mine"}, session=None
+    )
+
+    assert response.status_code == 201, "the report itself is still the thing being sent"
+    assert submit.await_args.kwargs["session_id"] is None
+
+
+def test_a_report_with_no_conversation_never_reads_session_metadata(client):
+    response, submit, session_read = _report_agent(client)
+
+    assert response.status_code == 201
+    assert session_read.await_count == 0
+    assert submit.await_args.kwargs["session_id"] is None
+
+
+def test_a_failed_session_lookup_does_not_lose_the_report(client):
+    """The attachment is context; the feedback is the payload. Never trade one for the other."""
+    with (
+        patch(
+            f"{REPORT_SERVICE}.get_assistant_with_access_check",
+            AsyncMock(return_value=(_make_assistant(), "viewer")),
+        ),
+        patch(
+            "apis.shared.sessions.metadata.get_session_metadata",
+            AsyncMock(side_effect=RuntimeError("DynamoDB is having a day")),
+        ),
+        patch(
+            f"{REPORT_SERVICE}.submit_report", AsyncMock(return_value=(_report(), False))
+        ) as submit,
+    ):
+        response = client.post(
+            f"/agents/{AGENT}/report", json={"reason": "broken", "sessionId": "sess-123"}
+        )
+
+    assert response.status_code == 201
+    assert submit.await_args.kwargs["session_id"] is None
+
+
+def test_the_reporter_response_never_echoes_the_attached_conversation(client):
+    """The reference is for the curator. Echoing it back adds nothing and widens the shape."""
+    response, _, _ = _report_agent(client, body={"reason": "broken", "sessionId": "sess-123"})
+
+    assert "sessionId" not in response.json()
+
+
 # ── one open report per reporter (D15.4) ─────────────────────────────────────────────
 def test_a_replaced_report_says_so(client):
     """The UI has to be able to say "we updated your report" rather than imply a second."""
-    response, _ = _report_agent(client, submitted=(_report(), True))
+    response, _, _ = _report_agent(client, submitted=(_report(), True))
 
     assert response.json()["replacedExisting"] is True
 
 
 def test_a_first_report_does_not_claim_to_have_replaced_anything(client):
-    response, _ = _report_agent(client, submitted=(_report(), False))
+    response, _, _ = _report_agent(client, submitted=(_report(), False))
 
     assert response.json()["replacedExisting"] is False
 
@@ -188,7 +268,7 @@ def test_the_reporter_response_leaks_nothing_about_the_queue(client):
     landed. Queue position, other reports and every admin field would each be a way to
     read a surface the reporter has no business in.
     """
-    response, _ = _report_agent(client)
+    response, _, _ = _report_agent(client)
 
     assert set(response.json()) == {
         "agentId",
@@ -223,7 +303,7 @@ def test_reporting_is_404_when_the_marketplace_is_off(client, monkeypatch):
     """404 rather than 403, so the surface reads as unmounted while the feature ships."""
     monkeypatch.setenv("AGENT_MARKETPLACE_ENABLED", "false")
 
-    response, submit = _report_agent(client)
+    response, submit, _ = _report_agent(client)
 
     assert response.status_code == 404
     assert submit.await_count == 0

--- a/backend/tests/shared/test_agent_reports.py
+++ b/backend/tests/shared/test_agent_reports.py
@@ -71,13 +71,16 @@ def table(monkeypatch):
         yield ddb.Table(TABLE)
 
 
-async def _file(agent_id=AGENT, reporter=REPORTER, reason="broken", note="It errors out"):
+async def _file(
+    agent_id=AGENT, reporter=REPORTER, reason="broken", note="It errors out", session_id=None
+):
     return await submit_report(
         agent_id,
         reporter_id=reporter,
         reporter_name=f"Name of {reporter}",
         reason=reason,
         note=note,
+        session_id=session_id,
     )
 
 
@@ -234,6 +237,71 @@ async def test_the_queue_is_oldest_first(table):
 
     ordered = await list_open_reports()
     assert [r.created_at for r in ordered] == sorted(r.created_at for r in ordered)
+
+
+# ── the attached conversation (opt-in) ───────────────────────────────────────────────
+# The reference is optional context, but the *unticking* case is a consent withdrawal and
+# is the one worth pinning: a stale sessionId left behind on an amendment would mean a user
+# cannot take back a conversation they already shared.
+@pytest.mark.asyncio
+async def test_an_attached_conversation_is_stored_on_the_report(table):
+    await _file(session_id="sess-123")
+
+    item = table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report_id_for(AGENT, REPORTER)}"}
+    )["Item"]
+    assert item["sessionId"] == "sess-123"
+    assert (await list_reports_for_agent(AGENT))[0].session_id == "sess-123"
+
+
+@pytest.mark.asyncio
+async def test_a_report_with_no_conversation_stores_no_reference(table):
+    await _file()
+
+    item = table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report_id_for(AGENT, REPORTER)}"}
+    )["Item"]
+    assert "sessionId" not in item
+    assert (await list_reports_for_agent(AGENT))[0].session_id is None
+
+
+@pytest.mark.asyncio
+async def test_amending_without_the_conversation_withdraws_the_reference(table):
+    """Unticking the box on a second submission must remove what the first one shared."""
+    await _file(session_id="sess-123")
+    await _file(note="Actually, keep me out of it", session_id=None)
+
+    item = table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report_id_for(AGENT, REPORTER)}"}
+    )["Item"]
+    assert "sessionId" not in item, "an amendment must not keep the withdrawn conversation"
+    assert (await list_reports_for_agent(AGENT))[0].session_id is None
+
+
+@pytest.mark.asyncio
+async def test_amending_can_swap_the_attached_conversation(table):
+    await _file(session_id="sess-123")
+    await _file(session_id="sess-456")
+
+    reports = await list_reports_for_agent(AGENT)
+    assert len(reports) == 1
+    assert reports[0].session_id == "sess-456"
+
+
+@pytest.mark.asyncio
+async def test_a_report_filed_after_a_resolution_starts_from_a_clean_reference(table):
+    """Path 3 (overwrite-a-closed-one) must not inherit the old row's conversation."""
+    await _file(session_id="sess-123")
+    await resolve_report(
+        AGENT, report_id_for(AGENT, REPORTER), state="resolved", resolved_by="Admin", note=None
+    )
+
+    await _file(reason="suggestion", note="It should also do X")
+
+    reports = await list_reports_for_agent(AGENT)
+    assert len(reports) == 1
+    assert reports[0].reason == "suggestion"
+    assert reports[0].session_id is None
 
 
 # ── reports never outlive their Agent ────────────────────────────────────────────────

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -439,8 +439,17 @@ only when a user matches zero AppRoles.
 ## D15 — Users report problems; the report is private and lands in the admin queue
 
 A store with no way to say "this one is wrong" pushes that signal into email, or nowhere.
-Any user who can run a published Agent can **report a problem with it** from the detail
-page, and the report joins the admin console as a second work stream beside submissions.
+Any user who can run a published Agent can **report a problem with it**, and the report
+joins the admin console as a second work stream beside submissions.
+
+**Where from: the foot of the conversation, and the detail page.** As first built this
+lived only on the detail page, which turned out to be the wrong place to *put* it and the
+right place to *have* it. The moment someone has something to say about an Agent is the
+moment it just answered them — not a later trip back to the tile they launched it from. So
+the same intake also sits at the end of a conversation with a published Agent, carrying two
+things the detail page cannot: a `suggestion` reason (feedback from inside a conversation
+is as often "it should also do X" as "it is broken"), and an **opt-in reference to the
+conversation itself**.
 
 **This is not a review, and the distinction is the whole design.** The non-goal below
 still stands: no stars, no public comments, no visible counts. A report is a *private
@@ -473,9 +482,33 @@ not a mirror of the listing state machine — the report is a note about an Agen
 state of it. Resolving a report never changes `listing.state`; if a report warrants
 delisting, the admin takes the Agent down and that is a separate, recorded act.
 
-`reason` is a small fixed set (`inaccurate`, `broken`, `inappropriate`, `other`) plus free
-text. The set exists so the queue can be sorted by severity without reading every note;
-`inappropriate` is the one that should page a human rather than wait for a sweep.
+**6. The attached conversation is opt-in, verified, and withdrawable.** A report filed from
+a conversation may carry its `sessionId` so the curator can look up what actually happened.
+Three rules make that safe rather than merely convenient:
+
+- **Opt-in.** A checkbox, ticked by default because it is what makes the feedback
+  actionable, but visible and undoable — it is the user's conversation.
+- **Verified, not trusted.** The id arrives in the request body, so the server keeps it
+  only if it resolves to a session the *caller* owns. Without that check, anyone could hand
+  an admin a pointer to somebody else's conversation and the queue would present it as
+  context the reporter chose to share. A session that does not check out is **dropped, not
+  rejected**: the feedback is the payload, the attachment is context, and failing the whole
+  submission to protect a nicety loses the thing the user came to say.
+- **Withdrawable.** Amending a report with the box unticked *removes* the stored reference
+  (D15.4 means the second submission updates the first). Consent that cannot be taken back
+  is not consent.
+
+⚠️ It is a **reference, not a transcript.** No admin surface reads the conversation today;
+the queue shows the id. An admin transcript reader is a separate feature with its own
+privacy weight, and is deliberately not smuggled in here.
+
+`reason` is a small fixed set (`inaccurate`, `broken`, `inappropriate`, `suggestion`,
+`other`) plus free text. The set exists so the queue can be sorted by severity without
+reading every note; `inappropriate` is the one that should page a human rather than wait
+for a sweep, and `suggestion` — the one reason that is not a defect — sorts last so it
+never displaces a complaint. It stays the *same* record in the *same* queue: a user does
+not know whether what they hit is a defect or a missing capability, and a second intake
+form would only mis-sort the ones who guess wrong.
 
 ⚠️ **A report is not a permission signal and not a ranking input.** It must not feed
 `usageCount`, the store front, or any ordering. The moment report volume influences
@@ -529,7 +562,7 @@ outlives it:
 
 ```
 PK = AST#{agent_id}, SK = "REPORT#{report_id}"
-{ reporterId, reporterName, reason, note, state, createdAt,
+{ reporterId, reporterName, reason, note, sessionId?, state, createdAt,
   resolvedAt?, resolvedBy?, resolutionNote? }
 ```
 
@@ -641,7 +674,7 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `POST /agents/{id}/listing/submit` | Author submits. Runs D7 checks; 400 on a `memory_space` binding. |
 | `DELETE /agents/{id}/listing` | Author unpublishes. |
 | `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). Pinning is gated on the caller being able to *reach* the Agent, not on it being published. |
-| `POST /agents/{id}/report` | Report a problem with a published Agent (D15). One open report per reporter. |
+| `POST /agents/{id}/report` | Feedback on a published Agent (D15) — from the foot of a conversation or the detail page. One open report per reporter. Optional `sessionId` attaches the conversation; verified against the caller and dropped if it does not check out. |
 | `GET /admin/agents/reports` · `POST /admin/agents/{id}/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). Also `GET /admin/agents/{id}/reports` for one Agent's history and `GET /admin/agents/queues` for the two nav counts. |
 | `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes (D2). |
 | `GET /admin/agents/listings` · `POST /admin/agents/{id}/takedown` | Listings table; delist with a reason. |

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -15,6 +15,7 @@ import {
   ListingState,
   LISTING_STATE_CLASSES,
   LISTING_STATE_LABELS,
+  ReportReason,
 } from '../../../agents/models/store.model';
 
 /**
@@ -318,8 +319,13 @@ export interface RoleAgentPinsUpdateRequest {
 /**
  * Why an agent was reported. A fixed set so the queue sorts by severity without anyone
  * reading every note; `inappropriate` is the one that should page a human.
+ *
+ * Re-exported from the user-facing model rather than restated. It *was* restated, and the
+ * two copies drifted the moment `suggestion` was added for the in-conversation feedback
+ * link: the reporter's dialog offered a reason the admin queue's own type did not admit.
+ * One declaration, in the file the submit side already reads from.
  */
-export type ReportReason = 'inaccurate' | 'broken' | 'inappropriate' | 'other';
+export type { ReportReason };
 
 /**
  * A report's own tiny lifecycle. Deliberately **not** a mirror of `ListingState`: a
@@ -350,6 +356,14 @@ export interface AdminReportRow {
   reporterName: string;
   reason: ReportReason;
   note?: string;
+  /**
+   * The conversation the reporter opted to attach, when they filed from inside one.
+   *
+   * A reference to look up, not a transcript — nothing on this surface reads the
+   * conversation. Absent is a normal state (they declined, or filed from the store page),
+   * so the row must not imply anything was withheld.
+   */
+  sessionId?: string;
   state: ReportState;
   createdAt: string;
   resolvedAt?: string;

--- a/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
@@ -4,6 +4,7 @@ import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
+  heroChatBubbleLeftRight,
   heroCheck,
   heroExclamationTriangle,
   heroFlag,
@@ -43,16 +44,25 @@ import { parseIso } from '../../../utils/date';
   selector: 'app-marketplace-reports',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, RouterLink, AgentTileComponent, TooltipDirective],
-  providers: [provideIcons({ heroCheck, heroExclamationTriangle, heroFlag, heroNoSymbol })],
+  providers: [
+    provideIcons({
+      heroChatBubbleLeftRight,
+      heroCheck,
+      heroExclamationTriangle,
+      heroFlag,
+      heroNoSymbol,
+    }),
+  ],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
         <div class="mb-6">
           <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Reports</h1>
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-            Problems users reported from an agent's page. These are private — they never
-            appear in the store, and the author is never told who reported them. Resolving one
-            records your decision; it does not change the agent.
+            Feedback users sent about an agent — from the foot of a conversation, or from the
+            agent's page. These are private: they never appear in the store, and the author is
+            never told who sent them. Resolving one records your decision; it does not change
+            the agent.
           </p>
         </div>
 
@@ -85,7 +95,7 @@ import { parseIso } from '../../../utils/date';
               Nothing reported
             </h2>
             <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-              Problems users report from an agent's page appear here.
+              Feedback users send from a conversation, or from an agent's page, appears here.
             </p>
           </div>
         } @else {
@@ -155,6 +165,31 @@ import { parseIso } from '../../../utils/date';
                         class="mt-2 whitespace-pre-wrap rounded-2xl bg-gray-50 px-3 py-2 text-sm/6 text-gray-700 dark:bg-gray-900 dark:text-gray-300"
                       >
                         {{ row.note }}
+                      </p>
+                    }
+
+                    <!--
+                      The conversation the reporter chose to share, when they filed from
+                      inside one. Rendered as a reference rather than a link: there is no
+                      admin transcript reader yet, and a link that 404s for everyone but
+                      the reporter would be worse than an id they can quote to support.
+                      Absent is normal and says nothing — they declined, or filed from the
+                      store page — so there is no "no conversation" state to render.
+                    -->
+                    @if (row.sessionId) {
+                      <p
+                        class="mt-2 flex flex-wrap items-center gap-1.5 text-sm/6 text-gray-500 dark:text-gray-400"
+                      >
+                        <ng-icon
+                          name="heroChatBubbleLeftRight"
+                          class="size-4 shrink-0"
+                          aria-hidden="true"
+                        />
+                        <span>Reporter shared their conversation:</span>
+                        <code
+                          class="rounded-sm bg-gray-100 px-1.5 py-0.5 font-mono text-xs/5 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                          >{{ row.sessionId }}</code
+                        >
                       </p>
                     }
                   </div>
@@ -259,6 +294,8 @@ export class ReportsPage implements OnInit {
         return 'Not working';
       case 'inappropriate':
         return 'Inappropriate';
+      case 'suggestion':
+        return 'Suggestion';
       default:
         return 'Other';
     }

--- a/frontend/ai.client/src/app/agents/components/agent-feedback-link.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-feedback-link.component.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { of, throwError } from 'rxjs';
+
+import { AgentFeedbackLinkComponent } from './agent-feedback-link.component';
+import { AgentApiService } from '../services/agent-api.service';
+import { SubmitReportRequest, SubmitReportResponse } from '../models/store.model';
+
+/**
+ * The link is self-contained: dialog → POST → confirmation, with nothing bubbling up.
+ * So the things worth testing are what it *sends* and what it *says afterwards*.
+ *
+ * The confirmation wording is not cosmetic. One open report per reporter (D15.4) means a
+ * second send amends the first — telling someone their feedback was "sent" when it
+ * amended leaves them expecting two things in a queue that only has one.
+ *
+ * DI tokens rather than vi.mock, per project convention.
+ */
+describe('AgentFeedbackLinkComponent', () => {
+  let sent: { id: string; request: SubmitReportRequest }[];
+  let dialogResult: unknown;
+  let response: SubmitReportResponse;
+  let failing: boolean;
+
+  function build(sessionId: string | null = 'sess-123'): AgentFeedbackLinkComponent {
+    sent = [];
+    failing = false;
+    response = {
+      agentId: 'ast-001',
+      reason: 'broken',
+      state: 'open',
+      createdAt: '2026-07-31T00:00:00Z',
+      replacedExisting: false,
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Dialog,
+          useValue: { open: vi.fn(() => ({ closed: of(dialogResult) })) },
+        },
+        {
+          provide: AgentApiService,
+          useValue: {
+            reportAgent: (id: string, request: SubmitReportRequest) => {
+              sent.push({ id, request });
+              return failing ? throwError(() => new Error('nope')) : of(response);
+            },
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AgentFeedbackLinkComponent);
+    fixture.componentRef.setInput('agentId', 'ast-001');
+    fixture.componentRef.setInput('agentName', 'Policy Lookup');
+    fixture.componentRef.setInput('sessionId', sessionId);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  beforeEach(() => {
+    dialogResult = { reason: 'broken', note: 'It errors out', sessionId: 'sess-123' };
+  });
+
+  it('posts what the dialog returned, conversation and all', async () => {
+    await build().onOpen();
+
+    expect(sent).toEqual([
+      { id: 'ast-001', request: { reason: 'broken', note: 'It errors out', sessionId: 'sess-123' } },
+    ]);
+  });
+
+  it('sends nothing when the user cancels', async () => {
+    dialogResult = undefined;
+    await build().onOpen();
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it('confirms in place rather than leaving the link looking untouched', async () => {
+    const component = build();
+    await component.onOpen();
+
+    expect(component['confirmation']()).toMatch(/curate the store/i);
+  });
+
+  it('says it updated, not sent, when it amended an open report (D15.4)', async () => {
+    const component = build();
+    response = { ...response, replacedExisting: true };
+    await component.onOpen();
+
+    expect(component['confirmation']()).toMatch(/updated the feedback/i);
+  });
+
+  it('tells the dialog the user already has one open, after the first send', async () => {
+    const component = build();
+    await component.onOpen();
+    await component.onOpen();
+
+    const dialog = TestBed.inject(Dialog) as unknown as { open: ReturnType<typeof vi.fn> };
+    expect(dialog.open.mock.calls[0][1].data.hasOpenReport).toBe(false);
+    expect(dialog.open.mock.calls[1][1].data.hasOpenReport).toBe(true);
+  });
+
+  it('surfaces a failure instead of a false confirmation', async () => {
+    const component = build();
+    failing = true;
+    await component.onOpen();
+
+    expect(component['confirmation']()).toBeNull();
+    expect(component['error']()).toMatch(/failed/i);
+    expect(component['busy']()).toBe(false);
+  });
+
+  it('still opens without a conversation — the store page has no session either', async () => {
+    dialogResult = { reason: 'suggestion' };
+    await build(null).onOpen();
+
+    expect(sent[0].request).toEqual({ reason: 'suggestion' });
+  });
+});

--- a/frontend/ai.client/src/app/agents/components/agent-feedback-link.component.ts
+++ b/frontend/ai.client/src/app/agents/components/agent-feedback-link.component.ts
@@ -1,0 +1,123 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChatBubbleLeftRight, heroCheckCircle } from '@ng-icons/heroicons/outline';
+import { firstValueFrom } from 'rxjs';
+import { AgentApiService } from '../services/agent-api.service';
+import {
+  ReportAgentDialogComponent,
+  ReportAgentDialogData,
+  ReportAgentDialogResult,
+} from './report-agent-dialog.component';
+
+/**
+ * "Give feedback on <agent>" at the foot of a conversation (D15).
+ *
+ * The store's detail page has carried this since Phase 8, and almost nobody used it —
+ * because the moment you *have* something to say about an agent is the moment it just
+ * answered you, not a later trip back to the tile you launched it from. So the same
+ * intake now sits where the reaction happens.
+ *
+ * **Self-contained on purpose.** The dialog, the POST, and the confirmation all live here
+ * rather than bubbling an output up through the message list and chat container to the
+ * session page. Nothing above needs to know feedback was sent — no session state changes,
+ * no message is added — so routing it through three components would be plumbing that
+ * exists only to come back to the same place.
+ *
+ * ⚠️ **Rendered only for a published agent**, mirroring `agent-detail.page.ts`. The backend
+ * gate is the real one (D15.3: you may report what the store offered you); this just keeps
+ * us from showing a link whose only possible outcome is a 400.
+ */
+@Component({
+  selector: 'app-agent-feedback-link',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroChatBubbleLeftRight, heroCheckCircle })],
+  template: `
+    <div class="mt-6 flex justify-center px-4 pb-2">
+      @if (confirmation(); as message) {
+        <p
+          class="flex items-center gap-2 text-sm/6 text-gray-500 dark:text-gray-400"
+          role="status"
+        >
+          <ng-icon
+            name="heroCheckCircle"
+            class="size-4 shrink-0 text-green-600 dark:text-green-400"
+            aria-hidden="true"
+          />
+          <span>{{ message }}</span>
+        </p>
+      } @else {
+        <button
+          type="button"
+          [disabled]="busy()"
+          (click)="onOpen()"
+          class="flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm/6 text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+        >
+          <ng-icon name="heroChatBubbleLeftRight" class="size-4 shrink-0" aria-hidden="true" />
+          <span>Give feedback on {{ agentName() }}</span>
+        </button>
+      }
+
+      @if (error(); as message) {
+        <p class="text-sm/6 text-red-600 dark:text-red-400" role="alert">{{ message }}</p>
+      }
+    </div>
+  `,
+})
+export class AgentFeedbackLinkComponent {
+  private readonly dialog = inject(Dialog);
+  private readonly api = inject(AgentApiService);
+
+  readonly agentId = input.required<string>();
+  readonly agentName = input.required<string>();
+
+  /** The conversation to offer to attach. Null before the session id settles. */
+  readonly sessionId = input<string | null>(null);
+
+  protected readonly busy = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  /**
+   * Session-local, exactly as on the detail page: there is no read endpoint for "have I
+   * given feedback on this", and the one-open-report rule (D15.4) means a second send
+   * amends the first. Knowing that within this page is enough to word the confirmation
+   * honestly; a reload starting fresh only costs the user a slightly wrong verb.
+   */
+  protected readonly confirmation = signal<string | null>(null);
+  private readonly hasOpenReport = signal(false);
+
+  private readonly dialogData = computed<ReportAgentDialogData>(() => ({
+    agentName: this.agentName(),
+    hasOpenReport: this.hasOpenReport(),
+    sessionId: this.sessionId() ?? undefined,
+  }));
+
+  async onOpen(): Promise<void> {
+    const ref = this.dialog.open<ReportAgentDialogResult, ReportAgentDialogData>(
+      ReportAgentDialogComponent,
+      { data: this.dialogData() },
+    );
+
+    const result = await firstValueFrom(ref.closed);
+    if (!result) return;
+
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      const response = await firstValueFrom(this.api.reportAgent(this.agentId(), result));
+      this.hasOpenReport.set(true);
+      // Telling someone their feedback was "sent" when it amended an earlier one would
+      // leave them expecting two things in the queue (D15.4).
+      this.confirmation.set(
+        response.replacedExisting
+          ? 'Thanks — we updated the feedback you already had open on this agent.'
+          : 'Thanks — your feedback went to the people who curate the store.',
+      );
+    } catch {
+      this.error.set('Failed to send this feedback.');
+    } finally {
+      this.busy.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+import {
+  ReportAgentDialogComponent,
+  ReportAgentDialogData,
+  ReportAgentDialogResult,
+} from './report-agent-dialog.component';
+
+/**
+ * One dialog serves two entry points — the store's detail page and the foot of a
+ * conversation — and `sessionId` is the only thing that tells them apart.
+ *
+ * The case worth pinning hardest is the **unticked** one. Attaching a conversation is the
+ * user handing curators a pointer to something they said; unticking it is them taking that
+ * back. If the result still carried the id, the backend would keep storing it and the
+ * consent would be un-withdrawable from the UI.
+ *
+ * DI tokens rather than vi.mock, per project convention — a shared worker pool makes
+ * module mocks leak across specs.
+ */
+describe('ReportAgentDialogComponent', () => {
+  let closedWith: ReportAgentDialogResult[];
+
+  function build(data: Partial<ReportAgentDialogData> = {}): ReportAgentDialogComponent {
+    closedWith = [];
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DialogRef,
+          useValue: { close: (v: ReportAgentDialogResult) => closedWith.push(v) },
+        },
+        {
+          provide: DIALOG_DATA,
+          useValue: { agentName: 'Policy Lookup', ...data } satisfies ReportAgentDialogData,
+        },
+      ],
+    });
+    return TestBed.createComponent(ReportAgentDialogComponent).componentInstance;
+  }
+
+  describe('opened from the store page (no conversation)', () => {
+    it('offers nothing to attach', () => {
+      expect(build().fromConversation()).toBe(false);
+    });
+
+    it('keeps the report framing', () => {
+      expect(build().submitLabel()).toBe('Send report');
+    });
+
+    it('sends no sessionId', () => {
+      const component = build();
+      component.reason.set('broken');
+      component.onSubmit();
+
+      expect(closedWith[0]?.sessionId).toBeUndefined();
+    });
+  });
+
+  describe('opened from a conversation', () => {
+    it('switches to feedback framing', () => {
+      const component = build({ sessionId: 'sess-123' });
+
+      expect(component.fromConversation()).toBe(true);
+      expect(component.submitLabel()).toBe('Send feedback');
+    });
+
+    it('offers the conversation ticked, because that is what makes it actionable', () => {
+      expect(build({ sessionId: 'sess-123' }).attachConversation()).toBe(true);
+    });
+
+    it('attaches the conversation when left ticked', () => {
+      const component = build({ sessionId: 'sess-123' });
+      component.reason.set('suggestion');
+      component.onSubmit();
+
+      expect(closedWith[0]).toEqual({
+        reason: 'suggestion',
+        note: undefined,
+        sessionId: 'sess-123',
+      });
+    });
+
+    it('sends no conversation at all when unticked', () => {
+      // Not `sessionId: ''`, not a separate flag — absent. An amendment that still carried
+      // the id would make the user's withdrawal un-actionable on the server.
+      const component = build({ sessionId: 'sess-123' });
+      component.reason.set('broken');
+      component.attachConversation.set(false);
+      component.onSubmit();
+
+      expect(closedWith[0]?.sessionId).toBeUndefined();
+    });
+
+    it('says it is amending when the user already has one open', () => {
+      expect(build({ sessionId: 'sess-123', hasOpenReport: true }).submitLabel()).toBe(
+        'Update feedback',
+      );
+    });
+  });
+
+  describe('the reason set', () => {
+    it('offers suggestion — feedback from a conversation is often not a defect', () => {
+      expect(build({ sessionId: 'sess-123' }).reasons.map((r) => r.value)).toContain('suggestion');
+    });
+
+    it('will not submit without one, so the queue can always sort by severity', () => {
+      const component = build();
+      component.onSubmit();
+
+      expect(closedWith).toHaveLength(0);
+    });
+
+    it('closes with undefined on cancel, which is how the caller reads "cancelled"', () => {
+      build().onCancel();
+
+      expect(closedWith).toEqual([undefined]);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/report-agent-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, signal } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroXMark } from '@ng-icons/heroicons/outline';
@@ -8,16 +8,26 @@ export interface ReportAgentDialogData {
   agentName: string;
   /** True when the user already has an open report on this agent, so the copy can say so. */
   hasOpenReport?: boolean;
+  /**
+   * The conversation this was opened from, when it was opened from one.
+   *
+   * Presence is what switches the dialog into feedback framing and reveals the
+   * attach-the-conversation checkbox — there is nothing to offer to attach without it.
+   */
+  sessionId?: string;
 }
 
-/** The reason + note, or undefined if cancelled. */
-export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | undefined;
+/** The reason + note (+ the conversation, if attached), or undefined if cancelled. */
+export type ReportAgentDialogResult =
+  | { reason: ReportReason; note?: string; sessionId?: string }
+  | undefined;
 
 /**
- * "Report a problem" (D15).
+ * Feedback on an agent (D15) — "Report a problem" from the store page, "Send feedback"
+ * from the foot of a conversation.
  *
  * The copy carries the one thing the user must not misread: **this is not a review**.
- * There is no rating here and none is coming — a report is a private message to the
+ * There is no rating here and none is coming — feedback is a private message to the
  * people who curate the store, it never appears on the agent's page, and the author never
  * learns who sent it. A user who thinks they are posting a public review will write a
  * different (and less useful) thing than one who knows they are filing a ticket.
@@ -25,6 +35,11 @@ export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | 
  * The reason set is fixed so the queue can be triaged by severity without reading every
  * note. The labels say what each one *means to the reader*, not what it is called in the
  * enum — "It gives wrong answers" is answerable; "inaccurate" is a category.
+ *
+ * **One dialog, two entry points, deliberately.** The conversation entry point could have
+ * had its own component with warmer copy, and then there would be two reason lists to keep
+ * in step with one backend enum. What actually differs is the title, the lead-in, and
+ * whether a conversation is on offer — so those are the only things `sessionId` changes.
  */
 @Component({
   selector: 'app-report-agent-dialog',
@@ -55,7 +70,11 @@ export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | 
         <div class="flex items-start justify-between gap-3 px-6 pt-5">
           <div class="min-w-0">
             <h2 id="report-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
-              Report a problem with “{{ data.agentName }}”
+              @if (fromConversation()) {
+                Feedback on “{{ data.agentName }}”
+              } @else {
+                Report a problem with “{{ data.agentName }}”
+              }
             </h2>
             <p id="report-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
               This goes privately to the people who curate the store. It is not a review —
@@ -85,7 +104,11 @@ export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | 
 
           <fieldset>
             <legend class="text-sm/6 font-medium text-gray-900 dark:text-white">
-              What's wrong?
+              @if (fromConversation()) {
+                What kind of feedback?
+              } @else {
+                What's wrong?
+              }
             </legend>
             <div class="mt-2 flex flex-col gap-2">
               @for (option of reasons; track option.value) {
@@ -131,6 +154,30 @@ export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | 
             placeholder="What did you ask, and what happened?"
             class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
           ></textarea>
+
+          <!-- Only offered when there is a conversation to offer. Ticked by default
+               because it is what makes the feedback actionable, but it is the user's
+               conversation, so it stays a choice they can see and undo. -->
+          @if (fromConversation()) {
+            <label
+              class="mt-4 flex cursor-pointer items-start gap-3 rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm/6 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700"
+            >
+              <input
+                type="checkbox"
+                class="mt-1 size-4 shrink-0 accent-blue-600"
+                [checked]="attachConversation()"
+                (change)="onAttachToggle($event)"
+              />
+              <span class="min-w-0">
+                <span class="block font-medium text-gray-900 dark:text-white">
+                  Include a reference to this conversation
+                </span>
+                <span class="block text-gray-500 dark:text-gray-400">
+                  Lets the curators look up what happened. Only they can see it.
+                </span>
+              </span>
+            </label>
+          }
         </div>
 
         <div
@@ -149,7 +196,7 @@ export type ReportAgentDialogResult = { reason: ReportReason; note?: string } | 
             (click)="onSubmit()"
             class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
           >
-            {{ data.hasOpenReport ? 'Update report' : 'Send report' }}
+            {{ submitLabel() }}
           </button>
         </div>
       </div>
@@ -165,20 +212,42 @@ export class ReportAgentDialogComponent {
     { value: 'inaccurate', label: 'It gives wrong answers', hint: 'The information it returns is incorrect or out of date.' },
     { value: 'broken', label: "It doesn't work", hint: 'It errors, hangs, or ignores what it is asked.' },
     { value: 'inappropriate', label: 'It produced something inappropriate', hint: 'Offensive, unsafe, or content that should not be here.' },
+    { value: 'suggestion', label: 'It could do more', hint: 'Something it should be able to do, but cannot yet.' },
     { value: 'other', label: 'Something else', hint: 'Tell us below.' },
   ];
 
   readonly reason = signal<ReportReason | null>(null);
   readonly note = signal('');
 
+  /** Ticked by default — see the checkbox comment in the template. */
+  readonly attachConversation = signal(true);
+
+  /** Whether this was opened from a conversation, which is the only thing `sessionId` decides. */
+  readonly fromConversation = computed(() => !!this.data.sessionId);
+
+  readonly submitLabel = computed(() => {
+    if (this.data.hasOpenReport) return 'Update feedback';
+    return this.fromConversation() ? 'Send feedback' : 'Send report';
+  });
+
   onNoteInput(event: Event): void {
     this.note.set((event.target as HTMLTextAreaElement).value);
+  }
+
+  onAttachToggle(event: Event): void {
+    this.attachConversation.set((event.target as HTMLInputElement).checked);
   }
 
   onSubmit(): void {
     const reason = this.reason();
     if (!reason) return;
-    this.dialogRef.close({ reason, note: this.note().trim() || undefined });
+    this.dialogRef.close({
+      reason,
+      note: this.note().trim() || undefined,
+      // Unticking must send *nothing*, not a falsy flag alongside the id — the backend
+      // treats an absent sessionId on an amendment as withdrawing what was shared before.
+      sessionId: this.attachConversation() ? this.data.sessionId : undefined,
+    });
   }
 
   onCancel(): void {

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -236,13 +236,26 @@ export interface CategoryShelf {
  * Why an agent is being reported.
  *
  * A small fixed set so the admin queue can sort by severity without reading every note.
- * `inappropriate` is the one meant to page a human rather than wait for a sweep.
+ * `inappropriate` is the one meant to page a human rather than wait for a sweep, and
+ * `suggestion` — which is not a defect at all — is deliberately last in that order.
+ *
+ * `suggestion` exists because feedback moved out of the store's detail page and into the
+ * foot of the conversation, where "it should also do X" is as common as "it is broken".
+ * It stays the same record in the same queue: a user does not know which kind of thing
+ * they hit, and a second intake form would only mis-sort the ones who guess wrong.
  */
-export type ReportReason = 'inaccurate' | 'broken' | 'inappropriate' | 'other';
+export type ReportReason = 'inaccurate' | 'broken' | 'inappropriate' | 'suggestion' | 'other';
 
 export interface SubmitReportRequest {
   reason: ReportReason;
   note?: string;
+  /**
+   * The conversation the user opted to attach, for the curator's context.
+   *
+   * ⚠️ Opt-in and **server-verified**: the backend keeps it only if it is a session this
+   * caller owns, and silently drops it otherwise rather than failing the submission.
+   */
+  sessionId?: string;
 }
 
 /**

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -244,6 +244,10 @@
 
       <div class="chat-messages-container embedded">
         <div class="min-w-0">
+          <!-- No feedback link in embedded mode: this is the Designer's preview of a
+               draft, so the only person here is the author, and "give feedback on your
+               own agent" routes them to a curator queue instead of the editor they are
+               already sitting in. -->
           <app-message-list
             [messages]="messages()"
             [isChatLoading]="isChatLoading()"
@@ -309,6 +313,8 @@
           [messages]="messages()"
           [isChatLoading]="isChatLoading()"
           [streamingMessageId]="streamingMessageId()"
+          [feedbackAgent]="feedbackAgent()"
+          [sessionId]="sessionId()"
           (continueRequested)="continueRequested.emit()" />
       </div>
     </div>

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { ChatContainerComponent } from './chat-container.component';
+import { Agent } from '../../../agents/models/agent.model';
+import { ListingState } from '../../../agents/models/store.model';
+
+/**
+ * The foot-of-conversation feedback link is offered for **published** marketplace agents
+ * and nothing else (D15.3 — you may report what the store offered you). The backend gate
+ * is the real one; this keeps us from rendering a link whose only outcome is a 400.
+ *
+ * The other half is what it reads *from*. It deliberately does not use the launch card's
+ * `listed` flag, which falls back to the Assistant shape with `listed: false` — an
+ * affordance that silently vanished whenever the `/agents` load lost a race would be hard
+ * to notice and harder to explain.
+ */
+describe('ChatContainerComponent — the feedback link gate', () => {
+  function agent(listingState: ListingState | null): Agent {
+    return {
+      agentId: 'ast-001',
+      ownerName: 'Ada Author',
+      name: 'Policy Lookup',
+      description: 'Find and cite university policy',
+      bindings: [],
+      visibility: 'PUBLIC',
+      tags: [],
+      starters: [],
+      usageCount: 0,
+      status: 'COMPLETE',
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+      ...(listingState
+        ? { listing: { state: listingState, category: 'Administration' } }
+        : {}),
+    } as Agent;
+  }
+
+  function feedbackAgentFor(value: Agent | null): { id: string; name: string } | null {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(ChatContainerComponent);
+    fixture.componentRef.setInput('messages', []);
+    fixture.componentRef.setInput('agent', value);
+    return fixture.componentInstance['feedbackAgent']();
+  }
+
+  it('offers feedback on a published agent', () => {
+    expect(feedbackAgentFor(agent('published'))).toEqual({ id: 'ast-001', name: 'Policy Lookup' });
+  });
+
+  it.each<ListingState>(['private', 'in_review', 'changes_requested', 'taken_down'])(
+    'offers nothing for a %s listing',
+    (state) => {
+      expect(feedbackAgentFor(agent(state))).toBeNull();
+    },
+  );
+
+  it('offers nothing for an agent that was never listed', () => {
+    expect(feedbackAgentFor(agent(null))).toBeNull();
+  });
+
+  it('offers nothing for plain chat', () => {
+    // No Agent means we do not *know* this is a store agent — the only honest reason to
+    // withhold the link.
+    expect(feedbackAgentFor(null)).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -184,6 +184,21 @@ export class ChatContainerComponent {
     };
   });
 
+  /**
+   * The agent the foot-of-conversation feedback link asks about, or null.
+   *
+   * Read off `agent()` rather than `launchCardView()` even though the card already carries
+   * a `listed` flag: the card falls back to the Assistant shape with `listed: false`, and
+   * an affordance that is silently absent whenever the `/agents` load loses a race would
+   * be a hard thing to notice and a harder one to explain. Here, no Agent means no link,
+   * for the one honest reason — we do not know that this is a store agent.
+   */
+  protected readonly feedbackAgent = computed<{ id: string; name: string } | null>(() => {
+    const agent = this.agent();
+    if (agent?.listing?.state !== 'published') return null;
+    return { id: agent.agentId, name: agent.name };
+  });
+
   // Computed signals
   protected readonly hasMessages = computed(() => this.messages().length > 0);
   protected readonly showSkeleton = computed(

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -150,6 +150,17 @@
       <app-pulsating-loader />
     </div>
   }
+
+  <!-- Last thing in the tail: feedback on the marketplace agent behind this
+       conversation. The moment someone has something to say about an agent is
+       the moment it just answered them — not a later trip back to the store
+       tile they launched it from. Published agents only (D15.3). -->
+  @if (showFeedbackLink()) {
+    <app-agent-feedback-link
+      [agentId]="feedbackAgent()!.id"
+      [agentName]="feedbackAgent()!.name"
+      [sessionId]="sessionId()" />
+  }
   </ng-template>
 
   <!-- No turns yet — no group to anchor the tail inside. -->

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -15,6 +15,7 @@ import { ArtifactCardComponent } from './components/artifact/artifact-card.compo
 import { ArtifactPanelComponent } from './components/artifact/artifact-panel.component';
 import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
 import { McpAppCardComponent } from './components/mcp-app-card/mcp-app-card.component';
+import { AgentFeedbackLinkComponent } from '../../../agents/components/agent-feedback-link.component';
 import { McpAppCardStateService } from '../../services/mcp-apps/mcp-app-card-state.service';
 import {
   OAuthConsentRequest,
@@ -43,6 +44,7 @@ import { ChatStateService } from '../../services/chat/chat-state.service';
     ArtifactCardComponent,
     ArtifactPanelComponent,
     McpAppCardComponent,
+    AgentFeedbackLinkComponent,
   ],
   templateUrl: './message-list.component.html',
   styleUrl: './message-list.component.css',
@@ -60,6 +62,16 @@ export class MessageListComponent {
   streamingMessageId = input<string | null>(null);
   embeddedMode = input<boolean>(false);
 
+  /**
+   * The published marketplace agent behind this conversation, when there is one — the
+   * foot-of-conversation feedback link, and nothing else. Null for plain chat, a legacy
+   * assistant, or an agent that is not published (D15.3).
+   */
+  feedbackAgent = input<{ id: string; name: string } | null>(null);
+
+  /** The conversation itself, offered to attach to that feedback. */
+  sessionId = input<string | null>(null);
+
   /** Bubbled up when the user clicks "Continue" on a max_tokens-truncated
    *  assistant message. The page reuses the normal submit path with a
    *  canned prompt. */
@@ -75,6 +87,15 @@ export class MessageListComponent {
   /** Persisted app-initiated tool cards, hydrated on reload (PR #6). */
   protected mcpAppCards = this.mcpAppCardState.cards;
   protected hasMcpAppCards = this.mcpAppCardState.hasCards;
+
+  /**
+   * The feedback link needs something to give feedback *about*, so it waits for a turn to
+   * have happened, and stays out of the way while one is still streaming — it sits at the
+   * very foot of the tail, and appearing under a half-written answer reads as part of it.
+   */
+  protected readonly showFeedbackLink = computed(
+    () => !!this.feedbackAgent() && this.messages().length > 0 && !this.isChatLoading(),
+  );
 
   /** Only the final message of a recoverable max_tokens turn gets the
    *  "Continue" affordance. Live-only state, never shown while a new


### PR DESCRIPTION
## What

Adds a **"Give feedback on _<agent>_"** link at the foot of a conversation with a published marketplace Agent. It opens the existing report dialog, and the submission lands in the existing admin **Reports** queue.

## Why this shape

Reporting an Agent has existed since Phase 8 — but only on the store's detail page, which is the wrong place to *put* it and the right place to *have* it. The moment someone has something to say about an Agent is the moment it just answered them, not a later trip back to the tile they launched it from.

It is deliberately the **same record, endpoint and queue** rather than a parallel "feedback" object: a user does not know whether what they hit is a defect or a missing capability, and a second intake form would only mis-sort the ones who guess wrong.

## Changes

**`suggestion` reason** — for the "it should also do X" a conversation produces and a store page does not. Sorts **last** in the severity sweep: it is the one reason that is not a defect, so it must never displace a complaint.

**Opt-in `sessionId`** — a checkbox, ticked by default, attaching the conversation so a curator can look up what happened. Three rules make that safe rather than merely convenient:

- **Verified, not trusted.** The id arrives in the request body, so the server keeps it only if it resolves to a session the *caller* owns. Without the check, anyone could hand an admin a pointer to somebody else's conversation and the queue would present it as context the reporter chose to share.
- **Dropped, not rejected.** A session that does not check out (or a metadata read that errors) is silently dropped. The feedback is the payload, the attachment is context — failing the whole submission to protect a nicety loses the thing the user came to say.
- **Withdrawable.** Amending with the box unticked *removes* the stored reference (D15.4 means a second submission updates the first). Consent that cannot be taken back is not consent.

**Admin queue** renders the attached conversation as a **reference, not a link**. There is no admin transcript reader yet, and a link that 404s for everyone but the reporter would be worse than an id they can quote. A real transcript reader is a separate feature with its own privacy weight and is deliberately not smuggled in here.

## Gating

- Rendered only for `listing.state === 'published'` (D15.3 — you may report what the store offered you). The backend gate is the real one; this just avoids a link whose only outcome is a 400.
- Waits for a turn to exist, and stays hidden while one is streaming.
- Not shown in the Designer's embedded preview — the only person there is the author.

## Notes for review

- **No new admin scope.** `admin.marketplace` already governs reports (its registry description literally says "handle reports and takedowns"), and `test_admin_scope_coverage.py` enforces one scope per admin router.
- **No new admin page.** The Reports queue already existed; this extends it.
- Collapses a duplicated `ReportReason` union — the admin model restated it, and the two copies drifted the moment `suggestion` landed. Now re-exported from one place.

## Verification

- Backend: **2458 passed** (`tests/shared`, `tests/routes`, `tests/architecture`), including 10 new cases covering the attach/withdraw/swap lifecycle and the ownership check.
- SPA: **1786 passed / 161 files**; 3 new spec files.
- **Live round trip** on a local stack: filed a `suggestion` with the conversation attached from a chat with a published Agent → `201 Created` → appeared in the admin queue with the Suggestion badge and the matching session reference → dismissed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)