### PR TITLE
fix(assistants): degrade user-facing GSI reads to empty when the index is missing

### DIFF
--- a/backend/src/apis/shared/assistants/listing_repository.py
+++ b/backend/src/apis/shared/assistants/listing_repository.py
@@ -30,11 +30,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .models import AgentListing
 from .serialization import from_ddb, to_ddb_safe
+from apis.shared.dynamo_errors import is_missing_index_error, log_missing_index
 
 logger = logging.getLogger(__name__)
 
 # Attributes this module owns. Nothing else writes them.
 _GSI5_ATTRS = ("GSI5_PK", "GSI5_SK")
+
+# GSI5. Named once so the query and the "it isn't there" log cannot drift apart.
+_STORE_INDEX = "AgentDirectoryIndex"
 
 
 def _table():
@@ -219,11 +223,17 @@ async def query_store(
     ``ScanIndexForward=False`` gives newest-first, since ``GSI5_SK`` is
     ``CREATED#{created_at}``. There is no popularity sort — the store front is the
     manual ranking lever instead (see the spec's ranking caveat).
+
+    **An absent index degrades to an empty shelf**, on the same reasoning as a malformed
+    cursor below: GSI5 can legitimately not exist yet, and this read is not important
+    enough to 500 over when it doesn't. See ``apis.shared.dynamo_errors`` for the deploy
+    states that produce it and for the production incident that made it worth handling.
     """
     from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
 
     params: Dict[str, Any] = {
-        "IndexName": "AgentDirectoryIndex",
+        "IndexName": _STORE_INDEX,
         "KeyConditionExpression": Key("GSI5_PK").eq(f"LISTED#{category}"),
         "ScanIndexForward": False,
         "Limit": limit,
@@ -233,7 +243,14 @@ async def query_store(
         if decoded:
             params["ExclusiveStartKey"] = decoded
 
-    response = _table().query(**params)
+    try:
+        response = _table().query(**params)
+    except ClientError as e:
+        if is_missing_index_error(e):
+            log_missing_index(_STORE_INDEX, "the agent store browse")
+            return [], None
+        raise
+
     items = [from_ddb(item) for item in response.get("Items", [])]
     next_cursor = _encode_cursor(response.get("LastEvaluatedKey"))
     return items, next_cursor

--- a/backend/src/apis/shared/assistants/reports.py
+++ b/backend/src/apis/shared/assistants/reports.py
@@ -50,11 +50,15 @@ import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from .models import AgentReport, ReportReason
+from apis.shared.dynamo_errors import is_missing_index_error, log_missing_index
 from apis.shared.timestamps import utc_now_iso
 
 logger = logging.getLogger(__name__)
 
 _SK_PREFIX = "REPORT#"
+
+# GSI6. Named once so the two queries and their "it isn't there" logs cannot drift apart.
+_REPORTS_INDEX = "AgentReportsIndex"
 
 # The single open-queue partition (D15). One partition is correct here and would not be
 # for the directory: the queue is bounded by how fast admins work, it is read only by the
@@ -302,15 +306,29 @@ async def list_open_reports(limit: int = 200) -> List[AgentReport]:
     Oldest-first because this is a work queue, not a feed: the report that has waited
     longest is the one to triage next. It cannot return a resolved report, because a
     resolved report has no key in this index.
+
+    **An absent index degrades to an empty queue.** GSI6 can legitimately not exist yet
+    (see ``apis.shared.dynamo_errors``), and an admin console that renders "nothing to
+    triage" is a better failure than one that renders an error page. This read is the
+    right place for that: the *writes* above still fail loudly, so a report filed while
+    the index is missing is still stored — it simply arrives in the queue once GSI6 does.
     """
     from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
 
-    response = _table().query(
-        IndexName="AgentReportsIndex",
-        KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
-        ScanIndexForward=True,
-        Limit=limit,
-    )
+    try:
+        response = _table().query(
+            IndexName=_REPORTS_INDEX,
+            KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
+            ScanIndexForward=True,
+            Limit=limit,
+        )
+    except ClientError as e:
+        if is_missing_index_error(e):
+            log_missing_index(_REPORTS_INDEX, "the admin problem-report queue")
+            return []
+        raise
+
     return [_to_report(item) for item in response.get("Items", [])]
 
 
@@ -318,14 +336,25 @@ async def count_open_reports() -> int:
     """How many reports await triage — the D10 nav badge.
 
     ``Select=COUNT`` so the badge never pays to project rows nobody renders.
+
+    Degrades to ``0`` on a missing index, matching ``list_open_reports`` — a badge and the
+    queue it links to disagreeing would be worse than either being empty.
     """
     from boto3.dynamodb.conditions import Key
+    from botocore.exceptions import ClientError
 
-    response = _table().query(
-        IndexName="AgentReportsIndex",
-        KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
-        Select="COUNT",
-    )
+    try:
+        response = _table().query(
+            IndexName=_REPORTS_INDEX,
+            KeyConditionExpression=Key("GSI6_PK").eq(_OPEN_PK),
+            Select="COUNT",
+        )
+    except ClientError as e:
+        if is_missing_index_error(e):
+            log_missing_index(_REPORTS_INDEX, "the admin problem-report badge")
+            return 0
+        raise
+
     return int(response.get("Count", 0))
 
 

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Tuple
 
 from .models import AgentBinding, AgentModelConfig, Assistant
 from .serialization import from_ddb, to_ddb_safe
+from apis.shared.dynamo_errors import is_missing_index_error, log_missing_index
 from apis.shared.timestamps import to_iso, utc_now_iso
 
 logger = logging.getLogger(__name__)
@@ -853,8 +854,14 @@ async def _list_user_assistants_cloud(
         return all_assistants, next_page_token
 
     except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        logger.error(f"Failed to list user assistants from DynamoDB: {error_code} - {e}")
+        # Already fail-soft for every ``ClientError``; the missing-index case is split out
+        # only so the log names the index rather than leaving someone to decode a botocore
+        # repr while a deploy is half-landed.
+        if is_missing_index_error(e):
+            log_missing_index("OwnerStatusIndex", "this user's own agents")
+        else:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            logger.error(f"Failed to list user assistants from DynamoDB: {error_code} - {e}")
         return [], None
     except Exception as e:
         logger.error(f"Failed to list user assistants from DynamoDB: {e}", exc_info=True)
@@ -1432,9 +1439,12 @@ async def list_shared_with_user(user_email: str) -> List[Assistant]:
         return assistants
 
     except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        if error_code == "ResourceNotFoundException":
-            logger.debug(f"SharedWithIndex GSI not found - sharing feature may not be deployed yet")
+        # The "not deployed yet" case used to be matched on ``ResourceNotFoundException``,
+        # which real DynamoDB never raises for a missing *index* — it raises
+        # ``ValidationException``, so that branch only ever fired under moto and the
+        # intended debug-level path logged at ERROR in production instead.
+        if is_missing_index_error(e):
+            log_missing_index("SharedWithIndex", "agents shared with this user")
         else:
             logger.error(f"Error listing shared assistants: {e}")
         return []

--- a/backend/src/apis/shared/dynamo_errors.py
+++ b/backend/src/apis/shared/dynamo_errors.py
@@ -1,0 +1,94 @@
+"""Recognizing the one DynamoDB error that a user-facing read should absorb.
+
+**A missing GSI is a deploy state, not a bug.** An index the code queries can be absent
+for several ordinary reasons, none of which mean the request is malformed:
+
+* CloudFormation reports ``CREATE_COMPLETE`` while a new GSI is still ``CREATING`` — the
+  stack is done, the index is not yet queryable.
+* A CloudFormation deploy rolls back for an unrelated reason, taking the new indexes with
+  it while the already-built container images ship anyway.
+* ``platform.yml`` (infrastructure) and ``backend.yml`` (application) are separate
+  workflows. Nothing orders them, so backend code can reach production first.
+
+All three happened at once on 2026-08-01: release 1.12.0's CloudFormation deploy rolled
+back on an unrelated DynamoDB limit, the backend and frontend shipped regardless, and the
+agent store — whose navigation gate had just opened to everyone in that same release —
+returned a 500 to every user until the infrastructure was repaired two releases later. An
+empty shelf would have been a bad day; an error page for the feature's GA was a worse one.
+
+**The match is deliberately narrow.** Two failure modes are worth naming:
+
+* Swallowing every ``ValidationException`` would hide real query bugs — a malformed key
+  condition, a reserved word used unescaped, a bad ``ExclusiveStartKey`` — behind a
+  permanently empty result set that nobody would ever debug.
+* Swallowing every ``ClientError`` would turn throttling (``ProvisionedThroughputExceeded``)
+  into "there is nothing here", which is a *lie about the data* rather than a degradation.
+
+So both the error code and the message shape have to line up before this returns True.
+
+**Two error codes, because the two DynamoDB implementations disagree.** Real DynamoDB
+raises ``ValidationException`` ("The table does not have the specified index: X"); moto,
+which every test in this repo runs against, raises ``ResourceNotFoundException``
+("Invalid index: X for table: Y"). Matching only the production spelling would leave the
+degradation path untestable, and matching only the code would swallow the genuinely
+distinct "table does not exist" ``ResourceNotFoundException`` — hence the message check,
+which is what actually distinguishes them.
+
+⚠️ **For reads only.** A write path or an admin mutation that cannot find its index should
+fail loudly: pretending a write succeeded is unrecoverable in a way that pretending a shelf
+is empty is not.
+"""
+
+import logging
+from typing import Any
+
+__all__ = ["is_missing_index_error", "log_missing_index"]
+
+logger = logging.getLogger(__name__)
+
+# Only these two can mean "the index isn't there". Anything else — throttling, access
+# denied, a conditional check — is a real failure and must propagate.
+_MISSING_INDEX_CODES = ("ValidationException", "ResourceNotFoundException")
+
+# Lowercased fragments of the two known messages. The message is what separates a missing
+# *index* from a missing *table* (which shares ``ResourceNotFoundException`` but reads
+# "Requested resource not found") and from every other ``ValidationException``.
+_MISSING_INDEX_MARKERS = (
+    "does not have the specified index",  # real DynamoDB
+    "invalid index",  # moto
+)
+
+
+def is_missing_index_error(error: Any) -> bool:
+    """True when ``error`` is a botocore ``ClientError`` meaning "that index isn't there".
+
+    Takes ``Any`` rather than ``ClientError`` so callers need not import botocore just to
+    type the parameter; a non-``ClientError`` simply has no ``response`` dict and returns
+    False.
+    """
+    response = getattr(error, "response", None)
+    if not isinstance(response, dict):
+        return False
+
+    err = response.get("Error") or {}
+    if err.get("Code") not in _MISSING_INDEX_CODES:
+        return False
+
+    message = str(err.get("Message", "")).lower()
+    return any(marker in message for marker in _MISSING_INDEX_MARKERS)
+
+
+def log_missing_index(index_name: str, surface: str) -> None:
+    """Record a degraded read at WARNING, naming the index so it is actionable.
+
+    WARNING rather than ERROR: the request was served, and paging someone at 3am for a
+    deploy that is still settling would train them to ignore the alert. WARNING rather
+    than INFO because an index that is *permanently* missing means a surface is silently
+    serving nothing, and that has to be visible in the logs without knowing to look.
+    """
+    logger.warning(
+        f"⚠️ DynamoDB index '{index_name}' does not exist — serving an empty result for "
+        f"{surface}. Expected transiently while a GSI is CREATING or a deploy is "
+        f"incomplete; if this persists, the index is missing and {surface} is showing "
+        f"nothing."
+    )

--- a/backend/tests/shared/test_dynamo_missing_index.py
+++ b/backend/tests/shared/test_dynamo_missing_index.py
@@ -1,0 +1,352 @@
+"""A missing GSI degrades user-facing reads to empty instead of 500ing.
+
+This regression exists because it shipped: on 2026-08-01, release 1.12.0's CloudFormation
+deploy rolled back on an unrelated DynamoDB limit while the backend and frontend shipped
+anyway, so ``AgentDirectoryIndex`` and ``AgentReportsIndex`` were absent in production.
+The agent store — GA'd to every user in that same release — returned a 500 on every page
+load until the infrastructure was repaired two releases later.
+
+Two properties are worth pinning, and they pull in opposite directions:
+
+* **The reads degrade.** A missing index must produce an empty shelf / empty queue, not an
+  exception. A refactor that drops the ``except`` block is the regression.
+* **The match stays narrow.** It would be trivially easy to "fix" this by catching every
+  ``ClientError``, at which point a throttle or a malformed key condition also produces an
+  empty result — a permanently silent surface nobody would think to debug. The narrowness
+  tests below fail on that "fix".
+
+Both wire spellings are covered. Moto raises ``ResourceNotFoundException`` ("Invalid index:
+X for table: Y"); real DynamoDB raises ``ValidationException`` ("The table does not have
+the specified index: X"). Only moto's is reachable by actually dropping the index from the
+fixture, so the production spelling is injected directly — testing only what moto emits
+would leave the code path that actually fired in production unexercised.
+"""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from apis.shared.assistants.listing_repository import query_store
+from apis.shared.assistants.reports import (
+    count_open_reports,
+    list_open_reports,
+    submit_report,
+)
+from apis.shared.dynamo_errors import is_missing_index_error
+
+REGION = "us-east-1"
+TABLE = "test-rag-assistants"
+AGENT = "ast-001"
+CATEGORY = "productivity"
+
+
+def _client_error(code: str, message: str, operation: str = "Query") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, operation)
+
+
+# The two messages that actually mean "that index is not there".
+_REAL_DDB = _client_error(
+    "ValidationException",
+    "The table does not have the specified index: AgentDirectoryIndex",
+)
+_MOTO = _client_error(
+    "ResourceNotFoundException",
+    "Invalid index: AgentDirectoryIndex for table: test-rag-assistants. "
+    "Available indexes are: ",
+)
+
+
+# ── the matcher: what it accepts ─────────────────────────────────────────────────────
+@pytest.mark.parametrize("error", [_REAL_DDB, _MOTO], ids=["real-dynamodb", "moto"])
+def test_both_wire_spellings_of_a_missing_index_are_recognized(error):
+    assert is_missing_index_error(error) is True
+
+
+# ── the matcher: what it must NOT accept ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "error,why",
+    [
+        (
+            _client_error(
+                "ValidationException",
+                "Query condition missed key schema element: GSI5_PK",
+            ),
+            "a malformed key condition is a code bug, not a deploy state",
+        ),
+        (
+            _client_error(
+                "ValidationException",
+                "Invalid attribute value type",
+            ),
+            "a bad ExclusiveStartKey must not silently empty the shelf",
+        ),
+        (
+            _client_error(
+                "ValidationException",
+                "Attribute name is a reserved keyword; reserved keyword: state",
+            ),
+            "an unescaped reserved word is a code bug",
+        ),
+        (
+            _client_error("ResourceNotFoundException", "Requested resource not found"),
+            "a missing *table* shares the code but is a misconfiguration, not a lag",
+        ),
+        (
+            _client_error(
+                "ProvisionedThroughputExceededException",
+                "The level of configured provisioned throughput for the table was exceeded",
+            ),
+            "throttling means 'ask again', never 'there is nothing here'",
+        ),
+        (
+            _client_error("AccessDeniedException", "User is not authorized to perform: dynamodb:Query"),
+            "a missing IAM grant must be loud",
+        ),
+        (
+            _client_error("ThrottlingException", "Rate of requests exceeds the allowed throughput"),
+            "same as above",
+        ),
+    ],
+)
+def test_narrow_match_leaves_every_other_failure_loud(error, why):
+    assert is_missing_index_error(error) is False, why
+
+
+def test_a_non_client_error_is_not_a_missing_index():
+    """The helper takes ``Any``, so a stray exception must not read as a deploy lag."""
+    assert is_missing_index_error(ValueError("boom")) is False
+    assert is_missing_index_error(None) is False
+
+
+# ── fixtures: the same table, with and without its indexes ───────────────────────────
+def _make_table(monkeypatch, *, gsis):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+
+    ddb = boto3.resource("dynamodb", region_name=REGION)
+    attrs = [
+        {"AttributeName": "PK", "AttributeType": "S"},
+        {"AttributeName": "SK", "AttributeType": "S"},
+    ]
+    definitions = {
+        "AgentDirectoryIndex": ("GSI5_PK", "GSI5_SK"),
+        "AgentReportsIndex": ("GSI6_PK", "GSI6_SK"),
+    }
+    index_params = []
+    for name in gsis:
+        pk, sk = definitions[name]
+        attrs.extend(
+            [
+                {"AttributeName": pk, "AttributeType": "S"},
+                {"AttributeName": sk, "AttributeType": "S"},
+            ]
+        )
+        index_params.append(
+            {
+                "IndexName": name,
+                "KeySchema": [
+                    {"AttributeName": pk, "KeyType": "HASH"},
+                    {"AttributeName": sk, "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        )
+
+    params = dict(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=attrs,
+        BillingMode="PAY_PER_REQUEST",
+    )
+    if index_params:
+        params["GlobalSecondaryIndexes"] = index_params
+    ddb.create_table(**params)
+    return ddb.Table(TABLE)
+
+
+@pytest.fixture()
+def indexed_table(monkeypatch):
+    """The table as production is *supposed* to have it — both GSIs present."""
+    with mock_aws():
+        yield _make_table(monkeypatch, gsis=["AgentDirectoryIndex", "AgentReportsIndex"])
+
+
+@pytest.fixture()
+def unindexed_table(monkeypatch):
+    """The table as production actually had it on 2026-08-01 — neither GSI built."""
+    with mock_aws():
+        yield _make_table(monkeypatch, gsis=[])
+
+
+def _seed_shelf_row(table, agent_id: str = AGENT, created_at: str = "2026-01-01T00:00:00.000000"):
+    """A published ``VERSION#`` row carrying the GSI5 keys browse reads."""
+    table.put_item(
+        Item={
+            "PK": f"AST#{agent_id}",
+            "SK": "VERSION#000001",
+            "assistantId": agent_id,
+            "name": "An Agent",
+            "GSI5_PK": f"LISTED#{CATEGORY}",
+            "GSI5_SK": f"CREATED#{created_at}",
+        }
+    )
+
+
+# ── the store browse ─────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_store_browse_returns_the_shelf_when_the_index_exists(indexed_table):
+    """The normal path, so a degradation that always fires cannot pass as a fix."""
+    _seed_shelf_row(indexed_table)
+
+    items, cursor = await query_store(CATEGORY)
+
+    assert [item["assistantId"] for item in items] == [AGENT]
+    assert cursor is None
+
+
+@pytest.mark.asyncio
+async def test_store_browse_serves_an_empty_shelf_when_the_index_is_missing(unindexed_table):
+    """The 2026-08-01 incident: this returned a 500 to every user on the store's GA."""
+    _seed_shelf_row(unindexed_table)
+
+    items, cursor = await query_store(CATEGORY)
+
+    assert items == []
+    assert cursor is None
+
+
+@pytest.mark.asyncio
+async def test_store_browse_logs_the_index_name_when_it_degrades(unindexed_table, caplog):
+    """An empty shelf with no log is indistinguishable from an empty store."""
+    with caplog.at_level("WARNING"):
+        await query_store(CATEGORY)
+
+    assert "AgentDirectoryIndex" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_store_browse_degrades_on_the_production_error_spelling(indexed_table, monkeypatch):
+    """Moto cannot produce ``ValidationException``, which is what actually fired in prod."""
+    import apis.shared.assistants.listing_repository as repo
+
+    class _Raises:
+        def query(self, **_kwargs):
+            raise _REAL_DDB
+
+    monkeypatch.setattr(repo, "_table", lambda: _Raises())
+
+    assert await query_store(CATEGORY) == ([], None)
+
+
+@pytest.mark.asyncio
+async def test_store_browse_still_raises_on_an_unrelated_failure(indexed_table, monkeypatch):
+    """The narrowness property, at the call site rather than only in the matcher."""
+    import apis.shared.assistants.listing_repository as repo
+
+    throttled = _client_error(
+        "ProvisionedThroughputExceededException",
+        "The level of configured provisioned throughput for the table was exceeded",
+    )
+
+    class _Raises:
+        def query(self, **_kwargs):
+            raise throttled
+
+    monkeypatch.setattr(repo, "_table", lambda: _Raises())
+
+    with pytest.raises(ClientError):
+        await query_store(CATEGORY)
+
+
+# ── the admin report queue ───────────────────────────────────────────────────────────
+async def _file_report(agent_id: str = AGENT):
+    return await submit_report(
+        agent_id,
+        reporter_id="user-reporter",
+        reporter_name="Rae Reporter",
+        reason="broken",
+        note="It errors out",
+    )
+
+
+@pytest.mark.asyncio
+async def test_report_queue_returns_open_reports_when_the_index_exists(indexed_table):
+    await _file_report()
+
+    assert [r.agent_id for r in await list_open_reports()] == [AGENT]
+    assert await count_open_reports() == 1
+
+
+@pytest.mark.asyncio
+async def test_report_queue_is_empty_rather_than_broken_when_the_index_is_missing(
+    unindexed_table,
+):
+    """The write still succeeds — only the indexed *read* degrades."""
+    report, replaced = await _file_report()
+    assert report.agent_id == AGENT and replaced is False
+
+    assert await list_open_reports() == []
+    assert await count_open_reports() == 0
+
+    # …and the report is genuinely stored, so it joins the queue once GSI6 exists.
+    stored = unindexed_table.get_item(
+        Key={"PK": f"AST#{AGENT}", "SK": f"REPORT#{report.report_id}"}
+    ).get("Item")
+    assert stored is not None and stored["state"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_report_queue_logs_the_index_name_when_it_degrades(unindexed_table, caplog):
+    with caplog.at_level("WARNING"):
+        await list_open_reports()
+        await count_open_reports()
+
+    assert caplog.text.count("AgentReportsIndex") == 2
+
+
+@pytest.mark.asyncio
+async def test_report_queue_degrades_on_the_production_error_spelling(
+    indexed_table, monkeypatch
+):
+    import apis.shared.assistants.reports as reports_module
+
+    missing = _client_error(
+        "ValidationException",
+        "The table does not have the specified index: AgentReportsIndex",
+    )
+
+    class _Raises:
+        def query(self, **_kwargs):
+            raise missing
+
+    monkeypatch.setattr(reports_module, "_table", lambda: _Raises())
+
+    assert await list_open_reports() == []
+    assert await count_open_reports() == 0
+
+
+@pytest.mark.asyncio
+async def test_report_queue_still_raises_on_an_unrelated_failure(indexed_table, monkeypatch):
+    import apis.shared.assistants.reports as reports_module
+
+    denied = _client_error(
+        "AccessDeniedException", "User is not authorized to perform: dynamodb:Query"
+    )
+
+    class _Raises:
+        def query(self, **_kwargs):
+            raise denied
+
+    monkeypatch.setattr(reports_module, "_table", lambda: _Raises())
+
+    with pytest.raises(ClientError):
+        await list_open_reports()
+    with pytest.raises(ClientError):
+        await count_open_reports()


### PR DESCRIPTION
## Problem

Two marketplace read paths queried a DynamoDB GSI with no handling for the index being absent, so an infrastructure lag surfaced to users as a **500**:

- [`listing_repository.py`](backend/src/apis/shared/assistants/listing_repository.py) — `AgentDirectoryIndex` (GSI5), the agent store browse
- [`reports.py`](backend/src/apis/shared/assistants/reports.py) — `AgentReportsIndex` (GSI6), the admin problem-report queue and its nav badge

An absent index is a legitimate transient deploy state, not a programming error. CloudFormation reports success while a GSI is still `CREATING`, deploys can roll back, and `platform.yml` and `backend.yml` are separate workflows that can land out of order.

All three converged on **2026-08-01**: release 1.12.0's CloudFormation deploy rolled back on an unrelated DynamoDB limit, the backend and frontend shipped anyway, and both indexes were missing. The agent store — whose navigation gate opened to GA in that same release — returned 500 for every user until the infrastructure was repaired across two follow-up releases.

Neither read is critical enough to justify a hard failure. An empty shelf or an empty admin queue is a far better degradation than an error page.

## Change

New `apis/shared/dynamo_errors.py` with `is_missing_index_error()` / `log_missing_index()`. Both reads now catch the missing-index case, log it at **WARNING** with the index name, and return an empty result with no cursor.

**The match is deliberately narrow.** Both the error code *and* the message shape have to line up:

- Swallowing every `ValidationException` would hide malformed key conditions, unescaped reserved words, and bad `ExclusiveStartKey`s behind a permanently empty surface nobody would think to debug.
- Swallowing every `ClientError` would turn throttling into "there is nothing here" — a lie about the data rather than a degradation.

Two error codes are accepted because the implementations disagree: real DynamoDB raises `ValidationException` ("The table does not have the specified index: X"), moto raises `ResourceNotFoundException` ("Invalid index: X for table: Y"). Matching only the production spelling would leave the degradation untestable; matching on code alone would swallow the genuinely distinct "table does not exist".

## Audit of the other GSIs on this table

| Index | Disposition |
|---|---|
| `SharedWithIndex` | Already returned `[]` on any `ClientError`, so it already degraded. But its "not deployed yet" branch matched `ResourceNotFoundException` — which real DynamoDB never raises for a missing index — so it only ever fired under moto, and production logged at ERROR instead. Now routed through the shared helper. **No behaviour change**, just a correct log. |
| `OwnerStatusIndex` | Same: already fail-soft. Split the missing-index case out so the log names the index rather than leaving someone to decode a botocore repr mid-deploy. **No behaviour change.** |
| `DueSyncIndex` | **Deliberately left loud.** The KB sync dispatcher is a background sweep, not a user-facing read — silently returning nothing means scheduled syncs stop with only a warning line, where a raised error is visible as a Lambda failure. |
| `VisibilityStatusIndex` | No read path exists. GSI2 keys are written; nothing queries the index. |

Writes and admin mutations are untouched and still fail loudly — pretending a write succeeded is unrecoverable in a way that pretending a shelf is empty is not. The report-queue test asserts this explicitly: filing a report while GSI6 is missing still stores it, so it joins the queue once the index exists.

## Tests

New [`tests/shared/test_dynamo_missing_index.py`](backend/tests/shared/test_dynamo_missing_index.py) — 20 tests pinning two properties that pull in opposite directions:

- **The reads degrade.** Missing index → empty shelf / empty queue / zero badge, against a real moto table built *without* the GSIs. The normal path is covered alongside each, so a degradation that always fires cannot pass as a fix.
- **The match stays narrow.** Seven non-matching errors (malformed key condition, bad attribute value, reserved keyword, missing *table*, provisioned-throughput, throttling, access-denied) must still raise — asserted both in the matcher and at each call site.

The production `ValidationException` spelling is injected directly, since moto cannot produce it; testing only what moto emits would leave the exact code path that fired in production unexercised.

```
5688 passed, 3 skipped in 378s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)