### PR TITLE
fix(security): scrub user-controlled values out of log records

### DIFF
--- a/backend/src/agents/main_agent/tools/tool_filter.py
+++ b/backend/src/agents/main_agent/tools/tool_filter.py
@@ -7,6 +7,7 @@ from agents.main_agent.config.constants import Prefixes
 from agents.main_agent.tools.tool_registry import ToolRegistry
 from apis.shared.tools.injected import INJECTED_TOOL_IDS
 from apis.shared.tools.scoped_ids import base_tool_id
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +101,7 @@ class ToolFilter:
                 # agent's tools as extra_tools - never in the registry.
                 pass
             else:
-                logger.warning(f"Tool '{tool_id}' is not a known tool id, skipping")
+                logger.warning(f"Tool '{scrub_log(tool_id)}' is not a known tool id, skipping")
 
         logger.info(f"Local tools enabled: {len(filtered_tools)}")
         logger.info(f"Gateway tools enabled: {len(gateway_tool_ids)}")
@@ -155,7 +156,7 @@ class ToolFilter:
                 # normal path — not a missing tool.
                 injected_tool_ids.append(tool_id)
             else:
-                logger.warning(f"Tool '{tool_id}' is not a known tool id, skipping")
+                logger.warning(f"Tool '{scrub_log(tool_id)}' is not a known tool id, skipping")
 
         logger.info(f"Local tools enabled: {len(filtered_tools)}")
         logger.info(f"Gateway tools enabled: {len(gateway_tool_ids)}")

--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -86,6 +86,7 @@ from apis.shared.assistants.publishers import (
 )
 from apis.shared.auth import User, require_admin_scope
 from apis.shared.feature_flags import agent_marketplace_enabled
+from apis.shared.security.log_sanitize import scrub_log
 from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
@@ -377,7 +378,7 @@ async def list_agent_report_history_endpoint(
             reports=rows, open_count=len([r for r in rows if r.state == "open"])
         )
     except Exception as e:
-        logger.error(f"Error listing reports for agent {agent_id}: {e}", exc_info=True)
+        logger.error(f"Error listing reports for agent {scrub_log(agent_id)}: {scrub_log(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list reports: {str(e)}")
 
 
@@ -407,7 +408,7 @@ async def resolve_agent_report(
     except ReportError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
     except Exception as e:
-        logger.error(f"Error resolving report {report_id}: {e}", exc_info=True)
+        logger.error(f"Error resolving report {scrub_log(report_id)}: {scrub_log(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to resolve report: {str(e)}")
 
 

--- a/backend/src/apis/app_api/admin/audit/routes.py
+++ b/backend/src/apis/app_api/admin/audit/routes.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from apis.shared.audit import ALL_ACTIONS, TARGET_APP_ROLE, AuditRepository
 from apis.shared.audit.repository import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from apis.shared.auth import User, require_admin
+from apis.shared.security.log_sanitize import scrub_log
 from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
@@ -136,7 +137,7 @@ async def list_for_target(
             target_type, target_id, limit=limit, cursor=start_key
         )
     except Exception:
-        logger.exception(f"Failed to read audit history for {target_id}")
+        logger.exception(f"Failed to read audit history for {scrub_log(target_id)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Audit log is unavailable.",
@@ -158,7 +159,7 @@ async def list_for_actor(
             actor_user_id, limit=limit, cursor=start_key
         )
     except Exception:
-        logger.exception(f"Failed to read audit history for actor {actor_user_id}")
+        logger.exception(f"Failed to read audit history for actor {scrub_log(actor_user_id)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Audit log is unavailable.",

--- a/backend/src/apis/app_api/admin/roles/agent_pins.py
+++ b/backend/src/apis/app_api/admin/roles/agent_pins.py
@@ -44,6 +44,7 @@ from apis.shared.assistants.role_pins import (
     put_role_pins,
 )
 from apis.shared.auth import User
+from apis.shared.security.log_sanitize import scrub_log
 from apis.shared.rbac.admin_service import get_app_role_admin_service
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ async def get_role_agent_pins(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error loading default pins for role {role_id}: {e}", exc_info=True)
+        logger.error(f"Error loading default pins for role {scrub_log(role_id)}: {scrub_log(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to load default pins: {str(e)}")
 
 
@@ -120,7 +121,7 @@ async def put_role_agent_pins(
         role = await _load_role(role_id)
         await put_role_pins(role_id, request.pins, updated_by=admin.user_id)
         logger.info(
-            f"Admin {admin.email} set {len(request.pins)} default pin(s) on role {role_id}",
+            f"Admin {scrub_log(admin.email)} set {len(request.pins)} default pin(s) on role {scrub_log(role_id)}",
             extra={
                 "event": "role_agent_pins_updated",
                 "role_id": role_id,
@@ -137,5 +138,5 @@ async def put_role_agent_pins(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Error saving default pins for role {role_id}: {e}", exc_info=True)
+        logger.error(f"Error saving default pins for role {scrub_log(role_id)}: {scrub_log(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to save default pins: {str(e)}")

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -120,6 +120,7 @@ from apis.shared.assistants.models import (
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.feature_flags import agent_marketplace_enabled, agents_enabled
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -410,7 +411,7 @@ async def get_agent_endpoint(agent_id: str, current_user: User = Depends(require
             response.model_label = model_label
             response.publisher, response.category_label = await resolve_listing_display(assistant)
         except Exception:
-            logger.warning(f"Failed to resolve capabilities for agent {agent_id}", exc_info=True)
+            logger.warning(f"Failed to resolve capabilities for agent {scrub_log(agent_id)}", exc_info=True)
         return response
     except HTTPException:
         raise

--- a/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/role_pin_service.py
@@ -59,9 +59,15 @@ from apis.app_api.agent_designer.services.agent_detail import (
 
 logger = logging.getLogger(__name__)
 
-# What a role's ``effective_permissions`` can actually decide. ``memory_space`` is absent
-# because a role does not grant memory spaces — people do, per space.
-_ROLE_GATED_KINDS = ("tool", "skill")
+# What a role's ``effective_permissions`` can actually decide, as (binding kind,
+# permission axis) pairs. ``memory_space`` is absent because a role does not grant memory
+# spaces — people do, per space (see ``_MEMORY_NOTE``, applied separately below).
+#
+# Read by the loop in ``role_pin_runnability``. It previously stated the kinds here and
+# then re-stated them as a literal at the loop, so the documented rule and the enforced
+# rule were two objects that could drift; CodeQL flagged the constant as unused, which is
+# what that drift looks like from the outside.
+_ROLE_GATED_KINDS = (("tool", "tools"), ("skill", "skills"))
 
 _MEMORY_NOTE = (
     "Binds a memory space, which is granted per person — this check cannot decide it for "
@@ -100,7 +106,7 @@ async def _diff_against_role(
         notes.append(_MEMORY_NOTE)
 
     labels = await _labels_by_kind(assistant, admin_user)
-    for kind, axis in (("tool", "tools"), ("skill", "skills")):
+    for kind, axis in _ROLE_GATED_KINDS:
         of_kind = [b for b in bindings if b.kind == kind]
         if not of_kind:
             continue

--- a/backend/tests/security/test_log_sanitize.py
+++ b/backend/tests/security/test_log_sanitize.py
@@ -1,0 +1,73 @@
+"""Tests for ``scrub_log`` — the CodeQL ``py/log-injection`` mitigation.
+
+The helper shipped without tests and is now wrapped around a user-controlled value at
+every admin/marketplace log site, so the properties it promises are worth pinning:
+line terminators must never survive into a log record, and the original content must
+still be legible to whoever is reading the log.
+"""
+
+import pytest
+
+from apis.shared.security.log_sanitize import scrub_log
+
+
+class TestLineTerminators:
+    """The whole point: a user-supplied value cannot start a new log line."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("plain", "plain"),
+            ("a\nb", "a\\nb"),
+            ("a\rb", "a\\rb"),
+            ("a\r\nb", "a\\r\\nb"),
+            ("a\tb", "a\\tb"),
+            ("\n", "\\n"),
+        ],
+    )
+    def test_terminators_become_visible_escapes(self, raw: str, expected: str) -> None:
+        assert scrub_log(raw) == expected
+
+    def test_no_raw_newline_survives(self) -> None:
+        forged = "agent-1\n2026-08-01 - root - ERROR - fabricated entry"
+        out = scrub_log(forged)
+        assert "\n" not in out
+        assert "\r" not in out
+        # Escaped rather than deleted — the attempt stays visible to a reader.
+        assert "\\n" in out
+        assert "fabricated entry" in out
+
+
+class TestControlCharacters:
+    def test_other_c0_controls_are_stripped(self) -> None:
+        # NUL and BEL carry no debugging value and can corrupt log viewers.
+        assert scrub_log("a\x00b\x07c") == "abc"
+
+    def test_delete_is_stripped(self) -> None:
+        assert scrub_log("a\x7fb") == "ab"
+
+    def test_printable_unicode_is_preserved(self) -> None:
+        # Only control characters are in scope; a name in any script must survive.
+        assert scrub_log("café — 日本語") == "café — 日本語"
+
+
+class TestNonStringInputs:
+    """Call sites pass exceptions and ids, not only strings."""
+
+    def test_exception_is_stringified(self) -> None:
+        assert scrub_log(ValueError("bad\nvalue")) == "bad\\nvalue"
+
+    @pytest.mark.parametrize("raw,expected", [(None, "None"), (42, "42"), (True, "True")])
+    def test_scalars_stringify(self, raw: object, expected: str) -> None:
+        assert scrub_log(raw) == expected
+
+    def test_result_is_always_str(self) -> None:
+        assert isinstance(scrub_log(object()), str)
+
+
+class TestIdempotence:
+    """Double-wrapping a value must not mangle it — nested helpers happen."""
+
+    def test_scrubbing_twice_matches_scrubbing_once(self) -> None:
+        raw = "a\nb\tc\x00d"
+        assert scrub_log(scrub_log(raw)) == scrub_log(raw)

--- a/frontend/ai.client/src/app/admin/admin-scope-wiring.spec.ts
+++ b/frontend/ai.client/src/app/admin/admin-scope-wiring.spec.ts
@@ -13,7 +13,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter, Routes, Route } from '@angular/router';
 import { signal } from '@angular/core';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 import { adminRoutes } from './admin.routes';
 import { AdminLayout } from './admin.layout';

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -3,7 +3,6 @@ import {
   ChangeDetectionStrategy,
   inject,
   signal,
-  computed,
   OnInit,
 } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';

--- a/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
+++ b/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
@@ -34,6 +34,12 @@ import { AgentListingRowComponent } from '../components/agent-listing-row.compon
   selector: 'app-agent-pinned',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [AgentsTabsComponent, AgentListingRowComponent, NgIcon, RouterLink],
+  // The empty state renders <ng-icon name="heroBookmark" />, and ng-icons resolves that
+  // name from a registration rather than from the import. Both symbols were imported and
+  // neither was ever called, so the glyph silently rendered as nothing — CodeQL surfaced
+  // it as two unused imports, which is what a missing registration looks like from the
+  // outside. Matches how discover.page.ts registers its own icons.
+  providers: [provideIcons({ heroBookmark })],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">

--- a/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/sync-policy-control.component.ts
@@ -9,7 +9,6 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowPath, heroChevronDown } from '@ng-icons/heroicons/outline';
 
 import { SyncInterval, SyncPolicy } from '../models/sync-policy.model';
-import { parseIso } from '../../utils/date';
 
 /** The select's "no policy / turn sync off" sentinel. */
 export type SyncIntervalSelection = SyncInterval | 'manual';


### PR DESCRIPTION
Clears the CodeQL findings raised against the 1.12.0 delta on #814. **Three of them turned out to be real defects rather than style noise** — including one where the correct fix is the opposite of what the finding suggested.

Deliberately kept out of the release branch: #814 is green and these are not blockers. This targets `develop` so it rides the next release.

## Log injection — 10 findings

`scrub_log` already exists in `apis/shared/security/log_sanitize.py` and is used in six files. The marketplace, audit and role-pin code shipped without adopting it. Path params (`agent_id`, `role_id`, `target_id`, `report_id`, `actor_user_id`) and exception text now go through it.

A percent-encoded `%0A` in a path segment survives URL decoding, and most of these sites are in `except` blocks where the value was never validated — so a forged log line was reachable. Low severity (log forging, not execution), but it sits awkwardly next to the durable audit trail this same release introduced.

**Scope decision:** only the message f-strings are scrubbed, *not* the `extra={...}` structured fields CodeQL also flags. `logging.basicConfig` formats as `%(asctime)s - %(name)s - %(levelname)s - %(message)s`, so `extra` is never rendered — scrubbing it would corrupt the stored value for any handler that later reads it and buy nothing against injection.

`tool_filter.py` carried the flagged warning **twice**, in two near-identical methods. CodeQL reported one; both are fixed.

## The bookmark icon never rendered

`pinned.page.ts` imported `provideIcons` and `heroBookmark`, called neither, and its empty state renders `<ng-icon name="heroBookmark" />`.

ng-icons resolves that name from a registration, not from the import. I checked every `provideIcons` in the SPA: registration is **per-component** across dozens of components, with **none** at root in `app.config.ts` or `main.ts` — and the sibling `discover.page.ts` registers its own icons exactly this way. So the glyph had nothing to resolve to.

**The fix adds the missing registration rather than deleting the imports**, which is what the finding literally suggested. Deleting them would have removed the evidence and left the empty state permanently glyph-less.

## Documented rule vs enforced rule

`_ROLE_GATED_KINDS` was flagged as an unused global. The rule it describes *was* enforced — but by a literal `(("tool","tools"),("skill","skills"))` re-stated at the loop, so the documented rule and the enforced rule were two objects free to drift. That is precisely what an unused constant looks like from outside. The constant now carries the pairs and the loop reads it.

## Genuinely unused imports

`computed` (listings.page.ts), `beforeEach` (admin-scope-wiring.spec.ts), `parseIso` (sync-policy-control.component.ts — shadowed by a private method of the same name). The local `parseIso` is a broader regex variant of the shared util and predates it; I left the duplication alone rather than widen scope, but it is worth a look someday.

## Declined

| Finding | Count | Why |
|---|---|---|
| Unnecessary lambda | 4 | `default_factory=lambda: utc_now_iso()` → cosmetic, semantically identical |
| assert has side-effect | 6 | Test-only, observable solely under `python -O`, which tests never run with |
| Superfluous trailing arguments | 1 | Spec passing `(route, state)` to a guard that ignores them |

## Verification

- New `backend/tests/security/test_log_sanitize.py` — **16 tests**. The helper is now load-bearing at ten more call sites and had zero coverage: terminator escaping, control-character stripping, non-string inputs (exceptions, `None`, scalars), unicode preservation, idempotence.
- Backend: **5713 passed, 3 skipped**.
- SPA: **162 files / 1791 tests passed**.

I could **not** verify the icon fix in a running app — the local stack sits at `/auth/first-boot`. The evidence above is structural: imports present and uncalled, template referencing the name as a string, no root registration anywhere in the SPA, sibling page registering identically.

## Deploy

`backend.yml` + `frontend-deploy.yml`. No infra, no migration, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)