### PR TITLE
fix(marketplace): add taken_down → private so the delete refusal names a real path

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -455,6 +455,12 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
     Neither act revokes anything retroactively: people who pinned it keep their pin,
     conversations underway keep running, and the agent stays reachable by direct link
     because ``visibility`` is a separate axis. It is a delisting, not a recall.
+
+    ``taken_down`` resolves to the immediate branch, and that is the point of the
+    ``taken_down → private`` edge: an admin has already pulled it, so there is nothing left to
+    request. Before the edge existed this raised, and an author who simply wanted to delete a
+    delisted agent had to resubmit it for review — posting to the D2 queue purely to withdraw
+    a moment later — because ``delete_assistant`` accepts only ``private``.
     """
     assistant = await _load_for_author(agent_id, user)
     if not assistant.listing:
@@ -522,12 +528,13 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
         )
         return listing
 
-    # Pre-publication withdrawal: nothing is on the shelf, so this is immediate. The
-    # unindex is belt-and-braces for a listing whose pointer outlived its key.
+    # Nothing is on the shelf, so this is immediate — either a pre-publication withdrawal or
+    # an author shelving something an admin already took down. The unindex is belt-and-braces
+    # for a listing whose pointer outlived its key.
     await _unindex_version(agent_id, assistant.listing.published_version)
     listing = assistant.listing.model_copy(update={"state": target, "published_version": None})
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
-    logger.info(f"📭 Agent {agent_id} submission withdrawn by its owner")
+    logger.info(f"📭 Agent {agent_id} withdrawn to private by its owner (from {current})")
     return listing
 
 

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -71,6 +71,8 @@ LISTING_STATES: Tuple[str, ...] = (
 #   taken_down        → changes_requested  admin annotates an already-delisted listing
 #   in_review         → private            author withdraws a pending submission
 #   changes_requested → private            author withdraws one that was never live
+#   taken_down        → private            author shelves a delisted agent (so it can be
+#                                          deleted — see below)
 #   published         → withdrawal_requested author ASKS to pull a live listing
 #   changes_requested → withdrawal_requested author ASKS to pull one that is *still* live
 #   withdrawal_requested → changes_requested admin declines; it goes back where it came from
@@ -87,8 +89,37 @@ LISTING_STATES: Tuple[str, ...] = (
 # listing unilaterally, with no admin ever seeing it — the D2 review queue makes
 # publication stop for a human, and unpublication should not be a side door around that.
 # Withdrawal is now a request an admin acts on (see §5.1 of the version-snapshots spec).
-# The edges an author still owns alone are the pre-publication ones: ``private → in_review``
-# and withdrawing a *pending* submission (``in_review``/``changes_requested`` → ``private``).
+# The edges an author still owns alone are the ones where nothing is on the shelf:
+# ``private → in_review``, withdrawing a *pending* submission
+# (``in_review``/``changes_requested`` → ``private``), and shelving one an admin has already
+# pulled (``taken_down → private``). None of them removes anything users can currently see.
+#
+# ⚠️ ``taken_down → private`` was absent, and its absence was load-bearing for nothing.
+# The stated reason was audit: the takedown record (``review_note``/``reviewed_by``/
+# ``reviewed_at``) lives on the listing block itself, so letting an author reach ``private``
+# lets them reach ``delete_assistant`` — which is refused for every state *except* ``private``
+# — and take the record with them.
+#
+# That protection never held. ``taken_down → in_review → private`` was always walkable by the
+# author alone (``submit_listing`` then ``withdraw_listing``: after a takedown
+# ``published_version`` is cleared, so ``is_on_shelf`` is False and the withdrawal resolves to
+# ``private`` immediately rather than to a request). The record was already erasable in three
+# author-only steps; all the missing edge bought was that the middle step posted a submission
+# to the D2 review queue that the author intended to withdraw a moment later. It taxed admins
+# to protect nothing.
+#
+# So the edge is added and the audit question is named honestly rather than half-defended: if
+# a takedown record must outlive the Agent, it needs a row that is not the Agent's own listing
+# block, and no arrangement of this table can supply that. What the delete guard actually
+# earns — and still earns — is that nothing *live or pending* is ever deleted out from under
+# the store: ``published``, ``withdrawal_requested`` and ``in_review`` all still refuse, so
+# unpublication stays an explicit act rather than a side effect of a delete.
+#
+# The edge is safe in the direction that matters. ``private`` is already an author target, and
+# ``is_on_shelf`` hardcodes ``taken_down`` to False, so this can never route to
+# ``withdrawal_requested`` and can never pull something off a shelf it is not on. Getting back
+# *into* the store is unchanged: ``private → in_review → published``, approval still the only
+# door.
 #
 # ⚠️ ``changes_requested`` covers two different listings — one that was never published, and
 # one that *was* and is still serving while the author revises it (``review_listing``
@@ -109,7 +140,7 @@ ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     "in_review": {"published", "changes_requested", "private"},
     "changes_requested": {"in_review", "private", "withdrawal_requested"},
     "published": {"taken_down", "changes_requested", "withdrawal_requested"},
-    "taken_down": {"in_review", "changes_requested"},
+    "taken_down": {"in_review", "changes_requested", "private"},
     "withdrawal_requested": {"private", "published", "changes_requested", "taken_down"},
 }
 

--- a/backend/src/apis/shared/assistants/service.py
+++ b/backend/src/apis/shared/assistants/service.py
@@ -898,6 +898,12 @@ def _assert_listing_allows_delete(existing) -> None:
         return
     # The message names the path forward rather than just refusing — an author who is told
     # "no" without being told "do this instead" files a ticket.
+    #
+    # ⚠️ Naming a path puts this string under the state machine's authority, and it drifted:
+    # ``taken_down`` was told to "take it back to private" while ``ALLOWED_TRANSITIONS`` had
+    # no ``taken_down → private`` edge, so the advice was for a door that did not exist.
+    # ``test_every_refusal_names_a_transition_the_machine_allows`` now derives the claim from
+    # the table, so the next divergence fails a test instead of reaching an author.
     nudge = (
         "Request withdrawal first, then delete it once an admin has removed it from the store."
         if state in ("published", "withdrawal_requested")
@@ -917,10 +923,19 @@ async def delete_assistant(assistant_id: str, owner_id: str) -> bool:
     the same unilateral removal that ``withdrawal_requested`` exists to stop, except
     irreversible and taking the review history with it.
 
-    ``taken_down`` is covered deliberately: an author must not be able to delete their way
-    out of a takedown record. So is ``withdrawal_requested`` — a pending request is not a
-    granted one. Only ``private`` (or no listing at all) may be deleted, which is reachable
-    from every other state through the normal paths.
+    What this earns is that **nothing live or pending is deleted out from under the store**:
+    ``published`` refuses, ``withdrawal_requested`` refuses because a requested withdrawal is
+    not a granted one, and ``in_review`` refuses because a reviewer is mid-decision. Only
+    ``private`` (or no listing at all) may be deleted, and reaching ``private`` is an explicit
+    act — so unpublication can never be a side effect of a delete.
+
+    ⚠️ What it does **not** earn, despite an earlier claim here, is that an author cannot
+    delete their way out of a takedown record. ``taken_down`` still refuses, but the author
+    now walks ``taken_down → private`` and deletes — and before that edge existed they walked
+    ``taken_down → in_review → private`` and deleted, which cost them one junk entry in the
+    review queue and cost the record exactly nothing. The takedown note lives on the listing
+    block, so it dies with the Agent either way. Making that survive needs a row that is not
+    the Agent's own, not a missing edge in ``ALLOWED_TRANSITIONS``.
 
     Args:
         assistant_id: Assistant identifier

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -585,6 +585,31 @@ class TestWithdraw:
         assert resp.status_code == 200
         assert resp.json()["state"] == "private"
 
+    def test_withdrawing_a_taken_down_listing_is_immediate(self, app, make_user, _no_writes):
+        """The route an author needs to delete a delisted agent, and it used to 400.
+
+        ``delete_assistant`` accepts only ``private``, and its refusal told the author of a
+        taken-down agent to "take it back to private first" — but ``taken_down → private`` was
+        not an edge, so this endpoint refused and the advice was for a door that did not
+        exist. The workaround was to resubmit for review and withdraw the submission a moment
+        later: a junk entry in the D2 queue as the price of a delete.
+
+        Immediate rather than a request because an admin has already pulled it. There is
+        nothing left to ask for, and routing it to ``withdrawal_requested`` would park a
+        listing nobody can see in the review queue.
+        """
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="taken_down", category="Teaching", publisherId="user-user-001"
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "private"
+
     def test_a_second_request_on_an_already_requested_listing_is_refused(
         self, app, make_user, _no_writes
     ):

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -21,6 +21,7 @@ from apis.shared.assistants.listing import (
     assert_transition,
     gsi5_keys,
     is_listed,
+    is_on_shelf,
     is_published,
 )
 
@@ -54,6 +55,45 @@ def test_author_may_withdraw_a_pending_submission_outright():
     """Before publication, withdrawing is the author's alone — nobody else has it yet."""
     for state in ("in_review", "changes_requested"):
         assert_transition(state, "private")
+
+
+def test_author_may_shelve_a_taken_down_listing():
+    """``taken_down → private``, and it is an author edge (both gates, not just the table).
+
+    Added because ``delete_assistant`` refuses every state but ``private`` while telling the
+    author of a taken-down agent to "take it back to private first" — advice for a door that
+    did not exist. The only route out was ``taken_down → in_review → private``: resubmit for
+    review purely to withdraw it a moment later, posting to the D2 queue to get somewhere the
+    author was already allowed to be.
+    """
+    assert_transition("taken_down", "private")
+    assert_author_target("private")
+
+
+def test_shelving_a_takedown_does_not_become_a_withdrawal_request():
+    """A takedown is already off the shelf, so there is nothing left to ask an admin for.
+
+    ``withdraw_listing`` picks its target with ``is_on_shelf``, which hardcodes ``taken_down``
+    to False whatever the pointer says. Asserted here because the new edge would be a real
+    hazard if that were not true: routing a taken-down listing to ``withdrawal_requested``
+    would park it in the admin queue forever over a listing nobody can see.
+    """
+    assert is_on_shelf("taken_down", None) is False
+    assert is_on_shelf("taken_down", 7) is False, "a stale pointer must not resurrect it"
+    with pytest.raises(ListingTransitionError):
+        assert_transition("taken_down", "withdrawal_requested")
+
+
+def test_shelving_a_takedown_is_not_a_way_back_into_the_store():
+    """The new edge must not shorten the route to ``published``.
+
+    ``taken_down → private`` is only useful if it stays a dead end for publication: from
+    ``private`` the author still has to submit and an admin still has to approve. If this ever
+    fails, the edge became a laundering step — pull it rather than patching the assertion.
+    """
+    assert ALLOWED_TRANSITIONS["private"] == {"in_review"}
+    with pytest.raises(ListingTransitionError):
+        assert_transition("private", "published")
 
 
 def test_a_live_listing_can_only_be_requested_down():

--- a/backend/tests/shared/test_assistant_delete_listing_guard.py
+++ b/backend/tests/shared/test_assistant_delete_listing_guard.py
@@ -17,6 +17,7 @@ import boto3
 import pytest
 from moto import mock_aws
 
+from apis.shared.assistants.listing import ALLOWED_TRANSITIONS, assert_transition
 from apis.shared.assistants.service import (
     AssistantListedError,
     assert_deletable,
@@ -116,10 +117,78 @@ def test_a_listed_agent_is_refused_and_survives(table, state):
 
 
 def test_taken_down_is_refused_deliberately(table):
-    """An author must not be able to delete their way out of a takedown record."""
+    """Refused, but **not** because it makes the takedown record undeletable.
+
+    That was the old claim here and it never held. The record (``reviewNote``/``reviewedBy``)
+    lives on the listing block, so it dies with the Agent — and the author could always reach
+    ``private`` and delete: today in one hop (``taken_down → private``), and before that edge
+    existed in two (``taken_down → in_review → private``), which cost them a junk review-queue
+    entry and cost the record nothing.
+
+    What the refusal earns is narrower and real: reaching ``private`` is an explicit act, so a
+    delete can never be the thing that takes a listing off the shelf. If the takedown record
+    must outlive the Agent, that needs a row that is not the Agent's own.
+    """
     seed(table, listing_of("taken_down"))
     with pytest.raises(AssistantListedError):
         asyncio.run(delete_assistant(AGENT_ID, OWNER))
+
+
+def test_a_taken_down_agent_deletes_once_it_is_shelved(table):
+    """The two halves joined: the machine's exit, then the guard's entry.
+
+    This is the whole bug in one test. The refusal tells the author to "take it back to
+    private first" — worth nothing unless ``taken_down → private`` exists *and* ``private``
+    is then actually deletable. Asserted end to end rather than as two separate facts,
+    because the failure was precisely that the two facts were maintained apart.
+    """
+    seed(table, listing_of("taken_down"))
+    with pytest.raises(AssistantListedError) as raised:
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+    assert "back to private" in raised.value.message
+    assert exists(table)
+
+    # What ``withdraw_listing`` does with a taken-down listing (route-level coverage lives in
+    # tests/routes/test_agent_listing.py); asserted legal here so this test fails if the edge
+    # is ever pulled while the message still promises it.
+    assert_transition("taken_down", "private")
+    seed(table, listing_of("private"))
+
+    assert asyncio.run(delete_assistant(AGENT_ID, OWNER)) is True
+    assert not exists(table)
+
+
+@pytest.mark.parametrize(
+    "state", ["in_review", "changes_requested", "taken_down", "published", "withdrawal_requested"]
+)
+def test_every_refusal_names_a_transition_the_machine_allows(table, state):
+    """The refusal gives directions, so the transition table is what makes them true or not.
+
+    ``taken_down`` was told to go "back to private" while ``ALLOWED_TRANSITIONS`` had no such
+    edge — a message and a machine maintained in two files, disagreeing, with only the author
+    to notice. Derived from the table rather than restated so the next divergence fails here
+    instead of reaching a user.
+    """
+    seed(table, listing_of(state))
+    with pytest.raises(AssistantListedError) as raised:
+        asyncio.run(delete_assistant(AGENT_ID, OWNER))
+    message = raised.value.message
+
+    if "back to private" in message:
+        assert "private" in ALLOWED_TRANSITIONS[state], (
+            f"the refusal sends a '{state}' listing to private, but the machine has no "
+            f"'{state} → private' edge — the author is being sent through a wall"
+        )
+    else:
+        # "Request withdrawal first, then delete it once an admin has removed it." Two claims:
+        # the author can ask from here, and the admin's grant lands somewhere deletable.
+        assert "Request withdrawal" in message
+        assert state == "withdrawal_requested" or (
+            "withdrawal_requested" in ALLOWED_TRANSITIONS[state]
+        ), f"'{state}' cannot reach withdrawal_requested, so asking is not open to the author"
+        assert "private" in ALLOWED_TRANSITIONS["withdrawal_requested"], (
+            "a granted withdrawal must land in the one state the delete guard admits"
+        )
 
 
 def test_a_pending_withdrawal_is_refused(table):

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.spec.ts
@@ -234,4 +234,43 @@ describe('ShareAgentDialogComponent', () => {
       expect(updateAssistant).toHaveBeenCalledWith('ast-test', { visibility: 'SHARED' });
     });
   });
+
+  /**
+   * `canWithdraw` mirrors the backend transition table, and it drifted from it.
+   *
+   * `taken_down` was excluded with a comment saying the machine allowed no author edge out
+   * of it — true when written. But delete accepts only `private`, and its refusal told the
+   * author to "take it back to private first", so the author of a taken-down agent was sent
+   * to a button this component did not render. Backend edge and button have to land together
+   * or the fix is invisible from the only seat that matters.
+   */
+  describe('canWithdraw', () => {
+    it('offers an exit from a taken-down listing', () => {
+      (component as any).listing.set({ state: 'taken_down' });
+
+      expect((component as any).canWithdraw()).toBe(true);
+      // Not "Withdraw" — an admin already pulled it, so there is nothing to withdraw from.
+      expect((component as any).withdrawLabel()).toBe('Remove listing');
+    });
+
+    it.each(['in_review', 'changes_requested', 'published'] as const)(
+      'still offers it from %s',
+      (state) => {
+        (component as any).listing.set({ state });
+        expect((component as any).canWithdraw()).toBe(true);
+      },
+    );
+
+    it.each(['private', 'withdrawal_requested'] as const)('offers nothing from %s', (state) => {
+      // `private` is already the destination. `withdrawal_requested` is a request the author
+      // has made and cannot make twice — the backend refuses it with a 400, and offering the
+      // button anyway would walk them into that error.
+      (component as any).listing.set({ state });
+      expect((component as any).canWithdraw()).toBe(false);
+    });
+
+    it('offers nothing when the agent was never submitted', () => {
+      expect((component as any).canWithdraw()).toBe(false);
+    });
+  });
 });

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
@@ -651,11 +651,25 @@ export class ShareAgentDialogComponent {
     this.listingState() ? 'Submit again' : 'Submit to marketplace',
   );
 
-  /** `taken_down` is absent on purpose: the machine allows no author edge out of it. */
+  /**
+   * `taken_down` is present now: the machine gained a `taken_down → private` author edge.
+   *
+   * It was absent because none existed, which left an author with a delisted agent no way to
+   * shelve it — and therefore no way to delete it, since delete accepts only `private`. The
+   * refusal even told them to "take it back to private first", naming a button this component
+   * did not render.
+   */
   protected readonly canWithdraw = computed(() => {
     const state = this.listingState();
-    return state === 'in_review' || state === 'changes_requested' || state === 'published';
+    return (
+      state === 'in_review' ||
+      state === 'changes_requested' ||
+      state === 'published' ||
+      state === 'taken_down'
+    );
   });
+
+  protected readonly isTakenDown = computed(() => this.listingState() === 'taken_down');
 
   protected readonly isPublished = computed(() => this.listingState() === 'published');
 
@@ -678,6 +692,10 @@ export class ShareAgentDialogComponent {
         return 'Request withdrawal';
       case 'in_review':
         return 'Withdraw submission';
+      // Not "Withdraw" — an admin already took it down, so there is nothing to withdraw
+      // from. This shelves the listing, which is also what makes the agent deletable.
+      case 'taken_down':
+        return 'Remove listing';
       default:
         return 'Withdraw';
     }
@@ -840,9 +858,14 @@ export class ShareAgentDialogComponent {
   protected async onWithdrawListing(): Promise<void> {
     const name = this.data.agent.name;
     const published = this.isPublished();
+    const takenDown = this.isTakenDown();
     const confirmRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
       data: {
-        title: published ? 'Request withdrawal?' : 'Withdraw this submission?',
+        title: published
+          ? 'Request withdrawal?'
+          : takenDown
+            ? 'Remove this listing?'
+            : 'Withdraw this submission?',
         // Two things this has to get right. (1) §5.1 — this is a *request*: the listing
         // stays in the store until an admin grants it. (2) D7.3 — say plainly that it
         // recalls nothing, because an author who thinks withdrawal revokes access decides
@@ -852,8 +875,15 @@ export class ShareAgentDialogComponent {
             'published until they decide. Even once it does come down, nothing is ' +
             'recalled: anyone who already added it keeps it, conversations underway keep ' +
             'running, and it stays reachable by direct link.'
-          : `"${name}" is pulled from the review queue. You can submit it again at any time.`,
-        confirmText: published ? 'Request withdrawal' : 'Withdraw',
+          : takenDown
+            ? // Already off the shelf, so this changes nothing users can see. Name the two
+              // things the author is actually deciding: they keep the agent either way, and
+              // this is what unblocks deleting it if that is where they were heading.
+              `"${name}" is already down from Discover, so this only clears its listing. ` +
+              'The agent itself is unaffected and stays yours — and once its listing is ' +
+              'cleared you can delete it, which a taken-down listing blocks.'
+            : `"${name}" is pulled from the review queue. You can submit it again at any time.`,
+        confirmText: published ? 'Request withdrawal' : takenDown ? 'Remove listing' : 'Withdraw',
         cancelText: 'Cancel',
         destructive: published,
       } as ConfirmationDialogData,


### PR DESCRIPTION
## The bug

`delete_assistant` (via `assert_deletable`) refuses every listing state but `private`. For a taken-down agent it says:

> This agent can't be deleted while it has a marketplace listing (taken_down). **Take it back to private first, then delete it.**

But `ALLOWED_TRANSITIONS["taken_down"]` was `{"in_review", "changes_requested"}` — there was no `taken_down → private` edge. The message named a door that did not exist. The only route out was `taken_down → in_review → private`: resubmit for review, then withdraw the submission a moment later, posting a junk entry to the D2 review queue purely to get somewhere the author was already allowed to be.

## The decision: add the edge (option a)

The absence was defended on audit grounds — the takedown record (`review_note`/`reviewed_by`/`reviewed_at`) lives on the listing block, so letting an author reach `private` lets them reach delete and take the record with them.

**That protection never held.** `taken_down → in_review → private` was always walkable by the author alone: `submit_listing` permits `taken_down → in_review`, and after a takedown `published_version` is cleared, so `is_on_shelf` is False and `withdraw_listing` resolves to `private` *immediately* rather than to a request. The record was already erasable in three author-only steps. All the missing edge bought was the queue entry in the middle — it taxed admins to protect nothing.

So the edge is added and the audit question is named honestly instead of half-defended: if a takedown record must outlive the Agent, it needs a row that is not the Agent's own listing block, and no arrangement of this table can supply that. Worth a follow-up issue if the audit trail matters; it is not something rewording the message would have fixed either.

Option (b) was rejected because the only honest wording would be *"submit it for review again, then withdraw the submission, then delete it"* — a message that documents an absurdity and instructs authors to spam the review queue.

### Why the edge is safe

- `is_on_shelf` hardcodes `taken_down` to False regardless of the pointer, so this can never route to `withdrawal_requested` and can never pull something off a shelf it is not on.
- `private` is already in `AUTHOR_TARGET_STATES`, so `assert_author_target` needed no change.
- Getting back *into* the store is untouched: `private → in_review → published`. Approval is still the only door — `test_approval_is_the_only_door_into_the_store` derives from the table and still passes.
- What the delete guard actually earns is unchanged: nothing live or pending (`published`, `withdrawal_requested`, `in_review`) is ever deleted out from under the store, so unpublication stays an explicit act rather than a side effect of a delete.

## Changes

**Backend**
- `listing.py` — the `taken_down → private` edge, plus the reasoning above recorded where the next reader will look.
- `service.py` — corrected the `delete_assistant` docstring, which asserted the protection the code did not provide. The refusal message itself needed no change; it is now true.
- `listing_service.py` — `withdraw_listing` docstring covers the third case; its log line no longer calls every immediate withdrawal a "submission".

**Frontend** — `share-agent-dialog.component.ts`. Its `canWithdraw` encoded the old rule explicitly (`` `taken_down` is absent on purpose: the machine allows no author edge out of it ``). Without this the backend would permit a path no author could walk, and the refusal would still name an unreachable button. Labelled **"Remove listing"** rather than "Withdraw" — an admin already pulled it, so there is nothing to withdraw from — with confirmation copy saying the agent itself is unaffected and that this is what unblocks deleting it.

## Tests

The key one is `test_every_refusal_names_a_transition_the_machine_allows`, which derives each refusal's advice from `ALLOWED_TRANSITIONS` rather than restating it. The message and the machine lived in two files and drifted with only the author to notice; the next divergence now fails a test.

- `test_agent_listing_state_machine.py` — the edge is legal and is an *author* edge (both gates); it cannot become a withdrawal request even with a stale pointer; it is not a shortcut back into the store.
- `test_assistant_delete_listing_guard.py` — the message/machine agreement test above; `taken_down → private → delete` asserted end to end, since the failure was precisely that the two halves were maintained apart; corrected the rationale on `test_taken_down_is_refused_deliberately` (behaviour unchanged, its stated reason was false).
- `test_agent_listing.py` — route-level: `DELETE /agents/{id}/listing` on a taken-down listing returns `private` instead of 400.
- `share-agent-dialog.component.spec.ts` — `canWithdraw` across every listing state.

All four new backend tests fail with the edge reverted. Note the pre-existing exhaustive `test_every_state_pair_matches_the_table` does **not** catch this — it is derived from the same table, so it cannot detect a table that is wrong.

**Verification:** full backend suite `5678 passed, 3 skipped`; full SPA suite `1814 passed` (163 files) via `ng test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)