### PR TITLE
docs: document-context-offload spec, adversarial validation, and eval design

### DIFF
--- a/docs/specs/document-context-offload-validation.md
+++ b/docs/specs/document-context-offload-validation.md
@@ -1,0 +1,280 @@
+# Validation report — document-context-offload & agent-cache-extra-tools-bypass
+
+**Scope:** adversarial re-verification of every headline claim in
+`docs/specs/document-context-offload.md` and
+`docs/specs/agent-cache-extra-tools-bypass.md`.
+**Method:** independent content-free re-scan of prod (profile `prod-ai`,
+2026-08-03 ~21:40 UTC — a few hours after the original scan, so counts drifted
+slightly upward: 19,137 `C#` rows vs 18,942; 897 FILE rows vs 882; 434
+attachment sessions vs 431), plus line-level verification of every code
+reference on `develop` (HEAD `79eb80a9`) and content inspection of
+`origin/main` (`3921f2d4`, Release/1.13.0), plus source reading of the pinned
+`strands-agents==1.48.0` and `bedrock_agentcore` (1.19.0; the repo pins no
+version) from the uv cache.
+
+Shipped-code checks used `git show origin/main:<path>` content inspection, not
+merge-base ancestry. The AgentCore blob-fallback claim was re-derived from SDK
+source, not taken on faith. Analysis scripts: session scratchpad
+`analyze.py` / `analyze2.py` (DynamoDB dumps were projected content-free:
+no `citations`, no `displayText`, no `D#` rows, no `S#.title`).
+
+---
+
+## Verdict table
+
+| # | Claim | Verdict |
+|---|-------|---------|
+| 1 | 11% of sessions / 31% of spend; means $0.620 vs $0.176; 47 of top-100 | **Confirmed** |
+| 2 | cacheWrite-dominated decomposition; uncached input *lower* for attachment sessions | **Confirmed** |
+| 3 | Cold re-write cliff at the 5-min TTL; $188/$747 fleet envelope | **Confirmed with caveats** (definition-sensitive; >15 min is ~55–75 % cold, not ~100 %; $ envelope reproduces at $160–173, not $188) |
+| 4 | 1h TTL a net loss: +12.3 % blanket / +5.7 % / +4.2 % / −8.7 % oracle | **Confirmed for blanket & oracle; conditional-policy magnitudes not reproduced** (my re-implementation gets ≈ break-even) |
+| 5 | 79.6 % of attachment / 76.3 % of all sessions bypass the agent cache | **Confirmed** |
+| 6 | 14 % of attachment sessions re-upload the same filename | **Confirmed, and strengthened** (87 % of duplicate groups are byte-size-identical) |
+| 7 | 4 of 615 upload clusters exceed the ~7.5 MB event bound | **Confirmed with caveats — the true rate is *higher*, not lower** (8–9 of ~500–620 under a better proxy) |
+
+Both specs' central defects (`_strip_document_bytes` placeholder strip;
+`extra_tools` cache bypass) are **live in `origin/main`**, byte-identical to
+develop (develop line numbers are shifted −9 in `turn_based_session_manager.py`
+by a comment-only PR #831 change; `service.py` is byte-identical).
+
+---
+
+## Claim-by-claim detail
+
+### Claim 1 — 11 % of sessions, 31 % of spend: **confirmed**
+
+Re-derived: 398/3,557 sessions (11.2 %) with uploads; $248.69 of $809.08
+(30.7 %). Mean $0.625 vs $0.177 (medians $0.161 vs $0.048); calls/session 10.1
+vs 4.8; output tok/call 1,397 vs 727; **exactly 47** of the top-100 sessions
+carry files. Per-type means also reproduce: tabular-only $1.04, non-PDF docs
+$0.63, PDF $0.59, images $0.29, none $0.18. Peak-context >100k: 9.8 % vs 2.2 %.
+
+Two bookkeeping defects in the spec, neither fatal:
+
+- **The spec quotes three different attachment-spend figures** ($244.91 in §1,
+  $233.61 in §6) **and two fleet totals** ($746.98, $798) without saying why.
+  The reconciliation: ~$51 of fleet spend (and ~$11 of attachment spend) sits on
+  legacy rows where `cost` is a bare float with no breakdown. $746.98/$233.61
+  are map-rows-only; $798/$244.91 include the floats. Any figure derived from
+  the breakdown (`cacheWriteCost` etc.) silently excludes the float rows. The
+  spec should state its denominator once and use it consistently.
+- **Missing-cost rows are 11.8 % (2,257/19,137) and are *not* random** — they
+  concentrate in 2026-04 (58 % of April rows) and 2026-05 (33 %). 2,242 of them
+  do carry `tokenUsage`; repricing them at snapshot/list prices adds ≈ $175 of
+  unrecorded fleet spend. This means **absolute fleet totals are understated
+  ~20 %**, but the headline is robust: the corrected attachment share is
+  29.6 % vs 30.7 % uncorrected. `AdminUsageAggregates` (the known 2.6×
+  triple-counter) was not used; the raw `C#` rows with both cost shapes handled
+  are the right source and the original scan used them.
+
+### Claim 2 — cacheWrite-dominated, input-not-document driven: **confirmed**
+
+Attachment cohort (map rows): cacheWrite 50.0 % / output 22.5 % / input 20.5 %
+/ cacheRead 7.0 % (spec: 47.9/21.5/19.9/6.2 — drift consistent with a few
+hours of new traffic). Uncached input per call is indeed *lower* for attachment
+sessions: 7,268 vs 8,080 (spec: 7,455 vs 8,130). The inversion — the cohort
+with big documents pays *less* per-call uncached input — is real and is the
+strongest single piece of evidence that the cost driver is prefix re-writes,
+not document tokens on the attach turn.
+
+One mechanism the spec missed that *supports* it (found in SDK source,
+`strands/models/bedrock.py:409–458`): with `CacheConfig(strategy="auto")` the
+message cache point is injected at the end of the **last user message**, but is
+moved to sit **before the first non-PDF document block** in that message — and
+if that block is at index 0, no message cache point is injected at all for the
+turn. Since `PromptBuilder` appends text first and documents after, a DOCX/TXT
+/HTML attach turn caches only up to the text block; the document bytes enter
+the cached prefix one turn later. (Also: the repo `CLAUDE.md` says auto-caching
+injects "at the end of the last assistant message" — wrong; it is the last
+*user* message.)
+
+### Claim 3 — cold re-write vs gap, 5-min TTL: **confirmed with caveats**
+
+The cliff at 5 minutes is unambiguous under every definition I tried:
+
+| definition | <1min | 1–5min | 5–15min | >15min |
+|---|---|---|---|---|
+| `cw>cr` | 5.0 % | 17.3 % | 73.3 % | 75.6 % |
+| `cw>0 ∧ cr==0` | 3.2 % | 10.3 % | 63.9 % | 66.6 % |
+| `cw ≥ 80 % of prev prefix` | 4.8 % | 11.6 % | 63.0 % | 63.2 % |
+| `cacheStatus` cold (post-#697 rows only) | 0.5 % | 1.3 % | 53.1 % | 55.3 % |
+
+Caveats:
+
+- **The spec's exact numbers (3.4/16.3/66.1/~65) are definition-dependent and
+  the definition is not written down.** They fall inside the band above, so the
+  claim stands, but it is not reproducible to the decimal. The spec should
+  state the predicate.
+- **">15 min ≈ 65 %" deserves its own explanation, which the spec doesn't
+  give:** if the 5-minute TTL were the whole story, >15 min would be ~100 %
+  cold. It is 55–75 % because the tools/system cache points are shared across
+  sessions with the same config (fleet traffic keeps them warm), and
+  classification mixes prefix levels. "Cold *full-prefix* re-write" therefore
+  overstates what the >5 min rows are; a substantial minority still read a
+  shared partial prefix.
+- The fleet envelope reproduces at **$159.93–172.62** depending on definition
+  (spec: $188 of $747, 25 %; mine is 20–21 % of $809). Part of the gap is the
+  float-cost rows, which carry no `cacheWriteCost` and drop out of my sum. Same
+  story for the attachment envelope: **$58.47–63.57** vs the spec's $66.24.
+  Right order, ±15 % on the magnitude.
+
+### Claim 4 — 1h TTL is a net loss: **blanket and oracle confirmed; conditional policies not reproduced**
+
+I re-implemented the counterfactual from scratch (1h writes at 2× base input vs
+1.25×; cold re-writes with gap ∈ (5 min, 1h] converted to cache reads):
+
+| policy | spec | my re-implementation |
+|---|---|---|
+| blanket 1h | +12.3 % | **+6.6 %** |
+| 1h after one >5 min gap | +5.7 % | **−0.2 %** |
+| 1h after two >5 min gaps | +4.2 % | **−0.4 %** |
+| perfect oracle | −8.7 % | **−9.9 %** |
+
+Blanket-1h-is-a-loss and oracle-upside-is-small both reproduce, and those are
+the two numbers §7 actually needs. But the conditional policies land at
+break-even in my model vs clearly-negative in the spec's, and neither model is
+documented enough to arbitrate. **The honest statement for §7 is: blanket 1h is
+confirmed a loss; heuristic policies are somewhere between −1 % and +6 % —
+i.e., not worth building, but not "independently confirmed a loss" either.**
+The conclusion (don't do 1h TTL) survives; the precision implied by "+5.7 %"
+does not. Note both simulations share an unstated assumption: session
+trajectories wouldn't change under a different TTL.
+
+### Claim 5 — cache bypass reach: **confirmed**
+
+76.5 % of sessions (2,735/3,574) have ≥1 injected tool enabled; 80.7 % of
+attachment sessions (342/424). Per-tool counts match (`analyze_spreadsheet`
+2,678, `list_spreadsheets` 2,671, `create_artifact` 974). Bypassed-cohort
+spend $718.26 — 94.8 % of map-row spend, matching the spec's "95 %" (which is
+map-only; against the all-rows total it is 88.8 % — same denominator issue as
+claim 1). Within-TTL (60–300 s) cold-write rates: bypassed 19.5 % vs cacheable
+6.1 % under `cw>cr` (spec: 11.2 % vs 5.8 % under its undocumented definition —
+the ~2–3× ratio is stable even though the absolute rates aren't).
+
+The denominator zoo across the two specs (395 vs 426 vs 431 attachment
+sessions) reconciles cleanly and should be footnoted: 431→434 = sessions in the
+uploads table; 426→424 = those with an `S#` row; 395→398 = those with `C#` cost
+rows; 8 upload sessions have neither.
+
+### Claim 6 — 14 % re-upload rate: **confirmed and strengthened**
+
+63/434 sessions (14.5 %) upload the same filename ≥2× (group sizes 2–6). The
+"maybe they're revised versions" objection now has an answer the original scan
+didn't have: **86 of 99 duplicate groups (87 %) have byte-identical
+`sizeBytes`**, and the median span from first to last duplicate is **200
+seconds** (p90 ≈ 82 min). A user attaching a revised document produces a
+different byte size essentially always; a user re-attaching because the model
+lost the file produces an identical one minutes later. This is still
+correlational — but it is now the *strip-loss* story that fits the data and the
+*revision* story that doesn't. (No content hash exists on `FileMetadata` to
+settle it outright; worth adding one in PR-7.)
+
+### Claim 7 — over-quota turns: **confirmed with caveats, in the opposite direction from the spec's hedge**
+
+The 120 s clustering reproduces (624 clusters, 7 > 7.5 MB = 1.1 %, 7 clusters
+>5 files, max 29.89 MB). The spec worried its proxy *merges* turns and
+therefore overstates the rate. I built the better proxy it asked for — group
+each upload by the **next `C#` model call** in the same session (uploads
+between two calls belong to the message that precedes the second call):
+
+- 622 call-aligned groups; **9 exceed 7.5 MB** (1.4 %) — 8 after excluding
+  tabular files that never reach the message (10.3/8.2/9.6/13.5/16.3/7.7/8.7/
+  7.5 MB).
+- Several over-quota groups have only **3–4 files** — inside the SPA's 5-file
+  cap. The 29.89 MB 120 s cluster splits into smaller per-call groups (max
+  16.34 MB), so merging did inflate the *maximum*, but the *count* of
+  over-quota turns goes up, not down.
+
+So the caveat cuts the other way: **~0.7 % was an undercount; ~1.3–1.4 % of
+attachment turns risk the 10 MB event quota**, and the SPA cap does not protect
+against it. Remaining limitations of both proxies: an upload isn't proof the
+file was sent, and sparse call timelines can still merge. The real fix is a
+`messageId` on `FileMetadata` (PR-7 material) — the table has no turn
+attribution at all today.
+
+Related code findings that sharpen PR-6:
+
+- The backend `max_files_per_message` setting (env-plumbed through CDK,
+  default 5) is **dead code** — assigned in `files/service.py` and never read.
+- The `file_upload_ids` resolver caps at 5 by **silently truncating**
+  (`upload_ids[:max_files]`) — files 6+ are dropped with no user feedback.
+- The direct inline-`files` request path has **no count cap at all**
+  server-side (per-file 4 MB is enforced; count and aggregate bytes are not).
+- The SDK re-check: neither `strands` 1.48.0 nor `bedrock_agentcore` 1.19.0
+  references the 10 MB event bound anywhere — it is server-side only, and the
+  batched flush path concatenates a session's buffered messages into one
+  `create_event` with no aggregate check, so batching can blow the quota with
+  individually-legal messages.
+
+---
+
+## The two prior reasoning errors — re-checked correctly
+
+1. **Shipped-to-prod**: verified by content on `origin/main`. Both defects are
+   live in prod. `§4E`'s "line 214" is the `origin/main` line number; on
+   develop it is line 223 (comment-only drift from PR #831). The spec should
+   cite develop's numbers.
+2. **Blob fallback**: independently confirmed in SDK source.
+   `exceeds_conversational_limit` (`CONVERSATIONAL_MAX_SIZE = 100000`,
+   `bedrock_converter.py`) routes oversized messages to a `blob` payload
+   (`session_manager.py:612–631`), and the read path decodes it back through
+   `SessionMessage.from_dict` → `b64decode` (`bedrock_converter.py:85–97`,
+   `strands/types/session.py:28–55`). A 4 MB document round-trips intact. Two
+   precision notes for §4E: the 100 KB check measures the *base64-inflated
+   JSON*, so the blob path actually triggers at ≈ 72 KB of raw bytes; and blob
+   decode failures are swallowed (`logger.error`, message dropped) — corruption
+   presents as missing history, not an exception.
+
+---
+
+## New defects found in the specs (things to fix before circulating)
+
+1. **Citations are not enabled today — anywhere.** The document block built by
+   `document_handler.py:84–92` has exactly three keys (`format`, `name`,
+   `source.bytes`); no request-side citations config exists in the repo. The
+   offload spec's lifecycle diagram labels the attach turn "citations on ←
+   unchanged", which is false — enabling citations is *new work*, not preserved
+   behavior. And the spec's citation of `_BEDROCK_CONTENT_BLOCK_KEYS`
+   containing `citationsContent` as supporting evidence conflates a
+   *response-side* history-sanitizer discriminator with request-side config.
+   Downstream consequence: whether prod PDFs currently get visual (page-image)
+   understanding at all is **unverified** — on Bedrock, full visual PDF
+   processing is tied to the citations-enabled document path. The evaluation
+   must establish the *current* fidelity baseline before scoring the digest
+   against it (see the evaluation spec §2).
+2. **The bypass spec's §6 isolating experiment is not clean — it is nearly
+   powerless.** 921 of 974 `create_artifact` sessions *also* have spreadsheet
+   tools enabled, so "enable caching for `create_artifact` only" changes the
+   caching behavior of the **53 sessions** (1.5 % of fleet) where it is the
+   sole injected tool — a tiny, self-selected cohort. The clean experiment must
+   treat the spreadsheet builders (1,761 sessions have *only* spreadsheet tools
+   injected), which requires keying `assistant_id` into the cache key first —
+   i.e., the experiment is gated on part of the fix it was meant to justify.
+   Alternative that avoids the confound entirely: measure `initialize()`
+   invocations per turn and p50 TTFT under a randomized per-session flag; the
+   latency claim is causal under randomization regardless of workload mix.
+3. **Line-number and location nits**: `INJECTED_TOOL_IDS` is at
+   `injected.py:48` (line 43 is `WORKSPACE_TOOL_IDS`);
+   `WORKSPACE_READ_MAX_BYTES` lives in `apis/shared/files/workspace.py:41`, not
+   `workspace_tools.py`; "MAX_FILES_PER_MESSAGE exists only in the SPA" is
+   imprecise — a backend count cap exists but is dead code, a per-file 4 MB cap
+   *is* enforced server-side, and the resolver path truncates at 5.
+4. **Minor data defect noticed in passing**: `FileMetadata.createdAt` is
+   malformed ISO — `...+00:00Z` (offset *and* Z suffix). Harmless to humans,
+   breaks strict parsers.
+
+## What was not checked, and why
+
+- **The prior session's exact cold-write predicate and TTL-simulation code** —
+  not recorded anywhere I could find; I rebuilt both from the spec text, which
+  is why claims 3/4 carry definitional error bars.
+- **Whether Bedrock Converse accepts `context_management` via
+  `additionalModelRequestFields`** — the spec flags this as an open question;
+  verifying it requires a live Bedrock call, out of scope for a read-only
+  validation pass.
+- **Actual visual fidelity of prod PDF handling** (dual-encoding) — requires a
+  live model probe; folded into the evaluation design as a required baseline
+  experiment instead.
+- **Whether every upload was actually sent as a message attachment** — no
+  turn/message attribution exists in the uploads table; both claim-7 proxies
+  inherit this.

--- a/docs/specs/document-context-offload.md
+++ b/docs/specs/document-context-offload.md
@@ -1,0 +1,492 @@
+# Document context offload — bound the cost of conversations with attachments
+
+**Status:** Draft (no branch yet)
+**Motivating measurement:** prod scan 2026-08-03, all 18,942 `C#` cost rows
+joined to `boisestateai-v2-user-file-uploads` on `GSI1PK = CONV#{sessionId}`
+**Related:** [[project-prod-cache-write-premium]] (the compaction root cause this
+depends on), `docs/specs/session-workspace-tools.md` (the retrieval primitive
+this extends), `docs/specs/tool-search-token-bloat-strategy.md` (same tenet,
+different payload)
+
+---
+
+## 1. Problem
+
+Conversations with attachments are 11% of prod sessions and **31% of prod
+spend**.
+
+| | sessions | mean $/session | median | calls/session | output tok/call | peak ctx >100k |
+|---|---|---|---|---|---|---|
+| With attachments | 395 (11%) | **$0.620** | $0.162 | 9.9 | 1,416 | 9.6% |
+| No attachments | 3,137 (89%) | $0.176 | $0.048 | 4.8 | 725 | 2.3% |
+
+47 of the 100 most expensive sessions carry files. Per-session cost by
+attachment type: **tabular only $1.01**, non-PDF documents $0.63, PDF only
+$0.59, images $0.29, none $0.18.
+
+The cost is **not** the document's tokens on the turn it is attached. It is that
+the document then lives in the cacheable prefix forever and is re-written in
+full every time the cache goes cold. Cost decomposition for attachment
+sessions: `cacheWrite 47.9%`, `output 21.5%`, `input 19.9%`, `cacheRead 6.2%`.
+
+Full-prefix re-write rate vs. gap since the previous model call — the 5-minute
+Bedrock cache TTL is plainly visible:
+
+| gap | <1min | 1–5min | 5–15min | >15min |
+|---|---|---|---|---|
+| cold re-write | 3.4% | 16.3% | **66.1%** | ~65% |
+
+Fleet-wide, cold re-writes on resumed turns are **$188 of $747 (25%)**.
+Attachment sessions pay it hardest because their prefix is larger and their
+users think longer between turns (2× the output tokens to read).
+
+### Four concrete defects behind it
+
+1. **The document never leaves the prefix.** `PromptBuilder.build_prompt`
+   ([prompt_builder.py:23](../../backend/src/agents/main_agent/multimodal/prompt_builder.py:23))
+   inlines the bytes as a `document` content block on the user message. Nothing
+   ever removes it while the agent is warm. A 2 MB PDF (p90 of prod uploads is
+   2.23 MB; PDFs run 1,500–3,000 tokens/page) enters on turn 1 and is re-written
+   on every cold turn for the life of the session.
+
+2. **Compaction cannot evict it.** `update_after_turn`
+   ([turn_based_session_manager.py:703](../../backend/src/agents/main_agent/session/turn_based_session_manager.py:703))
+   still only writes bookkeeping — `checkpoint`, `summary`, `truncation_anchor`.
+   `_apply_compaction` (line 267) is called *only* from `initialize()` (line
+   245), which never re-runs on an agent-cache hit. Nothing token-aware bounds
+   the live list. This is the pre-existing root cause traced 2026-07-27;
+   documents are what makes it expensive.
+
+3. **Restore discards the document.** `_strip_document_bytes`
+   ([turn_based_session_manager.py:944](../../backend/src/agents/main_agent/session/turn_based_session_manager.py:944))
+   runs unconditionally on every restore and replaces the document with
+   `[Document placeholder: name=…, format=…, original_size=… bytes]` — zero
+   content. The bytes are present and fully decoded in `agent.messages`
+   immediately before we overwrite them (verified — see §4E). **62 of 431
+   attachment sessions (14%) upload the same filename 2–5 times**, which is what
+   that looks like from the user's side. Each re-attach costs the document's
+   tokens again *plus* a full prefix re-write.
+
+4. **…and restore runs on nearly every turn, not just after an idle gap.**
+   `get_agent` reads the agent cache only when no per-request tools were built —
+   `if not extra_tools and cache_key in _agent_cache`
+   ([service.py:279](../../backend/src/apis/inference_api/chat/service.py:279)).
+   Any session with an injected tool enabled therefore builds a **fresh Agent
+   every turn**, re-running `initialize()` → restore → strip. `enabled_tools`
+   membership is the only precondition those builders check
+   ([routes.py:393](../../backend/src/apis/inference_api/chat/routes.py:393)).
+
+   **79.6% of prod attachment sessions (339/426) have at least one injected tool
+   enabled** — overwhelmingly `analyze_spreadsheet` / `list_spreadsheets`, which
+   look default-on in the picker (2,669 and 2,662 sessions; `create_artifact`
+   957). Fleet-wide it is 76.3% of all sessions.
+
+   So for four out of five attachment conversations the document is discarded on
+   **turn 2**, regardless of idle time. The idle reaper (armed in prod by
+   Release/1.13.0 on 2026-08-02) is a secondary trigger, not the main one.
+
+   Those sessions also rebuild the Agent on every turn — its own latency and
+   prompt-cache problem, but out of scope here. It deserves a separate issue.
+
+**Corollary that shapes the fix.** The strip is currently *saving* money by
+throwing the document away. Narrowing it to real name collisions — the obvious
+one-line quality fix — would push the full document back into the prefix on
+every turn and regress cost. Fixing quality without paying that is exactly what
+the digest path below is for.
+
+The `s3Location` path referenced in the comment at line 971 was never
+implemented. Every document is inline bytes.
+
+---
+
+## 2. What Strands already gives us (and what it doesn't)
+
+Checked against the pinned `strands-agents==1.48.0`.
+
+### `ContextOffloader` — right shape, wrong hook
+
+`strands/vended_plugins/context_offloader/plugin.py` intercepts oversized
+results, persists each content block, and replaces it in context with a preview
+plus per-block references. It registers a `retrieve_offloaded_content` tool
+whose interface is exactly the quality-preserving one we want:
+
+- `pattern` — regex/keyword grep, returns matching lines with `context_lines`
+- `line_range: {start, end}` — 1-indexed span
+- neither — full content, documented as "use sparingly — re-injects all tokens"
+
+`_decode_full_content` reconstructs native blocks on retrieval: `image/*` comes
+back as an `image` block, `application/*` as a `document` block. So a retrieved
+PDF page returns at **full model fidelity**, not as flattened text.
+
+**But it only fires on `AfterToolCallEvent`.** Our documents arrive on the user
+message via `PromptBuilder`, never through a tool. `ContextOffloader` will never
+see them. It is a template, not a drop-in.
+
+Its `Storage` protocol is two methods — `store(key, content, content_type) -> ref`
+and `retrieve(ref) -> (bytes, content_type)` — and an `S3Storage` backend ships
+in the box. Our `user-file-uploads` table + user-files bucket satisfy that
+protocol trivially.
+
+### Message pinning — usable as-is
+
+`strands/agent/conversation_manager/compression/pin_message.py` provides
+`pin_message` / `is_pinned` / `partition_pinned` via
+`message.metadata.custom.pinned`, with tool-pair partner protection.
+`SummarizingConversationManager._summarize_oldest` honours it and mutates via
+`agent.messages[:] = protected + [summary] + remaining` — **slice assignment**,
+which is the pattern our #741 aliasing contract requires. Good precedent to
+copy, not re-derive.
+
+### What is missing
+
+- No hook for user-message content. Offload for attachments must be ours.
+- `workspace_read` ([workspace_tools.py:94](../../backend/src/agents/builtin_tools/workspace_tools.py:94))
+  returns text inline up to 48 KB, but for binary (PDF, Office) it returns
+  **metadata plus a download URL** — a URL the model cannot read. There is no
+  path today to pull a specific PDF page back into context.
+
+---
+
+## 3. Existing methods, and the quality tension
+
+Anthropic's [effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+names four primitives — compaction, structured note-taking, sub-agents, and
+just-in-time retrieval — and explicitly recommends a **hybrid**: load critical
+data upfront for speed, enable autonomous exploration on demand, "useful for
+less dynamic content like legal or finance work." That is exactly our corpus
+(policy PDFs, contracts, job descriptions, award nominations). It also calls
+tool-result clearing "one of the safest lightest touch forms of compaction," and
+warns that "overly aggressive compaction can result in loss of subtle but
+critical context" — maximize recall first, tighten precision after.
+
+Anthropic's [context editing](https://platform.claude.com/docs/en/build-with-claude/context-editing)
+API (`clear_tool_uses_20250919`) is the productized version: server-side
+clearing of old tool results, measured at **84% token savings and +39% task
+performance on a 100-turn benchmark**. Two things carry over directly:
+
+- **Clearing invalidates the cache prefix.** The API exposes `clear_at_least` so
+  you only break the cache when the clearing is large enough to pay for itself.
+  Our design must obey the same rule — an offload event costs one re-write.
+- **`exclude_tools`** exists because some results must never be cleared. We need
+  the same escape hatch for documents the user is actively working through.
+
+Open question: whether Bedrock Converse accepts `context_management` via
+`additionalModelRequestFields` (we already pass `anthropic_beta` there for
+fine-grained tool streaming). It is undocumented on the Bedrock side. **Verify
+before designing around it** — and note it would only cover tool results anyway,
+not user attachments.
+
+### The quality tension, stated honestly
+
+The 2026 literature is consistent that neither extreme wins:
+
+- Long context degrades non-linearly well before the window fills ("context
+  rot"), and relevant content buried mid-window loses 20+ points versus the same
+  content at the edges.
+- But long context **beats** retrieval on holistic tasks that reason across a
+  whole document — summarize, compare, "does this contract contradict itself."
+- The 2026 default is hybrid: retrieve a focused slab, then reason over it.
+
+Two stack-specific costs that the generic literature does not cover:
+
+1. **Native citations require the document inline.** Bedrock's `DocumentBlock`
+   citations config produces `citationsContent` blocks
+   ([already in `_BEDROCK_CONTENT_BLOCK_KEYS`](../../backend/src/agents/main_agent/session/turn_based_session_manager.py:831)).
+   Offload the document and Claude can no longer cite passages in it natively.
+2. **PDFs are dual-encoded.** Each page is understood as an image *and* an
+   extracted text layer — that is what preserves tables, charts, seals, and
+   layout. A text-only digest throws the visual channel away. Any offload that
+   flattens a PDF to text is a real quality regression on exactly the documents
+   people attach.
+
+Both push the same design conclusion: **offload by page/section as native
+blocks, never as flattened text, and never on the turn the document is
+introduced.**
+
+---
+
+## 4. Design
+
+### Principle
+
+The turn that introduces a document gets the **full document, inline, with
+citations enabled** — best possible quality where it matters most. Subsequent
+turns get a **digest plus a retrieval handle**, and the model pulls back the
+pages it needs as native blocks.
+
+This is the CLAUDE.md tenet ("per-turn payloads should be bounded or offloaded,
+never unbounded pass-through") applied to the one payload that currently
+violates it — and it is *not* a quality-for-cost trade, because today the
+alternative after a restore is a placeholder carrying zero content.
+
+### Lifecycle
+
+```
+turn N   (attach)  user msg: [text] [document: full bytes, citations on]   ← unchanged
+                   pinned; the model answers with citations
+
+turn N+1 (offload) user msg: [text] [text: <document-digest .../>]         ← ~800–1,500 tok
+                   + tool: document_read(upload_id, page_range|pattern)
+                   document bytes live in S3 (already there)
+
+turn N+k (recall)  model calls document_read(upload_id, page_range={4,7})
+                   tool result: native [document] block, pages 4–7 only
+                   → full fidelity where it matters, ~4 pages not 200
+```
+
+### Components
+
+**A. `DocumentDigest` — built once, at upload, off the model path.**
+
+Extends the existing upload flow (`apis/app_api/files/service.py`). For each
+non-tabular document: page/section count, a per-section outline with heading +
+first-line snippet, detected structure (tables, figures), and a 3–5 sentence
+abstract. Stored on the `FileMetadata` row. Rendered into context as a compact
+XML-ish block:
+
+```xml
+<document name="BBR 5.0 Policy Form.pdf" upload_id="u-abc123" pages="47">
+  <abstract>Cyber liability policy form, Beazley Breach Response 5.0 …</abstract>
+  <section pages="1-3">Declarations — named insured, limits, retentions</section>
+  <section pages="4-11">Insuring Agreements — A. Breach Response …</section>
+  …
+</document>
+```
+
+Budget: **≤1,500 tokens per document**, hard-capped. Generated with Haiku (the
+extraction step does not need a frontier model; the *answer* still does).
+
+**B. `document_read` tool — page-range and pattern retrieval, native blocks.**
+
+New injected tool, bound to `(session_id, user_id)` like the workspace tools.
+
+**Gated on session state, not `enabled_tools`.** The tool is built when the
+session has at least one attachment, full stop — no catalog entry, no RBAC
+grant, no picker toggle. Its ids stay **out** of `INJECTED_TOOL_IDS`
+([injected.py:43](../../backend/src/apis/shared/tools/injected.py:43)) so they
+never reach `ToolFilter`, exactly as Memory-Space tools do
+([routes.py:609](../../backend/src/apis/inference_api/chat/routes.py:609)):
+*"Not gated on `enabled_tools`: the governing capability is the Agent's
+binding, not the user's tool picker."* Here the governing capability is the
+user's own attachment.
+
+Why not the obvious `workspace_files` key: **it is granted to no prod role.**
+Verified against `boisestateai-v2-app-roles` — `staff` (27 tools), `faculty`
+(26), `student` (13), `default` (0) and `demo_day` (0) all lack it; only
+`system_admin` has it via `*`. Registering there would ship the recovery path
+dark and reproduce the half-write trap in
+[[project-rbac-grant-half-write-trap]] — the fix would be merged, deployed, and
+reach nobody.
+
+This also fixes a gap the check exposed: `analyze_spreadsheet` /
+`list_spreadsheets` **are** granted, so CSV/XLSX already have a recovery path
+(and are diverted from inline anyway). Everything that actually goes
+inline — PDF, DOCX, TXT, MD, HTML, images, ~692 of 882 prod file rows — has
+none today, text included.
+
+```
+document_read(upload_id, page_range={start,end} | pattern, max_pages=8)
+```
+
+- PDF → returns a `document` block containing **only the requested pages**,
+  re-assembled server-side. Citations stay enabled on it.
+- DOCX/HTML/MD/TXT → returns text for the matching sections, bounded by the
+  existing `WORKSPACE_READ_MAX_BYTES` (48 KB) with `offset` continuation.
+- `pattern` greps the extracted text layer and returns the *page numbers* that
+  match plus surrounding lines, so the model can then ask for those pages.
+- Hard cap `max_pages` so one call cannot re-inject the whole document.
+
+Modelled on `retrieve_offloaded_content`'s interface deliberately — same three
+modes (pattern / range / full-as-last-resort), same guidance text shape.
+
+**C. Offload trigger — deferred, cache-aware, once per document.**
+
+Runs in `update_after_turn`, alongside (not inside) the compaction checkpoint
+logic. Replace a document block with its digest when **all** of:
+
+- the document is no longer pinned (see D), **and**
+- ≥1 full turn has elapsed since it was introduced, **and**
+- the document's estimated tokens ≥ `DOCUMENT_OFFLOAD_MIN_TOKENS` (default
+  5,000 — our `clear_at_least`; below this the cache re-write costs more than it
+  saves), **and**
+- the prompt cache is already cold (>`cache_ttl_seconds` since the last call),
+  *or* the live context exceeds the compaction threshold.
+
+The last condition is the one [[project-prod-cache-write-premium]] found being
+violated by the existing truncation deferral — 72% of truncation events fired
+while the cache was still live. **Get this guard right here, and fix it there.**
+
+Mutation is **slice assignment on `agent.messages`, never rebinding** — guard
+test `test_second_cache_key_for_a_session_shares_the_conversation`. The offload
+is monotonic and recorded in the compaction state so it never runs twice and
+never moves backwards (the #751 shape).
+
+**D. Pinning — the `exclude_tools` equivalent.**
+
+A document stays pinned (never offloaded) while it is the active subject:
+
+- the turn it was attached, plus the next turn;
+- any turn where the model called `document_read` against it;
+- while the user's message names its filename.
+
+Uses Strands' `pin_message` / `is_pinned` so compaction and offload agree on one
+flag. A user working through one contract for ten turns keeps it inline; a user
+who attached six files and is now discussing one keeps one.
+
+**E. Restore becomes lossless.**
+
+*Verified: the content is still there to recover.* Uploads are capped at 4 MB
+([`MAX_FILE_SIZE_BYTES`](../../frontend/ai.client/src/app/services/file-upload/file-upload.service.ts:43),
+`FILE_UPLOAD_MAX_SIZE_BYTES`, `INLINE_DOCUMENT_MAX_BYTES`). AgentCore's 100 KB
+`CreateEvent` *message* quota looks like it would reject the write, but the SDK
+checks `exceeds_conversational_limit` (`CONVERSATIONAL_MAX_SIZE = 100000`) and
+falls back to a `blob` payload, bounded by the 10 MB *event* quota. Strands'
+`SessionMessage` base64-encodes bytes on write and decodes them on read. So a
+4 MB document (~5.33 MB encoded) round-trips intact and is present in
+`agent.messages` immediately before line 214 discards it. **PR-3 can rehydrate
+from restored history itself — it does not need S3.**
+
+*Measured edge (real, rare, own PR).* The message — not the file — is the
+stored unit, so a turn's attachments are summed against the 10 MB event quota;
+the break point is ~7.5 MB of raw attachments. `MAX_FILES_PER_MESSAGE = 5`
+exists **only in the SPA**
+([file-upload.service.ts:48](../../frontend/ai.client/src/app/services/file-upload/file-upload.service.ts:48));
+there is no backend count or aggregate-size cap, and 5 × 4 MB is comfortably
+over. In prod, clustering uploads within 120s in a session as a proxy for one
+turn: **4 of 615 clusters (0.7%) exceed the threshold**, largest 29.89 MB across
+11 files; median cluster 0.17 MB, p90 2.58 MB. Both caveats push the true rate
+lower — the 120s window can merge distinct turns, and tabular files are diverted
+before the message is built. `create_message` re-raises as `SessionException`
+rather than swallowing, so the failure mode is a hole in history: worse than the
+strip, but ~100× rarer.
+
+`_strip_document_bytes` stops emitting a contentless placeholder and emits the
+**same digest block** instead, rehydrated from `FileMetadata` (`GSI1PK =
+CONV#{sessionId}` already indexes it), with `document_read` live. A returning
+user gets a model that still knows what is in their document and can pull any
+page back. This is the change that should end the 14% re-upload rate — and it is
+a *correctness* fix that happens to save money.
+
+### Failure modes, all fail-open
+
+Digest generation fails → keep the document inline (today's behaviour).
+S3 unreachable at `document_read` → tool returns an error string, model reasons
+from the digest. Offload raises → leave the message untouched, log, continue.
+Kill switch `DOCUMENT_OFFLOAD_ENABLED=false` (default-on-with-kill-switch, the
+`WORKSPACE_TOOLS_ENABLED` pattern).
+
+---
+
+## 5. PR sequence
+
+Re-sequenced around defect 4: the loss fires on turn 2 for ~80% of attachment
+sessions, so the recovery path and the digest are the urgent half, and the
+turn-level offload — the cost work — comes after.
+
+| PR | Scope | Gate |
+|----|-------|------|
+| 1 | `document_read` (page-range + pattern), native `document` block reassembly, **gated on the session having an attachment**; ids kept out of `INJECTED_TOOL_IDS` | 47-page PDF: `page_range={4,7}` returns 4 pages, ≤6k tok; `max_pages` cap holds; tool present for a `student`-role session with no grants |
+| 2 | `DocumentDigest` model + Haiku extractor + persist on `FileMetadata`, generated at upload; **not yet used in context** | digest ≤1,500 tok for a 200-page PDF; extractor p95 < 8s; no chat-path change |
+| 3 | `_strip_document_bytes` → digest + live `document_read` handle instead of the placeholder (restore path only) | a session with `analyze_spreadsheet` enabled answers a document question correctly on **turn 2**; re-upload rate starts falling |
+| 4 | Offload trigger in `update_after_turn` + pinning, behind `DOCUMENT_OFFLOAD_ENABLED` | slice-assignment guard test passes; offload fires at most once per document; never fires while cache is live |
+| 5 | Fix the cache-live guard on the *existing* truncation deferral (same predicate as PR-4) | truncation events while cache live: 72% → ~0 |
+| 6 | Backend guard on a turn's aggregate inline attachment bytes (~7.5 MB), mirroring the SPA's `MAX_FILES_PER_MESSAGE` | oversized turn degrades to the `oversized_inline` guidance path, never to `SessionException` |
+| 7 | `hasDocuments` / `documentTokens` on `MessageMetadata`; admin cost anatomy shows document share | the two-table join this spec required becomes a dashboard column |
+
+**PRs 1–3 are the correctness fix and should ship together as a unit.** None
+carries cost-regression risk: the digest is strictly smaller than the document,
+and `document_read` only adds tokens when the model chooses to spend them. PR-1
+must precede PR-3 — a digest that points at a tool nobody has is no better than
+today's placeholder.
+
+PR-4 is the cost work and is independently revertible. PR-6 is unrelated to both
+and can go whenever.
+
+**Out of scope, but surfaced by this work:** the `extra_tools` agent-cache
+bypass makes ~76% of *all* sessions rebuild their Agent every turn. Fixing that
+would cut latency and re-run `initialize()` far less often, but it interacts
+with the #741 aliasing fix and the paused-agent resume path, so it needs its own
+design. File it separately; do not fold it in here.
+
+---
+
+## 6. Expected impact, and how we'll know
+
+Steady-state prefix for a document session drops from the document's full token
+count to ~1,500. Against the measured prod trajectories, the recoverable
+envelope is the cold-re-write cost in attachment sessions — **$66.24 of the
+$233.61 attachment spend (28%)** — minus what pinning deliberately leaves
+inline. A conservative target is **−15% on attachment-session cost with no
+quality regression**, measured as:
+
+- `cacheWrite` tokens per attachment session, before/after (primary)
+- write:read ratio for the attachment cohort — the metric
+  [[project-prod-cache-write-premium]] established as the one that actually
+  moves. `wastedUsd` and the `AvoidableMiss` alarm are blind to this mode.
+- re-upload rate (same filename ≥2× in a session): 14% → target <3%. Note this
+  is the one metric PRs 1–3 move on their own, and it should move *before* PR-4
+  lands — if it doesn't, the recovery path isn't reaching users (check the gate
+  first, per the `workspace_files` finding in §4B)
+- `document_read` call rate per attachment session — if it is near zero the
+  digest is too good to be true and the model is answering without the source;
+  if it is >3/turn the digest is too thin
+
+### Quality gate — this must not ship on cost numbers alone
+
+**Full evaluation design: `docs/specs/document-offload-evaluation.md`** (three
+axes — answer quality, token efficiency, cost effectiveness — with the
+randomized-flag comparison, the blinded scoring protocol, and the stopping
+rule). Validation of this spec's measurements:
+`docs/specs/document-context-offload-validation.md`.
+
+In brief: a fixed eval set of real-shaped tasks over held documents (~120, not
+the ~30 first sketched here — 30 paired tasks only detects ~25-point
+regressions), scored blind across three arms (today / PRs 1–3 / PRs 1–4):
+holistic tasks (summarize, compare two documents, find internal
+contradictions), lookup tasks (single fact, table cell, figure/chart — the
+dual-encoding canaries), and citation tasks (right page, including page-number
+identity under `document_read` reassembly). Holistic and citation tasks are
+where offload is most likely to hurt — if either regresses, pinning is too
+narrow, and the answer is to widen pinning, not to accept the regression. Per
+the CLAUDE.md tenet: when cost and quality genuinely conflict, quality wins; we
+look for the cheaper path to the *same* quality.
+
+Note from validation: the lifecycle diagram's "citations on ← unchanged" is
+wrong — no citations config is sent anywhere today (`document_handler.py`
+emits only `format`/`name`/`source.bytes`), so enabling citations is new work
+in PR-1, and the evaluation's §1 baseline probe must establish current PDF
+visual fidelity before any digest comparison is scored.
+
+---
+
+## 7. Non-goals
+
+- **Extended (1h) cache TTL.** Modelled against the real prod trajectories:
+  blanket +12.3% fleet cost; "1h once the session has shown a >5min gap" +5.7%;
+  "after two >5min gaps" +4.2%; a perfect oracle only −8.7%. `CacheConfig(ttl=)`
+  and `CacheToolsConfig` exist in the pinned SDK and it looks like a one-line
+  win, which is exactly why this is written down. Independently confirms the
+  2026-07-27 finding — do not re-litigate a third time.
+- **Per-session RAG over attachments.** A real option (S3 Vectors + the
+  assistant-KB pipeline already exist) and complementary, but it is a bigger
+  build and the digest+`document_read` path covers the same cases with less
+  machinery and no embedding-model lock-in. Revisit if `document_read` call
+  rates show the model thrashing.
+- **The tabular cohort.** Most expensive per session ($1.01) but a different
+  mechanism — the Code Interpreter probe loop, not prefix re-writes. Separate
+  spec.
+- **Replacing `SlidingWindowConversationManager` wholesale.** Out of scope; this
+  spec must not depend on that landing first.
+
+---
+
+## Sources
+
+- [Effective context engineering for AI agents — Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- [Context editing — Claude Platform Docs](https://platform.claude.com/docs/en/build-with-claude/context-editing)
+- [Managing context on the Claude Developer Platform](https://claude.com/blog/context-management)
+- [PDF support — Claude Platform Docs](https://platform.claude.com/docs/en/build-with-claude/pdf-support)
+- [Citations — Claude Platform Docs](https://platform.claude.com/docs/en/build-with-claude/citations)
+- [Citations API and PDF support for Claude models in Amazon Bedrock](https://aws.amazon.com/about-aws/whats-new/2025/06/citations-api-pdf-claude-models-amazon-bedrock/)
+- [Long Context vs. RAG for LLMs: An Evaluation and Revisits](https://arxiv.org/pdf/2501.01880)
+- [Context Rot, RAG, and Long Context: How to Architect LLM Systems in 2026](https://glasp.co/articles/context-rot-rag-long-context-hybrid)

--- a/docs/specs/document-offload-evaluation.md
+++ b/docs/specs/document-offload-evaluation.md
@@ -1,0 +1,266 @@
+# Evaluating document-context offload — quality, tokens, cost
+
+**Status:** Draft, companion to `docs/specs/document-context-offload.md` (§6)
+**Validation basis:** `docs/specs/document-context-offload-validation.md` —
+every prod number cited here was independently re-derived 2026-08-03.
+
+**The guardrail, stated first.** Per the repo tenet (`CLAUDE.md`, the
+token-cost bullet): *when cost and answer quality genuinely conflict, quality
+wins — the goal is the cheaper path to the **same** quality, not a cheaper
+answer.* Operationally: the quality gate in §2 is a **veto**. No cost result,
+however good, ships a confirmed quality regression; the permitted responses to
+a quality regression are widen pinning, fatten the digest, or abandon (§4).
+This design's job is to be able to *detect* that conflict, which is why the
+quality axis gets the most machinery.
+
+---
+
+## 1. What is actually being compared
+
+Three system states, not two:
+
+| arm | restore path (turn 2+ after rebuild) | steady-state prefix |
+|---|---|---|
+| **A. today (prod)** | contentless placeholder | full document until the strip fires |
+| **B. PRs 1–3** | digest + `document_read` | full document (no offload trigger yet) |
+| **C. PRs 1–4** | digest + `document_read` | digest + retrieval after offload |
+
+A→B is the *correctness* comparison (quality should go **up**; cost roughly
+flat). B→C is the *cost* comparison (cost should go down; quality must not).
+Evaluating only A→C conflates them: a quality win from fixing the strip could
+mask a quality loss from the offload, and would misattribute both. Every
+experiment below names which comparison it serves.
+
+**Required baseline experiment (before any scoring).** The validation pass
+found that **no citations config is sent today**, and on Bedrock the visual
+(page-image) PDF path is tied to citations-enabled document handling. So we do
+not currently know whether arm A even sees charts. Run a 10-question probe
+(chart-only PDF, table-in-image PDF, scanned page) against arm A twice — bare
+document block, and with `citations: {enabled: true}` — and record what the
+model can actually answer. Every subsequent quality comparison inherits its
+definition of "full fidelity" from this probe, and the offload spec's
+"dual-encoded" premise is unverified until it runs.
+
+---
+
+## 2. Answer quality
+
+### 2.1 Critique of the spec's ~30-task design, and what replaces it
+
+The shape (holistic / lookup / citation) is right and maps onto the failure
+modes offload can cause. The size is not defensible as a gate: with 30 paired
+tasks scored pass/fail, McNemar at α=0.05 / 80 % power only detects a
+regression of roughly ≥25 percentage points. That detects breakage, not the
+"subtle but critical context loss" the spec itself warns about. Fixes, in
+order of leverage:
+
+1. **Scale tasks, not effort per task.** Lookup and citation tasks are
+   programmatically generatable and scorable (planted facts, known pages), so
+   n is cheap there. Target: **120 tasks** (40 holistic / 50 lookup / 30
+   citation) over ~20 documents. At 120 paired binary outcomes, detectable
+   regression drops to ~10–12 points; holistic tasks scored on a rubric add
+   sensitivity via continuous scores.
+2. **Replicate generation, not just tasks.** k=3 samples per (task, arm) at the
+   production temperature; score all three. Generation variance is otherwise
+   indistinguishable from arm effects at this n.
+3. **Score paired, report per-family.** Offload's predicted failure signature
+   is family-specific (holistic and citation degrade, lookup holds). A pooled
+   score would dilute exactly the signal the spec says matters.
+
+### 2.2 Documents — provenance without touching user content
+
+Never prod user files. Two sources, both matched to the measured prod corpus
+shape (mime mix 290 PDF / 172 DOCX / 185 image / 54 text-family per the
+validation scan; upload p50 ≈ 0.2 MB, p90 ≈ 2.2 MB; include several 40+ page
+documents since >100k-token peaks are 4× more common in attachment sessions):
+
+- **Public BSU corpus** (realism): policy PDFs, the academic catalog, job
+  descriptions, award nomination forms, financial-report PDFs — the same
+  genres the offload spec names. Scrape from public boisestate.edu pages.
+- **Synthetic planted-fact corpus** (ground truth): generated DOCX/PDFs with
+  known facts at known pages, tables with known cells, figures with known
+  captions, and **deliberately planted internal contradictions** for holistic
+  tasks. Render PDFs with real layout (tables, charts as images) so the
+  dual-encoding question is exercised — a text-extractable-only synthetic
+  corpus would hide exactly the regression we fear. Include chart-only pages
+  whose answer is unreachable from any text layer.
+
+### 2.3 Task families, with the two stack-specific risks built in
+
+- **Holistic** (A/B/C): summarize; compare two documents; find the planted
+  contradiction. Scored by rubric (coverage of gold key-points, correctness,
+  no fabrication).
+- **Lookup**: single fact; **table cell**; **figure/chart caption and
+  chart-value questions**. The last two are the *dual-encoding canaries*: the
+  digest is text-only, so a correct answer in arm C requires the model to call
+  `document_read` and get **native blocks** back. If `document_read` returns
+  flattened text for DOCX (as specced) the DOCX-table tasks will show it.
+  Scored by exact/normalized match — no judge needed.
+- **Citation**: does the answer cite the right page. Two sub-checks the spec
+  misses:
+  - *Page-identity under reassembly*: `document_read(page_range={4,7})`
+    returns a re-assembled sub-document whose internal pages are 1–4. A native
+    citation against it will say "page 2" meaning original page 5. The tool
+    must remap (or embed original page labels); this task family is the test
+    that it does.
+  - *Citations only exist if the config ships*: arm A scores here reflect the
+    §1 baseline probe; if citations aren't enabled in prod yet, the citation
+    family gates B/C against each other, not against A.
+- **Restore/turn-2 family** (the PR-3 fix, A→B): two-turn conversations run
+  with a spreadsheet tool enabled (forcing the cache bypass, hence a rebuild
+  between turns): attach + ask on turn 1, follow-up question on turn 2. Arm A
+  should fail these near-totally (the placeholder has zero content) — which
+  doubles as a harness canary: if arm A *passes*, the harness isn't actually
+  exercising the restore path.
+- **Pinning-boundary family** (B→C): ask about the document on the attach
+  turn, digress for two turns (so it unpins and offloads), then ask a holistic
+  question. This is where "pinning too narrow" shows up first.
+
+### 2.4 Scoring, blinding, agreement
+
+- **Lookup/citation:** programmatic scoring against planted ground truth.
+  Blinding is moot; bias-free by construction.
+- **Holistic:** LLM judge, pairwise A-vs-B per task, both orders (positions
+  swapped), judged against the gold key-point list — not free-form preference,
+  which is where self-preference bias lives. **Blinding is a real problem the
+  spec hand-waves:** arm C transcripts contain `<document-digest>` blocks and
+  `document_read` tool calls — an instant giveaway. The harness must strip
+  transcripts to *final answer text only* before judging, and a scrubber must
+  verify no digest/tool artifacts survive (grep for the digest tag and tool
+  names; reject the sample into manual review if found).
+- **Consistency checks:** (1) each pair judged in both orders — an
+  order-flipped verdict is recorded as a tie; (2) a second judge model on a
+  20 % sample, report inter-judge agreement; (3) human (Phil or delegate)
+  scores a 20 % sample blind, target κ ≥ 0.7 vs the judge — below that, the
+  rubric is rewritten before results are read; (4) 5 % of tasks duplicated
+  verbatim as self-consistency probes for the judge.
+- **Detectable effect, stated honestly:** with 120 tasks × 3 replicates,
+  binary families resolve ~10-point differences; the holistic rubric resolves
+  ~0.4 SD. The ship gate is **non-inferiority**: arm C within δ = 5 points of
+  arm B per family at 90 % CI is the *goal*, but at this n a true 5-point
+  regression can evade detection — which is why the per-family canaries
+  (chart-lookup, pinning-boundary, citation-page-identity) exist: they are
+  designed so the predicted failure modes produce *large*, detectable effects,
+  not diffuse small ones.
+
+---
+
+## 3. Token efficiency
+
+### 3.1 Metrics and exactly where each is read
+
+| metric | source | comparison |
+|---|---|---|
+| **cacheWrite:cacheRead token ratio** per attachment session (primary) | `C#` rows, `tokenUsage.cacheWriteInputTokens` / `cacheReadInputTokens` | B vs C cohorts |
+| cacheWrite tokens per session, and `cacheWriteCost` share of session cost | `C#` `tokenUsage` + `cost` map (map-shaped rows only — floats carry no split; ~6 % of spend, footnote it) | B vs C |
+| steady-state prefix size | `contextWindow` (written per call by `stream_coordinator`) trajectory within session | B vs C |
+| offload events fired, tokens evicted per event | **new**: counter + EMF emitted by the PR-4 trigger; also stamp an `offloadEvent` marker field on the next `C#` row | C only (mechanism check) |
+| `document_read` calls per attachment session, pages per call, mode (range/pattern/full) | **new**: EMF from the tool, mirroring the workspace-tools pattern | C health band: ~0.3–3 calls/session; ≈0 ⇒ digest answering unaided (suspicious — cross-check quality); >3/turn ⇒ digest too thin |
+| re-upload rate, **byte-identical duplicates only** (per validation: 87 % of dup groups are size-identical; that subset is the loss signal, size-differing ones are revisions) | uploads table, (sessionId, filename, sizeBytes) groups | A vs B — this is the one metric PRs 1–3 must move on their own |
+
+Explicitly **not** trusted, per the prior findings this spec inherits:
+`wastedUsd` and the `AvoidableMiss` alarm are blind to the dominant waste mode
+(`cacheStatus="hit"` masks partial-prefix misses), and `cacheStatus` counts are
+therefore secondary color, not endpoints. The write:read *token ratio* is the
+metric that actually moves.
+
+### 3.2 Comparison design — how workload mix is kept out
+
+Plain before/after is disqualified by the validation findings themselves
+(missing-cost rows cluster in specific months; traffic mix drifts; July has
+13× March's rows). Instead:
+
+1. **Randomized per-session flag.** Extend `DOCUMENT_OFFLOAD_ENABLED` from a
+   boolean to a percentage rollout keyed on `hash(session_id) % 100` (the
+   standard default-on-with-kill-switch pattern, plus a bucket knob). Arm B =
+   flag off, arm C = flag on, running **concurrently**. Randomization at the
+   session level removes user- and time-mix confounds outright — this is the
+   lesson of the bypass spec's confounded §3 cohort comparison, and of its
+   proposed `create_artifact` experiment, which validation showed would treat
+   only 53 self-selected sessions. Do not repeat either shape here.
+2. **Cohort hygiene:** attachment sessions only; exclude tabular-only sessions
+   (different mechanism, per §7 of the offload spec); stratify reporting by
+   {PDF, DOCX/text, image, mixed} and by model id. Sessions that never had a
+   rebuild or a >5 min gap can't benefit and dilute — report the treated-
+   opportunity subset (≥1 cold-eligible turn) alongside intent-to-treat.
+3. **A→B (PRs 1–3 ship together, unflagged):** this one is before/after by
+   necessity. Use difference-in-differences with non-attachment sessions as
+   the control series to absorb temporal drift, and report the re-upload rate
+   (byte-identical definition) weekly: 14 % → <3 % is the spec's own success
+   line, and it should start moving within days of deploy if the recovery path
+   reaches users (if it doesn't, check the tool gate first — the
+   `workspace_files` grant lesson).
+
+One measurement caveat to carry: turn-1 of every non-PDF attachment writes its
+document into the cache one turn late (the leading-document cache-point rule
+found in validation §claim-2). This inflates turn-2 cacheWrite in *both* arms
+equally under randomization — harmless for B vs C, but it will make absolute
+write:read ratios look worse than the offload can fix; don't chase it as a
+regression.
+
+---
+
+## 4. Cost effectiveness
+
+### 4.1 Is −15 % well-founded?
+
+The measured envelope: attachment-session spend $233–249 (denominator
+convention per validation claim 1), of which cold-write cost on >5 min-gap
+turns is **$58–66 (~25–28 %)**. But the offload recovers only the *document
+share* of each cold re-write — history, system prompt, and tool config still
+re-write in full — minus whatever pinning deliberately keeps inline, and minus
+new spend it introduces (digest tokens every turn ≈1.5k, `document_read`
+retrievals, Haiku extraction off-path). The document share of attachment-
+session prefixes is **currently unmeasured** (no `documentTokens`
+instrumentation exists — that is PR-7).
+
+So: −15 % is *plausible* (it requires documents ≈ 55–60 % of cold-write bytes
+net of pinning and digest overhead) but it is a guess sitting on an unmeasured
+quantity. Two consequences:
+
+- **Land PR-7's `documentTokens` before or with the PR-4 flag**, and restate
+  the target as derived: expected recovery ≈ `0.6 × documentShare × 25 %` of
+  attachment spend. If measured documentShare comes back at 30 %, −15 % was
+  never achievable and a −5 % result is a *success*, not a miss — without the
+  measurement, that outcome would read as failure and kill a good fix.
+- Power: session cost is heavy-tailed (median $0.16, mean $0.62). Compare on
+  log-cost (or Mann-Whitney), and expect to need **≥150 attachment sessions
+  per arm** (≈4 weeks at ~50/week prod rate, so plan for 6–8 weeks or
+  supplement with replayed synthetic sessions in dev for a faster directional
+  read).
+
+### 4.2 Stopping rule
+
+Evaluate at 150 sessions/arm or 8 weeks, whichever first. Primary endpoint:
+attachment-session cost per session (log scale), arm C vs arm B. Secondary:
+write:read ratio, quality gate (§2), `document_read` health band.
+
+- **Ship (flag to 100 %):** cost −10 % or better at 90 % CI *and* quality
+  non-inferior per §2 *and* `document_read` in band *and* offload events
+  actually firing (mechanism check — a win with zero offload events is a
+  confound, not a result).
+- **Widen pinning (iterate, don't ship or kill):** quality regression
+  concentrated in holistic / citation / pinning-boundary families, or
+  `document_read` >3 calls/turn. Widen pinning or raise the digest budget,
+  re-run the quality gate only (cost re-check follows automatically from the
+  running flag). Two iterations maximum — the tenet says quality wins, and it
+  is satisfied by *paying* for quality, not by shipping the regression.
+- **Abandon (or re-scope):** cost improvement <5 % with quality flat *and*
+  offload events confirmed firing — the prefix is dominated by non-document
+  content, and the recoverable envelope was mis-attributed. The money then
+  says: keep PRs 1–3 (they're a correctness fix and cost-neutral), drop PR-4,
+  and put the effort into the `extra_tools` cache-bypass fix, whose cohort
+  carries ~95 % of spend. Also abandon if two pinning-widening iterations
+  can't clear the quality gate: that is the "cost and quality genuinely
+  conflict" case, and quality wins.
+
+### 4.3 What this design can and can't conclude
+
+It can causally attribute cost movement to the offload (randomized flag), can
+detect the *predicted* quality failure modes at practical n (targeted
+canaries), and can distinguish "fix works" from "envelope was misjudged"
+(mechanism counters + documentTokens). It cannot detect a diffuse ≤5-point
+quality regression across all families at n=120×3 — that residual risk is
+accepted explicitly and bounded by the post-ship signals (re-upload rate and
+`document_read` anomalies both regress quickly if users are silently getting
+worse answers).


### PR DESCRIPTION
## What

Adds the three companion documents from the 2026-08-03 document-conversation cost investigation:

1. **`document-context-offload.md`** — the spec. Attachment conversations are **11% of prod sessions and 31% of prod spend** ($0.62 vs $0.18 mean per session), and the cost driver is not the document's tokens on the attach turn — it's that the document lives in the cacheable prefix forever and is re-written in full on every cold turn (cacheWrite is ~48–50% of the cohort's spend; the 5-minute TTL cliff is directly visible in the gap-binned cold-rewrite rates). Four file:line-anchored defects, a digest+retrieval design built on Strands' `ContextOffloader`/pinning primitives (right shape, wrong hook — details in §2), an all-fail-open lifecycle, a PR sequence, and a quality gate that explicitly must not ship on cost numbers alone.

2. **`document-context-offload-validation.md`** — independent adversarial re-verification of every headline claim in the offload spec *and* the `extra_tools` bypass spec (#834): fresh content-free prod re-scan, line-level verification of every code reference on develop **and** `origin/main`, and SDK-source re-derivation rather than taking claims on faith. Verdict: all seven claims **confirmed**, three with quantified caveats (the >15-min cold-rewrite rate is ~55–75% not ~100%; the fleet waste envelope reproduces at $160–173 not $188; conditional-TTL-policy magnitudes did not reproduce). It also caught two bookkeeping defects in the original scan — inconsistent denominators across legacy float-cost rows, and non-random missing-cost rows understating fleet totals ~20% — with the corrected headline still robust (29.6% vs 30.7%).

3. **`document-offload-evaluation.md`** — the evaluation design. Three arms (today / strip-fix / offload) so the correctness comparison and the cost comparison are never conflated; the quality-veto guardrail stated first (a confirmed quality regression blocks shipping regardless of cost result); paired per-family scoring with an honest power analysis that replaces the original ~30-task gate (which could only detect ~25-point regressions) with ~120 scaled tasks plus dual-encoding canaries for chart/table lookups; and a required baseline probe — citations config is not sent in prod today, so what arm A can even see is unverified until it runs.

## How this connects to the open spec PRs

These documents are the origin of the investigation thread: the bypass spec (#834) was found during this measurement, the cache-spiral spec (#833) borrows this trio's validation/eval discipline and provides the attachment-free counterexample proving prefix re-writes aren't document-specific, and compaction v2 (#835) names offload as its escalation target (I5). Landing these makes the cross-references in all three resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)