### PR TITLE
feat(release): pre-merge guard for DynamoDB's one-GSI-per-UpdateTable limit

### DIFF
--- a/.claude/skills/cutting-a-release/SKILL.md
+++ b/.claude/skills/cutting-a-release/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   ship, or prep a release, bump the version, or update RELEASE_NOTES.md /
   CHANGELOG.md — e.g. "let's cut a release", "make a new release", "bump the
   version and update the release notes", "ship the next version". Covers the
-  release-branch workflow, the SemVer bump + version sync, identifying what
-  changed across the divergent main/develop histories, writing the changelog and
-  release notes sized to the release, the squash-merge PR into main, and the
-  required backmerge into develop.
+  release-branch workflow, the pre-merge DynamoDB GSI check, the SemVer bump +
+  version sync, identifying what changed across the divergent main/develop
+  histories, writing the changelog and release notes sized to the release, the
+  squash-merge PR into main, and the required backmerge into develop.
 ---
 
 # Cutting a Release
@@ -18,7 +18,7 @@ Single source of truth for cutting a release. Three concerns move together: the
 (`RELEASE_NOTES.md` + `CHANGELOG.md`). Do the steps in order, all on one
 `release/x.y.z` branch cut from `develop`.
 
-Detailed format templates live in reference files — load them when you reach §5:
+Detailed format templates live in reference files — load them when you reach §6:
 
 - Release-notes structure, section order, and spotlight template →
   [references/release-notes-format.md](references/release-notes-format.md)
@@ -47,12 +47,141 @@ Two hard rules of this repo's branch model:
 1. **Never commit directly to `develop` or `main`.** Both are PR-only — the
    release bump and the backmerge each land through a branch + PR.
 2. **After the squash-merge into `main`, you MUST backmerge `main` → `develop`**
-   (§6). Skipping it leaves the branches divergent and every future release
+   (§7). Skipping it leaves the branches divergent and every future release
    conflicts on the release-artifact files.
 
 ---
 
-## 1. Branch workflow
+## 1. Pre-merge prerequisite — the DynamoDB GSI limit
+
+**Ask before opening the release PR: does any table that ALREADY EXISTS in
+production gain more than one Global Secondary Index in this release?**
+
+If yes, the release **must be split into two deploys** — ship one index, wait for
+it to report `ACTIVE`, then ship the next. That split has to happen **before the
+merge**, not after a rollback.
+
+### Why one is the limit
+
+DynamoDB's `UpdateTable` API permits **exactly one GSI creation or deletion per
+call**. CloudFormation issues one `UpdateTable` per changed table, so a template
+that adds two indexes to an existing table fails with:
+
+```
+Cannot perform more than one GSI creation or deletion in a single update
+```
+
+The limit applies to **`UpdateTable` only**. `CreateTable` accepts any number of
+indexes, so **a brand-new table with five GSIs is fine** — which is exactly why
+the question is "does an *existing* table gain more than one?" and not "are there
+new indexes?".
+
+The blast radius is the whole stack, not the table: when the update fails,
+CloudFormation rolls back **every other resource in the deploy** with it.
+Meanwhile `backend.yml` and `frontend-deploy.yml` are separate workflows that
+succeed on their own, so the release ends up running **new application code
+against old infrastructure**.
+
+### Why an incremental environment cannot reveal this
+
+`dev` deploys on every merge into `develop`. Two indexes that arrive in two
+separate PRs therefore get **two separate platform deploys**, one index each —
+both succeed, and dev looks completely healthy.
+
+`main` only ever sees the *aggregate*. A release collapses a whole batch of
+merges into a single CloudFormation update, so the two indexes that dev applied
+one at a time arrive at prod **in the same `UpdateTable` call**. Only an
+environment that jumps a whole release at once is exposed, which means **no
+amount of dev soak time will surface it** and passing CI proves nothing here.
+Reviewing the release diff is the only place it can be caught.
+
+> **This is what took production down on 2026-08-01.** Release 1.12.0 (#814)
+> added `AgentDirectoryIndex` and `AgentReportsIndex` to the existing
+> `{prefix}-rag-assistants` table in one update. They had reached `develop` in
+> separate merges (`02d0f2e9`, `a128831d`) and dev had deployed each one
+> cleanly. The prod update failed, rolled back the rest of the deploy including a
+> brand-new audit-log table, and left the agent store returning 500 against
+> already-deployed new code. Recovery took two more patch releases. The 1.12.0
+> release notes *did* flag GSI backfill timing — but not the per-update limit.
+
+### How to check
+
+CI enforces this on every PR into `main` (`.github/workflows/gsi-update-limit.yml`).
+To check locally before you open the PR:
+
+```bash
+node scripts/release/check-gsi-update-limit.mjs
+```
+
+It diffs `infrastructure/gsi-inventory.json` — a committed, synth-generated
+inventory of every DynamoDB table and its indexes — between `origin/main` and
+your branch, and fails when a table present in **both** needs more than one index
+operation. Tables that appear only on your branch are exempt (`CreateTable`), as
+are tables dropped entirely (`DeleteTable`).
+
+Note it counts **creations and deletions together**, because the API limit is one
+GSI *operation* per update: renaming an index — one add plus one drop — fails
+exactly like adding two does.
+
+The inventory is regenerated and verified by the infrastructure test suite, so a
+GSI added in code without the inventory updated fails `npx jest` first:
+
+```bash
+cd infrastructure && UPDATE_GSI_INVENTORY=1 npx jest gsi-update-limit
+```
+
+> The check reports **SKIPPED** when `main` has no inventory to diff against —
+> true only until the first release carrying `gsi-inventory.json` lands. For that
+> one release, answer the question by reading the diff yourself.
+
+**The automation does not replace the question.** It compares committed
+inventories, so it only sees what `git` sees. Read the `gsi-inventory.json` diff
+in the release PR: one added line under an existing table is fine, two is a split.
+
+### If the answer is yes — split the release
+
+Ship the indexes in separate releases, each merged and deployed on its own:
+
+1. Release N carries **one** of the new indexes. Merge, deploy, and confirm the
+   index reports `ACTIVE` before continuing — CloudFormation reporting
+   `UPDATE_COMPLETE` is **not** the same as the index being usable:
+
+   ```bash
+   aws dynamodb describe-table --table-name <prefix>-rag-assistants \
+     --query 'Table.GlobalSecondaryIndexes[].{Name:IndexName,Status:IndexStatus}'
+   ```
+
+2. Release N+1 adds the second index, once the first is `ACTIVE`.
+
+Prefer doing this **on the release branch before the merge**: drop the second
+index from the release branch, ship it, then restore it in the next release.
+
+### Recovery, if it has already failed
+
+Each half needs its **own patch release** — there is no way to ship them as one
+PR and no way to skip the version bump. `.github/workflows/version-check.yml`
+fails any PR into `main` whose `VERSION` is unchanged, and it has **no label,
+flag, or skip path**. So a failed two-index deploy costs two patch releases
+(1.12.0 → 1.12.1 added the first index alone, 1.12.2 restored the second).
+
+> **Do NOT stack PR 2 on PR 1.** After PR 1 squash-merges into `main`, the
+> merge-base for a branch cut from PR 1 does not move. PR 1's removal and PR 2's
+> restoration then **cancel out in the three-dot diff GitHub shows and merges** —
+> the PR looks correct, CI passes, and the restore silently no-ops. The index
+> never comes back.
+>
+> Open PR 2 **only after PR 1 has merged**, branched fresh from `main`, as a
+> `git revert` of PR 1's squash commit:
+>
+> ```bash
+> git fetch origin main
+> git switch -c release/x.y.z origin/main
+> git revert --no-commit <pr-1-squash-sha>   # restores the second index
+> ```
+
+---
+
+## 2. Branch workflow
 
 ```bash
 git switch develop
@@ -63,8 +192,8 @@ git switch -c release/x.y.z           # branch name == version being shipped (no
 The branch name **corresponds to the version being pushed** (`release/1.2.0` ships
 `1.2.0`) and carries **all commits currently on `develop`**.
 
-Then, on the release branch: create a task list, determine the bump (§3), bump
-`VERSION` + sync (§2), write both docs (§4–§5). Keep every edit on the release
+Then, on the release branch: create a task list, determine the bump (§4), bump
+`VERSION` + sync (§3), write both docs (§5–§6). Keep every edit on the release
 branch — `develop` stays untouched. Commit and push:
 
 ```bash
@@ -76,13 +205,13 @@ git commit -m "Release/x.y.z" -m "<one-paragraph summary + bullet notes>"
 git push -u origin release/x.y.z
 ```
 
-Open a PR `release/x.y.z` → `main`. After prerequisites + code review pass, it is
+Open a PR `release/x.y.z` → `main`. After prerequisites (§1) + code review pass, it is
 **squash-merged** into `main` (the version-check gate passes because `VERSION`
-changed). Then do the backmerge (§6).
+changed). Then do the backmerge (§7).
 
 ---
 
-## 2. Version bump
+## 3. Version bump
 
 Single `VERSION` file at the repo root is the source of truth. Format:
 `MAJOR.MINOR.PATCH[-PRERELEASE]` (SemVer 2.0), no `v` prefix.
@@ -105,7 +234,7 @@ versions).
 
 ---
 
-## 3. Decide the bump — SemVer + release sizing
+## 4. Decide the bump — SemVer + release sizing
 
 Pick the tier from what shipped, then size the write-up to match.
 
@@ -121,7 +250,7 @@ capability counts as user-facing → **minor**.
 
 ---
 
-## 4. Identify what changed (the divergent-history trap)
+## 5. Identify what changed (the divergent-history trap)
 
 `develop` is squash-merged → `main`, so **`main` and `develop` have divergent
 histories**; a squash collapses a whole release into one commit on `main` whose
@@ -165,7 +294,7 @@ refactors, typo/comment/formatter churn.
 
 ---
 
-## 5. Write the two documents
+## 6. Write the two documents
 
 Same pass, same categorized list. Write `CHANGELOG.md` first (factual log), then
 `RELEASE_NOTES.md` (narrative). Cross-check every changelog line maps to something
@@ -192,7 +321,7 @@ the new version above the untouched previous entries.
 
 ---
 
-## 6. Backmerge `main` → `develop` (required)
+## 7. Backmerge `main` → `develop` (required)
 
 After the release PR squash-merges into `main`, reconcile the branches — PR-based,
 you cannot push directly to `develop`.
@@ -233,16 +362,20 @@ anyway (VERSION + both docs correct, feature code intact) before committing.
 
 ---
 
-## 7. Common pitfalls
+## 8. Common pitfalls
 
-- **`git log main..develop`** returns all history, not the delta (§4) — use the
+- **Adding two GSIs to an existing table in one release** — `UpdateTable` allows
+  one per call, and dev's per-merge deploys never show it (§1). Split the release.
+- **Stacking the second GSI PR on the first** — the three-dot diff cancels the two
+  commits and the restore silently no-ops (§1). Revert off `main` instead.
+- **`git log main..develop`** returns all history, not the delta (§5) — use the
   prior release cut point.
 - **Trusting commit messages** — read the diff for non-trivial commits.
 - **Forgetting lockfiles** — `sync-version.sh` regenerates `uv.lock` + both
   `package-lock.json`; commit them or CI drifts.
 - **Squashing the backmerge** — recreates divergence; use a merge commit.
 - **Committing straight to `develop`/`main`** — both are PR-only.
-- **Padding a patch / starving a feature** — size the notes to the release (§3).
+- **Padding a patch / starving a feature** — size the notes to the release (§4).
 - **Inventing PR numbers or fragile `{#anchor}` links** — omit / use plain text.
 - **Skipping the backmerge** — the #1 cause of next-release conflict pain.
 

--- a/.github/workflows/gsi-update-limit.yml
+++ b/.github/workflows/gsi-update-limit.yml
@@ -1,0 +1,110 @@
+name: "GSI Update Limit"
+
+# Release gate for DynamoDB's one-GSI-per-UpdateTable limit.
+#
+# DynamoDB's UpdateTable API permits exactly ONE GSI creation or deletion per
+# call. CloudFormation issues one UpdateTable per changed table, so a template
+# that adds two indexes to an EXISTING table fails the deploy and rolls back
+# every other resource in the stack with it. CreateTable has no such limit, so
+# a brand-new table with many indexes is fine.
+#
+# This only ever triggers on PRs into `main`, because only `main` is exposed.
+# `develop` deploys on every merge, so two indexes arriving in two PRs get two
+# separate deploys — one index each — and both succeed. A release collapses
+# those merges into a single CloudFormation update, which is where the two
+# indexes finally meet. Dev soak time cannot surface this; the release diff is
+# the only place it can be caught.
+#
+# Release 1.12.0 hit exactly this on 2026-08-01 and took production down.
+# See .claude/skills/cutting-a-release/SKILL.md §1.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# Safe to cancel superseded runs: this workflow reads two JSON files and does
+# no AWS work, so there is no CloudFormation rollback hazard.
+concurrency:
+  group: gsi-update-limit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gsi-update-limit:
+    name: GSI Update Limit
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: |
+          git fetch origin main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      # Compares infrastructure/gsi-inventory.json — a committed, synth-generated
+      # inventory — between origin/main and this PR. No npm install and no CDK
+      # synth needed: the inventory for both sides is already in git.
+      #
+      # This gate assumes the PR's inventory actually matches its CDK code. That
+      # is enforced separately by infrastructure/test/gsi-update-limit.test.ts,
+      # which re-synthesizes the app and fails if the committed inventory has
+      # drifted. That test runs on every PR via ci.yml (run_infra), so both
+      # checks must be required for this gate to mean anything.
+      #
+      # Until a release carrying gsi-inventory.json has reached `main`, there is
+      # no baseline to diff against and this step reports SKIPPED rather than
+      # failing. Do the §1 check by hand for that first release.
+      - name: Check GSI update limit
+        id: gsi-check
+        continue-on-error: true
+        run: |
+          node scripts/release/check-gsi-update-limit.mjs --base origin/main \
+            2>&1 | tee /tmp/gsi-check-output.txt
+
+          # tee masks the script's exit status, so read it back from PIPESTATUS.
+          exit "${PIPESTATUS[0]}"
+
+      - name: Generate summary
+        if: always()
+        run: |
+          source scripts/common/summary.sh
+
+          if [ "${{ steps.gsi-check.outcome }}" = "success" ]; then
+            STATUS="success"
+          else
+            STATUS="failure"
+          fi
+
+          write_workflow_header "GSI Update Limit" "${STATUS}"
+
+          {
+            echo '```'
+            cat /tmp/gsi-check-output.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+            echo ""
+            if [ "${STATUS}" != "success" ]; then
+              echo "This release must be **split across two deploys** — ship one index,"
+              echo "wait for it to report \`ACTIVE\`, then ship the next. Do the split"
+              echo "**before merging**: see \`.claude/skills/cutting-a-release/SKILL.md\` §1."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Evaluate result
+        run: |
+          if [ "${{ steps.gsi-check.outcome }}" != "success" ]; then
+            echo "::error::This release would need more than one GSI operation on an existing DynamoDB table. DynamoDB rejects that and CloudFormation will roll back the entire stack update. Split the release — see .claude/skills/cutting-a-release/SKILL.md §1."
+            exit 1
+          fi
+          echo "GSI update-limit check passed."

--- a/infrastructure/gsi-inventory.json
+++ b/infrastructure/gsi-inventory.json
@@ -1,0 +1,89 @@
+{
+  "tables": {
+    "api-keys": [
+      "KeyHashIndex"
+    ],
+    "app-roles": [
+      "JwtRoleMappingIndex",
+      "ModelRoleMappingIndex",
+      "SkillOwnerIndex",
+      "ToolRoleMappingIndex"
+    ],
+    "audit-log": [
+      "ActorIndex",
+      "RecentIndex"
+    ],
+    "auth-providers": [
+      "EnabledProvidersIndex"
+    ],
+    "bff-sessions": [
+      "HeadlessGrantUserIndex"
+    ],
+    "fine-tuning-access": [],
+    "fine-tuning-jobs": [
+      "StatusIndex"
+    ],
+    "managed-models": [
+      "ModelIdIndex"
+    ],
+    "memory-spaces": [
+      "MemberIndex",
+      "OwnerIndex"
+    ],
+    "oauth-providers": [
+      "EnabledProvidersIndex"
+    ],
+    "oauth-user-tokens": [
+      "ProviderUsersIndex"
+    ],
+    "oidc-state": [],
+    "quota-events": [
+      "TierEventIndex"
+    ],
+    "rag-assistants": [
+      "AgentDirectoryIndex",
+      "AgentReportsIndex",
+      "DueSyncIndex",
+      "OwnerStatusIndex",
+      "SharedWithIndex",
+      "VisibilityStatusIndex"
+    ],
+    "sessions-metadata": [
+      "DueScheduleIndex",
+      "SessionLookupIndex",
+      "SessionRecencyIndex",
+      "UserTimestampIndex"
+    ],
+    "shared-conversations": [
+      "OwnerShareIndex",
+      "SessionShareIndex"
+    ],
+    "system-cost-rollup": [],
+    "system-prompts": [],
+    "user-artifacts": [
+      "SessionIndex"
+    ],
+    "user-cost-summary": [
+      "PeriodCostIndex"
+    ],
+    "user-file-uploads": [
+      "SessionIndex"
+    ],
+    "user-menu-links": [],
+    "user-quotas": [
+      "AppRoleAssignmentIndex",
+      "AssignmentTypeIndex",
+      "RoleAssignmentIndex",
+      "UserAssignmentIndex",
+      "UserOverrideIndex"
+    ],
+    "user-settings": [],
+    "users": [
+      "EmailDomainIndex",
+      "EmailIndex",
+      "StatusLoginIndex",
+      "UserIdIndex"
+    ],
+    "voice-ticket-replay": []
+  }
+}

--- a/infrastructure/test/gsi-update-limit.test.ts
+++ b/infrastructure/test/gsi-update-limit.test.ts
@@ -1,0 +1,234 @@
+/**
+ * DynamoDB GSI inventory + the one-GSI-per-UpdateTable guard.
+ *
+ * DynamoDB's `UpdateTable` API permits exactly ONE GSI creation or deletion per
+ * call. CloudFormation issues one `UpdateTable` per changed table, so a template
+ * that adds two indexes to an *existing* table fails the deploy and rolls the
+ * whole stack back with it. `CreateTable` has no such limit, so a brand-new
+ * table with any number of indexes is fine.
+ *
+ * An environment that deploys on every merge never sees this: two indexes from
+ * two PRs get two deploys, one index each. Only an environment that jumps a
+ * whole release at once — prod, deploying from `main` — collapses them into a
+ * single update. That is how release 1.12.0 took production down on 2026-08-01.
+ *
+ * This file owns the *generation* half of the guard: it synthesizes the app and
+ * keeps `infrastructure/gsi-inventory.json` honest, so the committed inventory
+ * can never silently drift from the CDK code. The *comparison* half — diffing
+ * the inventory against `origin/main` — lives in
+ * `scripts/release/check-gsi-update-limit.mjs` and runs in CI on PRs into
+ * `main`. Its exit-code contract is covered at the bottom of this file.
+ *
+ * Regenerate after intentionally adding or removing an index:
+ *
+ *     cd infrastructure && UPDATE_GSI_INVENTORY=1 npx jest gsi-update-limit
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+import {
+  createMockConfig,
+  mockSsmContext,
+  MOCK_ACCOUNT,
+  MOCK_PREFIX,
+  MOCK_REGION,
+} from './helpers/mock-config';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const INVENTORY_PATH = resolve(REPO_ROOT, 'infrastructure/gsi-inventory.json');
+const CHECKER = resolve(REPO_ROOT, 'scripts/release/check-gsi-update-limit.mjs');
+
+interface Inventory {
+  tables: Record<string, string[]>;
+}
+
+/**
+ * Synthesize the whole app and inventory every DynamoDB table's indexes.
+ *
+ * Keyed by physical table name with the project prefix stripped, because the
+ * per-update limit applies to the physical table — that is the identity that
+ * survives a construct-tree refactor and the identity CloudFormation issues the
+ * `UpdateTable` against.
+ */
+function buildInventory(): Inventory {
+  const cert = 'arn:aws:acm:us-east-1:123456789012:certificate/test';
+  const config = createMockConfig({
+    domainName: 'example.com',
+    infrastructureHostedZoneDomain: 'example.com',
+    certificateArn: cert,
+    frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
+    artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+    mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
+    fineTuning: {},
+  });
+
+  const app = new cdk.App();
+  mockSsmContext(app, config);
+  const platform = new PlatformStack(app, 'Platform', {
+    config,
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  platform.wireCompute();
+
+  const resources = Template.fromStack(platform).findResources('AWS::DynamoDB::Table');
+
+  const tables: Record<string, string[]> = {};
+  for (const [logicalId, resource] of Object.entries(resources)) {
+    const props = (resource as { Properties?: Record<string, unknown> }).Properties ?? {};
+    const tableName = props.TableName;
+    // Fall back to the logical id for any table CDK auto-names — still a stable
+    // key, and better than dropping the table from the inventory entirely.
+    const key =
+      typeof tableName === 'string'
+        ? tableName.replace(new RegExp(`^${MOCK_PREFIX}-`), '')
+        : `<logical:${logicalId}>`;
+
+    const gsis = (props.GlobalSecondaryIndexes ?? []) as Array<{ IndexName?: unknown }>;
+    const indexNames = gsis
+      .map((g) => g.IndexName)
+      .filter((n): n is string => typeof n === 'string')
+      .sort();
+
+    if (key in tables) {
+      throw new Error(`Duplicate table key "${key}" in inventory (logical id ${logicalId})`);
+    }
+    tables[key] = indexNames;
+  }
+
+  // Sort keys so the committed file diffs cleanly and reviewers can see an added
+  // index as a one-line change.
+  const sorted: Record<string, string[]> = {};
+  for (const key of Object.keys(tables).sort()) sorted[key] = tables[key];
+  return { tables: sorted };
+}
+
+function serialize(inventory: Inventory): string {
+  return `${JSON.stringify(inventory, null, 2)}\n`;
+}
+
+describe('DynamoDB GSI inventory', () => {
+  let inventory: Inventory;
+
+  beforeAll(() => {
+    inventory = buildInventory();
+    if (process.env.UPDATE_GSI_INVENTORY) {
+      writeFileSync(INVENTORY_PATH, serialize(inventory));
+    }
+  });
+
+  it('matches the committed infrastructure/gsi-inventory.json', () => {
+    const committed = readFileSync(INVENTORY_PATH, 'utf8');
+    expect(serialize(inventory)).toEqual(committed);
+    // If this fails you added or removed a GSI. Regenerate with:
+    //   cd infrastructure && UPDATE_GSI_INVENTORY=1 npx jest gsi-update-limit
+    // then check the diff: if an EXISTING table gained more than one index, the
+    // release must be split across two deploys. See
+    // .claude/skills/cutting-a-release/SKILL.md §1.
+  });
+
+  it('captures every table the stack creates', () => {
+    // Guards against a synth-shape change silently emptying the inventory,
+    // which would make the checker vacuously pass forever.
+    expect(Object.keys(inventory.tables).length).toBeGreaterThan(15);
+  });
+
+  it('records the assistants-table indexes that caused the 1.12.0 outage', () => {
+    // Regression anchor: these two arrived in separate develop merges and
+    // collapsed into one prod UpdateTable.
+    expect(inventory.tables['rag-assistants']).toEqual(
+      expect.arrayContaining(['AgentDirectoryIndex', 'AgentReportsIndex']),
+    );
+  });
+
+  it('names no table by logical-id fallback', () => {
+    // Every table should have an explicit TableName; a fallback key means the
+    // inventory key would churn on an unrelated construct-tree refactor.
+    const fallbacks = Object.keys(inventory.tables).filter((k) => k.startsWith('<logical:'));
+    expect(fallbacks).toEqual([]);
+  });
+});
+
+describe('check-gsi-update-limit.mjs', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gsi-check-'));
+  });
+
+  /** Run the real CLI the way CI does; returns its exit code and output. */
+  function run(baseline: Inventory, current: Inventory) {
+    const basePath = join(dir, `base-${Math.random().toString(36).slice(2)}.json`);
+    const currPath = join(dir, `curr-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(basePath, serialize(baseline));
+    writeFileSync(currPath, serialize(current));
+
+    try {
+      const stdout = execFileSync(
+        process.execPath,
+        [CHECKER, '--baseline-file', basePath, '--current', currPath],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      return { code: 0, output: stdout };
+    } catch (err) {
+      const e = err as { status: number; stdout: string; stderr: string };
+      return { code: e.status, output: `${e.stdout}${e.stderr}` };
+    }
+  }
+
+  it('passes when an existing table gains exactly one index', () => {
+    const { code } = run({ tables: { t: ['A'] } }, { tables: { t: ['A', 'B'] } });
+    expect(code).toBe(0);
+  });
+
+  it('fails when an existing table gains two indexes — the 1.12.0 shape', () => {
+    const { code, output } = run(
+      { tables: { 'rag-assistants': ['OwnerStatusIndex'] } },
+      { tables: { 'rag-assistants': ['OwnerStatusIndex', 'AgentDirectoryIndex', 'AgentReportsIndex'] } },
+    );
+    expect(code).toBe(1);
+    expect(output).toContain('rag-assistants');
+    expect(output).toContain('AgentDirectoryIndex');
+    expect(output).toContain('AgentReportsIndex');
+  });
+
+  it('exempts a brand-new table with many indexes (CreateTable has no limit)', () => {
+    const { code } = run(
+      { tables: { existing: ['A'] } },
+      { tables: { existing: ['A'], 'audit-log': ['X', 'Y', 'Z'] } },
+    );
+    expect(code).toBe(0);
+  });
+
+  it('fails when an existing table loses two indexes', () => {
+    // The API limit counts deletions too, not just creations.
+    const { code } = run({ tables: { t: ['A', 'B', 'C'] } }, { tables: { t: ['C'] } });
+    expect(code).toBe(1);
+  });
+
+  it('fails on one addition combined with one removal in the same update', () => {
+    // "more than one GSI creation OR DELETION in a single update" — a swap is
+    // two operations and is rejected exactly like two creations.
+    const { code } = run({ tables: { t: ['A'] } }, { tables: { t: ['B'] } });
+    expect(code).toBe(1);
+  });
+
+  it('ignores a table dropped entirely (DeleteTable, not UpdateTable)', () => {
+    const { code } = run({ tables: { gone: ['A', 'B', 'C'], kept: [] } }, { tables: { kept: [] } });
+    expect(code).toBe(0);
+  });
+
+  it('passes on an unchanged inventory', () => {
+    const { code } = run({ tables: { t: ['A', 'B'] } }, { tables: { t: ['A', 'B'] } });
+    expect(code).toBe(0);
+  });
+
+  it('passes the committed inventory against itself', () => {
+    const committed = JSON.parse(readFileSync(INVENTORY_PATH, 'utf8')) as Inventory;
+    const { code } = run(committed, committed);
+    expect(code).toBe(0);
+  });
+});

--- a/scripts/release/check-gsi-update-limit.mjs
+++ b/scripts/release/check-gsi-update-limit.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Pre-merge guard for DynamoDB's one-GSI-per-UpdateTable limit.
+ *
+ * DynamoDB's `UpdateTable` API permits exactly ONE GSI creation or deletion per
+ * call. CloudFormation issues one `UpdateTable` per changed table, so a template
+ * that adds two indexes to an *existing* table fails the whole deploy with:
+ *
+ *     Cannot perform more than one GSI creation or deletion in a single update
+ *
+ * ...and rolls back every other resource in the stack with it.
+ *
+ * The limit is specific to `UpdateTable`. `CreateTable` accepts any number of
+ * indexes, so a brand-new table with five GSIs is fine — which is why this check
+ * only considers tables present in BOTH the baseline and the current inventory.
+ *
+ * WHY THIS NEEDS A DEDICATED CHECK: an environment that deploys on every merge
+ * never sees it. Two indexes landing in two PRs get two separate deploys, one
+ * index each, and both succeed. Only an environment that jumps a whole release
+ * at once — i.e. prod, deploying from `main` — collapses them into a single
+ * `UpdateTable`. Dev soak time cannot surface this; the release diff is the only
+ * place it can be caught. This took production down on 2026-08-01 (release
+ * 1.12.0, two indexes on the `rag-assistants` table).
+ *
+ * Usage:
+ *   node scripts/release/check-gsi-update-limit.mjs
+ *   node scripts/release/check-gsi-update-limit.mjs --base origin/develop
+ *   node scripts/release/check-gsi-update-limit.mjs --baseline-file a.json --current b.json
+ *
+ * Exit codes: 0 = safe to deploy in one update, 1 = must be split, 2 = bad usage.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const INVENTORY_PATH = 'infrastructure/gsi-inventory.json';
+
+function parseArgs(argv) {
+  const opts = { base: 'origin/main', baselineFile: null, current: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const v = argv[i + 1];
+      if (v === undefined) {
+        throw new Error(`${arg} requires a value`);
+      }
+      i += 1;
+      return v;
+    };
+    if (arg === '--base') opts.base = next();
+    else if (arg === '--baseline-file') opts.baselineFile = next();
+    else if (arg === '--current') opts.current = next();
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+/** Normalise an inventory document into Map<tableName, Set<indexName>>. */
+function toTableMap(doc, source) {
+  const tables = doc && doc.tables;
+  if (!tables || typeof tables !== 'object' || Array.isArray(tables)) {
+    throw new Error(`${source}: expected an object with a "tables" property`);
+  }
+  const map = new Map();
+  for (const [name, indexes] of Object.entries(tables)) {
+    if (!Array.isArray(indexes)) {
+      throw new Error(`${source}: table "${name}" must map to an array of index names`);
+    }
+    map.set(name, new Set(indexes));
+  }
+  return map;
+}
+
+/**
+ * Compare two inventories and return one violation entry per table that would
+ * need more than one GSI mutation in a single `UpdateTable`.
+ *
+ * Note the rule counts creations AND deletions together: the API limit is one
+ * GSI *operation* per update, so removing one index while adding another in the
+ * same deploy fails exactly like adding two does.
+ */
+export function findUpdateLimitViolations(baseline, current) {
+  const violations = [];
+  for (const [table, currentIndexes] of current) {
+    const baselineIndexes = baseline.get(table);
+    // Absent from the baseline => created by this deploy. `CreateTable` has no
+    // per-call index limit, so any number of indexes is fine.
+    if (baselineIndexes === undefined) continue;
+
+    const added = [...currentIndexes].filter((i) => !baselineIndexes.has(i)).sort();
+    const removed = [...baselineIndexes].filter((i) => !currentIndexes.has(i)).sort();
+    if (added.length + removed.length > 1) {
+      violations.push({ table, added, removed });
+    }
+  }
+  // Tables dropped entirely are a `DeleteTable`, not an `UpdateTable` — no limit.
+  return violations.sort((a, b) => a.table.localeCompare(b.table));
+}
+
+function readBaselineFromGit(ref) {
+  try {
+    return execFileSync('git', ['show', `${ref}:${INVENTORY_PATH}`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    return 2;
+  }
+
+  if (opts.help) {
+    console.log(
+      'Usage: check-gsi-update-limit.mjs [--base <git-ref>] ' +
+        '[--baseline-file <path>] [--current <path>]',
+    );
+    return 0;
+  }
+
+  const currentPath = opts.current ?? resolve(REPO_ROOT, INVENTORY_PATH);
+  if (!existsSync(currentPath)) {
+    console.error(
+      `error: ${currentPath} not found. Generate it with:\n` +
+        '  cd infrastructure && UPDATE_GSI_INVENTORY=1 npx jest gsi-update-limit',
+    );
+    return 2;
+  }
+
+  let baselineRaw;
+  let baselineLabel;
+  if (opts.baselineFile) {
+    if (!existsSync(opts.baselineFile)) {
+      console.error(`error: baseline file ${opts.baselineFile} not found`);
+      return 2;
+    }
+    baselineRaw = readFileSync(opts.baselineFile, 'utf8');
+    baselineLabel = opts.baselineFile;
+  } else {
+    baselineRaw = readBaselineFromGit(opts.base);
+    baselineLabel = `${opts.base}:${INVENTORY_PATH}`;
+    if (baselineRaw === null) {
+      // First introduction of the inventory, a shallow clone, or an unfetched
+      // ref. Nothing to compare against — pass rather than block the PR.
+      console.log(
+        `GSI update-limit check SKIPPED — no inventory at ${baselineLabel}.\n` +
+          'If this is not the commit that introduces the inventory, run ' +
+          `\`git fetch origin ${opts.base.replace(/^origin\//, '')}\` and retry.`,
+      );
+      return 0;
+    }
+  }
+
+  let baseline;
+  let current;
+  try {
+    baseline = toTableMap(JSON.parse(baselineRaw), baselineLabel);
+    current = toTableMap(JSON.parse(readFileSync(currentPath, 'utf8')), currentPath);
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    return 2;
+  }
+
+  const violations = findUpdateLimitViolations(baseline, current);
+
+  if (violations.length === 0) {
+    console.log(
+      `GSI update-limit check PASSED — ${current.size} table(s) compared against ` +
+        `${baselineLabel}; no existing table needs more than one GSI operation.`,
+    );
+    return 0;
+  }
+
+  console.error(
+    'GSI update-limit check FAILED — this deploy would need more than one GSI\n' +
+      'operation on a table that already exists. DynamoDB rejects that, and\n' +
+      'CloudFormation will roll back the ENTIRE stack update with it.\n',
+  );
+  for (const { table, added, removed } of violations) {
+    console.error(`  ${table} (${added.length + removed.length} operations in one update)`);
+    for (const i of added) console.error(`    + ${i}`);
+    for (const i of removed) console.error(`    - ${i}`);
+  }
+  console.error(
+    '\nSplit this into consecutive releases: ship ONE index, wait for it to\n' +
+      'report ACTIVE (`aws dynamodb describe-table ... IndexStatus`), then ship\n' +
+      'the next. Do the split BEFORE merging — see\n' +
+      '.claude/skills/cutting-a-release/SKILL.md §1.',
+  );
+  return 1;
+}
+
+// Only run when invoked directly, so tests can import the pure comparison.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Why

Release 1.12.0 (#814) added two GSIs — `AgentDirectoryIndex` and `AgentReportsIndex` — to the existing `{prefix}-rag-assistants` table in a single CloudFormation update. DynamoDB's `UpdateTable` permits **exactly one GSI creation or deletion per call**, so the update failed with `Cannot perform more than one GSI creation or deletion in a single update` and CloudFormation rolled back every other resource in the deploy with it, including a brand-new audit-log table.

`backend.yml` and `frontend-deploy.yml` succeeded independently, so production ended up running **new code against old infrastructure**, with the agent store returning 500. Recovery took two more patch releases (1.12.1 #816, 1.12.2 #817).

Two things made this invisible:

- The limit applies to **`UpdateTable` only**. `CreateTable` accepts any number of indexes — which is why the new audit-log table's *own* two GSIs were never a problem. So the question is **"does any EXISTING table gain more than one GSI?"**, not "are there new indexes?".
- The two indexes reached `develop` in **separate merges** (`02d0f2e9`, `a128831d`), so dev got a platform deploy for each and never saw them collapse into one update. **Only an environment that jumps a whole release at once is exposed.** No amount of dev soak time surfaces it; the release diff is the only place it can be caught.

## What's here

**Documentation** — `.claude/skills/cutting-a-release/SKILL.md` gains a §1 prerequisite covering the question, why `CreateTable` is exempt, why an incremental environment cannot reveal it, how to split the release (ship one index, wait for `ACTIVE`, ship the next), and the recovery mechanics. Sections 1–7 renumbered to 2–8; all cross-references updated.

Two non-obvious recovery facts are recorded because they cost real time:

- **Each half needs its own patch release.** `version-check.yml` fails any PR into `main` whose `VERSION` is unchanged, with no label or skip path.
- **PR 2 must NOT be stacked on PR 1.** After PR 1 squash-merges, the merge-base doesn't move, PR 1's removal and PR 2's restoration cancel out in the three-dot diff GitHub shows and merges, and **the restore silently no-ops**. Open PR 2 only after PR 1 merges, as a `git revert` of PR 1's squash commit.

**Automation** — judged worth it, and built so it costs almost nothing to run:

| File | Role |
|---|---|
| `infrastructure/gsi-inventory.json` | Committed, synth-generated inventory of every DynamoDB table and its indexes |
| `infrastructure/test/gsi-update-limit.test.ts` | Synthesizes `PlatformStack` and fails if the committed inventory drifted from the CDK code |
| `scripts/release/check-gsi-update-limit.mjs` | Dependency-free diff of the inventory between `origin/main` and the PR |
| `.github/workflows/gsi-update-limit.yml` | Runs the check on PRs into `main` — the only exposed branch |

Rather than synthesizing two git refs (which needs the old ref's `node_modules` and two full synths), the inventory is **committed**, so the previous release's copy is already in git. The CI gate diffs two JSON files: no `npm install`, no CDK synth, a couple of seconds. The jest test is what keeps the inventory honest, so the two checks are only meaningful together — both should be required.

Rules the checker applies:

- Table in **both** inventories → more than one index operation fails.
- Table only in the new inventory → **exempt** (`CreateTable` has no limit).
- Table dropped entirely → exempt (`DeleteTable`).
- Creations and deletions are **counted together** — the API limit is one GSI *operation* per update, so renaming an index (one add + one drop) fails exactly like adding two.

## Verification

- Replayed the real incident: reconstructed the pre-1.12.0 inventory and ran the checker against `develop`'s current state — **fails**, naming both indexes, while correctly exempting the new `audit-log` table (2 GSIs, `CreateTable`).
- Replayed the fix: the 1.12.1 (first index alone + new table) and 1.12.2 (second index) splits both **pass**.
- `npx jest` in `infrastructure/` — 26 suites, 495 tests pass (12 new). The worker-teardown warning is pre-existing.
- `pytest backend/tests/supply_chain/` — 31 pass; the new workflow satisfies action pinning (shared checkout SHA), runner pinning, concurrency, and secret scoping.
- Exit-code propagation through `tee` verified with and without `pipefail`.

## Note

Until a release carrying `gsi-inventory.json` reaches `main`, there is no baseline to diff and the check reports **SKIPPED** rather than failing. For that one release, the §1 question has to be answered by hand — the skill says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)