### PR TITLE
docs: sync the spiral spec with what PR-1 actually shipped

### DIFF
--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -48,7 +48,7 @@ spend, and the plan has to hold both levers in frame.
 
 | # | workstream | what it protects | authority | state |
 |---|---|---|---|---|
-| W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, dashboards #699/#700 | **PR-1 built** (`feature/partial-miss-cache-status`) — G0 clears on deploy; cohort scan §4.1 next |
+| W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, dashboards #699/#700 | **PR-1 merged (#838) and live in dev**; prod awaits a release, and that is when the baseline clock starts. Cohort scan §4.1 next |
 | W2 | **Prefix stability** | don't rewrite what didn't change | #834 bypass fix → #833 PR-2/3/4 → #835 v2 (gated) | specs open, nothing built |
 | W3 | **Payload boundedness** | nothing unbounded enters the prefix | #836 offload · tool-search strategy · workspace tools (PR-1 built) · S3 share-offload | offload PRs unbuilt; citations baseline probe required first |
 | W4 | **Demand governance** | bound the blast radius of any failure | quota-cooldown spec · #833 PR-5 (earlier warnings, per-session notice) | drafted; PR-5 unbuilt |
@@ -80,8 +80,10 @@ graph LR
 Gate summary — each is a *measurement with a decision attached*, not a date:
 
 - **G0** — nothing else in W1–W3 is credibly evaluable before `partial_miss`
-  exists. **Built**; the gate clears when it is deployed and has produced a
-  baseline week, since an instrument nobody has read yet proves nothing. It
+  exists. **Merged (#838), live in dev.** The gate clears on a *prod* baseline
+  week — dev traffic is not the fleet, and nothing is backfilled, so the clock
+  starts at the release, not at the merge. An instrument nobody has read yet
+  proves nothing. It
   also ships the first *per-session* alarm ($5 of partial-miss waste in 24h) —
   the fleet sums it sits beside never saw the incident that motivated any of
   this.

--- a/docs/specs/compaction-over-threshold-cache-spiral.md
+++ b/docs/specs/compaction-over-threshold-cache-spiral.md
@@ -1,6 +1,8 @@
 # Compaction over-threshold cache spiral — stop paying a full prefix re-write on every turn
 
-**Status:** Draft (no branch yet)
+**Status:** PR-1 shipped (#838, merged 2026-08-05 — see "As shipped" under §3
+PR-1, which differs from what this section originally specified). PR-2 through
+PR-5 unbuilt.
 **Motivating incident:** prod, 2026-08-05 analysis. One faculty user exhausted
 their $30/month quota in 5 days on a **single conversation** (session
 `c94a3172-e1fb-4a1d-b375-6e51a56c75ad`, an essay-editing session created
@@ -67,9 +69,10 @@ paid by one user's quota.**
 
 Five distinct problems compound. Each is independently fixable.
 
-### D1 — `cacheStatus` calls a 95% prefix miss a "hit"
+### D1 — `cacheStatus` calls a 95% prefix miss a "hit" — FIXED (#838)
 
-[prompt_cache.py:116](../../backend/src/apis/shared/observability/prompt_cache.py:116):
+As it stood in
+[prompt_cache.py](../../backend/src/apis/shared/observability/prompt_cache.py):
 
 ```python
 if cache_read_tokens > 0:
@@ -153,6 +156,13 @@ prove (byte stability then only matters on genuine cold starts, which are
 observable via `cacheGapSeconds`). PR-2 is independent of it — an unbounded
 summary breaks the threshold math regardless of who assembles the prefix.
 
+That sequencing held: its first arm (`create_artifact` only — that spec's §6
+experiment) is open as #839, and PR-1's `partial_miss` is how it gets read.
+Note the arm covers artifacts, **not** the `analyze_spreadsheet` /
+`list_spreadsheets` pair the incident session actually had enabled (D3), so it
+does not yet change this session's turn shape — spreadsheets need the cache key
+extended first.
+
 ### PR-1 — observability: classify partial prefix misses (ship first)
 
 - In `classify_cache_status`, before the `cache_read_tokens > 0` early return:
@@ -176,6 +186,48 @@ summary breaks the threshold math regardless of who assembles the prefix.
 **Acceptance:** replaying the incident session's 56 `C#` rows through the
 classifier yields ≥ 47 `partial_miss` with wastedUsd ≈ $20 ± 15%; fleet EMF
 dashboards show the new status; no change to any request sent to Bedrock.
+
+**As shipped (#838).** The bullets above are the design; three things changed
+while building it, and the acceptance criteria only hold *with* those changes.
+Recorded here because §3 as originally written would produce a different
+classifier — and because PR-2..PR-5 and the §4.2 arms read this instrument.
+
+1. **Two conditions the bullet omits.** The predicate also requires
+   `cache_read_tokens > 0` and a same-prefix gap inside the TTL:
+   - Without the read condition, `write > 3 × 0` is trivially true, so every
+     zero-read call would be stolen from `miss_avoidable`. The *read* is what
+     makes a miss partial.
+   - Without the TTL gate, a re-write after the entry legitimately expired is
+     booked as waste — the #753 mistake that made the previous metric
+     untrustworthy. It also breaks the acceptance number: the incident's 8
+     post->1h-gap calls join the other 48, giving 56 classifications and ~$24,
+     outside the ±15% band. With the gate: 48 and $20.98. The cost of the gate
+     is under-reporting when no same-prefix predecessor sits in the 10-row
+     lookback (`gap_seconds=None` → stays `hit`), which is the deliberate
+     direction.
+2. **The session alarm is cumulative-per-session, not trailing-24h.**
+   "Any session whose trailing `partial_miss` waste exceeds $5 in 24h" is not
+   directly expressible: `sessionId` cannot be a metric dimension (unbounded
+   cardinality). Shipped as `SessionPartialMissUsd` — the session's running
+   `partialMissUsd`, emitted from the rollup bump's own `UPDATED_NEW` return —
+   alarmed on `Maximum > 5` over a 24h period, which reads as "a session at or
+   over $5 was active in the last day" and clears when it goes quiet. A Logs
+   Insights widget names which session.
+3. **Constant is `PARTIAL_MISS_WRITE_READ_RATIO`** (not `PARTIAL_MISS_RATIO`),
+   value 3, in the module this section names.
+
+**The incident's implied prices, for the §4.2 replay harness.** §1's "$2.50/MTok
+write premium" is the write *price*: $27.39 ÷ 10.95M write tokens. The read side
+is ~$0.20/MTok, so the premium `compute_wasted_usd` charges is **$2.30/MTok** —
+which is what makes the per-call figure $0.437 (190k × 2.30/1M) and the session
+$20.98. Any replay that assumes a standard Sonnet snapshot ($3.75/$0.30) prices
+the same incident at ~$31 and will look like a regression against §1.
+
+**No backfill.** Rows written before the deploy keep whatever status they were
+given, so the incident session's own 56 rows still read `hit`. §4.4's standing
+regression case works forward from the deploy, not backward, and the fleet
+baseline in the roadmap's metric 1 starts at the first prod release — dev
+deployment alone does not start that clock.
 
 ### PR-2 — bound the compaction summary
 


### PR DESCRIPTION
Docs only. `compaction-over-threshold-cache-spiral.md` still said **"Draft (no branch yet)"** after #838 merged, and more importantly its §3 PR-1 predicate does not describe the classifier that shipped — anyone implementing from that section would build something different, and the section's own acceptance numbers would not reproduce.

## What diverged, and why it matters

**Two conditions §3 omits.** The shipped predicate also requires `cache_read_tokens > 0` and a same-prefix gap inside the TTL:

- Without the read condition, `write > 3 × 0` is trivially true, so every zero-read call gets stolen from `miss_avoidable`. The *read* is what makes a miss partial.
- Without the TTL gate, a re-write after the entry legitimately expired is booked as waste — the #753 mistake that made the previous metric untrustworthy. It also breaks the stated acceptance: the incident's 8 post->1h-gap calls join the other 48, giving 56 classifications and ~$24 — outside the ±15% band. With the gate: 48 and $20.98.

**The session alarm's shape.** "Trailing `partial_miss` waste in 24h" isn't directly expressible — `sessionId` can't be a metric dimension. Shipped as the session's running total alarmed on `Maximum > 5` over 24h. Recorded so the next reader doesn't file it as a bug.

**Constant name**: `PARTIAL_MISS_WRITE_READ_RATIO`, not `PARTIAL_MISS_RATIO`.

## The pricing trap, recorded for the §4.2 replay harness

§1 calls **$2.50/MTok** the write *premium*. It's the write **price** ($27.39 ÷ 10.95M). Read is ~$0.20, so the premium `compute_wasted_usd` charges is **$2.30/MTok** — which is exactly what makes the per-call figure $0.437 and the session $20.98.

This matters beyond pedantry: a replay that assumes a standard Sonnet snapshot ($3.75/$0.30) prices the same incident at **~$31** and will read as a regression against §1's numbers. §4.2's replay harness is unowned and will hit this.

## Also

- **D1 marked fixed**, with the stale line-anchored code quote de-anchored.
- **No backfill, stated plainly.** The incident session's own 56 rows still read `hit`; §4.4's standing regression case works forward from deploy.
- **A scope note worth reading**: #834's arm 1 (#839) covers `create_artifact`, but D3 records that the incident session had `analyze_spreadsheet` / `list_spreadsheets` enabled. **Arm 1 will not change that session's turn shape** — spreadsheets need the cache key extended first. The G1 experiment is deliberately on a clean cohort, not on the motivating incident, and expectations should be set accordingly.
- **Roadmap W1 / G0** moved to merged-and-live-in-dev, with the baseline clock starting at the prod release rather than the merge.

No code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
