### PR TITLE
feat: pin conversations to a microVM via runtime session id

### DIFF
--- a/backend/scripts/experiment_agent_cache_arms.py
+++ b/backend/scripts/experiment_agent_cache_arms.py
@@ -1,0 +1,424 @@
+"""G1 read: does narrowing the agent-cache bypass actually change anything?
+
+Drives real multi-turn sessions through the deployed AgentCore Runtime and
+reports, per arm, whether turns reused a cached Agent and what that did to the
+prompt-cache token split. This is the controlled experiment
+`docs/specs/agent-cache-extra-tools-bypass.md` §6 asks for — the §3 numbers
+cannot separate the bypass from the workload, and dev never accumulates enough
+observational traffic to try.
+
+**The arms need no redeploy.** Rather than flipping
+`AGENT_CACHE_INJECTED_TOOLS_ENABLED` (a platform deploy each way), the arms use
+injected-tool families with *identical capture profiles* that differ only in
+whether arm 1 promoted them:
+
+    control    enabled_tools=[create_word_document]  bypassed (not promoted)
+    treatment  enabled_tools=[create_artifact]       cached   (promoted)
+    ceiling    enabled_tools=[]                      no injected tools at all
+
+Same builder shape, same closures, one variable.
+
+**What this can and cannot establish.** It proves *mechanism and direction*:
+whether `initialize()` stops running per turn, and whether the prefix gets read
+instead of re-written. It does **not** establish fleet-wide magnitude — that is
+the roadmap's metric 1 and needs prod traffic. Say which claim you are making.
+
+⚠️ **Read the affinity column first.** The in-process agent cache can only hit
+if consecutive turns land on the same microVM, and nothing forwards
+`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` today, so AWS assigns a fresh
+runtime session per invocation. If the treatment arm shows miss/miss/miss, the
+finding is *"no microVM affinity"* — NOT "the prompt-cache theory is wrong".
+Distinguishing those two is the whole reason this script prints hit/miss per
+turn instead of only dollars.
+
+Usage (needs an authenticated dev-ai profile and an active headless grant for
+--user-id; see apis/shared/harness/grants.py for what a grant is):
+
+    cd backend
+    AWS_PROFILE=dev-ai uv run python scripts/experiment_agent_cache_arms.py \
+        --user-id b8d1a320-8021-7065-3a43-6157cdff3e53 --turns 4
+
+    # one arm only, e.g. while iterating
+    AWS_PROFILE=dev-ai uv run python scripts/experiment_agent_cache_arms.py \
+        --user-id <sub> --arms treatment
+
+Turns are attributed to --user-id and draw on that user's quota.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logger = logging.getLogger("experiment")
+
+# Reuse the spike driver's env resolution — one definition of how dev-ai names
+# map to harness env vars, already proven against this runtime.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Turn 1 carries a large document. Without it the whole experiment is void: a
+# short prompt sits below Bedrock's minimum cacheable prefix, so every call
+# comes back `uncached` with read=0/write=0 and there is no cache behavior to
+# compare (observed on the first smoke run). Priming once and asking short
+# questions afterwards also mirrors the incident's shape — a big history with
+# small turns — which is the workload the arms are supposed to represent.
+PRIMING_PREAMBLE = (
+    "Here is a reference document. Read it, then answer my questions about "
+    "unrelated topics concisely. Do not summarize the document unless asked.\n\n"
+)
+
+
+def build_priming_prompt(target_chars: int) -> str:
+    """A deterministic filler document of roughly ``target_chars`` characters.
+
+    Deterministic so both arms prime with byte-identical text — a difference
+    here would show up as a prefix difference and confound the comparison.
+    """
+    paragraph = (
+        "Section {n}. The platform records each model call with its token "
+        "usage, pricing snapshot, and derived cache classification. Operators "
+        "review these records to distinguish an appended-tail write from a "
+        "re-written prefix, since only the latter represents avoidable spend. "
+        "Retention policies, quota windows, and compaction checkpoints are "
+        "documented separately and are not restated in this section.\n\n"
+    )
+    out = [PRIMING_PREAMBLE]
+    n = 1
+    while sum(len(p) for p in out) < target_chars:
+        out.append(paragraph.format(n=n))
+        n += 1
+    out.append("\nIn one sentence, what is the capital of France?")
+    return "".join(out)
+
+
+# Follow-up prompts are deliberately boring and tool-free: the experiment
+# measures agent construction and prefix caching, not tool behavior. A turn that
+# actually invoked create_artifact would add tool_use/tool_result blocks and
+# change the history shape between arms, which is the one thing that must stay
+# comparable.
+TURN_PROMPTS = [
+    "In one sentence, what is the capital of France?",
+    "In one sentence, what is the capital of Japan?",
+    "In one sentence, what is the capital of Brazil?",
+    "In one sentence, what is the capital of Kenya?",
+    "In one sentence, what is the capital of Norway?",
+    "In one sentence, what is the capital of Peru?",
+]
+
+ARMS: Dict[str, Optional[List[str]]] = {
+    # Injected tools that arm 1 did NOT promote → still bypasses the cache.
+    "control": ["create_word_document"],
+    # Injected tools that arm 1 promoted → eligible for the cache.
+    "treatment": ["create_artifact"],
+    # No injected tools at all → always was cacheable. The ceiling: whatever
+    # this arm achieves is the best the treatment arm could possibly reach.
+    "ceiling": [],
+}
+
+
+@dataclass
+class TurnObservation:
+    index: int
+    ok: bool
+    latency_s: float
+    error: Optional[str] = None
+    cache_read: int = 0
+    cache_write: int = 0
+    cache_status: Optional[str] = None
+    input_tokens: int = 0
+
+
+@dataclass
+class ArmResult:
+    name: str
+    session_id: str
+    enabled_tools: Optional[List[str]]
+    turns: List[TurnObservation] = field(default_factory=list)
+    agent_cache_outcomes: List[str] = field(default_factory=list)
+
+
+async def run_arm(
+    *,
+    name: str,
+    user_id: str,
+    enabled_tools: Optional[List[str]],
+    turns: int,
+    model_id: Optional[str],
+    gap_seconds: float,
+    priming_chars: int,
+) -> ArmResult:
+    """Run one arm's session: N sequential turns, same session_id."""
+    from apis.shared.harness import run_agent_headless
+    from apis.shared.harness.auth import CognitoRefreshBearerAuth
+
+    session_id = f"exp-{name}-{uuid.uuid4().hex[:12]}"
+    result = ArmResult(name=name, session_id=session_id, enabled_tools=enabled_tools)
+    auth = CognitoRefreshBearerAuth()
+
+    logger.info("── arm %s · session %s · tools=%s", name, session_id, enabled_tools)
+    for i in range(turns):
+        # Turn 1 primes the history over the minimum cacheable prefix; every
+        # turn after it is short, so what gets cached is the accumulated history.
+        prompt = (
+            build_priming_prompt(priming_chars) if i == 0
+            else TURN_PROMPTS[i % len(TURN_PROMPTS)]
+        )
+        started = time.monotonic()
+        try:
+            run = await run_agent_headless(
+                user_id=user_id,
+                prompt=prompt,
+                auth=auth,
+                session_id=session_id,
+                # None would mean "all RBAC-allowed tools" — an explicit list is
+                # what makes the arms differ by exactly one variable.
+                enabled_tools=enabled_tools,
+                model_id=model_id,
+                trigger="experiment",
+            )
+            elapsed = time.monotonic() - started
+            # RunStatus is completed | error | timeout | oauth_required.
+            ok = run.status == "completed"
+            result.turns.append(
+                TurnObservation(
+                    index=i + 1, ok=ok, latency_s=elapsed,
+                    error=None if ok else (run.error or run.status),
+                )
+            )
+            logger.info(
+                "   turn %d/%d %s (%.1fs)", i + 1, turns,
+                "ok" if ok else f"FAILED: {run.error or run.status}", elapsed,
+            )
+        except Exception as exc:  # noqa: BLE001 - one bad turn shouldn't kill the arm
+            elapsed = time.monotonic() - started
+            result.turns.append(
+                TurnObservation(index=i + 1, ok=False, latency_s=elapsed, error=str(exc)[:200])
+            )
+            logger.warning("   turn %d/%d raised: %s", i + 1, turns, exc)
+
+        # Stay inside the 5-minute Bedrock TTL so a re-write is unexplained —
+        # that is the only window where a cache miss means anything.
+        if i < turns - 1:
+            await asyncio.sleep(gap_seconds)
+
+    return result
+
+
+def attach_cost_rows(result: ArmResult, prefix: str, region: str) -> None:
+    """Read this arm's `C#` rows back and attach the cache verdicts."""
+    import boto3
+    from boto3.dynamodb.conditions import Key
+
+    table = boto3.resource("dynamodb", region_name=region).Table(
+        f"{prefix}-sessions-metadata"
+    )
+    rows = table.query(
+        IndexName="SessionLookupIndex",
+        KeyConditionExpression=(
+            Key("GSI_PK").eq(f"SESSION#{result.session_id}")
+            & Key("GSI_SK").begins_with("C#")
+        ),
+        ScanIndexForward=True,
+    )["Items"]
+
+    for turn, row in zip(result.turns, rows):
+        usage = row.get("tokenUsage") or {}
+        turn.cache_read = int(usage.get("cacheReadInputTokens") or 0)
+        turn.cache_write = int(usage.get("cacheWriteInputTokens") or 0)
+        turn.input_tokens = int(usage.get("inputTokens") or 0)
+        turn.cache_status = row.get("cacheStatus")
+
+    if len(rows) != len(result.turns):
+        logger.warning(
+            "arm %s: %d cost rows for %d turns — rows are written asynchronously, "
+            "so re-read if this looks short",
+            result.name, len(rows), len(result.turns),
+        )
+
+
+def runtime_log_group(runtime_arn: str) -> str:
+    """The runtime's CloudWatch log group.
+
+    Named after the runtime *id* (underscores, hyphen-suffixed hash) plus the
+    endpoint qualifier — NOT the project prefix. Getting this wrong returns an
+    empty result set rather than an error, which is how the CDK dashboard's
+    Logs Insights widgets have been querying a non-existent group since #697.
+    """
+    runtime_id = runtime_arn.rsplit("/", 1)[-1]
+    return f"/aws/bedrock-agentcore/runtimes/{runtime_id}-DEFAULT"
+
+
+def attach_agent_cache_outcomes(
+    result: ArmResult, log_group: str, region: str, since_epoch: int
+) -> None:
+    """Pull `agent_cache outcome=` lines for this session from the runtime log.
+
+    This is the `initialize()`-per-turn gate: a hit is exactly the turn that
+    skipped `initialize()`. Best-effort — CloudWatch ingestion lags, and a
+    missing line is not evidence of a miss.
+    """
+    import boto3
+
+    logs = boto3.client("logs", region_name=region)
+    try:
+        resp = logs.filter_log_events(
+            logGroupName=log_group,
+            startTime=since_epoch * 1000,
+            filterPattern=f'"agent_cache outcome=" "{result.session_id}"',
+            limit=100,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("log lookup failed for arm %s: %s", result.name, exc)
+        return
+
+    # The runtime emits each log event twice (an OTEL JSON envelope and a
+    # formatted text line), so dedupe on the event's timestamp — otherwise a
+    # 4-turn arm reports "0 hit of 8" and reads like twice the traffic.
+    seen_ts: set = set()
+    for event in sorted(resp.get("events", []), key=lambda e: e.get("timestamp", 0)):
+        ts = event.get("timestamp")
+        if ts in seen_ts:
+            continue
+        message = event.get("message", "")
+        for token in message.split():
+            if token.startswith("outcome="):
+                seen_ts.add(ts)
+                result.agent_cache_outcomes.append(token.split("=", 1)[1])
+                break
+
+
+def report(results: List[ArmResult]) -> None:
+    print("\n" + "=" * 78)
+    print("AGENT-CACHE ARM COMPARISON  (#834 G1)")
+    print("=" * 78)
+
+    for r in results:
+        ok = sum(1 for t in r.turns if t.ok)
+        print(f"\n▸ {r.name}   tools={r.enabled_tools}   session={r.session_id}")
+        print(f"  turns ok: {ok}/{len(r.turns)}")
+
+        print(f"  {'turn':>4} {'cacheStatus':<16} {'read':>9} {'write':>9} {'latency':>8}")
+        for t in r.turns:
+            print(
+                f"  {t.index:>4} {(t.cache_status or '—'):<16} "
+                f"{t.cache_read:>9,} {t.cache_write:>9,} {t.latency_s:>7.1f}s"
+            )
+
+        if r.agent_cache_outcomes:
+            seq = "/".join(r.agent_cache_outcomes)
+            hits = sum(1 for o in r.agent_cache_outcomes if o == "hit")
+            print(f"  agent_cache: {seq}   ({hits} hit of {len(r.agent_cache_outcomes)})")
+        else:
+            print("  agent_cache: no log lines found (ingestion lag, or none emitted)")
+
+        writes = sum(t.cache_write for t in r.turns)
+        reads = sum(t.cache_read for t in r.turns)
+        if reads or writes:
+            print(f"  totals: read={reads:,} write={writes:,} ratio={writes / max(reads, 1):.2f} write:read")
+
+    print("\n" + "-" * 78)
+    print("HOW TO READ THIS")
+    print("-" * 78)
+    treatment = next((r for r in results if r.name == "treatment"), None)
+    ceiling = next((r for r in results if r.name == "ceiling"), None)
+    if treatment and treatment.agent_cache_outcomes:
+        hits = sum(1 for o in treatment.agent_cache_outcomes if o == "hit")
+        if hits == 0:
+            print("  Treatment never hit the cache. Before concluding the bypass fix does")
+            print("  nothing, check the CEILING arm: if it also never hit, the cause is")
+            print("  microVM affinity (no runtime session id is forwarded), not the")
+            print("  predicate — and session-id forwarding is a prerequisite for #834.")
+        else:
+            print(f"  Treatment hit the cache {hits}x — the predicate works end to end.")
+            print("  Compare its write:read against control for the prefix-cost effect.")
+    if ceiling and ceiling.agent_cache_outcomes:
+        c_hits = sum(1 for o in ceiling.agent_cache_outcomes if o == "hit")
+        print(f"  Ceiling arm hit {c_hits}x — treatment cannot beat this; it is the bound.")
+    print("  Magnitude claims need prod. This measures mechanism and direction only.")
+    print()
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-id", required=True, help="Cognito sub with an active headless grant")
+    parser.add_argument("--prefix", default="dev-boisestateai-v2")
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument("--gap-seconds", type=float, default=20.0,
+                        help="Delay between turns; keep well inside the 300s cache TTL")
+    parser.add_argument("--model-id", default=None)
+    parser.add_argument("--priming-chars", type=int, default=20000,
+                        help="Size of turn 1's document; must clear the model's "
+                             "minimum cacheable prefix or every call reads `uncached`")
+    parser.add_argument("--arms", default="control,treatment,ceiling",
+                        help="Comma-separated subset of: control, treatment, ceiling")
+    parser.add_argument("--json-out", default=None, help="Write raw observations here")
+    args = parser.parse_args()
+
+    from spike_headless_run import resolve_environment
+
+    resolved = resolve_environment(args.prefix, args.region)
+    log_group = runtime_log_group(resolved["runtime_arn"])
+    logger.info("runtime: %s", resolved["runtime_arn"])
+    logger.info("log group: %s", log_group)
+
+    started_epoch = int(time.time()) - 60
+    selected = [a.strip() for a in args.arms.split(",") if a.strip()]
+    unknown = [a for a in selected if a not in ARMS]
+    if unknown:
+        parser.error(f"unknown arm(s): {unknown}; choose from {list(ARMS)}")
+
+    results: List[ArmResult] = []
+    for name in selected:
+        results.append(
+            await run_arm(
+                name=name,
+                user_id=args.user_id,
+                enabled_tools=ARMS[name],
+                turns=args.turns,
+                model_id=args.model_id,
+                gap_seconds=args.gap_seconds,
+                priming_chars=args.priming_chars,
+            )
+        )
+
+    # Cost rows and logs are both written asynchronously; give them a moment.
+    logger.info("waiting for cost rows / log ingestion…")
+    await asyncio.sleep(30)
+
+    for r in results:
+        attach_cost_rows(r, args.prefix, args.region)
+        attach_agent_cache_outcomes(r, log_group, args.region, started_epoch)
+
+    report(results)
+
+    if args.json_out:
+        payload = [
+            {
+                "arm": r.name,
+                "session_id": r.session_id,
+                "enabled_tools": r.enabled_tools,
+                "agent_cache_outcomes": r.agent_cache_outcomes,
+                "turns": [t.__dict__ for t in r.turns],
+            }
+            for r in results
+        ]
+        with open(args.json_out, "w") as fh:
+            json.dump(payload, fh, indent=2)
+        logger.info("wrote %s", args.json_out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/probe_runtime_session_affinity.py
+++ b/backend/scripts/probe_runtime_session_affinity.py
@@ -84,6 +84,21 @@ async def run_turn(
     return "ok"
 
 
+def read_cost_rows(prefix: str, region: str, session_id: str) -> list:
+    """This session's `C#` rows, chronological."""
+    import boto3
+    from boto3.dynamodb.conditions import Key
+
+    table = boto3.resource("dynamodb", region_name=region).Table(f"{prefix}-sessions-metadata")
+    return table.query(
+        IndexName="SessionLookupIndex",
+        KeyConditionExpression=(
+            Key("GSI_PK").eq(f"SESSION#{session_id}") & Key("GSI_SK").begins_with("C#")
+        ),
+        ScanIndexForward=True,
+    )["Items"]
+
+
 def read_outcomes(log_group: str, region: str, session_id: str, since_epoch: int) -> List[str]:
     """agent_cache hit/miss for one session, deduped (the runtime double-logs)."""
     import boto3
@@ -155,9 +170,13 @@ async def main() -> int:
         )
         statuses = []
         for i in range(args.turns):
+            # Salt turn 1 per arm. Without this the second arm inherits the
+            # first's Bedrock cache entry (identical priming bytes → same
+            # prefix) and its write column reads 0 for reasons that have
+            # nothing to do with pinning — the confound in the first run.
             prompt = (
-                build_priming_prompt(args.priming_chars) if i == 0
-                else TURN_PROMPTS[i % len(TURN_PROMPTS)]
+                f"Reference set {session_id}.\n" + build_priming_prompt(args.priming_chars)
+                if i == 0 else TURN_PROMPTS[i % len(TURN_PROMPTS)]
             )
             started = time.monotonic()
             status = await run_turn(
@@ -185,6 +204,16 @@ async def main() -> int:
         print(f"  turns ok:    {ok}/{len(data['statuses'])}")
         print(f"  agent_cache: {'/'.join(outcomes) or '(no lines found)'}")
         print(f"  hits:        {hits} of {len(outcomes)}")
+        rows = read_cost_rows(args.prefix, args.region, data["session_id"])
+        tr = tw = 0
+        print(f"  {'turn':>6} {'cacheStatus':<14} {'read':>8} {'write':>8}")
+        for i, r in enumerate(rows, 1):
+            u = r.get("tokenUsage") or {}
+            cr = int(u.get("cacheReadInputTokens") or 0)
+            cw = int(u.get("cacheWriteInputTokens") or 0)
+            tr += cr; tw += cw
+            print(f"  {i:>6} {str(r.get('cacheStatus')):<14} {cr:>8,} {cw:>8,}")
+        print(f"  totals: read={tr:,} write={tw:,} ratio={tw / max(tr, 1):.3f} write:read")
         for s in data["statuses"]:
             if s != "ok":
                 print(f"  error: {s[:200]}")

--- a/backend/scripts/probe_runtime_session_affinity.py
+++ b/backend/scripts/probe_runtime_session_affinity.py
@@ -1,0 +1,201 @@
+"""Does pinning the runtime session id give the agent cache microVM affinity?
+
+The #834 G1 arm experiment found the in-process agent cache never hits in
+cloud — not even for sessions that were always eligible. The suspected cause
+is that nothing forwards ``X-Amzn-Bedrock-AgentCore-Runtime-Session-Id``, so
+AWS assigns a fresh runtime session per invocation and consecutive turns can
+land on different microVMs, where a process-local cache is cold by definition.
+
+This probe settles it with a two-arm A/B that differs by exactly one header:
+
+    unpinned   no session-id header   (reproduces today's behavior)
+    pinned     same session-id header on every turn
+
+If the pinned arm shows hits and the unpinned arm doesn't, affinity is
+achievable and session-id forwarding is a prerequisite for #834 delivering
+anything. If neither hits, the agent cache is dead in this architecture and
+narrowing the bypass predicate cannot help regardless.
+
+Bypasses ``run_agent_headless`` deliberately: that helper sends only
+Content-Type and Authorization, and adding a header to shared code before we
+know whether it helps would be building the fix to test the hypothesis.
+
+Usage:
+
+    cd backend
+    AWS_PROFILE=dev-ai uv run python scripts/probe_runtime_session_affinity.py \
+        --user-id <cognito-sub> --turns 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import time
+import uuid
+from typing import Dict, List, Optional
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logger = logging.getLogger("probe")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# AgentCore requires a runtime session id of at least 33 characters.
+RUNTIME_SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+
+async def run_turn(
+    *,
+    url: str,
+    bearer: str,
+    session_id: str,
+    prompt: str,
+    enabled_tools: List[str],
+    runtime_session_id: Optional[str],
+    timeout: float = 180.0,
+) -> str:
+    """POST one turn, drain the SSE stream, return 'ok' or an error string."""
+    import httpx
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {bearer}",
+    }
+    if runtime_session_id is not None:
+        headers[RUNTIME_SESSION_HEADER] = runtime_session_id
+
+    payload = {
+        "session_id": session_id,
+        "message": prompt,
+        "enabled_tools": enabled_tools,
+    }
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        async with client.stream("POST", url, headers=headers, json=payload) as resp:
+            if resp.status_code >= 400:
+                body = await resp.aread()
+                return f"HTTP {resp.status_code}: {body.decode('utf-8', 'replace')[:300]}"
+            async for _ in resp.aiter_lines():
+                pass
+    return "ok"
+
+
+def read_outcomes(log_group: str, region: str, session_id: str, since_epoch: int) -> List[str]:
+    """agent_cache hit/miss for one session, deduped (the runtime double-logs)."""
+    import boto3
+
+    logs = boto3.client("logs", region_name=region)
+    try:
+        resp = logs.filter_log_events(
+            logGroupName=log_group,
+            startTime=since_epoch * 1000,
+            filterPattern=f'"agent_cache outcome=" "{session_id}"',
+            limit=200,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("log lookup failed: %s", exc)
+        return []
+
+    outcomes: List[str] = []
+    seen_ts: set = set()
+    for event in sorted(resp.get("events", []), key=lambda e: e.get("timestamp", 0)):
+        ts = event.get("timestamp")
+        if ts in seen_ts:
+            continue
+        for token in event.get("message", "").split():
+            if token.startswith("outcome="):
+                seen_ts.add(ts)
+                outcomes.append(token.split("=", 1)[1])
+                break
+    return outcomes
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-id", required=True)
+    parser.add_argument("--prefix", default="dev-boisestateai-v2")
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument("--gap-seconds", type=float, default=15.0)
+    parser.add_argument("--priming-chars", type=int, default=20000)
+    args = parser.parse_args()
+
+    from spike_headless_run import resolve_environment
+    from experiment_agent_cache_arms import build_priming_prompt, runtime_log_group, TURN_PROMPTS
+
+    resolved = resolve_environment(args.prefix, args.region)
+    log_group = runtime_log_group(resolved["runtime_arn"])
+    logger.info("runtime: %s", resolved["runtime_arn"])
+
+    from apis.shared.harness.auth import CognitoRefreshBearerAuth
+    from apis.shared.harness.runner import build_invocations_url
+
+    url = build_invocations_url(os.environ["INFERENCE_API_URL"])
+    bearer = await CognitoRefreshBearerAuth().mint_bearer_for_user(args.user_id)
+    logger.info("bearer minted")
+
+    started_epoch = int(time.time()) - 60
+    # create_artifact: the family arm 1 promoted, so `cacheable=True` and the
+    # only thing left that can prevent a hit is the process being cold.
+    tools = ["create_artifact"]
+
+    results: Dict[str, Dict] = {}
+    for arm in ("unpinned", "pinned"):
+        session_id = f"aff-{arm}-{uuid.uuid4().hex[:12]}"
+        runtime_session_id = (
+            f"pinned-{uuid.uuid4().hex}" if arm == "pinned" else None  # 39 chars
+        )
+        logger.info(
+            "── arm %s · session %s · runtime-session-id=%s",
+            arm, session_id, runtime_session_id or "(none — AWS assigns per call)",
+        )
+        statuses = []
+        for i in range(args.turns):
+            prompt = (
+                build_priming_prompt(args.priming_chars) if i == 0
+                else TURN_PROMPTS[i % len(TURN_PROMPTS)]
+            )
+            started = time.monotonic()
+            status = await run_turn(
+                url=url, bearer=bearer, session_id=session_id, prompt=prompt,
+                enabled_tools=tools, runtime_session_id=runtime_session_id,
+            )
+            statuses.append(status)
+            logger.info("   turn %d/%d %s (%.1fs)", i + 1, args.turns, status[:80],
+                        time.monotonic() - started)
+            if i < args.turns - 1:
+                await asyncio.sleep(args.gap_seconds)
+        results[arm] = {"session_id": session_id, "statuses": statuses}
+
+    logger.info("waiting for log ingestion…")
+    await asyncio.sleep(35)
+
+    print("\n" + "=" * 74)
+    print("RUNTIME SESSION-ID AFFINITY PROBE")
+    print("=" * 74)
+    for arm, data in results.items():
+        outcomes = read_outcomes(log_group, args.region, data["session_id"], started_epoch)
+        hits = sum(1 for o in outcomes if o == "hit")
+        ok = sum(1 for s in data["statuses"] if s == "ok")
+        print(f"\n▸ {arm:9} session={data['session_id']}")
+        print(f"  turns ok:    {ok}/{len(data['statuses'])}")
+        print(f"  agent_cache: {'/'.join(outcomes) or '(no lines found)'}")
+        print(f"  hits:        {hits} of {len(outcomes)}")
+        for s in data["statuses"]:
+            if s != "ok":
+                print(f"  error: {s[:200]}")
+
+    print("\n" + "-" * 74)
+    print("If pinned shows hits and unpinned does not, affinity is achievable and")
+    print("session-id forwarding is a prerequisite for #834. If neither hits, the")
+    print("in-process agent cache cannot work in this architecture.")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -15,15 +15,20 @@ access token — to inference-api, which accepts Cognito Bearer tokens via
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from typing import Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
-from apis.shared.harness.runner import build_invocations_url
+from apis.shared.harness.runner import (
+    apply_runtime_session_header,
+    build_invocations_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +78,27 @@ async def chat_stream(
         "Content-Type": "application/json",
         "Authorization": f"Bearer {current_user.raw_token}",
     }
+
+    # Pin this conversation to one microVM so inference-api's in-process caches
+    # survive between turns. Measured in dev: without it every turn is an agent
+    # cache miss and pays a full `initialize()` (~7.5-8.1s/turn); with it, turns
+    # after the first hit and run ~3.1s. It does NOT change the prompt-cache
+    # token split — that was already stable — so this is a latency fix, not a
+    # cost one (docs/specs/agent-cache-extra-tools-bypass.md §6 read).
+    #
+    # This is the one place that has to look inside the body, which the proxy
+    # otherwise relays verbatim. Read-only and best-effort: a body that isn't
+    # JSON, or carries no session_id, simply goes unpinned rather than failing
+    # the turn — schema validation still belongs to inference-api.
+    session_id: Optional[str] = None
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict):
+            raw = parsed.get("session_id")
+            session_id = raw if isinstance(raw, str) and raw else None
+    except (ValueError, TypeError):
+        logger.debug("chat proxy: body is not JSON; skipping runtime-session pinning")
+    apply_runtime_session_header(headers, session_id)
 
     # Forward OAuth2CallbackUrl when the SPA supplies it. Inference-api's
     # AgentCoreContextMiddleware reads this header to scope the on-tool

--- a/backend/src/apis/app_api/mcp_apps/routes.py
+++ b/backend/src/apis/app_api/mcp_apps/routes.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
+
+from apis.shared.harness.runner import apply_runtime_session_header
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -86,10 +88,13 @@ async def proxy_call(
     target_url = proxy_routes._build_invocations_url(
         proxy_routes._inference_api_url()
     )
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {current_user.raw_token}",
-    }
+    headers = apply_runtime_session_header(
+        {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {current_user.raw_token}",
+        },
+        body.session_id,
+    )
 
     client = proxy_routes._build_upstream_client()
     try:
@@ -190,10 +195,13 @@ async def update_context(
     target_url = proxy_routes._build_invocations_url(
         proxy_routes._inference_api_url()
     )
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {current_user.raw_token}",
-    }
+    headers = apply_runtime_session_header(
+        {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {current_user.raw_token}",
+        },
+        body.session_id,
+    )
 
     client = proxy_routes._build_upstream_client()
     try:

--- a/backend/src/apis/shared/harness/runner.py
+++ b/backend/src/apis/shared/harness/runner.py
@@ -16,6 +16,7 @@ as an A2A server, its advertised ``capabilities`` MUST include
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import uuid
@@ -37,6 +38,55 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT_SECONDS = 300.0
 
 OnEvent = Callable[[str, Dict[str, Any]], Awaitable[None]]
+
+# ============================================================
+# Runtime session affinity
+# ============================================================
+
+# AgentCore pins an invocation to a microVM by runtime session id. Send the
+# same one for every turn of a conversation and those turns land on the same
+# container; omit it and AWS assigns a fresh one per call, so anything held in
+# process — notably the agent cache — is cold every turn.
+RUNTIME_SESSION_ID_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+# Kill switch. Default ON; only the literal string "false" disables it — an
+# empty or unset value stays enabled (workflow env vars can materialize as "").
+# Turning it off restores per-call runtime sessions exactly.
+AGENTCORE_SESSION_AFFINITY_ENABLED_ENV = "AGENTCORE_RUNTIME_SESSION_AFFINITY_ENABLED"
+
+
+def runtime_session_affinity_enabled() -> bool:
+    """Whether conversations pin their AgentCore runtime session."""
+    return os.environ.get(AGENTCORE_SESSION_AFFINITY_ENABLED_ENV, "").lower() != "false"
+
+
+def runtime_session_id_for(session_id: str) -> str:
+    """Deterministic AgentCore runtime session id for one conversation.
+
+    Hashed rather than passed through because the runtime session id has a
+    charset and a **33-character minimum**, and our session ids meet neither
+    reliably (they range from short prefixed strings to UUIDs). A hash is
+    always valid, always the same for a given conversation — which is the
+    whole point, since affinity requires byte-identical values across turns —
+    and keeps our identifiers out of an AWS-side one.
+    """
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return f"sid-{digest}"  # 68 chars, [a-z0-9-] — inside the 33..128 window
+
+
+def apply_runtime_session_header(
+    headers: Dict[str, str], session_id: Optional[str]
+) -> Dict[str, str]:
+    """Add the affinity header to ``headers`` when we know the conversation.
+
+    Mutates and returns ``headers`` so callers stay one-liners. A missing
+    ``session_id`` or a disabled kill switch is a no-op, which degrades to
+    exactly the pre-affinity behavior rather than failing the turn.
+    """
+    if not session_id or not runtime_session_affinity_enabled():
+        return headers
+    headers[RUNTIME_SESSION_ID_HEADER] = runtime_session_id_for(session_id)
+    return headers
 
 
 def _build_http_client(timeout_seconds: float) -> httpx.AsyncClient:
@@ -177,10 +227,13 @@ async def run_agent_headless(
             async with client.stream(
                 "POST",
                 url,
-                headers={
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {bearer}",
-                },
+                headers=apply_runtime_session_header(
+                    {
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {bearer}",
+                    },
+                    session_id,
+                ),
                 json=payload,
             ) as response:
                 if response.status_code >= 400:

--- a/backend/tests/shared/test_runtime_session_affinity.py
+++ b/backend/tests/shared/test_runtime_session_affinity.py
@@ -1,0 +1,89 @@
+"""Runtime session affinity — pinning a conversation to one microVM.
+
+AgentCore routes an invocation to a microVM by runtime session id. Nothing
+forwarded it, so AWS assigned a fresh one per call and every turn landed on a
+possibly-different container — where inference-api's in-process agent cache is
+cold by definition.
+
+Measured in dev (docs/specs/agent-cache-extra-tools-bypass.md §6 read):
+
+    unpinned   agent_cache miss/miss/miss/miss   turns ~7.5-8.1s
+    pinned     agent_cache miss/hit/hit/hit      turns ~3.1s
+
+Both arms produced an identical prompt-cache split (write:read 0.336), so this
+is a **latency** fix, not a cost one. The first probe appeared to show a cost
+win too; that was run-order confound — the second arm inherited the first's
+Bedrock entry because both primed with byte-identical text.
+"""
+
+import pytest
+
+from apis.shared.harness.runner import (
+    AGENTCORE_SESSION_AFFINITY_ENABLED_ENV,
+    RUNTIME_SESSION_ID_HEADER,
+    apply_runtime_session_header,
+    runtime_session_affinity_enabled,
+    runtime_session_id_for,
+)
+
+
+class TestRuntimeSessionId:
+    def test_is_stable_for_a_session(self):
+        # The entire mechanism: affinity requires byte-identical values across
+        # turns. A value that varied would pin nothing.
+        assert runtime_session_id_for("sess-1") == runtime_session_id_for("sess-1")
+
+    def test_differs_between_sessions(self):
+        assert runtime_session_id_for("sess-1") != runtime_session_id_for("sess-2")
+
+    @pytest.mark.parametrize(
+        "session_id",
+        [
+            "s",                                    # shorter than the minimum
+            "exp-ceiling-6cbf29172f48",             # a short prefixed id
+            "c94a3172-e1fb-4a1d-b375-6e51a56c75ad",  # a UUID
+            "sess with spaces/and-slashes",          # outside the charset
+        ],
+    )
+    def test_always_satisfies_the_agentcore_constraints(self, session_id):
+        # AgentCore requires 33..128 chars from a restricted charset, and our
+        # session ids meet neither reliably — which is why this hashes rather
+        # than passes through.
+        value = runtime_session_id_for(session_id)
+        assert 33 <= len(value) <= 128
+        assert all(c.isalnum() or c in "-_" for c in value)
+
+    def test_does_not_embed_the_session_id(self):
+        # Keeps our identifiers out of an AWS-side one.
+        assert "c94a3172" not in runtime_session_id_for("c94a3172-e1fb-4a1d")
+
+
+class TestApplyRuntimeSessionHeader:
+    def test_sets_the_header_for_a_known_session(self):
+        headers = apply_runtime_session_header({"Content-Type": "application/json"}, "s1")
+        assert headers[RUNTIME_SESSION_ID_HEADER] == runtime_session_id_for("s1")
+
+    def test_leaves_existing_headers_alone(self):
+        headers = apply_runtime_session_header({"Authorization": "Bearer x"}, "s1")
+        assert headers["Authorization"] == "Bearer x"
+
+    @pytest.mark.parametrize("session_id", [None, ""])
+    def test_unknown_session_degrades_to_the_old_behavior(self, session_id):
+        # Not an error: an unpinned turn is exactly what shipped before.
+        headers = apply_runtime_session_header({}, session_id)
+        assert RUNTIME_SESSION_ID_HEADER not in headers
+
+    def test_kill_switch_restores_per_call_runtime_sessions(self, monkeypatch):
+        monkeypatch.setenv(AGENTCORE_SESSION_AFFINITY_ENABLED_ENV, "false")
+        headers = apply_runtime_session_header({}, "s1")
+        assert RUNTIME_SESSION_ID_HEADER not in headers
+
+    def test_empty_flag_value_stays_enabled(self, monkeypatch):
+        # Workflow env vars can materialize as "" — that must not read as off.
+        monkeypatch.setenv(AGENTCORE_SESSION_AFFINITY_ENABLED_ENV, "")
+        assert runtime_session_affinity_enabled() is True
+        assert RUNTIME_SESSION_ID_HEADER in apply_runtime_session_header({}, "s1")
+
+    def test_default_is_on(self, monkeypatch):
+        monkeypatch.delenv(AGENTCORE_SESSION_AFFINITY_ENABLED_ENV, raising=False)
+        assert runtime_session_affinity_enabled() is True


### PR DESCRIPTION
Forwards `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` so every turn of a conversation lands on the same microVM. **~60% faster turns**, measured. This is also the missing prerequisite that makes #839 (#834 arm 1) actually do something.

## How this was found

The #834 G1 arm experiment came back with the in-process agent cache **never hitting in cloud** — not for artifact sessions, not even for the ceiling arm with no injected tools that was always eligible. The logs said `injected_tools=True cacheable=True … outcome=miss`: arm 1's predicate fires correctly, the agent is cached, and then it isn't there next turn.

AgentCore routes an invocation to a microVM by runtime session id. Nothing in this repo forwarded one — `run_agent_headless` sent Content-Type and Authorization, and no other caller referenced the header — so AWS assigned a fresh session per call. A process-local cache is cold by definition under those conditions.

A two-arm A/B differing **only** by that header (`scripts/probe_runtime_session_affinity.py`):

| | agent_cache | turn 1 | turns 2–4 | write:read |
|---|---|---|---|---|
| unpinned | miss/miss/miss/miss | 7.9s | 7.2s, 8.0s, 7.5s | 0.336 |
| pinned | miss/**hit/hit/hit** | 7.2s | **3.1s, 3.1s, 3.1s** | 0.336 |

Pinned turn 1 is a cache *miss* and takes the full 7.2s; only turns 2–4 get fast. A warm Bedrock cache can't produce a speedup that appears exactly when the agent cache starts hitting — this is `initialize()` churn (AgentCore Memory `list_events`, deserialization, tool registry construction, compaction, history repair) disappearing.

## A number I had to walk back

The first probe showed the pinned arm writing **zero** cache tokens and I nearly reported a cost win. It was run-order confound: both arms primed with byte-identical text, so the second inherited the first's Bedrock entry. Re-running with per-arm salted priming gives **identical** splits — 7,231 vs 7,229 tokens written, 0.336 both.

**So this is a latency fix, not a cost one.** The restore path was already producing a byte-stable prefix; rebuilding the Agent per turn costs time, not cache writes. That resolves §6's falsifiable branch exactly as written: *"If the cold-write rate doesn't move, the prompt-cache theory is wrong and the remaining case is latency, which is still worth having."*

## What changed

- `apis/shared/harness/runner.py` — `runtime_session_id_for()` + `apply_runtime_session_header()`, next to `build_invocations_url` since that's already the canonical resolver all the proxies import.
- Four call sites wired: the headless runner, the BFF chat proxy, and both MCP Apps dispatch paths.

**The id is a sha256 of our session id**, not the id itself: the runtime session id has a restricted charset and a **33-character minimum**, and our session ids meet neither reliably (they range from `exp-ceiling-6cbf29172f48` to UUIDs). A hash is always valid, always identical for a given conversation — which is the entire mechanism — and keeps our identifiers out of an AWS-side one.

**One trade-off worth review:** the chat proxy relays the body as opaque bytes by design, and now has to read `session_id` out of it. It's a read, not validation — a non-JSON body or a missing session id goes unpinned rather than failing the turn, and schema validation still belongs to inference-api. The alternative was a new SPA header, i.e. a frontend contract change for something the server already knows.

## Safety

- Kill switch `AGENTCORE_RUNTIME_SESSION_AFFINITY_ENABLED=false` restores per-call runtime sessions exactly. Default ON per repo convention; `""` stays enabled, pinned by a test.
- Every failure mode degrades to today's behavior: no session id, disabled flag, or unparseable body all just skip the header.
- A dead microVM falls back to a cold rebuild — which is the current behavior for every turn, so no regression.

Worth thinking about before merge, and I don't consider either settled: pinning concentrates a conversation on one container, so **hot-spotting** under load is a real question dev traffic can't answer; and concurrent turns on one session now share a process, though the #653 single-flight lease should already prevent that.

5862 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
