### PR TITLE
fix(spa): stop the Memory Spaces kill switch from announcing itself

### DIFF
--- a/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.spec.ts
+++ b/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { Observable } from 'rxjs';
+import { MemorySpaceApiService } from './memory-space-api.service';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
+import { ConfigService } from '../../services/config.service';
+
+const BASE = 'http://localhost:8000/memory/spaces';
+
+describe('MemorySpaceApiService', () => {
+  let service: MemorySpaceApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MemorySpaceApiService,
+        { provide: ConfigService, useValue: { appApiUrl: signal('http://localhost:8000') } },
+      ],
+    });
+    service = TestBed.inject(MemorySpaceApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true);
+    TestBed.resetTestingModule();
+  });
+
+  /**
+   * Regression guard for the kill switch. While `MEMORY_SPACES_ENABLED` is off the
+   * backend 404s this whole surface on purpose, and MemorySpaceService reads that as
+   * "feature unavailable" and hides the nav entry. error.interceptor toasts every
+   * non-401 unless the request opts out, so without SUPPRESS_ERROR_TOAST the feature
+   * hides itself and then pops a dialog naming an endpoint the user should not see.
+   *
+   * Asserted per call rather than once on `list()`: a dark-stopped environment 404s
+   * every one of these, and a deep link to a space detail page hits `get`/`listEntries`
+   * without ever calling `list`.
+   */
+  // Widened to Observable<unknown> so the thunks form one callable signature —
+  // a heterogeneous union of Observable<T> has no compatible `.subscribe`.
+  const calls: Array<[string, () => Observable<unknown>]> = [
+    ['list', () => service.list()],
+    ['create', () => service.create({ name: 'x', template: 'blank' })],
+    ['get', () => service.get('spc_1')],
+    ['remove', () => service.remove('spc_1')],
+    ['export', () => service.export('spc_1')],
+    ['updateIndex', () => service.updateIndex('spc_1', '# hi')],
+    ['readEntry', () => service.readEntry('spc_1', 'note')],
+    ['upsertEntry', () => service.upsertEntry('spc_1', 'note', { body: 'x' })],
+    ['deleteEntry', () => service.deleteEntry('spc_1', 'note')],
+    ['listEntries', () => service.listEntries('spc_1')],
+    ['listShares', () => service.listShares('spc_1')],
+    ['addShare', () => service.addShare('spc_1', { email: 'a@b.c', permission: 'viewer' })],
+    ['updateShare', () => service.updateShare('spc_1', 'a@b.c', 'editor')],
+    ['removeShare', () => service.removeShare('spc_1', 'a@b.c')],
+  ];
+
+  it.each(calls)('%s opts out of the global error toast', (_name, call) => {
+    call().subscribe({ next: () => undefined, error: () => undefined });
+
+    const req = httpMock.expectOne(r => r.url.startsWith(BASE));
+    expect(req.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(true);
+    req.flush(null);
+  });
+
+  it('still sends the type filter on listEntries', () => {
+    service.listEntries('spc_1', 'fact').subscribe();
+
+    const req = httpMock.expectOne(r => r.url === `${BASE}/spc_1/entries`);
+    expect(req.request.params.get('type')).toBe('fact');
+    expect(req.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(true);
+    req.flush({ entries: [] });
+  });
+
+  it('still requests a blob for export', () => {
+    service.export('spc_1').subscribe();
+
+    const req = httpMock.expectOne(`${BASE}/spc_1/export`);
+    expect(req.request.responseType).toBe('blob');
+    expect(req.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(true);
+    req.flush(new Blob());
+  });
+});

--- a/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.ts
+++ b/frontend/ai.client/src/app/memory-spaces/services/memory-space-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, computed } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
 import { ConfigService } from '../../services/config.service';
 import {
   CreateSpaceRequest,
@@ -32,29 +33,57 @@ export class MemorySpaceApiService {
 
   private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/memory/spaces`);
 
+  /**
+   * Per-request options shared by every Memory Spaces call. `SUPPRESS_ERROR_TOAST`
+   * opts these requests out of the global error toast.
+   *
+   * The reason is the kill switch. While `MEMORY_SPACES_ENABLED` is off the whole
+   * surface 404s *on purpose*, so the feature can be hidden without being removed —
+   * MemorySpaceService reads that 404 as "feature unavailable", clears its state and
+   * drops the nav entry. But error.interceptor toasts every non-401 it sees unless a
+   * request opts out, so the surface would hide itself and then announce that it had:
+   * a dismissable error dialog naming an endpoint the user is not meant to know about.
+   *
+   * Suppressing here costs nothing for genuine failures. MemorySpaceService already
+   * translates every non-404 into its own `error$` signal, which the pages render
+   * inline and in context; the generic toast was only ever a duplicate of that.
+   */
+  private requestContext(): HttpContext {
+    return new HttpContext().set(SUPPRESS_ERROR_TOAST, true);
+  }
+
   // ---- spaces ----------------------------------------------------------
 
   list(): Observable<SpacesListResponse> {
-    return this.http.get<SpacesListResponse>(this.baseUrl());
+    return this.http.get<SpacesListResponse>(this.baseUrl(), {
+      context: this.requestContext(),
+    });
   }
 
   create(request: CreateSpaceRequest): Observable<MemorySpaceSummary> {
-    return this.http.post<MemorySpaceSummary>(this.baseUrl(), request);
+    return this.http.post<MemorySpaceSummary>(this.baseUrl(), request, {
+      context: this.requestContext(),
+    });
   }
 
   get(spaceId: string): Observable<MemorySpaceDetail> {
-    return this.http.get<MemorySpaceDetail>(`${this.baseUrl()}/${spaceId}`);
+    return this.http.get<MemorySpaceDetail>(`${this.baseUrl()}/${spaceId}`, {
+      context: this.requestContext(),
+    });
   }
 
   /** Owner deletes the space; a member drops their own grant (leave). */
   remove(spaceId: string): Observable<void> {
-    return this.http.delete<void>(`${this.baseUrl()}/${spaceId}`);
+    return this.http.delete<void>(`${this.baseUrl()}/${spaceId}`, {
+      context: this.requestContext(),
+    });
   }
 
   /** The whole space as a `.zip` of raw markdown (viewer+). */
   export(spaceId: string): Observable<Blob> {
     return this.http.get(`${this.baseUrl()}/${spaceId}/export`, {
       responseType: 'blob',
+      context: this.requestContext(),
     });
   }
 
@@ -64,6 +93,7 @@ export class MemorySpaceApiService {
     return this.http.put<{ content: string }>(
       `${this.baseUrl()}/${spaceId}/index`,
       { content },
+      { context: this.requestContext() },
     );
   }
 
@@ -72,6 +102,7 @@ export class MemorySpaceApiService {
   readEntry(spaceId: string, slug: string): Observable<EntryContent> {
     return this.http.get<EntryContent>(
       `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
+      { context: this.requestContext() },
     );
   }
 
@@ -83,12 +114,14 @@ export class MemorySpaceApiService {
     return this.http.put<MemoryEntryRef>(
       `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
       request,
+      { context: this.requestContext() },
     );
   }
 
   deleteEntry(spaceId: string, slug: string): Observable<void> {
     return this.http.delete<void>(
       `${this.baseUrl()}/${spaceId}/entries/${encodeURIComponent(slug)}`,
+      { context: this.requestContext() },
     );
   }
 
@@ -99,18 +132,22 @@ export class MemorySpaceApiService {
     }
     return this.http.get<{ entries: MemoryEntryRef[] }>(
       `${this.baseUrl()}/${spaceId}/entries`,
-      { params },
+      { params, context: this.requestContext() },
     );
   }
 
   // ---- sharing ---------------------------------------------------------
 
   listShares(spaceId: string): Observable<MembersListResponse> {
-    return this.http.get<MembersListResponse>(`${this.baseUrl()}/${spaceId}/shares`);
+    return this.http.get<MembersListResponse>(`${this.baseUrl()}/${spaceId}/shares`, {
+      context: this.requestContext(),
+    });
   }
 
   addShare(spaceId: string, request: ShareRequest): Observable<SpaceMember> {
-    return this.http.post<SpaceMember>(`${this.baseUrl()}/${spaceId}/shares`, request);
+    return this.http.post<SpaceMember>(`${this.baseUrl()}/${spaceId}/shares`, request, {
+      context: this.requestContext(),
+    });
   }
 
   updateShare(
@@ -121,12 +158,14 @@ export class MemorySpaceApiService {
     return this.http.patch<SpaceMember>(
       `${this.baseUrl()}/${spaceId}/shares/${encodeURIComponent(email)}`,
       { permission },
+      { context: this.requestContext() },
     );
   }
 
   removeShare(spaceId: string, email: string): Observable<void> {
     return this.http.delete<void>(
       `${this.baseUrl()}/${spaceId}/shares/${encodeURIComponent(email)}`,
+      { context: this.requestContext() },
     );
   }
 }


### PR DESCRIPTION
Reported in production: opening the app pops an error dialog reading `404 Not Found — https://boisestate.ai/api/memory/spaces`.

## The 404 is correct. The dialog is not.

Memory Spaces is deliberately dark-stopped in production (`CDK_MEMORY_SPACES_ENABLED=false` on the `production` environment, set 2026-08-01; issue #812 holds the questions blocking rollout). [routes.py:84](backend/src/apis/app_api/memory_spaces/routes.py:84) returns **404 by design** when the flag is off, so the surface behaves as if the feature does not exist. The live prod task definition carries `MEMORY_SPACES_ENABLED=false`; this is the switch working.

It only became visible now because the variable is *deploy-time* and 1.12.0's `platform.yml` run rolled back. The first platform deploy to reach production since it was set was 1.12.1 (#816), which is when the switch actually landed.

The SPA half already handles this. [memory-space.service.ts:55](frontend/ai.client/src/app/memory-spaces/services/memory-space.service.ts:55) treats a 404 as "feature unavailable", clears state and drops the nav entry — the comment there says "fail gracefully rather than surfacing an error."

What defeats it is [error.interceptor.ts:65](frontend/ai.client/src/app/auth/error.interceptor.ts:65): it toasts **every** non-401 unless the URL contains `/health` or `/ping`, or the request sets `SUPPRESS_ERROR_TOAST`. `MemorySpaceApiService` never set it. So the feature hides itself and then announces that it had.

## The change

`SUPPRESS_ERROR_TOAST` on every Memory Spaces request, via a shared `requestContext()` helper — the same idiom as [file-source.service.ts:68](frontend/ai.client/src/app/assistants/services/file-source.service.ts:68).

Applied to the whole service, not just `list()`. A dark-stopped environment 404s every one of these endpoints, and a deep link to a space detail page hits `get` / `listEntries` without ever calling `list`.

Suppression costs nothing for genuine failures. `MemorySpaceService` already translates every non-404 into its own `error$` signal, which the pages render inline and in context; the generic toast was only ever a duplicate of that.

## Tests

New `memory-space-api.service.spec.ts` — a table-driven assertion that all fourteen methods set the token, plus two guards that the existing `params` and `responseType: 'blob'` options survived being merged with `context`.

- `npx ng test` — **163 files, 1807 tests, all passing** (full suite, not `--include`-scoped; a scoped run changes bundling and can mask cross-file issues).

Verified by unit test rather than in the browser: `localhost:4200` points at the dev backend, where Memory Spaces is deliberately still **enabled** for dogfooding, so the 404 path cannot be reproduced there without turning the feature off in dev.

## Scope

Frontend only. Does not touch the flag — Memory Spaces stays dark in production, as decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)