### PR TITLE
style(spa): match the Knowledge base section to its sibling cards

### DIFF
--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
@@ -1,7 +1,8 @@
-<!-- Knowledge (grouped inset — mildly contrasted from the page) -->
-<section class="space-y-4 rounded-2xl border border-gray-200 bg-gray-100/60 p-5 dark:border-gray-700 dark:bg-gray-800/40 sm:p-6">
-  <div class="flex items-center gap-3">
-    <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Knowledge base</h2>
+<!-- Knowledge (card surface — matches the Skills / Memory spaces sections) -->
+<section class="space-y-4 rounded-2xl border border-gray-200/80 bg-white p-5 shadow-xs dark:border-gray-700/60 dark:bg-gray-800/80 sm:p-6">
+  <div class="flex items-center gap-2">
+    <ng-icon name="heroBookOpen" class="size-5 text-amber-500" aria-hidden="true" />
+    <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Knowledge base</h2>
     @if (webCrawlActive()) {
       <span class="inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-2 py-0.5 text-xs/4 font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
         <span class="size-1.5 animate-pulse rounded-full bg-blue-500"></span>

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
@@ -13,6 +13,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowDownTray,
   heroArrowPath,
+  heroBookOpen,
   heroGlobeAlt,
   heroLink,
   heroPlus,
@@ -76,6 +77,7 @@ import { parseIso } from '../utils/date';
     provideIcons({
       heroArrowDownTray,
       heroArrowPath,
+      heroBookOpen,
       heroGlobeAlt,
       heroLink,
       heroPlus,


### PR DESCRIPTION
## What

On the Edit Agent page the Knowledge base section rendered as a grey inset (`bg-gray-100/60`, no shadow) with a larger, icon-less heading, while the Skills and Memory spaces sections directly above it are white cards with an icon + `text-sm/6` title. The three sit in a row, so the odd one out read as a different *kind* of surface rather than a peer.

This adopts the sibling tokens on the Knowledge base card:

- `bg-white` + `shadow-xs` + `border-gray-200/80` (and the dark-mode equivalents `dark:bg-gray-800/80` / `dark:border-gray-700/60`)
- an icon-led `text-sm/6` heading, using `heroBookOpen` in amber to stay distinct from tools blue / skills purple / memory emerald

The nested document lists and connector rows keep their own `border-gray-200`, so they stay delineated against the now-white surface — same as the rows inside Memory spaces.

## Verification

Checked on the agent form against the dev backend:

- computed `background-color`, `border-color` and `box-shadow` on the Knowledge base section are identical to the Memory spaces card
- all three headings resolve to `14px / 24px / 600`
- no console errors; the icon renders
- `npx ng test --include="**/agent-form.page.spec.ts"` → 8 passed

## Notes

`ng-icon`'s host resolves to black in all three sections, so the accent colour isn't actually visible today. The amber class matches the existing sibling pattern rather than introducing new behaviour — worth a separate look if the accents are meant to show.

Scope is styling only. No component logic, no API surface, no template control flow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
