### PR TITLE
feat(marketplace): let authors ship updates to a live listing

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -37,6 +37,7 @@ from apis.shared.assistants.listing import (
     ListingTransitionError,
     assert_author_target,
     assert_transition,
+    author_cancel_target,
     gsi5_keys,
     is_listed,
     is_on_shelf,
@@ -293,14 +294,26 @@ async def _exposed_skills(assistant: Assistant) -> List[SkillExposure]:
 
 
 # ── publisher resolution (D12) ───────────────────────────────────────────────────────
-async def _resolve_proposed_publisher(user: User, publisher_id: Optional[str]) -> str:
+async def _resolve_proposed_publisher(
+    user: User, publisher_id: Optional[str], *, current: Optional[str] = None
+) -> str:
     """The publisher an author may propose, defaulting to their own individual profile.
 
     Eligibility is checked *here*, on the author's proposal path only. An admin may set
     any publisher on any listing regardless of it (D12) — see ``patch_listing_presentation``,
     which deliberately does not call this.
+
+    ⚠️ ``current`` — the attribution the listing already carries — wins over the individual
+    default, and deliberately skips the eligibility check. An admin who reattributed a
+    listing to a department made a D12 decision; resolving an author's *silence* back to
+    their personal profile would undo it on every update, invisibly, and re-checking
+    eligibility would instead 403 the author out of updating their own listing. Neither is
+    the author proposing anything. An explicit ``publisher_id`` is still a proposal and is
+    still checked.
     """
     if not publisher_id:
+        if current:
+            return current
         profile = await ensure_individual_profile(user.user_id, user.name)
         return profile.id
 
@@ -354,7 +367,17 @@ async def preflight_listing(
 async def submit_listing(
     agent_id: str, user: User, request: SubmitListingRequest
 ) -> Tuple[AgentListing, List[SkillExposure]]:
-    """Author submits an Agent for review (D2), after the D7 checks pass."""
+    """Author submits an Agent for review (D2), after the D7 checks pass.
+
+    Also how an author ships an **update** to a listing that is already live. Since version
+    snapshots, edits to a published Agent land on the draft and reach nobody until a new
+    version is approved, so submitting again is the only way to get a change in front of
+    users — and it is the same act, with the same checks, whatever the listing's state.
+
+    A submission over a live listing changes nothing users can see. ``published_version``
+    and its index key are carried through untouched, so the approved snapshot keeps serving
+    for the whole review; only approval swaps it.
+    """
     assistant = await _load_for_author(agent_id, user)
     await _validate_category(request.category)
 
@@ -368,7 +391,11 @@ async def submit_listing(
     await _memory_space_block(assistant, user)
     _visibility_block(assistant, consented=request.make_public)
     exposed = await _exposed_skills(assistant)
-    publisher_id = await _resolve_proposed_publisher(user, request.publisher_id)
+    publisher_id = await _resolve_proposed_publisher(
+        user,
+        request.publisher_id,
+        current=assistant.listing.publisher_id if assistant.listing else None,
+    )
 
     now = _now()
     previous = assistant.listing
@@ -408,6 +435,20 @@ async def submit_listing(
         # its index key and keeps serving until an admin promotes the new one, so the shelf
         # never goes blank while a review is pending.
         published_version=previous.published_version if previous else None,
+        # Where to put it back if the author cancels — recorded here rather than inferred at
+        # cancel time, when ``in_review`` no longer says which state this came from. Set only
+        # when the listing is on the shelf *now*, because that is the case where cancelling
+        # must not fall through to ``private``: the ordinary withdraw path would read a live
+        # listing and turn "take back my edit" into a request to pull the whole thing.
+        #
+        # The only on-shelf states that can reach here are ``published`` and
+        # ``changes_requested`` — ``in_review`` has no self-loop, and the other two are not
+        # live — which is exactly ``UPDATE_ORIGIN_STATES``, the set the cancel path accepts.
+        submitted_from=(
+            previous.state
+            if previous and is_on_shelf(previous.state, previous.published_version)
+            else None
+        ),
         # A resubmission carries its review history forward; the note stays visible until
         # the reviewer replaces it, so the author keeps the context they are acting on.
         reviewed_at=previous.reviewed_at if previous else None,
@@ -441,9 +482,9 @@ async def submit_listing(
 
 
 async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
-    """Author withdraws — immediately if nothing is live, as a *request* if something is.
+    """Author withdraws — cancelling an update, pulling a draft, or *asking* to delist.
 
-    **The same endpoint, two different acts, and the listing state decides which.** Before
+    **The same endpoint, three different acts, and the listing decides which.** Before
     publication, withdrawing is the author's alone: a pending submission is their own work
     and pulling it costs nobody anything. Once a listing is live, other people have pinned
     it, so removal becomes something an admin sees — the same reasoning that makes
@@ -452,7 +493,14 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
     ("take this down"), and making them pick the right verb for their listing's state is
     asking them to know the state machine.
 
-    Neither act revokes anything retroactively: people who pinned it keep their pin,
+    The third act is the one that is easy to miss. An author with a live listing who submits
+    an **update** and then changes their mind is not asking for anything to come down — they
+    want their edit back. Read by "is something on the shelf?" alone, that cancellation turns
+    into a request to delist a listing nobody asked to delist, parked in an admin's queue. So
+    a pending update cancels back to the state it was submitted from and the listing carries
+    on serving the version it always was; see ``author_cancel_target``.
+
+    No act here revokes anything retroactively: people who pinned it keep their pin,
     conversations underway keep running, and the agent stays reachable by direct link
     because ``visibility`` is a separate axis. It is a delisting, not a recall.
     """
@@ -476,6 +524,48 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
             "it stays in the store until they do.",
             status_code=400,
         )
+
+    # ── cancelling a pending update ──────────────────────────────────────────────────
+    #
+    # Checked before the live/not-live split below, because that split answers the wrong
+    # question for this case: the listing *is* on the shelf, but the thing being withdrawn
+    # is the submission sitting on top of it, not the listing underneath.
+    #
+    # ``submitted_from`` is the whole discriminator. It is written only when a submission
+    # was made over something already on the shelf, so its presence means "there is a live
+    # version this can go back to" and its absence means the ordinary paths below are right.
+    # ``is_on_shelf`` is still asked, so a pointer that lost its version cannot cancel into
+    # a ``published`` state with nothing published.
+    if (
+        current == "in_review"
+        and assistant.listing.submitted_from
+        and is_on_shelf(assistant.listing.submitted_from, assistant.listing.published_version)
+    ):
+        try:
+            target = author_cancel_target(assistant.listing.submitted_from)
+            assert_transition(current, target)
+        except ListingTransitionError as e:  # pragma: no cover - both edges are in the table
+            raise ListingError(str(e), status_code=400) from e
+        except ListingAuthorityError as e:  # pragma: no cover - guarded by the branch itself
+            raise ListingError(str(e), status_code=403) from e
+
+        now = _now()
+        # Nothing is unindexed and ``published_version`` is untouched: the update never
+        # reached the store, so there is nothing to undo there.
+        #
+        # ⚠️ ``submitted_version`` deliberately stays. It is not just "what is awaiting
+        # review" — ``_latest_version`` reads it as the high-water mark that tells the admin
+        # Listings table another snapshot exists, and clearing it here would hide the
+        # rollback control for exactly the versions this author just cut.
+        listing = assistant.listing.model_copy(
+            update={"state": target, "submitted_from": None}
+        )
+        await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
+        logger.info(
+            f"↩️ Agent {agent_id} pending update cancelled by its owner; listing returns "
+            f"to {target} still serving v{assistant.listing.published_version}"
+        )
+        return listing
 
     # A live listing can only be *requested* down; anything else goes straight to private.
     #
@@ -525,7 +615,9 @@ async def withdraw_listing(agent_id: str, user: User) -> AgentListing:
     # Pre-publication withdrawal: nothing is on the shelf, so this is immediate. The
     # unindex is belt-and-braces for a listing whose pointer outlived its key.
     await _unindex_version(agent_id, assistant.listing.published_version)
-    listing = assistant.listing.model_copy(update={"state": target, "published_version": None})
+    listing = assistant.listing.model_copy(
+        update={"state": target, "published_version": None, "submitted_from": None}
+    )
     await write_listing(agent_id, listing, assistant.created_at, updated_at=now)
     logger.info(f"📭 Agent {agent_id} submission withdrawn by its owner")
     return listing

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -64,6 +64,7 @@ LISTING_STATES: Tuple[str, ...] = (
 #   changes_requested → in_review          author resubmits after addressing the note
 #   taken_down        → in_review          author resubmits after addressing the takedown
 #                                          (the takedown dialog promises exactly this)
+#   published         → in_review          author submits an UPDATE to a live listing
 #   in_review         → published          admin approves
 #   in_review         → changes_requested  admin requests changes, with a reason
 #   published         → taken_down         admin delists, with a reason
@@ -90,6 +91,19 @@ LISTING_STATES: Tuple[str, ...] = (
 # The edges an author still owns alone are the pre-publication ones: ``private → in_review``
 # and withdrawing a *pending* submission (``in_review``/``changes_requested`` → ``private``).
 #
+# ⚠️ ``published → in_review`` is how an author ships an UPDATE, and its absence used to make
+# a published listing a dead end. Version snapshots mean an author's edits land on the draft
+# and reach nobody until a new version is approved, so the only way to get a fix in front of
+# users is to submit again — and from ``published`` there was no edge to submit along. The
+# author's alternatives were to request withdrawal (taking their own listing off the shelf to
+# fix a typo) or to wait for an admin to send it back with ``request_changes``. Neither is a
+# thing a working author should have to do, and the second one isn't even theirs to start.
+#
+# This is not a second door into the store. Submitting an update leaves ``published_version``
+# and its index key exactly where they are (``submit_listing``), so the previously approved
+# snapshot keeps serving; approval of the new one is still the only thing that changes what
+# users get. What it does open is the reverse edge — see ``author_cancel_target``.
+#
 # ⚠️ ``changes_requested`` covers two different listings — one that was never published, and
 # one that *was* and is still serving while the author revises it (``review_listing``
 # deliberately does not unpublish). Only the first may walk ``→ private`` alone; the second
@@ -108,10 +122,18 @@ ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     "private": {"in_review"},
     "in_review": {"published", "changes_requested", "private"},
     "changes_requested": {"in_review", "private", "withdrawal_requested"},
-    "published": {"taken_down", "changes_requested", "withdrawal_requested"},
+    "published": {"in_review", "taken_down", "changes_requested", "withdrawal_requested"},
     "taken_down": {"in_review", "changes_requested"},
     "withdrawal_requested": {"private", "published", "changes_requested", "taken_down"},
 }
+
+# States a submission can be made *from* while the listing is already on the shelf — and
+# therefore the states cancelling that submission can return it to.
+#
+# ``published`` is the ordinary update. ``changes_requested`` is the one that is easy to
+# forget: an admin who requests changes on a live listing deliberately does not unpublish it
+# (``review_listing``), so that author is also updating something users can currently see.
+UPDATE_ORIGIN_STATES: Set[str] = {"published", "changes_requested"}
 
 # States an author may drive. Everything else is the reviewer's (``require_admin``).
 #
@@ -120,6 +142,12 @@ ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
 # because "an author cannot pull a live listing" deserves a real gate and not just an absent
 # edge in the table. Both checks run on the author path: the table says the move is legal at
 # all, this says the author is allowed to be the one making it.
+#
+# ⚠️ ``published`` and ``changes_requested`` stay out even though an author cancelling an
+# update lands on one of them. Widening this set would be the wrong fix by a mile: from
+# ``in_review`` the author would then be able to walk their *own first submission* to
+# ``published``. That act is narrow, has its own gate, and derives its target from the
+# recorded origin rather than accepting one — see ``author_cancel_target``.
 AUTHOR_TARGET_STATES: Set[str] = {"in_review", "private", "withdrawal_requested"}
 
 # Listing states whose Agent is live in the store.
@@ -204,6 +232,48 @@ def assert_author_target(target: str) -> None:
         raise ListingAuthorityError(
             f"Moving a listing to '{target}' is a reviewer's decision, not the author's."
         )
+
+
+def author_cancel_target(submitted_from: Optional[str]) -> str:
+    """Where cancelling a pending *update* puts the listing back, or raise.
+
+    An author with a live listing who submits an update and then changes their mind is doing
+    something the ordinary withdraw path gets badly wrong: it reads "there is something on
+    the shelf" and turns their cancellation into a ``withdrawal_requested`` — a request to
+    pull the whole listing, sitting in an admin's queue, when all they wanted was to take
+    back an edit. So cancelling an update is its own act, and this is where its target comes
+    from.
+
+    **Returns the target rather than checking one.** The caller has no business choosing
+    here: the only safe answer is the state the submission came *from*, and a function that
+    validated a proposed target would let a caller propose ``published`` for a listing that
+    was in ``changes_requested`` — silently discarding an outstanding change request, and
+    publishing something no admin approved. That is the identical trap ``withdrawal_from``
+    exists to close on the withdrawal path (see ``ALLOWED_TRANSITIONS``), so it is closed the
+    same way: record the origin on the way in, and read it on the way out.
+
+    ``in_review → published`` is not a door into the store here for the same reason declining
+    a withdrawal isn't: the listing never left. ``submit_listing`` leaves ``published_version``
+    and its index key untouched, so this returns the record to what the store was already
+    serving. Approval remains the only edge that *changes* what users get.
+
+    ⚠️ Raising when ``submitted_from`` is absent is load-bearing, not defensive. Absent means
+    "this submission was not an update to a live listing" — a first submission, or one from
+    ``private``/``taken_down`` — and those cancel to ``private`` down the ordinary path. If
+    this ever answered a default instead, a first-time submission could walk itself into
+    ``published`` without a reviewer, which is the one thing the machine must never allow.
+    """
+    if submitted_from is None:
+        raise ListingAuthorityError(
+            "This submission is not an update to a live listing, so there is nothing to "
+            "return it to. Withdraw it instead."
+        )
+    if submitted_from not in UPDATE_ORIGIN_STATES:
+        raise ListingAuthorityError(
+            f"A submission from '{submitted_from}' is not an update to a live listing; "
+            "cancelling it cannot put it back there."
+        )
+    return submitted_from
 
 
 def is_published(state: Optional[str]) -> bool:

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -193,6 +193,26 @@ class AgentListing(BaseModel):
             "free of a second door into the store."
         ),
     )
+    submitted_from: Optional[ListingState] = Field(
+        None,
+        alias="submittedFrom",
+        description=(
+            "Set only while a submission is an *update to a listing that is already on the "
+            "shelf*, and names the state it came from, so cancelling it restores exactly "
+            "that. The withdrawal-path twin of ``withdrawal_from``, and for the same reason: "
+            "two states can be live (``published``, and a ``changes_requested`` listing that "
+            "was published before the admin sent it back), so assuming ``published`` would "
+            "discard an outstanding change request and publish something no admin approved.\n\n"
+            "Absent means the submission is not over a live listing — a first submission, or "
+            "one from ``private``/``taken_down`` — which cancels to ``private`` instead. That "
+            "distinction is what keeps an author from walking their own first submission into "
+            "``published``; see ``listing.author_cancel_target``.\n\n"
+            "Meaningful only while ``state == in_review``, and every submission rewrites it, "
+            "so a value an earlier cycle left behind is never read. Any new reader must gate "
+            "on the state as well — the field answers 'where did the pending submission come "
+            "from?', which is not a question a listing with no pending submission has."
+        ),
+    )
     submitted_version: Optional[int] = Field(
         None,
         alias="submittedVersion",

--- a/backend/tests/routes/test_agent_listing.py
+++ b/backend/tests/routes/test_agent_listing.py
@@ -505,6 +505,129 @@ class TestSubmit:
         assert resp.json()["listing"]["state"] == "in_review"
         assert resp.json()["listing"]["reviewNote"] == "Please add a tagline."
 
+    def test_a_published_listing_can_be_updated(self, app, make_user, _no_writes):
+        """The gap this closes: a published listing had no way to ship a fix.
+
+        Version snapshots put the author's edits on the draft, so submitting again is the
+        only route to users — and ``published`` had no edge to submit along. The author's
+        alternatives were to request withdrawal (taking their own listing off the shelf to
+        fix a typo) or to wait for an admin to send it back, which is not theirs to start.
+        """
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state="published",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=2,
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Teaching"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["listing"]["state"] == "in_review"
+
+    def test_updating_a_live_listing_keeps_the_approved_version_serving(
+        self, app, make_user, _no_writes
+    ):
+        """⚠️ The half that makes the new edge safe rather than a second door.
+
+        Submitting an update must change nothing users can see: the approved snapshot keeps
+        its pointer *and* its index key for the whole review, and only approval swaps them.
+        """
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state="published",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=2,
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            TestClient(app).post("/agents/ast-001/listing/submit", json={"category": "Teaching"})
+
+        written = _no_writes.call_args.args[1]
+        assert written.published_version == 2, "an update must not unpublish"
+        assert written.submitted_version == 1
+        _no_writes.set_version_index.assert_not_awaited()
+
+    @pytest.mark.parametrize("origin", ["published", "changes_requested"])
+    def test_an_update_records_where_it_can_be_cancelled_back_to(
+        self, app, make_user, _no_writes, origin
+    ):
+        """Recorded on the way in, because ``in_review`` cannot say where it came from."""
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state=origin,
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=2,
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            TestClient(app).post("/agents/ast-001/listing/submit", json={"category": "Teaching"})
+
+        assert _no_writes.call_args.args[1].submitted_from == origin
+
+    @pytest.mark.parametrize(
+        "listing",
+        [
+            None,
+            AgentListing(state="private", category="Teaching", publisherId="user-user-001"),
+            AgentListing(
+                state="changes_requested", category="Teaching", publisherId="user-user-001"
+            ),
+        ],
+        ids=["first-submission", "private", "changes-requested-never-published"],
+    )
+    def test_a_submission_over_nothing_live_records_no_origin(
+        self, app, make_user, _no_writes, listing
+    ):
+        """Absent is what routes these down the ordinary withdraw path, to ``private``.
+
+        ``changes_requested`` is in here twice on purpose — with a published version it is
+        an update, without one it is a draft, and only the pointer tells them apart.
+        """
+        mock_auth_user(app, make_user())
+        with _owner(_make_assistant(bindings=[], listing=listing)):
+            TestClient(app).post("/agents/ast-001/listing/submit", json={"category": "Teaching"})
+
+        assert _no_writes.call_args.args[1].submitted_from is None
+
+    def test_an_update_keeps_the_publisher_an_admin_assigned(self, app, make_user, _no_writes):
+        """⚠️ An author's silence must not undo a D12 reattribution.
+
+        The submit dialog never sends ``publisherId``, so every update arrives with none —
+        and resolving that to the author's individual profile would quietly re-credit a
+        departmental listing to a person, on every update, for as long as they kept
+        shipping. Re-checking eligibility instead would 403 them out of their own listing.
+        """
+        assistant = _make_assistant(
+            bindings=[],
+            listing=AgentListing(
+                state="published",
+                category="Teaching",
+                publisherId="pub-registrar",
+                publishedVersion=2,
+            ),
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).post(
+                "/agents/ast-001/listing/submit", json={"category": "Teaching"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["listing"]["publisherId"] == "pub-registrar"
+
     def test_cannot_resubmit_an_agent_already_in_review(self, app, make_user, _no_writes):
         assistant = _make_assistant(
             bindings=[],
@@ -599,6 +722,84 @@ class TestWithdraw:
             resp = TestClient(app).delete("/agents/ast-001/listing")
 
         assert resp.status_code == 400
+
+    @pytest.mark.parametrize("origin", ["published", "changes_requested"])
+    def test_cancelling_a_pending_update_returns_it_to_its_origin(
+        self, app, make_user, _no_writes, origin
+    ):
+        """⚠️ Not a withdrawal request. The author wants their edit back, not a delisting.
+
+        Read by "is something on the shelf?" alone — which is all this endpoint used to ask
+        — this became a request to pull a live listing nobody asked to pull, sitting in an
+        admin's queue. ``changes_requested`` is the case that must not collapse to
+        ``published``: the outstanding change request is still outstanding.
+        """
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="in_review",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=2,
+                submittedVersion=3,
+                submittedFrom=origin,
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == origin
+        assert resp.json()["submittedFrom"] is None, "the origin has done its job"
+
+    def test_cancelling_an_update_leaves_the_store_exactly_as_it_was(
+        self, app, make_user, _no_writes
+    ):
+        """The published version never moved, so there is nothing to restore."""
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="in_review",
+                category="Teaching",
+                publisherId="user-user-001",
+                publishedVersion=2,
+                submittedVersion=3,
+                submittedFrom="published",
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            TestClient(app).delete("/agents/ast-001/listing")
+
+        written = _no_writes.call_args.args[1]
+        assert written.published_version == 2
+        # ⚠️ ``submittedVersion`` is the high-water mark ``_latest_version`` reads to decide
+        # whether another snapshot exists. Clearing it here would hide the rollback control
+        # for exactly the versions this author just cut.
+        assert written.submitted_version == 3
+        _no_writes.set_version_index.assert_not_awaited()
+
+    def test_a_pending_submission_with_no_live_version_still_withdraws_to_private(
+        self, app, make_user, _no_writes
+    ):
+        """The origin is only half the discriminator; the pointer is the other half.
+
+        A listing whose published version went away has nothing to cancel back *to*, and
+        landing it in ``published`` would claim a version the store cannot serve.
+        """
+        assistant = _make_assistant(
+            listing=AgentListing(
+                state="in_review",
+                category="Teaching",
+                publisherId="user-user-001",
+                submittedFrom="published",
+            )
+        )
+        mock_auth_user(app, make_user())
+        with _owner(assistant):
+            resp = TestClient(app).delete("/agents/ast-001/listing")
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "private"
 
     def test_withdrawing_an_unsubmitted_agent_is_404(self, app, make_user, _no_writes):
         mock_auth_user(app, make_user())

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -15,12 +15,15 @@ from apis.shared.assistants.listing import (
     LISTED_STATES,
     LISTING_STATES,
     PENDING_DECISION_STATES,
+    UPDATE_ORIGIN_STATES,
     ListingAuthorityError,
     ListingTransitionError,
     assert_author_target,
     assert_transition,
+    author_cancel_target,
     gsi5_keys,
     is_listed,
+    is_on_shelf,
     is_published,
 )
 
@@ -48,6 +51,16 @@ def test_request_changes_then_resubmit():
 def test_resubmit_after_takedown():
     """The takedown dialog promises the author can resubmit once it's addressed."""
     assert_transition("taken_down", "in_review")
+
+
+def test_a_published_listing_can_be_updated():
+    """Since version snapshots, submitting again is the *only* way to change what users get.
+
+    Edits to a published Agent land on the draft, so without this edge a published listing
+    was a dead end: the author's choices were to request withdrawal (taking their own
+    listing down to fix a typo) or to wait for an admin to send it back.
+    """
+    assert_transition("published", "in_review")
 
 
 def test_author_may_withdraw_a_pending_submission_outright():
@@ -85,6 +98,59 @@ def test_author_target_states_gate_the_authors_own_moves():
     for reviewer_only in ("published", "changes_requested", "taken_down"):
         with pytest.raises(ListingAuthorityError):
             assert_author_target(reviewer_only)
+
+
+# ── cancelling a pending update ──────────────────────────────────────────────────────
+@pytest.mark.parametrize("origin", sorted(UPDATE_ORIGIN_STATES))
+def test_cancelling_an_update_returns_it_to_where_it_came_from(origin):
+    """Not to ``published`` — the twin of ``withdrawal_from``, for the identical reason.
+
+    A ``changes_requested`` listing that was published before the admin sent it back is
+    live, so its author is updating something users can see. Cancelling that into
+    ``published`` would discard the outstanding change request *and* publish a listing no
+    admin approved.
+    """
+    assert author_cancel_target(origin) == origin
+    assert_transition("in_review", origin)
+
+
+def test_cancelling_a_first_submission_has_nowhere_to_return_to():
+    """⚠️ The assertion that keeps this from being a second door into the store.
+
+    ``None`` means the submission was not an update to a live listing. If this answered a
+    default instead of raising, an author could walk their own unreviewed first submission
+    into ``published``.
+    """
+    with pytest.raises(ListingAuthorityError):
+        author_cancel_target(None)
+
+
+@pytest.mark.parametrize(
+    "state", [s for s in LISTING_STATES if s not in UPDATE_ORIGIN_STATES]
+)
+def test_only_an_on_shelf_origin_can_be_cancelled_back_to(state):
+    with pytest.raises(ListingAuthorityError):
+        author_cancel_target(state)
+
+
+def test_every_cancel_target_is_reachable_from_in_review():
+    """The gate returns a target rather than validating one, so the table must accept it.
+
+    If an origin were ever added here without the matching edge, cancelling would raise a
+    transition error from inside a path the author is entitled to walk.
+    """
+    for origin in UPDATE_ORIGIN_STATES:
+        assert origin in ALLOWED_TRANSITIONS["in_review"]
+
+
+def test_every_update_origin_is_a_state_that_can_be_on_the_shelf():
+    """The other half of the contract, and what the service branch keys on.
+
+    Cancelling *back into* a state that can never be live would put the record in a state
+    claiming a published version it does not have.
+    """
+    for origin in UPDATE_ORIGIN_STATES:
+        assert is_on_shelf(origin, 3), f"{origin} can never be live; it cannot be an origin"
 
 
 # ── the edges that must not exist ────────────────────────────────────────────────────

--- a/docs/specs/agent-version-snapshots.md
+++ b/docs/specs/agent-version-snapshots.md
@@ -256,6 +256,44 @@ An author can still take an Agent **private before it is ever published** — th
 `private → in_review` and `in_review → private` (withdraw a pending submission)
 edges are unchanged. The new constraint applies only once something is live.
 
+### 5.1a Updating a live listing — added 2026-08-01
+
+**The gap this closes was created by §3 and missed by §5.1.** Once the store serves a
+snapshot, an author's edits reach nobody until a new version is approved — so submitting
+again is the *only* way to ship a fix. But `published` had no edge to `in_review`, and
+§5.1 had just removed `published → private`. A published author's routes to their own
+users were: request withdrawal (take the listing off the shelf to fix a typo, and wait
+for an admin to grant it), or wait for an admin to send it back with `request_changes`,
+which is not theirs to start. In practice a live listing was a dead end.
+
+```
+published → in_review     author submits an UPDATE to a live listing
+```
+
+This is not a second door into the store. `submit_listing` carries `publishedVersion`
+and its index key through untouched, so the approved snapshot keeps serving for the whole
+review; approval still promotes `submittedVersion` and is still the only edge that changes
+what users get.
+
+**Cancelling an update is its own act**, and the reverse edge is the subtle half.
+Withdrawal picks its target from `is_on_shelf`, so an author cancelling a pending update
+was read as an author asking to delist — a request they never made, parked in an admin's
+queue. So a submission made over something already on the shelf records where it came
+from (`AgentListing.submittedFrom`), and cancelling returns it there:
+
+```
+in_review → published            author cancels an update to a live listing
+in_review → changes_requested    ...one submitted while a change request was outstanding
+```
+
+Both are legal edges already; what makes them safe is that the target is *derived from the
+recorded origin* rather than accepted from a caller (`listing.author_cancel_target`), and
+that the origin is absent for any submission not over a live listing. That is the exact
+mechanism — and the exact reasoning — behind `withdrawal_from` in §5.1: assuming
+`published` would discard an outstanding change request and publish something no admin
+approved. `AUTHOR_TARGET_STATES` deliberately does **not** gain `published`; widening it
+would let an author walk their own unreviewed first submission into the store.
+
 ### 5.2 Delete is refused while a listing exists
 
 `delete_assistant` gains a listing check and refuses when `listing.state` is anything

--- a/frontend/ai.client/src/app/agents/components/listing-status.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/listing-status.component.spec.ts
@@ -65,6 +65,26 @@ describe('ListingStatusComponent', () => {
     expect(text).not.toContain('reviewer');
   });
 
+  // ── "in review" must not read as "off the shelf" ────────────────────────────────
+  it('says the published version stays live while an update is reviewed', () => {
+    // Without this the badge lies by omission: an author shipping a fix to a live agent
+    // sees "In review" and reasonably concludes their listing came down. It did not —
+    // the approved snapshot keeps serving until the update is approved.
+    const fixture = create(block({ state: 'in_review', publishedVersion: 2 }));
+    expect(fixture.nativeElement.textContent).toContain('stays in the store');
+  });
+
+  it('says the same while a live listing is being revised', () => {
+    // Requesting changes on a published listing deliberately does not unpublish it.
+    const fixture = create(block({ state: 'changes_requested', publishedVersion: 2 }));
+    expect(fixture.nativeElement.textContent).toContain('still in the store');
+  });
+
+  it('claims nothing about a first submission that has never been published', () => {
+    const fixture = create(block({ state: 'in_review' }));
+    expect(fixture.nativeElement.textContent).not.toContain('store');
+  });
+
   it('surfaces the D13 admin-edit trail with a date', () => {
     const fixture = create(
       block({ adminEdits: [{ field: 'category', at: '2026-07-24T10:00:00Z', by: 'Dana' }] }),

--- a/frontend/ai.client/src/app/agents/components/listing-status.component.ts
+++ b/frontend/ai.client/src/app/agents/components/listing-status.component.ts
@@ -38,6 +38,12 @@ export type ListingStatusPart = 'all' | 'badge' | 'note';
       }
 
       @if (showNote()) {
+        @if (stillLive()) {
+          <p class="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+            {{ stillLive() }}
+          </p>
+        }
+
         @if (note(); as text) {
           <div
             class="mt-2 rounded-2xl border px-3 py-2 text-xs/5"
@@ -83,6 +89,27 @@ export class ListingStatusComponent {
   });
 
   readonly note = computed(() => this.listing()?.reviewNote?.trim() || null);
+
+  /**
+   * The sentence that stops the badge from lying, or `null`.
+   *
+   * "In review" and "Changes requested" both describe a *submission*, and an author whose
+   * agent is in the store reads them as a statement about their listing — that it came
+   * down, or is about to. Neither is true: submitting an update leaves the approved version
+   * serving, and requesting changes on a live listing deliberately does not unpublish it.
+   * The pointer is what tells them apart, which is why `publishedVersion` is on the wire.
+   */
+  readonly stillLive = computed(() => {
+    const l = this.listing();
+    if (!l?.publishedVersion) return null;
+    if (l.state === 'in_review') {
+      return 'Your published version stays in the store, unchanged, until this update is approved.';
+    }
+    if (l.state === 'changes_requested') {
+      return 'Your published version is still in the store while you make these changes.';
+    }
+    return null;
+  });
 
   /**
    * Who wrote the note depends on the state, and mislabelling it is worse than not

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.spec.ts
@@ -13,6 +13,7 @@ import { ConfigService } from '../../services/config.service';
 import { AgentService } from '../services/agent.service';
 import { AgentListingService } from '../services/agent-listing.service';
 import { ShareEntry } from '../../assistants/models/assistant.model';
+import { AgentListingBlock } from '../models/store.model';
 
 /** Network-bound doubles. None of the behaviour under test reaches them. */
 function baseProviders(overrides: {
@@ -232,6 +233,84 @@ describe('ShareAgentDialogComponent', () => {
       await (isolated as any).onSave();
 
       expect(updateAssistant).toHaveBeenCalledWith('ast-test', { visibility: 'SHARED' });
+    });
+  });
+
+  /**
+   * The marketplace controls, which have to mirror the backend transition table exactly —
+   * a button the machine refuses is a dead click, and a missing button is a dead end.
+   *
+   * The dead end is why these exist: `published` was absent from `canSubmit`, so an author
+   * whose agent was live had no way to ship a fix. Their edits land on the draft and reach
+   * nobody until a new version is approved, and the only routes out were to request
+   * withdrawal (taking their own listing down over a typo) or to wait for an admin.
+   */
+  describe('marketplace controls', () => {
+    function withListing(listing: Partial<AgentListingBlock> | undefined) {
+      (component as any).listing.set(
+        listing
+          ? ({
+              state: 'published',
+              category: 'Teaching',
+              publisherId: 'user-user-001',
+              ...listing,
+            } as AgentListingBlock)
+          : undefined,
+      );
+      return component as any;
+    }
+
+    it('offers an update on a published listing', () => {
+      const c = withListing({ state: 'published', publishedVersion: 2 });
+      expect(c.canSubmit()).toBe(true);
+      expect(c.submitLabel()).toBe('Submit an update');
+    });
+
+    it('calls a first submission what it is', () => {
+      const c = withListing(undefined);
+      expect(c.canSubmit()).toBe(true);
+      expect(c.submitLabel()).toBe('Submit to marketplace');
+    });
+
+    it('offers nothing to submit while a submission is already pending', () => {
+      expect(withListing({ state: 'in_review' }).canSubmit()).toBe(false);
+    });
+
+    it('offers nothing to submit while a withdrawal is awaiting a decision', () => {
+      // `withdrawal_requested → in_review` is not an edge; the admin decides first.
+      expect(withListing({ state: 'withdrawal_requested', publishedVersion: 2 }).canSubmit()).toBe(
+        false,
+      );
+    });
+
+    it('calls taking back a pending update a cancellation, not a withdrawal', () => {
+      // ⚠️ The author is taking back an edit, and the listing goes on serving the version
+      // it always was. "Withdraw submission" reads as though the live listing were at
+      // stake, and the confirm copy behind it promised an admin review that never happens.
+      const c = withListing({
+        state: 'in_review',
+        publishedVersion: 2,
+        submittedFrom: 'published',
+      });
+      expect(c.hasPendingUpdate()).toBe(true);
+      expect(c.withdrawLabel()).toBe('Cancel update');
+    });
+
+    it('still calls a first submission a withdrawal', () => {
+      const c = withListing({ state: 'in_review' });
+      expect(c.hasPendingUpdate()).toBe(false);
+      expect(c.withdrawLabel()).toBe('Withdraw submission');
+    });
+
+    it('does not read a stale origin left behind by an earlier cycle', () => {
+      // `submittedFrom` is meaningful only while `in_review`; approval does not clear it.
+      const c = withListing({
+        state: 'published',
+        publishedVersion: 3,
+        submittedFrom: 'published',
+      });
+      expect(c.hasPendingUpdate()).toBe(false);
+      expect(c.withdrawLabel()).toBe('Request withdrawal');
     });
   });
 });

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
@@ -639,17 +639,41 @@ export class ShareAgentDialogComponent {
 
   /**
    * Submittable states, mirroring the backend transition table: never submitted,
-   * withdrawn (`private`), returned (`changes_requested`) or delisted (`taken_down`).
-   * `in_review` and `published` are absent — there is nothing to submit.
+   * withdrawn (`private`), returned (`changes_requested`), delisted (`taken_down`) — and
+   * `published`, which is how an author ships an **update**.
+   *
+   * `published` belongs here because edits to a published agent land on the draft and
+   * reach nobody until a new version is approved: submitting again is the only route to
+   * users. Only `in_review` is absent, because there is already a submission pending.
    */
   protected readonly canSubmit = computed(() => {
     const state = this.listingState();
-    return !state || state === 'private' || state === 'changes_requested' || state === 'taken_down';
+    return state !== 'in_review' && state !== 'withdrawal_requested';
   });
 
-  protected readonly submitLabel = computed(() =>
-    this.listingState() ? 'Submit again' : 'Submit to marketplace',
-  );
+  /**
+   * True while the thing being submitted (or already submitted) sits on top of a version
+   * users can currently see. `changes_requested` counts: an admin who requests changes on
+   * a live listing deliberately leaves it published while the author revises.
+   */
+  private updatesLiveListing(state: ListingState | undefined): boolean {
+    return (
+      !!this.listing()?.publishedVersion &&
+      (state === 'published' || state === 'changes_requested' || state === 'in_review')
+    );
+  }
+
+  /** A submission sitting on top of a listing users can see — cancellable, not withdrawable. */
+  protected readonly hasPendingUpdate = computed(() => {
+    const l = this.listing();
+    return l?.state === 'in_review' && !!l.submittedFrom && this.updatesLiveListing(l.state);
+  });
+
+  protected readonly submitLabel = computed(() => {
+    const state = this.listingState();
+    if (!state) return 'Submit to marketplace';
+    return this.updatesLiveListing(state) ? 'Submit an update' : 'Submit again';
+  });
 
   /** `taken_down` is absent on purpose: the machine allows no author edge out of it. */
   protected readonly canWithdraw = computed(() => {
@@ -671,8 +695,14 @@ export class ShareAgentDialogComponent {
   /**
    * "Request withdrawal" on a live listing, not "Unpublish" (§5.1) — the author no longer
    * owns that edge, and "Unpublish" promised an outcome the button cannot deliver.
+   *
+   * A pending *update* is the third case and needs its own word: the author is taking back
+   * an edit, not asking for anything to come down, and the listing goes on serving what it
+   * always was. Labelling that "Withdraw submission" would read as though the live listing
+   * were at stake.
    */
   protected readonly withdrawLabel = computed(() => {
+    if (this.hasPendingUpdate()) return 'Cancel update';
     switch (this.listingState()) {
       case 'published':
         return 'Request withdrawal';
@@ -839,6 +869,27 @@ export class ShareAgentDialogComponent {
 
   protected async onWithdrawListing(): Promise<void> {
     const name = this.data.agent.name;
+    // A pending update is a different act with a different outcome, and it is neither
+    // destructive nor a request: the listing keeps serving its approved version either way.
+    // Confirmed anyway, because the edit being taken back is work the author may not have
+    // saved anywhere else — they resubmit from the draft, they do not get the snapshot back.
+    if (this.hasPendingUpdate()) {
+      const cancelRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+        data: {
+          title: 'Cancel this update?',
+          message:
+            `The version of "${name}" in the store now stays live and unchanged — this ` +
+            'only takes back the update waiting for review. Your edits stay on the agent, ' +
+            'so you can submit again whenever you want.',
+          confirmText: 'Cancel update',
+          cancelText: 'Keep it in review',
+        } as ConfirmationDialogData,
+      });
+      if (!(await firstValueFrom(cancelRef.closed))) return;
+      await this.runWithdraw(`Could not cancel the update to "${name}".`);
+      return;
+    }
+
     const published = this.isPublished();
     const confirmRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
       data: {
@@ -861,19 +912,28 @@ export class ShareAgentDialogComponent {
 
     if (!(await firstValueFrom(confirmRef.closed))) return;
 
+    await this.runWithdraw(
+      published ? `Could not request withdrawal of "${name}".` : `Could not withdraw "${name}".`,
+    );
+  }
+
+  /**
+   * The one call all three acts make (§5.1) — cancel an update, withdraw a submission, or
+   * request a delisting. Which one it was is the backend's to decide from the listing, so
+   * the SPA sends the same DELETE and reflects whatever state comes back.
+   *
+   * `fallback` is used only when the error carries no `detail`. The backend's own message
+   * names the actual reason, and replacing it with a generic line has bitten this feature
+   * before — it told authors to "try again" for something retrying could never fix.
+   */
+  private async runWithdraw(fallback: string): Promise<void> {
     this.listingBusy.set(true);
     this.listingError.set(null);
     try {
       this.listing.set(await this.listingService.withdraw(this.data.agent.assistantId));
     } catch (err) {
       const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
-      this.listingError.set(
-        typeof detail === 'string'
-          ? detail
-          : published
-            ? `Could not request withdrawal of "${name}".`
-            : `Could not withdraw "${name}".`,
-      );
+      this.listingError.set(typeof detail === 'string' ? detail : fallback);
     } finally {
       this.listingBusy.set(false);
     }

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
@@ -201,4 +201,72 @@ describe('SubmitListingDialogComponent — category preselection', () => {
     expect(neverPublished.isUpdate()).toBe(false);
     expect(neverPublished.isResubmission()).toBe(true);
   });
+
+  /**
+   * ⚠️ Asserts the **rendered** select, not `category()`.
+   *
+   * Every other test here reads the signal, and the signal was never the broken half — which
+   * is how a live desync survived a describe block named for exactly this behaviour. The
+   * picker showed `Administration` on a `Student Support` listing (verified in dev), because
+   * `categories()` resolves after the first render and a `[value]` on the select had nothing
+   * to match yet. The author saw a shelf they never chose.
+   *
+   * The ordering below is the test, and it is subtler than "options load late". The whole
+   * form sits behind `@if (loading())`, so the select never renders with an empty list —
+   * select and options render together, in one pass, and Angular applies an element's own
+   * bindings before it creates that element's children. A `[value]` on the select therefore
+   * lands while the select still has no options, and the browser drops it. Binding on the
+   * options cannot lose that race, because the option *is* the thing being created.
+   *
+   * So: first render (loading, no form), flush the load, second render (the real one).
+   */
+  it('shows the author the shelf their listing is already on', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DialogRef, useValue: { close: () => undefined } },
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            agentId: 'ast-001',
+            agentName: 'Policy Lookup',
+            listing: { state: 'published', category: 'Student Support', publishedVersion: 2 },
+          },
+        },
+        {
+          provide: AgentListingService,
+          useValue: {
+            // Deliberately not first in the list: the bug selects index 0, so a category
+            // that sorts first would let it pass.
+            loadCategories: async () => [
+              { id: 'Administration', label: 'Administration' },
+              { id: 'Teaching', label: 'Teaching' },
+              { id: 'Student Support', label: 'Student Support' },
+            ],
+            preflight: async (): Promise<ListingPreflight> => ({
+              agentId: 'ast-001',
+              exposedSkills: [],
+              blockReason: null,
+              requiresPublic: false,
+              reachability: 'everyone',
+            }),
+            submit: async () => ({ listing: { state: 'in_review' } }),
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(SubmitListingDialogComponent);
+    fixture.detectChanges();
+    // A macrotask, not `whenStable` — the component's loads are bare promises, and the
+    // form stays behind `loading()` until they settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    fixture.detectChanges();
+
+    const select: HTMLSelectElement =
+      fixture.nativeElement.querySelector('#listing-category');
+    expect(select.value).toBe('Student Support');
+    expect(select.options[select.selectedIndex].text.trim()).toBe('Student Support');
+    expect(fixture.componentInstance.category()).toBe('Student Support');
+  });
 });

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
@@ -185,4 +185,20 @@ describe('SubmitListingDialogComponent — category preselection', () => {
 
     expect(component.category()).toBe('');
   });
+
+  // ── an update is not a first appearance ────────────────────────────────────────
+  it('knows an update from a submission by what is published, not by state', async () => {
+    // A listing an admin sent back for changes keeps serving while the author revises it,
+    // so the state name alone gets this wrong. Promising "an admin reviews this before it
+    // appears in the store" to someone whose agent is already in the store reads as though
+    // submitting had taken it down.
+    const update = build({
+      listing: { state: 'changes_requested', category: 'Teaching', publishedVersion: 2 },
+    });
+    expect(update.isUpdate()).toBe(true);
+
+    const neverPublished = build({ listing: { state: 'changes_requested', category: 'Teaching' } });
+    expect(neverPublished.isUpdate()).toBe(false);
+    expect(neverPublished.isResubmission()).toBe(true);
+  });
 });

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -74,11 +74,21 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
         <div class="flex items-start justify-between gap-3 px-6 pt-5">
           <div class="min-w-0">
             <h2 id="submit-listing-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
-              {{ isResubmission() ? 'Submit again for review' : 'Submit to the marketplace' }}
+              @if (isUpdate()) {
+                Submit an update
+              } @else {
+                {{ isResubmission() ? 'Submit again for review' : 'Submit to the marketplace' }}
+              }
             </h2>
             <p id="submit-listing-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-              An admin reviews <span class="font-medium">{{ data.agentName }}</span> before it
-              appears in the store. You'll see their decision here.
+              @if (isUpdate()) {
+                An admin reviews your changes before they reach anyone. The version of
+                <span class="font-medium">{{ data.agentName }}</span> in the store stays live and
+                unchanged until they approve.
+              } @else {
+                An admin reviews <span class="font-medium">{{ data.agentName }}</span> before it
+                appears in the store. You'll see their decision here.
+              }
             </p>
           </div>
           <button
@@ -230,9 +240,14 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
             }
 
             <p class="mt-5 text-xs/5 text-gray-500 dark:text-gray-400">
-              You'll be credited as the publisher. An admin may reattribute the listing to a
-              department or the university at approval — that changes the name shown with it in
-              Discover and nothing about who can run it.
+              @if (data.listing) {
+                This keeps whoever the listing is already credited to.
+              } @else {
+                You'll be credited as the publisher.
+              }
+              An admin may reattribute the listing to a department or the university at
+              approval — that changes the name shown with it in Discover and nothing about who
+              can run it.
             </p>
 
             @if (error(); as message) {
@@ -292,6 +307,16 @@ export class SubmitListingDialogComponent implements OnInit {
   readonly taglineMax = TAGLINE_MAX;
 
   readonly isResubmission = computed(() => !!this.data.listing);
+
+  /**
+   * A resubmission over something users can currently see — which changes what the dialog
+   * can honestly promise. "An admin reviews this before it appears in the store" is false
+   * for a listing already in the store, and reads as though submitting took it down.
+   *
+   * `publishedVersion` is the fact, not the state name: a listing an admin sent back for
+   * changes keeps serving while the author revises it.
+   */
+  readonly isUpdate = computed(() => !!this.data.listing?.publishedVersion);
 
   readonly canSubmit = computed(
     () =>

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -156,15 +156,27 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
               <p class="text-xs/5 text-gray-500 dark:text-gray-400">
                 Where it appears in Discover. An admin may move it.
               </p>
+              <!--
+                ⚠️ The selection lives on the options ([selected]), NOT as [value] on the
+                select. The category list arrives from an await in ngOnInit, so on the first
+                render the preselected category names an option that does not exist yet:
+                setting select.value matches nothing, the browser silently resets to index 0,
+                and when the options finally render it displays the first one. The author then
+                sees a category they never chose — reading as though submitting had moved
+                their listing — while the signal still holds the right value underneath.
+                Binding on the option instead resolves as each one renders, which is exactly
+                when the value becomes matchable.
+              -->
               <select
                 id="listing-category"
-                [value]="category()"
                 (change)="onCategoryChange($event)"
                 class="mt-2 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
               >
-                <option value="" disabled>Choose a category…</option>
+                <option value="" disabled [selected]="!category()">Choose a category…</option>
                 @for (option of categories(); track option.id) {
-                  <option [value]="option.id">{{ option.label }}</option>
+                  <option [value]="option.id" [selected]="option.id === category()">
+                    {{ option.label }}
+                  </option>
                 }
               </select>
               @if (!categories().length) {

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -89,6 +89,21 @@ export interface AgentListingBlock {
   reviewNote?: string;
   /** Append-only log of admin presentation edits (D13). */
   adminEdits?: AdminEdit[];
+  /**
+   * Which snapshot the store is serving, or absent when nothing is published.
+   *
+   * Read here as a fact about *now*: a listing back `in_review` with this set is an
+   * update over something users can still see, and the UI has to say so — "In review"
+   * alone reads as "not live", which is wrong and alarming for an author whose agent is.
+   */
+  publishedVersion?: number;
+  /**
+   * Where a pending update came from, and therefore where cancelling it puts it back.
+   *
+   * ⚠️ Meaningful only while `state === 'in_review'` — an earlier cycle can leave a value
+   * behind, and the backend says so on the field. Every read here gates on the state.
+   */
+  submittedFrom?: ListingState;
 }
 
 /** Author submits an Agent for review (D2). */


### PR DESCRIPTION
## The gap

Version snapshots (§3) made a published listing a **dead end for its author**, and §5.1 closed the last way out without noticing.

Once the store serves a snapshot, an author's edits land on the draft and reach nobody until a new version is approved. But `published` had no edge to `in_review`, and §5.1 had just removed `published → private`. So an author who wanted to fix a typo in a live listing had two routes:

1. **Request withdrawal** — take their own listing off the shelf and wait for an admin to grant it, over a typo.
2. **Wait** for an admin to send it back with `request_changes` — which isn't an action they can start.

Neither is a thing a working author should have to do, and the second one isn't even theirs.

## The change

Adds `published → in_review`.

**This is not a second door into the store.** `submit_listing` carries `published_version` and its index key through untouched, so the approved snapshot keeps serving for the whole review. Approval still promotes `submittedVersion` and remains the only edge that changes what users get.

### Cancelling an update is the subtle half

Withdrawal picks its target from `is_on_shelf`, so an author cancelling a pending update was read as an author *asking to delist* — a request they never made, parked in an admin's queue.

So a submission made over something already on the shelf now records where it came from (`AgentListing.submittedFrom`), and cancelling returns it there:

```
in_review → published            author cancels an update to a live listing
in_review → changes_requested    ...one submitted while a change request was outstanding
```

What makes this safe is that the target is **derived from the recorded origin** rather than accepted from a caller (`listing.author_cancel_target`) — the same mechanism, for the same reason, as the existing `withdrawal_from`. Assuming `published` would silently discard an outstanding change request and publish something no admin approved.

`AUTHOR_TARGET_STATES` deliberately does **not** gain `published`. Widening it would let an author walk their own unreviewed first submission into the store. That's also why `author_cancel_target` raises rather than defaulting when `submittedFrom` is absent.

### A D12 fix caught along the way

An author's silence on `publisherId` now preserves whatever publisher the listing already carries. Previously, an admin who reattributed a listing to a department would have had that decision silently reverted on the author's next update — and re-checking eligibility instead would have 403'd the author out of updating their own listing.

### SPA

- "Submit an update" / "Cancel update" wording, with confirm copy that says the live version stays live
- A line on the status badge for the same reason — "In review" alone reads as *your agent came down*, which is wrong and alarming for an author whose agent isn't
- `publishedVersion` + `submittedFrom` on the wire so the UI can tell an update from a first submission

## For reviewers

**No backfill needed.** Existing `in_review` listings predate `submittedFrom` and won't have it. Absence means "not an update over a live listing" and falls through to the ordinary withdraw path — which is the correct reading for any submission made before this change.

**`submittedFrom` is only meaningful while `state == 'in_review'`.** Approval doesn't clear it, so any new reader must gate on the state too. Both the field description and the SPA model say so, and there's a test for the stale-origin case.

## Merge note

Includes a merge of `origin/develop` (14 commits). Two conflicts, both against #824, which touched this state machine for related reasons:

- **`listing.py`** — both sides added a row to the transition table, to different states (#824's `taken_down → private`, this branch's `published → in_review`). Unioned; they don't interact.
- **`share-agent-dialog.component.spec.ts`** — both appended an independent describe block. Kept both.

`share-agent-dialog.component.ts` auto-merged and was checked by hand, since both sides edited `withdrawLabel` — #824's `'Remove listing'` case and this branch's `'Cancel update'` guard both survived in the right precedence.

## Testing

- Backend: **5788 passed**, 3 skipped (full suite)
- SPA: **1825 passed** across 163 files (full `ng test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)