### PR TITLE
fix(lambda-images): COPY the whole handler import closure

### DIFF
--- a/backend/Dockerfile.kb-sync
+++ b/backend/Dockerfile.kb-sync
@@ -23,14 +23,24 @@ COPY backend/src/apis/app_api/kb_sync/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Application code — namespace-package layout mirrors backend/src.
-# Keep this surface minimal: apis.shared domains the handlers import,
-# plus the kb_sync package itself. If a handler needs more, COPY it
-# here AND add the path to the kb-sync SOURCE_DIRS in
-# scripts/build/build-one.sh so the content-hash tag notices changes.
+# Keep this surface minimal but COMPLETE: it must cover the handlers'
+# whole import closure, including function-local imports (those still run
+# on invocation). A module the closure reaches but this list omits either
+# kills every cold start or — worse — trips a `except ImportError` branch
+# and silently no-ops. backend/tests/supply_chain/test_lambda_image_imports.py
+# enforces the closure. When adding a COPY here, also add the path to the
+# kb-sync SOURCE_DIRS/MANIFESTS in scripts/build/build-one.sh so the
+# content-hash tag notices changes.
 COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
+COPY backend/src/apis/shared/timestamps.py ${LAMBDA_TASK_ROOT}/apis/shared/timestamps.py
+COPY backend/src/apis/shared/dynamo_errors.py ${LAMBDA_TASK_ROOT}/apis/shared/dynamo_errors.py
 COPY backend/src/apis/shared/sync_policies/ ${LAMBDA_TASK_ROOT}/apis/shared/sync_policies/
 COPY backend/src/apis/shared/oauth/ ${LAMBDA_TASK_ROOT}/apis/shared/oauth/
 COPY backend/src/apis/shared/embeddings/ ${LAMBDA_TASK_ROOT}/apis/shared/embeddings/
+# assistants/ — document_service verifies assistant ownership via
+# get_assistant before soft-deleting; the worker's miss-eviction path
+# (_delete_missing_web_document) goes through it.
+COPY backend/src/apis/shared/assistants/ ${LAMBDA_TASK_ROOT}/apis/shared/assistants/
 COPY backend/src/apis/app_api/file_sources/ ${LAMBDA_TASK_ROOT}/apis/app_api/file_sources/
 COPY backend/src/apis/app_api/documents/ ${LAMBDA_TASK_ROOT}/apis/app_api/documents/
 COPY backend/src/apis/app_api/web_sources/ ${LAMBDA_TASK_ROOT}/apis/app_api/web_sources/

--- a/backend/Dockerfile.rag-ingestion
+++ b/backend/Dockerfile.rag-ingestion
@@ -157,10 +157,19 @@ ENV DOCLING_ARTIFACTS_PATH=/opt/ml/models/docling-artifacts \
 # 5. Copy Your Handler Code
 COPY backend/src/apis/app_api/documents/ingestion/ ${LAMBDA_TASK_ROOT}
 
-# 6. Copy shared embeddings module (required by ingestion/embeddings/bedrock_embeddings.py)
-# The ingestion embeddings re-export from apis.shared.embeddings, so we need the
-# full apis.shared.embeddings package available in LAMBDA_TASK_ROOT.
+# 6. Copy the apis.shared modules the handler's import closure reaches.
+# Keep this list COMPLETE — it must cover the whole closure, including
+# function-local imports (handler.py reaches status.py exactly that way,
+# and status.py is what needs timestamps.py). A module the closure reaches
+# but this list omits raises ModuleNotFoundError on every invocation;
+# backend/tests/supply_chain/test_lambda_image_imports.py enforces it.
+# When adding a COPY here, also add the path to the rag-ingestion
+# SOURCE_DIRS/MANIFESTS in scripts/build/build-one.sh so the content-hash
+# tag notices changes.
+#   embeddings/   — ingestion/embeddings/bedrock_embeddings.py re-exports it
+#   timestamps.py — ingestion/status.py imports utc_now_iso
 COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
+COPY backend/src/apis/shared/timestamps.py ${LAMBDA_TASK_ROOT}/apis/shared/timestamps.py
 COPY backend/src/apis/shared/embeddings/ ${LAMBDA_TASK_ROOT}/apis/shared/embeddings/
 RUN touch ${LAMBDA_TASK_ROOT}/apis/__init__.py
 

--- a/backend/Dockerfile.scheduled-runs
+++ b/backend/Dockerfile.scheduled-runs
@@ -25,14 +25,21 @@ COPY backend/src/lambdas/scheduled_runs_dispatcher/requirements.txt /tmp/require
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Application code — namespace-package layout mirrors backend/src for the
-# apis.shared modules the handlers import. If a handler needs more, COPY
-# it here AND add the path to the scheduled-runs SOURCE_DIRS in
-# scripts/build/build-one.sh so the content-hash tag notices changes.
+# apis.shared modules the handlers import. This must cover the handlers'
+# whole import closure, including function-local imports (those still run
+# on invocation); backend/tests/supply_chain/test_lambda_image_imports.py
+# enforces it. When adding a COPY here, also add the path to the
+# scheduled-runs SOURCE_DIRS in scripts/build/build-one.sh so the
+# content-hash tag notices changes.
 COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
+COPY backend/src/apis/shared/errors.py ${LAMBDA_TASK_ROOT}/apis/shared/errors.py
 COPY backend/src/apis/shared/harness/ ${LAMBDA_TASK_ROOT}/apis/shared/harness/
 COPY backend/src/apis/shared/scheduled_prompts/ ${LAMBDA_TASK_ROOT}/apis/shared/scheduled_prompts/
 COPY backend/src/apis/shared/sessions_bff/ ${LAMBDA_TASK_ROOT}/apis/shared/sessions_bff/
 COPY backend/src/apis/shared/sessions/ ${LAMBDA_TASK_ROOT}/apis/shared/sessions/
+# sessions/metadata.py lazily reaches these on its storage + EMF paths.
+COPY backend/src/apis/shared/storage/ ${LAMBDA_TASK_ROOT}/apis/shared/storage/
+COPY backend/src/apis/shared/observability/ ${LAMBDA_TASK_ROOT}/apis/shared/observability/
 
 # The two handlers themselves, as plain top-level modules.
 COPY backend/src/lambdas/scheduled_runs_dispatcher/dispatcher.py ${LAMBDA_TASK_ROOT}/dispatcher.py

--- a/backend/tests/supply_chain/test_lambda_image_imports.py
+++ b/backend/tests/supply_chain/test_lambda_image_imports.py
@@ -1,0 +1,216 @@
+"""Every module a Lambda handler can import must actually be in its image.
+
+The app-api / inference-api images COPY all of `backend/src`, so their
+import graph is trivially satisfied. The three Lambda images do NOT — each
+COPYs a hand-maintained subset of `apis.shared` to keep the image small.
+That subset was a manual list with nothing keeping it in sync with the
+code, and it drifted twice over:
+
+* `apis/shared/timestamps.py` was introduced in 8544d87a and imported by
+  `documents/ingestion/status.py`; neither Dockerfile.rag-ingestion nor
+  Dockerfile.kb-sync copied it. Document ingestion and KB sync ran at a
+  100% error rate in dev and prod for days. Nothing surfaced it — the SPA
+  just showed crawled documents sitting at `uploading` forever.
+* `document_service.soft_delete_document` imports `apis.shared.assistants`
+  inside a `try/except ImportError` that logs "boto3 is required" and
+  returns None. In the kb-sync image that except branch was always taken,
+  so the worker's miss-eviction path silently no-opped.
+
+Those two failure modes are why this test does NOT distinguish
+module-level imports from function-local ones. A function-local import
+still executes when its function is called — `handler.py` reaches
+`status.py` exactly that way — and a *swallowed* one is worse than a
+crash, because it degrades quietly. The invariant is simply: if a module
+is reachable from an entrypoint's import graph, the image must contain
+it.
+
+The cost of being complete is bounded — these are leaf-ish helper modules
+whose own dependencies (stdlib, boto3, pydantic) are already pinned in
+each image's requirements. If a genuinely heavy module ever shows up
+here, the right fix is to stop importing it from a Lambda path, not to
+weaken this test.
+"""
+
+import ast
+import re
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC = REPO_ROOT / "backend/src"
+
+# image -> (dockerfile, handler entrypoints, flattened roots)
+#
+# `flattened roots` are directories whose *contents* land directly at
+# LAMBDA_TASK_ROOT (`COPY <dir>/ ${LAMBDA_TASK_ROOT}`), so a bare
+# `import status` inside them resolves as a top-level module.
+IMAGES: Dict[str, Tuple[str, List[str], List[str]]] = {
+    "rag-ingestion": (
+        "backend/Dockerfile.rag-ingestion",
+        ["apis/app_api/documents/ingestion/handler.py"],
+        ["apis/app_api/documents/ingestion"],
+    ),
+    "kb-sync": (
+        "backend/Dockerfile.kb-sync",
+        [
+            "apis/app_api/kb_sync/dispatcher.py",
+            "apis/app_api/kb_sync/worker.py",
+        ],
+        [],
+    ),
+    "scheduled-runs": (
+        "backend/Dockerfile.scheduled-runs",
+        [
+            "lambdas/scheduled_runs_dispatcher/dispatcher.py",
+            "lambdas/scheduled_runs_worker/worker.py",
+        ],
+        ["lambdas/scheduled_runs_dispatcher", "lambdas/scheduled_runs_worker"],
+    ),
+}
+
+# The kb-sync image deliberately ships these alongside their packages but
+# never imports them — they pull FastAPI, which the image lacks (see the
+# note in Dockerfile.kb-sync). Excluding them keeps the walk honest about
+# what a Lambda actually reaches.
+NOT_AN_ENTRYPOINT = (
+    "apis/app_api/documents/routes.py",
+    "apis/app_api/web_sources/routes.py",
+    "apis/app_api/file_sources/service.py",
+)
+
+_COPY = re.compile(r"^COPY\s+(?:--from=\S+\s+)?(backend/src/\S+)\s")
+
+
+def _copied_paths(dockerfile: str) -> List[str]:
+    """Paths (relative to backend/src) that the Dockerfile COPYs in."""
+    out: List[str] = []
+    for line in (REPO_ROOT / dockerfile).read_text().splitlines():
+        match = _COPY.match(line.strip())
+        if match:
+            out.append(match.group(1)[len("backend/src/") :].rstrip("/"))
+    return out
+
+
+def _is_copied(rel: str, copied: List[str]) -> bool:
+    return any(rel == c or rel.startswith(c + "/") for c in copied)
+
+
+def _resolve(module: str, flattened_roots: List[str]) -> Optional[str]:
+    """Map a dotted module name to its path under backend/src, or None.
+
+    Returning None *is* the third-party filter: `json`, `boto3` and friends
+    have no file under backend/src. Note the flattened-root candidates —
+    rag-ingestion's handler reaches `status.py` as a bare `import status`,
+    with no `apis.` prefix to key off. An earlier version of this test
+    filtered on that prefix and so never walked into `status.py` at all,
+    missing the very import that broke the image.
+    """
+    bases = [module.replace(".", "/")]
+    bases += [f"{root}/{module.replace('.', '/')}" for root in flattened_roots]
+    for base in bases:
+        for candidate in (f"{base}.py", f"{base}/__init__.py"):
+            if (SRC / candidate).exists():
+                return candidate
+    return None
+
+
+def _imports(path: Path) -> Iterator[str]:
+    """Yield every dotted module name imported anywhere in a file.
+
+    `from x import y` yields both `x` and `x.y` — the latter matters when
+    `y` is a submodule rather than a name. Relative imports are skipped:
+    they resolve inside a package that is copied as a unit.
+    """
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            yield node.module
+            for alias in node.names:
+                yield f"{node.module}.{alias.name}"
+
+
+def missing_modules(image: str) -> Dict[str, Set[str]]:
+    """Return {module path not in the image -> {files that import it}}.
+
+    Walks *through* missing modules as well, so one absent package does
+    not hide the rest of the closure behind it.
+    """
+    dockerfile, entrypoints, flattened_roots = IMAGES[image]
+    copied = _copied_paths(dockerfile)
+
+    missing: Dict[str, Set[str]] = {}
+    seen: Set[str] = set()
+    queue: List[str] = list(entrypoints)
+
+    while queue:
+        rel = queue.pop()
+        if rel in seen or rel in NOT_AN_ENTRYPOINT:
+            continue
+        seen.add(rel)
+        path = SRC / rel
+        if not path.exists():
+            continue
+        try:
+            found = list(_imports(path))
+        except SyntaxError:  # pragma: no cover - the linter catches this first
+            continue
+        for module in found:
+            resolved = _resolve(module, flattened_roots)
+            if resolved is None:
+                continue
+            if not _is_copied(resolved, copied):
+                missing.setdefault(resolved, set()).add(rel)
+            if resolved not in seen:
+                queue.append(resolved)
+
+    return missing
+
+
+@pytest.mark.parametrize("image", sorted(IMAGES))
+def test_lambda_image_copies_its_full_import_closure(image: str) -> None:
+    missing = missing_modules(image)
+    if missing:
+        detail = "\n".join(
+            f"  {path}\n      imported by: {', '.join(sorted(importers))}"
+            for path, importers in sorted(missing.items())
+        )
+        dockerfile = IMAGES[image][0]
+        pytest.fail(
+            f"{image}: these modules are reachable from the handler's import "
+            f"graph but are not COPYed into the image. At runtime they raise "
+            f"ModuleNotFoundError — at cold start if imported at module "
+            f"level, or mid-invocation (possibly swallowed by an "
+            f"`except ImportError`) if imported inside a function:\n{detail}\n\n"
+            f"Fix: add a COPY for each to {dockerfile}, AND add the path to "
+            f"the {image} SOURCE_DIRS/MANIFESTS in scripts/build/build-one.sh "
+            f"so the content-hash tag notices future changes."
+        )
+
+
+def test_entrypoints_exist() -> None:
+    """Guards the test itself: a renamed handler would silently pass above."""
+    for image, (_dockerfile, entrypoints, _flattened) in IMAGES.items():
+        for entry in entrypoints:
+            assert (SRC / entry).exists(), f"{image}: missing entrypoint {entry}"
+
+
+@pytest.mark.parametrize("image", sorted(IMAGES))
+def test_walk_reaches_beyond_the_entrypoint(image: str) -> None:
+    """Guards the test itself: a resolver bug would make every image 'pass'.
+
+    If `_resolve` or the COPY parser broke, `missing_modules` would return
+    {} for everything and the suite would go quietly green. Asserting the
+    walk visits real first-party modules keeps that failure visible.
+    """
+    _dockerfile, entrypoints, flattened_roots = IMAGES[image]
+    reached = {
+        _resolve(module, flattened_roots)
+        for entry in entrypoints
+        for module in _imports(SRC / entry)
+    }
+    assert [r for r in reached if r], f"{image}: walk resolved no first-party imports"

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -92,10 +92,13 @@ case "$SERVICE" in
             "backend/src/apis/app_api/documents/ingestion"
             "backend/src/apis/shared/embeddings"
         )
-        # shared/__init__.py is a single file, hashed as a manifest.
-        # The requirements.lock lives inside the first source-dir
-        # already, so it doesn't need a separate --manifest entry.
-        MANIFESTS=("backend/src/apis/shared/__init__.py")
+        # shared/__init__.py and shared/timestamps.py are single files,
+        # hashed as manifests. The requirements.lock lives inside the
+        # first source-dir already, so it doesn't need its own entry.
+        MANIFESTS=(
+            "backend/src/apis/shared/__init__.py"
+            "backend/src/apis/shared/timestamps.py"
+        )
         # The RAG ingestion Lambda is arm64 (see the rag-ingestion CDK
         # construct), and the Dockerfile installs arm64 torch wheels.
         # Build for arm64 — an amd64 image fails the arm64 Lambda at
@@ -119,10 +122,15 @@ case "$SERVICE" in
             "backend/src/apis/shared/sync_policies"
             "backend/src/apis/shared/oauth"
             "backend/src/apis/shared/embeddings"
+            "backend/src/apis/shared/assistants"
         )
-        # shared/__init__.py hashed as a manifest (same as rag-ingestion);
+        # Single-file COPYs hashed as manifests (same as rag-ingestion);
         # kb_sync/requirements.txt lives inside the first source dir.
-        MANIFESTS=("backend/src/apis/shared/__init__.py")
+        MANIFESTS=(
+            "backend/src/apis/shared/__init__.py"
+            "backend/src/apis/shared/timestamps.py"
+            "backend/src/apis/shared/dynamo_errors.py"
+        )
         # Both kb-sync Lambdas are arm64 (see the kb-sync CDK construct).
         PLATFORM="linux/arm64"
         SSM_KEY="/${CDK_PROJECT_PREFIX}/kb-sync/image-tag"
@@ -140,10 +148,15 @@ case "$SERVICE" in
             "backend/src/apis/shared/scheduled_prompts"
             "backend/src/apis/shared/sessions_bff"
             "backend/src/apis/shared/sessions"
+            "backend/src/apis/shared/storage"
+            "backend/src/apis/shared/observability"
         )
-        # shared/__init__.py hashed as a manifest (same as kb-sync/rag-ingestion);
+        # Single-file COPYs hashed as manifests (same as kb-sync/rag-ingestion);
         # the dispatcher's requirements.txt lives inside its own source dir.
-        MANIFESTS=("backend/src/apis/shared/__init__.py")
+        MANIFESTS=(
+            "backend/src/apis/shared/__init__.py"
+            "backend/src/apis/shared/errors.py"
+        )
         # Both scheduled-runs Lambdas are arm64 (see the scheduled-runs
         # CDK construct).
         PLATFORM="linux/arm64"


### PR DESCRIPTION
## Summary

Document ingestion and KB sync have been **100% dead in dev since ~2026-07-27 and in prod since the 2026-08-01 18:46 UTC deploy**. Every invocation of the rag-ingestion Lambda and both kb-sync Lambdas fails at import:

```
[ERROR] ModuleNotFoundError: No module named 'apis.shared.timestamps'
  File "/var/task/status.py", line 10, in <module>
    from apis.shared.timestamps import utc_now_iso
```

`apis/shared/timestamps.py` landed in 8544d87a and is imported by `documents/ingestion/status.py`, but the Lambda images don't COPY all of `backend/src` — each hand-maintains a subset of `apis.shared`, and nothing kept those lists in sync with the code.

## How it stayed invisible

The S3 events fired, the crawler staged its markdown correctly, and the container died before any handler code ran. So documents just sat at `uploading` forever with no error, and scheduled KB sync silently stopped. Found while investigating a knowledge-base crawl that looked stuck — the crawl had actually completed (25/25 pages fetched, 0 failed, all markdown in S3); only the ingestion behind it was broken.

Measured impact at time of diagnosis:

| | broken since | state |
|---|---|---|
| dev rag-ingestion | ~2026-07-27 | 75 invocations / 75 errors on the one crawl alone |
| dev kb-sync dispatcher | ~2026-07-27 | 288 failures/day |
| prod rag-ingestion | 2026-08-01 18:46 UTC | 100% errors (1 document lost so far) |
| prod kb-sync dispatcher | 2026-08-01 18:46 UTC | ~288/day — all scheduled KB sync dead |

## Two more gaps of the same shape

Both already present, found by the new test:

- **kb-sync** omitted `assistants/` and `dynamo_errors.py`, which `document_service.soft_delete_document` imports inside a `try/except ImportError` that logs `"boto3 is required"` and returns `None`. That except branch was always taken, so the worker's miss-eviction path silently no-opped rather than crashing.
- **scheduled-runs** omitted `errors.py`, `storage/` and `observability/`, reached from `sessions/metadata.py`. Latent — those paths hadn't been exercised (0 errors on both functions).

## Changes

- `Dockerfile.rag-ingestion`, `Dockerfile.kb-sync`, `Dockerfile.scheduled-runs` — close each image's import closure.
- `scripts/build/build-one.sh` — add the new paths to each image's `SOURCE_DIRS`/`MANIFESTS`, or the content-hash tag wouldn't notice future changes to them.
- `backend/tests/supply_chain/test_lambda_image_imports.py` (new) — walks each image's real import graph from its handler entrypoints and fails on anything not COPYed.

All new COPYs are leaf-ish helpers whose own dependencies (stdlib, boto3, pydantic) are already pinned in each image's requirements — no new packages.

## On the test's design

Two things it deliberately does, both because the obvious version misses the actual bug:

1. **It does not distinguish module-level imports from function-local ones.** `handler.py` reaches `status.py` via a function-local import, so a module-level-only check *passes rag-ingestion without the fix* (I wrote that version first and watched it go green). A function-local import still runs on invocation, and a swallowed one is worse than a crash because it degrades quietly — see the kb-sync case above.
2. **It resolves bare module names against each image's flattened COPY root.** rag-ingestion's handler reaches `status.py` as `import status`, with no `apis.` prefix to key off; filtering on that prefix means never walking into `status.py` at all.

## Verification

- Reverted all three Dockerfiles → the test fails on all three images and names the exact missing modules; restored → passes.
- Staged each image's COPY surface into a bare tree and imported the handlers against **only** that: `dispatcher`, `worker`, `status`, and the previously-broken `get_assistant` path all import clean. `docker` wasn't available in the session, so this is an import-level proof, not a built-image one — worth a look at the build logs on merge.
- `tests/supply_chain/` + `tests/architecture/`: 79 passed.

## After merge

Once `backend.yml` redeploys rag-ingestion, the 25 dev documents from the crawl need their S3 events re-fired (their markdown is already staged):

```
aws s3 cp --recursive --profile dev-ai --metadata-directive REPLACE --content-type text/markdown \
  s3://dev-boisestateai-v2-rag-documents-490617140655/assistants/ast-aa738adac137/documents/ \
  s3://dev-boisestateai-v2-rag-documents-490617140655/assistants/ast-aa738adac137/documents/
```

**Prod needs this via a release to `main`** — its KB sync has been fully down since 8/1.

Separately worth doing: nothing alarms on these Lambdas' error rate, and documents have no staleness rule (contrast `is_crawl_stale` on `CrawlJob`), which is the whole reason a total outage went unnoticed for days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
