### PR TITLE
feat: cache agents carrying artifact tools (#834 arm 1)

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -51,6 +51,7 @@ from apis.shared.tools.injected import (
     SPREADSHEET_TOOL_IDS,
     WORD_DOCUMENT_TOOL_IDS,
     WORKSPACE_TOOL_IDS,
+    injected_tools_are_key_described,
 )
 from apis.shared.user_settings.repository import UserSettingsRepository
 
@@ -1092,6 +1093,9 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=effective_skill_ids,
+                # This path builds no injected tools, but shares a cache slot
+                # with the real turns that do. Read the slot; never seed it.
+                cache_write=False,
             )
             payload = await dispatch_app_tool_call(
                 agent,
@@ -1140,6 +1144,8 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 agent_type=effective_agent_type,
                 is_resume=False,
                 accessible_skill_ids=effective_skill_ids,
+                # Same partial-toolset hazard as app_tool_call above.
+                cache_write=False,
             )
             payload = dispatch_app_context_update(
                 agent,
@@ -2009,10 +2015,24 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 enabled_tools=effective_enabled_tools,
                 session_id=input_data.session_id,
                 user_id=user_id,
-            ) + _build_memory_tools(
+            )
+
+            memory_tools = _build_memory_tools(
                 agent_memory=agent_memory,
                 user_id=user_id,
                 user_email=current_user.email,
+            )
+            extra_tools = extra_tools + memory_tools
+
+            # Can this turn's agent be cached despite carrying injected tools?
+            # Only when every builder that fired closes over values the cache
+            # key already carries (session, user, enabled_tools). Derived from
+            # the same `effective_enabled_tools` that goes into the key below —
+            # passing the request's list here instead would let the predicate
+            # and the key disagree about which builders ran.
+            extra_tools_key_described = injected_tools_are_key_described(
+                enabled_tools=effective_enabled_tools,
+                has_memory_binding=bool(memory_tools),
             )
 
             agent = await get_agent(
@@ -2031,6 +2051,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 extra_tools=extra_tools,
                 is_resume=False,
                 accessible_skill_ids=effective_skill_ids,
+                extra_tools_key_described=extra_tools_key_described,
             )
 
         # Resume requests must target interrupts that the cached agent

--- a/backend/src/apis/inference_api/chat/service.py
+++ b/backend/src/apis/inference_api/chat/service.py
@@ -105,6 +105,18 @@ def _create_cache_key(
 _agent_cache: dict = {}
 _CACHE_MAX_SIZE = 100
 
+# Kill switch for caching agents that carry key-described injected tools
+# (docs/specs/agent-cache-extra-tools-bypass.md). Default ON; only the literal
+# string "false" disables it — an empty or unset value stays enabled, because
+# workflow env vars can materialize as "". Setting it to "false" restores the
+# blanket `if extra_tools` bypass exactly.
+AGENT_CACHE_INJECTED_TOOLS_ENABLED_ENV = "AGENT_CACHE_INJECTED_TOOLS_ENABLED"
+
+
+def agent_cache_injected_tools_enabled() -> bool:
+    """Whether agents carrying key-described injected tools may be cached."""
+    return os.environ.get(AGENT_CACHE_INJECTED_TOOLS_ENABLED_ENV, "").lower() != "false"
+
 
 def _is_paused_on_interrupt(agent: BaseAgent) -> bool:
     """Return True if the wrapped Strands agent is mid-interrupt.
@@ -210,6 +222,8 @@ async def get_agent(
     mantle_region: Optional[str] = None,
     is_resume: bool = False,
     accessible_skill_ids: Optional[List[str]] = None,
+    extra_tools_key_described: bool = False,
+    cache_write: bool = True,
 ) -> BaseAgent:
     """
     Get or create agent instance with current configuration for session
@@ -233,6 +247,16 @@ async def get_agent(
         inference_params: Canonical-name -> value map for inference params.
             When provided, supersedes the legacy ``temperature``/``max_tokens``
             kwargs (the explicit dict wins on key conflicts).
+        extra_tools_key_described: Whether every tool in ``extra_tools``
+            closes over only values this cache key already carries. Callers
+            derive it with ``injected_tools_are_key_described``; the default
+            (False) keeps the historical bypass, so any caller that has not
+            reasoned about its closures gets the safe behavior.
+        cache_write: Whether this caller may *populate* the cache. Read stays
+            allowed either way. Set False by callers that build a partial
+            toolset for a session whose real turns build more — otherwise they
+            would seed the shared slot with an agent missing those tools, and
+            the next real turn would cache-hit into it.
 
     Returns:
         BaseAgent subclass instance (cached or newly created)
@@ -276,7 +300,16 @@ async def get_agent(
         skills_hash=skills_hash,
     )
 
-    if not extra_tools and cache_key in _agent_cache:
+    # Whether this turn's injected tools (if any) let it use the cache at all.
+    # `extra_tools` used to veto the cache outright, standing in for "this agent
+    # captured something the key doesn't describe". True for two families; for
+    # the rest it cost 76% of sessions a full `initialize()` + AgentCore Memory
+    # restore on every turn (docs/specs/agent-cache-extra-tools-bypass.md).
+    cacheable = not extra_tools or (
+        extra_tools_key_described and agent_cache_injected_tools_enabled()
+    )
+
+    if cacheable and cache_key in _agent_cache:
         cached = _agent_cache[cache_key]
         # Defense in depth: a non-resume request should never be served a
         # paused agent. If we ever desync the cache key between the original
@@ -294,10 +327,23 @@ async def get_agent(
             del _agent_cache[cache_key]
         else:
             logger.debug("✅ Agent cache hit")
+            # Experiment instrument (spec §6): "initialize() invocations per
+            # turn" should approach 1 per *session* for treated sessions, not 1
+            # per turn. A cache hit is exactly the turn that skips initialize(),
+            # so counting these against misses over the same session id measures
+            # the gate. INFO and structured, so Logs Insights can group it.
+            logger.info(
+                "agent_cache outcome=hit injected_tools=%s session=%s",
+                bool(extra_tools), scrub_log(session_id),
+            )
             return cached
 
     # Cache miss - create new agent
     logger.debug("⚠️ Agent cache miss - creating new instance")
+    logger.info(
+        "agent_cache outcome=miss injected_tools=%s cacheable=%s session=%s",
+        bool(extra_tools), cacheable, scrub_log(session_id),
+    )
 
     # Create agent via the type registry. Both "chat" and "skill" resolve to
     # ChatAgent (Skills v2 retired the SkillAgent subclass); a "skill" turn just
@@ -347,9 +393,20 @@ async def get_agent(
         if resolved_agent_type != "voice" and accessible_skill_ids is not None:
             agent._construction_snapshot["enabled_skills"] = list(accessible_skill_ids)
 
-    # Don't cache agents with context-bound extra_tools
-    if extra_tools:
+    # Don't cache agents whose context-bound extra_tools captured anything the
+    # key doesn't describe — a cached agent holds the *old* closures, so reuse
+    # is only safe when those are provably equivalent under this key. That is
+    # the decision spec §6 asks to be explicit about: cached tools are NOT
+    # refreshed on a hit; eligibility is proven at the key instead.
+    if not cacheable:
         logger.debug("⏭️ Skipping cache for agent with extra_tools")
+        return agent
+
+    # Caller builds a partial toolset for a slot that real turns fill more
+    # completely (the MCP App dispatch paths). Reading is fine — a properly
+    # built agent is strictly better — but writing would poison the slot.
+    if not cache_write:
+        logger.debug("⏭️ Not populating cache from a partial-toolset caller")
         return agent
 
     # Add to cache with LRU eviction

--- a/backend/src/apis/shared/tools/injected.py
+++ b/backend/src/apis/shared/tools/injected.py
@@ -53,3 +53,69 @@ INJECTED_TOOL_IDS = frozenset(
     | POWERPOINT_PRESENTATION_TOOL_IDS
     | WORKSPACE_TOOL_IDS
 )
+
+
+# ============================================================
+# Agent-cache eligibility
+# ============================================================
+
+# Ids whose factories capture *nothing the agent cache key does not already
+# describe*. `_create_cache_key` carries `session_id`, `user_id` and a hash of
+# `enabled_tools`, so a builder that closes over only those produces tools that
+# are provably equivalent to freshly-built ones for any turn that hits the same
+# slot — which is what makes reusing the cached agent safe.
+#
+# Why this set exists at all: `get_agent` bypassed the cache for *any*
+# `extra_tools`, which reads as "this agent captured something the key doesn't
+# describe". That is correct for two families and far too broad for the rest —
+# it reaches 76% of sessions and 95% of spend, and makes every turn pay a full
+# `initialize()` + AgentCore Memory restore (see
+# docs/specs/agent-cache-extra-tools-bypass.md §1–§2).
+#
+# Deliberately starting at ARTIFACT only. That spec's §6 asks for a
+# single-builder experiment rather than more observational data, because the
+# bypass→cache-write correlation is confounded by workload; artifacts are the
+# clean arm (no `assistant_id`, no memory binding, ~957 sessions). The rest are
+# excluded for now, each for a stated reason:
+#
+#   - SPREADSHEET: `make_*_tool(assistant_id, …)` closes over `assistant_id`,
+#     which is NOT a key element. Needs the key (and `PausedTurnSnapshot`)
+#     extended first, per that spec's §6.
+#   - WORD / EXCEL / POWERPOINT / WORKSPACE: capture only session+user, so they
+#     are *eligible on the same reasoning as artifacts* — held back only so the
+#     experiment measures one variable. Promote them once the artifact arm reads
+#     clean.
+#   - Memory-Space tools: capture the resolved binding (space id + access) and
+#     are not gated on `enabled_tools` at all, so they are not in any set here.
+#     `get_agent`'s caller must treat a live memory binding as an independent
+#     veto — see `injected_tools_are_key_described`.
+KEY_DESCRIBED_INJECTED_TOOL_IDS = frozenset(ARTIFACT_TOOL_IDS)
+
+
+def injected_tools_are_key_described(
+    enabled_tools: list | frozenset | set | None,
+    has_memory_binding: bool,
+) -> bool:
+    """Whether this turn's injected tools are fully described by the cache key.
+
+    True means every per-request tool the turn built closes over only values the
+    agent cache key already carries, so a cached agent from an earlier turn in
+    the same slot holds equivalent closures and can be reused.
+
+    Args:
+        enabled_tools: The turn's *effective* enabled tool ids (an Agent's tool
+            binding replaces the request's list — pass whatever reaches
+            ``get_agent``, or the key and this predicate disagree).
+        has_memory_binding: Whether a resolved Memory-Space binding produced
+            tools this turn. An independent veto: those tools close over the
+            binding, which is not in the key, and they are not gated on
+            ``enabled_tools`` so no id here can represent them.
+
+    Conservative in both directions that matter. A feature-flagged-off family
+    whose id is still in ``enabled_tools`` counts as not-described even though
+    it built nothing — that costs a cache bypass, never a wrong reuse.
+    """
+    if has_memory_binding:
+        return False
+    built = INJECTED_TOOL_IDS.intersection(enabled_tools or ())
+    return built.issubset(KEY_DESCRIBED_INJECTED_TOOL_IDS)

--- a/backend/tests/apis/inference_api/test_chat_service.py
+++ b/backend/tests/apis/inference_api/test_chat_service.py
@@ -376,3 +376,175 @@ async def test_adoption_does_not_reach_across_sessions(mock_freshness_hash):
 
     assert b.agent.messages == [], "a different session adopted someone else's conversation"
     assert a.agent.messages is not b.agent.messages
+
+
+# ============================================================
+# #834 — narrowing the `extra_tools` agent-cache bypass
+# ============================================================
+
+
+class TestInjectedToolCacheEligibility:
+    """`get_agent` used to refuse the cache for *any* per-request tool.
+
+    That predicate stands for "this agent captured something the key doesn't
+    describe" — true for spreadsheets (`assistant_id`) and Memory Spaces (the
+    resolved binding), and false for the rest, which close over only session and
+    user. Both are already key elements, so the cached closures are equivalent
+    and the bypass was pure cost: 76% of sessions paid a full `initialize()` +
+    AgentCore Memory restore every turn
+    (docs/specs/agent-cache-extra-tools-bypass.md §1–§2).
+
+    These pin the narrowed predicate, one builder at a time per that spec's §6.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_artifact_turn_now_caches_and_the_next_turn_hits(
+        self, mock_create_agent, mock_freshness_hash
+    ):
+        first = await service.get_agent(
+            session_id="s", user_id="u",
+            enabled_tools=["create_artifact"],
+            extra_tools=[object()],
+            extra_tools_key_described=True,
+        )
+        second = await service.get_agent(
+            session_id="s", user_id="u",
+            enabled_tools=["create_artifact"],
+            extra_tools=[object()],
+            extra_tools_key_described=True,
+        )
+
+        assert second is first, "the artifact turn rebuilt its agent"
+        assert mock_create_agent.call_count == 1, "initialize() ran twice for one session"
+
+    @pytest.mark.asyncio
+    async def test_a_turn_that_captured_something_unkeyed_still_bypasses(
+        self, mock_create_agent, mock_freshness_hash
+    ):
+        """Spreadsheet tools close over `assistant_id`, which is not in the key —
+        a cached agent could answer against the wrong assistant's corpus."""
+        for _ in range(2):
+            await service.get_agent(
+                session_id="s", user_id="u",
+                enabled_tools=["analyze_spreadsheet"],
+                extra_tools=[object()],
+                extra_tools_key_described=False,
+            )
+
+        assert mock_create_agent.call_count == 2, "cached an agent with unkeyed captures"
+
+    @pytest.mark.asyncio
+    async def test_callers_that_do_not_declare_get_the_old_safe_behavior(
+        self, mock_create_agent, mock_freshness_hash
+    ):
+        """The parameter defaults to False: a caller that has not reasoned about
+        its closures must not be opted in by omission."""
+        for _ in range(2):
+            await service.get_agent(
+                session_id="s", user_id="u", extra_tools=[object()]
+            )
+
+        assert mock_create_agent.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_the_kill_switch_restores_the_blanket_bypass(
+        self, mock_create_agent, mock_freshness_hash, monkeypatch
+    ):
+        monkeypatch.setenv("AGENT_CACHE_INJECTED_TOOLS_ENABLED", "false")
+        for _ in range(2):
+            await service.get_agent(
+                session_id="s", user_id="u",
+                enabled_tools=["create_artifact"],
+                extra_tools=[object()],
+                extra_tools_key_described=True,
+            )
+
+        assert mock_create_agent.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_an_empty_flag_value_stays_enabled(
+        self, mock_create_agent, mock_freshness_hash, monkeypatch
+    ):
+        # Workflow env vars can materialize as "" — that must not read as off.
+        monkeypatch.setenv("AGENT_CACHE_INJECTED_TOOLS_ENABLED", "")
+        for _ in range(2):
+            await service.get_agent(
+                session_id="s", user_id="u",
+                enabled_tools=["create_artifact"],
+                extra_tools=[object()],
+                extra_tools_key_described=True,
+            )
+
+        assert mock_create_agent.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_partial_toolset_caller_may_read_the_slot_but_never_seed_it(
+        self, mock_create_agent, mock_freshness_hash
+    ):
+        """The regression this narrowing would otherwise introduce.
+
+        The MCP App dispatch paths call `get_agent` with NO injected tools but
+        the same cache key as the session's real turns. Before the narrowing they
+        could not collide, because artifact turns never cached. Now they share a
+        slot — so if an App call seeded it first, the next real turn would
+        cache-hit an agent with no `create_artifact` and silently lose the tool
+        for the rest of the session.
+        """
+        app_call = await service.get_agent(
+            session_id="s", user_id="u",
+            enabled_tools=["create_artifact"],
+            cache_write=False,
+        )
+        real_turn = await service.get_agent(
+            session_id="s", user_id="u",
+            enabled_tools=["create_artifact"],
+            extra_tools=[object()],
+            extra_tools_key_described=True,
+        )
+
+        assert real_turn is not app_call, "a real turn inherited the App path's toolless agent"
+
+        # …and once a real turn owns the slot, the App path reuses it rather
+        # than building a throwaway.
+        assert await service.get_agent(
+            session_id="s", user_id="u",
+            enabled_tools=["create_artifact"],
+            cache_write=False,
+        ) is real_turn
+
+    @pytest.mark.asyncio
+    async def test_a_newly_cacheable_agent_still_shares_the_session_conversation(
+        self, mock_freshness_hash
+    ):
+        """#741's invariant, under more concurrent siblings.
+
+        Caching agents that never cached before means more instances alive per
+        session, so the aliasing guard gets *more* load, not less — §5 hazard 2.
+        """
+        store: list[dict] = []
+
+        with patch.object(service, "create_agent") as mock:
+            mock.side_effect = lambda **kwargs: _fake_agent_with_messages(
+                system_prompt=kwargs.get("system_prompt"), restored=store
+            )
+
+            artifact_turn = await service.get_agent(
+                session_id="s", user_id="u",
+                enabled_tools=["create_artifact"],
+                extra_tools=[object()],
+                extra_tools_key_described=True,
+            )
+            artifact_turn.agent.messages.append({"role": "user", "t": 1})
+            store.append({"role": "user", "t": 1})
+
+            # An `@`-mention: different system prompt → different slot, second
+            # live Agent for the same session.
+            mentioned = await service.get_agent(
+                session_id="s", user_id="u",
+                enabled_tools=["create_artifact"],
+                system_prompt="You are the mentioned Agent.",
+                extra_tools=[object()],
+                extra_tools_key_described=True,
+            )
+
+        assert mentioned.agent.messages, "the second live Agent forked the conversation"

--- a/backend/tests/shared/test_injected_tool_cache_eligibility.py
+++ b/backend/tests/shared/test_injected_tool_cache_eligibility.py
@@ -1,0 +1,77 @@
+"""`injected_tools_are_key_described` — which turns may reuse a cached Agent.
+
+The agent cache key carries session, user and a hash of enabled_tools. A
+per-request tool builder that closes over only those produces tools equivalent
+to freshly-built ones, so the cached agent is safe to reuse. One that captures
+anything else (an assistant id, a memory binding) is not.
+
+Getting this predicate wrong in the permissive direction is a correctness bug —
+an agent answering against the wrong assistant's corpus or the wrong memory
+space — so these lean on the "unless proven, bypass" default.
+"""
+
+from apis.shared.tools.injected import (
+    ARTIFACT_TOOL_IDS,
+    INJECTED_TOOL_IDS,
+    KEY_DESCRIBED_INJECTED_TOOL_IDS,
+    SPREADSHEET_TOOL_IDS,
+    injected_tools_are_key_described,
+)
+
+
+class TestKeyDescribedPredicate:
+    def test_an_artifact_only_turn_is_key_described(self):
+        assert injected_tools_are_key_described(
+            ["create_artifact"], has_memory_binding=False
+        )
+
+    def test_a_turn_with_no_injected_tools_is_trivially_key_described(self):
+        assert injected_tools_are_key_described(["web_search"], has_memory_binding=False)
+        assert injected_tools_are_key_described(None, has_memory_binding=False)
+        assert injected_tools_are_key_described([], has_memory_binding=False)
+
+    def test_spreadsheet_tools_are_not_key_described(self):
+        # They close over `assistant_id`, which the key does not carry.
+        for tool_id in SPREADSHEET_TOOL_IDS:
+            assert not injected_tools_are_key_described(
+                [tool_id], has_memory_binding=False
+            )
+
+    def test_one_unkeyed_builder_disqualifies_the_whole_turn(self):
+        # The agent is one object; a single unkeyed capture taints it.
+        assert not injected_tools_are_key_described(
+            ["create_artifact", "analyze_spreadsheet"], has_memory_binding=False
+        )
+
+    def test_a_memory_binding_vetoes_regardless_of_enabled_tools(self):
+        # Memory-Space tools are gated on the binding, not on enabled_tools, so
+        # no id in the list can represent them — the caller must say so.
+        assert not injected_tools_are_key_described(
+            ["create_artifact"], has_memory_binding=True
+        )
+        assert not injected_tools_are_key_described([], has_memory_binding=True)
+
+    def test_every_family_still_awaiting_promotion_bypasses(self):
+        """The experiment measures one variable (spec §6).
+
+        Word/Excel/PowerPoint/workspace capture only session+user, so they are
+        eligible on the same reasoning as artifacts — but they stay out until the
+        artifact arm reads clean. This fails the day someone widens the set
+        without revisiting the experiment.
+        """
+        for tool_id in INJECTED_TOOL_IDS - KEY_DESCRIBED_INJECTED_TOOL_IDS:
+            assert not injected_tools_are_key_described(
+                [tool_id], has_memory_binding=False
+            ), f"{tool_id} was promoted without updating the experiment"
+
+    def test_the_experiment_arm_is_artifacts_only(self):
+        assert KEY_DESCRIBED_INJECTED_TOOL_IDS == ARTIFACT_TOOL_IDS
+
+    def test_accepts_a_set_as_well_as_a_list(self):
+        # Callers pass whatever `effective_enabled_tools` happens to be.
+        assert injected_tools_are_key_described(
+            {"create_artifact"}, has_memory_binding=False
+        )
+        assert not injected_tools_are_key_described(
+            frozenset({"analyze_spreadsheet"}), has_memory_binding=False
+        )

--- a/docs/one-pagers/aicc-assistants-to-agents.md
+++ b/docs/one-pagers/aicc-assistants-to-agents.md
@@ -1,0 +1,85 @@
+# From "Assistants" to "Agents"
+
+### And why the Agent Marketplace is the governed answer to what we learned
+
+**For:** AI Coordinating Committee · **Date:** August 3, 2026 · **Owner:** Phil Merrell
+
+---
+
+## What we shipped first, and what it taught us
+
+Our first public AI capability let anyone at Boise State create an **Assistant**: a saved set of
+instructions, optionally pointed at a knowledge base, shareable by link. It worked. On the legacy
+platform, **383 people created 795 Assistants** — real, unprompted adoption from across the
+institution.
+
+It also showed us the limits of the model:
+
+- **An Assistant was not the whole thing.** Instructions and one knowledge base — but not tools, not
+  skills, not memory, not a governed choice of model. Capability kept arriving as separate features
+  with nothing to bind them together.
+- **Sharing had no front door.** An Assistant spread by someone sending you a link. There was no way
+  to browse what existed, no way to tell a maintained one from an abandoned one, and no way for the
+  institution to say "this is the one we stand behind."
+- **Publication had no review.** Anything shared was, in practice, published. Nothing checked what
+  data it reached, what it claimed to be, or whether it still said what it said when it was shared.
+
+None of that was a failure of the pilot. It was the pilot doing its job.
+
+## The shift: one noun, and it is Agent
+
+We have retired "Assistant." There is now **one concept — the Agent** — and it is a composition of
+the platform's governed building blocks: instructions, a **model**, knowledge bases, tools, skills,
+and memory. Users compose an Agent in the **Agent Designer**, and they only see the building blocks
+their **role** permits. Access is enforced at the role record, not at the resource, so what a person
+can bind is the same thing the platform will actually let them run.
+
+This matters to governance for a simple reason: the unit we review, approve, publish, and audit is
+now the same unit the runtime executes. There is no gap between the description and the thing.
+
+## The Agent Marketplace: governance made operational
+
+The Marketplace is the institutional shelf — a browse page of published Agents, a detail page worth
+reading, and the administrative controls behind it. It deliberately reversed the pilot's posture:
+
+| | Assistants (pilot) | Agent Marketplace (today) |
+|---|---|---|
+| **Publication** | Self-service via link | **Author submits → administrator approves** |
+| **Disclosure** | None | Exposed skills and data bindings shown to the author *before* they submit, and to the reviewer at review |
+| **Change after approval** | Invisible | Approved instructions are fingerprinted; a published Agent whose instructions drift is **flagged for re-review** |
+| **Removal** | Delete only | **Takedown** as a first-class state, with version history and rollback |
+| **Discovery** | Word of mouth | Curated store front, categories, and **role-seeded starting sets** — a student's first session already has the Agents we chose for them |
+| **Accountability** | Anonymous | Every listing carries an administrator-managed **publisher** |
+| **Reporting** | None | A user report queue, with `inappropriate` on a same-day clock |
+
+**We committed to a service level, because review is only governance if it doesn't become a
+bottleneck:** submissions reviewed within **two business days**; `inappropriate` reports **same
+day**; all other reports on a **weekly sweep**. A pending count is visible on the administrative
+navigation so the queue is seen rather than discovered.
+
+## What this gives the institution
+
+1. **A defensible answer to "who approved this?"** — every published Agent has a named reviewer, a
+   recorded approval, and a fingerprint of exactly what was approved.
+2. **Curation as a lever, not a hope.** We can promote what's good, seed what's essential by role,
+   and take down what isn't — without deleting someone's work.
+3. **Access control that actually holds.** Role permissions govern which models, tools, skills, and
+   data an Agent may bind, so an approved Agent cannot quietly exceed what its author was entitled
+   to.
+4. **A path for the good work already out there.** The 795 pilot Assistants aren't discarded — the
+   Marketplace is the route by which the best of them become institutionally endorsed.
+
+## Open questions for the committee
+
+- **Who reviews?** Today approval requires full system-administrator rights. A scoped "marketplace
+  curator" role is designed but not built — we would like the committee's view on who should hold it.
+- **What is the standard for approval?** We have a process; we do not yet have a written rubric.
+  Accuracy, scope, data sensitivity, and disclaimer language are the candidate criteria.
+- **How far do role-seeded defaults go?** Seeding an Agent to a role puts it in front of every member
+  of that role. That is a publishing decision with real reach, and it should have an owner.
+
+---
+
+*Detail: `docs/specs/agent-designer.md` (the Agent record and authoring surface) and
+`docs/specs/agent-marketplace.md` (the store, review lifecycle, and curation). Both shipped in full;
+usage figures measured against production August 2, 2026.*

--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -49,7 +49,7 @@ spend, and the plan has to hold both levers in frame.
 | # | workstream | what it protects | authority | state |
 |---|---|---|---|---|
 | W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, dashboards #699/#700 | **PR-1 built** (`feature/partial-miss-cache-status`) — G0 clears on deploy; cohort scan §4.1 next |
-| W2 | **Prefix stability** | don't rewrite what didn't change | #834 bypass fix → #833 PR-2/3/4 → #835 v2 (gated) | specs open, nothing built |
+| W2 | **Prefix stability** | don't rewrite what didn't change | #834 bypass fix → #833 PR-2/3/4 → #835 v2 (gated) | **#834 arm 1 built** (`feature/agent-cache-artifact-builder`) — artifacts only, the G1 experiment; rest of #834 and all of #833 PR-2/3/4 unbuilt |
 | W3 | **Payload boundedness** | nothing unbounded enters the prefix | #836 offload · tool-search strategy · workspace tools (PR-1 built) · S3 share-offload | offload PRs unbuilt; citations baseline probe required first |
 | W4 | **Demand governance** | bound the blast radius of any failure | quota-cooldown spec · #833 PR-5 (earlier warnings, per-session notice) | drafted; PR-5 unbuilt |
 | W5 | **Infrastructure economics** | the 73% of the bill that isn't tokens | reaper #827 (shipped) + open follow-ups: session-id forwarding, `StopRuntimeSession` | follow-ups un-specced — **gap** |
@@ -87,6 +87,12 @@ Gate summary — each is a *measurement with a decision attached*, not a date:
   this.
 - **G1** — the bypass→cache-write causality is confounded in observational
   data (#834 §3 says so itself). The single-builder experiment settles it.
+  **The arm is built** (`create_artifact` only, kill switch
+  `AGENT_CACHE_INJECTED_TOOLS_ENABLED`); the gate clears on its read: treated
+  cohort's within-TTL cold-write rate (now `partial_miss` + `miss_avoidable`
+  from G0), p50/p95 TTFT, and `initialize()` per turn → per *session*. If the
+  cold-write rate doesn't move, the prompt-cache theory is wrong and the
+  remaining case is latency — still worth having, but it re-prices W2.
 - **G2** — #835 §7 lists the falsifiable go criteria (cohort >3% of sessions
   or >15% of spend, or residual waste >$50/mo post-triage). Defer is a
   respectable outcome: the invariants persist as review criteria.

--- a/docs/specs/agent-cache-extra-tools-bypass.md
+++ b/docs/specs/agent-cache-extra-tools-bypass.md
@@ -1,6 +1,9 @@
 # The `extra_tools` agent-cache bypass — 76% of sessions rebuild their Agent every turn
 
-**Status:** Issue write-up / fix direction. No branch.
+**Status:** Arm 1 built (`feature/agent-cache-artifact-builder`) — the §6
+single-builder experiment, `create_artifact` only, behind
+`AGENT_CACHE_INJECTED_TOOLS_ENABLED`. Remaining families and the key/snapshot
+work in §6 are unbuilt. See §5 hazard 4, found while building arm 1.
 **Found while:** measuring document-conversation cost (2026-08-03) — see
 `docs/specs/document-context-offload.md`, defect 4
 **Related:** [[project-prod-cache-write-premium]] · #741 (history fork) · #751
@@ -127,6 +130,20 @@ Three hazards, all documented in the code and all previously paid for:
    state). Anything a manager loads once and holds must be aliased or re-read
    per turn. Caching agents that currently never cache moves more state into
    that category — including whatever the injected tools captured.
+
+4. **Callers that share a cache slot but build a different toolset.** Found
+   while building arm 1, not anticipated above. The MCP App dispatch paths
+   (`app_tool_call`, `app_context_update` —
+   [routes.py:1081](../../backend/src/apis/inference_api/chat/routes.py:1081))
+   call `get_agent` with **no** `extra_tools` but otherwise the same key as the
+   session's real turns. They could not collide before, because injected-tool
+   turns never cached; the moment one does, whichever caller reaches the slot
+   first wins — and if that is an App call, every later real turn cache-hits an
+   agent missing its injected tools and silently loses them for the session.
+   Arm 1 closes this with a `cache_write=False` flag on those two callers (read
+   the slot, never seed it). **Any future caller of `get_agent` that builds a
+   partial toolset needs the same treatment** — this is the generalization of
+   hazard 3, and it is a *tool-loss* bug, not a staleness one.
 
 Hazard 3 is the real work: today the bypass *is* the mechanism that keeps
 injected-tool state fresh.

--- a/docs/specs/agent-cache-extra-tools-bypass.md
+++ b/docs/specs/agent-cache-extra-tools-bypass.md
@@ -162,6 +162,27 @@ injected-tool state fresh.
 - Because injected tools are rebuilt per request anyway, a cached agent must
   have its bound tools **refreshed** on a hit, or the cached closures must be
   provably equivalent under the key. Decide which; do not leave it implicit.
+  **Decided (arm 1): equivalence, proven at the key — cached tools are never
+  refreshed on a hit.** Eligibility *is* the proof, so the predicate has to
+  stay conservative: a family only joins `KEY_DESCRIBED_INJECTED_TOOL_IDS`
+  once every value its factory closes over is a key element. Refresh-on-hit
+  was rejected because it re-introduces per-turn work on the path whose whole
+  purpose is to skip it, and because "rebuild the tools but keep the agent"
+  is a third state to reason about on top of hazards 2 and 3.
+
+**Which families are already eligible** (read off the factories while building
+arm 1, so the next promotion is mechanical rather than another audit):
+
+| family | captures | eligible? |
+|---|---|---|
+| `ARTIFACT` | session, user | **yes — shipped in arm 1** |
+| `WORD_DOCUMENT` / `EXCEL_SPREADSHEET` / `POWERPOINT_PRESENTATION` | session, user | yes on identical reasoning — held back only so the experiment measures one variable |
+| `WORKSPACE` | session, user | same |
+| `SPREADSHEET` | session, user, **`assistant_id`** | no — needs the key + snapshot work above |
+| Memory-Space | user, email, **resolved binding** | no — and not gated on `enabled_tools`, so it can never be represented by an id; callers pass it as a separate veto |
+
+So four of the six families are a one-line change to that frozenset once the
+artifact arm reads clean; only spreadsheets need the key extended.
 
 **Validate with an experiment, not more observational data.** The §3 numbers
 cannot separate the bypass from the workload. Enable caching for one builder
@@ -175,6 +196,15 @@ case is latency, which is still worth having.
 cohort; p50/p95 time-to-first-token; `initialize()` invocations per turn (should
 approach 1 per *session* for treated sessions, not 1 per turn); and the #741
 aliasing guard test staying green under concurrent siblings.
+
+**How to read them, now that the instruments exist.** The cold-write rate is
+`partial_miss` + `miss_avoidable` from
+`docs/specs/compaction-over-threshold-cache-spiral.md` PR-1 (#838) — that gate
+is the reason PR-1 shipped first, and note it counts only calls written *after*
+that deploy, so the pre/post comparison needs a clean cutover date rather than
+a look back at history. `initialize()` per turn comes from the structured
+`agent_cache outcome=hit|miss` logs arm 1 adds; group by `session` in Logs
+Insights and the treated cohort should trend toward one miss per session.
 
 ## 7. Non-goals
 


### PR DESCRIPTION
First arm of `docs/specs/agent-cache-extra-tools-bypass.md` — the §6 **single-builder experiment**, which is roadmap gate **G1**. Follows #838 (G0), whose `partial_miss` metric is how this arm gets read.

## The bypass

`get_agent` refused the cache for *any* per-request tool:

```python
if not extra_tools and cache_key in _agent_cache:   # read
if extra_tools: return agent                        # write
```

`extra_tools` stands in for "this agent captured something the key doesn't describe." That's true for exactly two builders — spreadsheets close over `assistant_id`, Memory-Space tools close over the resolved binding — and false for the rest, which close over only `session_id` and `user_id`. **Both are already cache-key elements.** The blanket predicate reaches **76% of sessions and 95% of spend** (spec §2), so three quarters of the fleet pays a full `initialize()` + AgentCore Memory restore on every turn.

## What this changes

A predicate over what a turn actually captured (`injected_tools_are_key_described`), starting at `create_artifact` **only**. That's deliberate: spec §3 says the bypass→cache-write correlation is confounded by workload — sessions with these tools also do tool-heavy work — so §6 asks for one variable, and artifacts are the clean arm (957 sessions, no `assistant_id`, no memory binding).

**Scope win: no cache-key or `PausedTurnSnapshot` change.** Artifact closures are already fully described by the existing key, so §5 hazard 1 — a new key element orphaning a paused agent on resume — is not in play at all. That's most of what made this spec look expensive.

§6 asks for an explicit decision on refresh-vs-equivalence. **Chosen: equivalence, proven at the key.** Cached tools are not refreshed on a hit; eligibility is the proof. The predicate is conservative in the directions that matter — a memory binding is an independent veto, one unkeyed builder taints the whole turn, and a flagged-off family whose id is still enabled counts as not-described (costs a bypass, never a wrong reuse).

## A hazard §5 didn't anticipate — added to the spec as hazard 4

The MCP App dispatch paths (`app_tool_call`, `app_context_update`) call `get_agent` with **no** injected tools but otherwise the same cache key as the session's real turns. They couldn't collide while artifact turns never cached. The moment one does, they share a slot — and if an App call reaches it first, **every later real turn cache-hits an agent with no `create_artifact` and silently loses the tool for the rest of the session.** That's tool loss, not staleness.

Closed here with `cache_write=False` on those two callers: read the slot, never seed it. `test_a_partial_toolset_caller_may_read_the_slot_but_never_seed_it` pins both directions. Recorded in the spec so the next family promotion inherits the rule.

## Safety posture

- **Kill switch** `AGENT_CACHE_INJECTED_TOOLS_ENABLED=false` restores the blanket bypass exactly. Default ON per repo convention, `""` stays enabled (the workflow-env-var trap), pinned by a test.
- **Default-safe parameter**: `extra_tools_key_described` defaults to `False`, so any caller that hasn't reasoned about its closures gets the old behavior by omission.
- **§5 hazard 2 (#741 aliasing)** gets *more* load, not less — more live siblings per session. `test_a_newly_cacheable_agent_still_shares_the_session_conversation` exercises it under the new path; the original guard test stays green.

## How to read the experiment (G1 gates, spec §6)

- `initialize()` per turn → should approach 1 per **session** for treated sessions. Instrumented by the new structured `agent_cache outcome=hit|miss` INFO logs.
- Within-TTL unexplained cold-write rate for the treated cohort — now directly measurable via #838's `partial_miss` + `miss_avoidable`. This is the reading that decides G1.
- p50/p95 time-to-first-token.

**If the cold-write rate doesn't move, the prompt-cache theory is wrong** and the remaining case is latency — still worth having, but it re-prices W2. Worth saying out loud before the numbers arrive.

## Not in this PR

Word/Excel/PowerPoint/workspace capture only session+user and are eligible on identical reasoning — held back purely so the experiment measures one variable, with a test that fails if someone widens the set without revisiting it. Spreadsheets and Memory Spaces need the key + snapshot work from §6 first.

5848 backend tests pass. Roadmap W2 row and G1 updated per that page's maintenance contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
