### PR TITLE
fix: point runtime Logs Insights widgets at the real log group

### DIFF
--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -3,7 +3,6 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ecr_assets from 'aws-cdk-lib/aws-ecr-assets';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as xray from 'aws-cdk-lib/aws-xray';
 import * as bedrock from 'aws-cdk-lib/aws-bedrockagentcore';
@@ -69,6 +68,15 @@ export class InferenceAgentCoreConstruct extends Construct {
    * which would chicken-and-egg on a same-stack first deploy.
    */
   public readonly runtimeEndpointUrl: string;
+  /**
+   * The log group the runtime actually writes to.
+   *
+   * Bedrock AgentCore creates this itself, named after the runtime *id*
+   * (which carries an AWS-assigned suffix) plus the endpoint qualifier —
+   * NOT after our project prefix. Exposed so dashboards elsewhere in the
+   * stack query the group that has data in it.
+   */
+  public readonly runtimeLogGroupName: string;
 
   constructor(scope: Construct, id: string, props: InferenceAgentCoreConstructProps) {
     super(scope, id);
@@ -432,11 +440,23 @@ export class InferenceAgentCoreConstruct extends Construct {
     // Observability: CloudWatch Log Group for Runtime
     // ============================================================
 
-    const runtimeLogGroup = new logs.LogGroup(this, 'AgentCoreRuntimeLogGroup', {
-      logGroupName: `/aws/bedrock-agentcore/runtimes/${config.projectPrefix}`,
-      retention: logs.RetentionDays.ONE_MONTH,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    });
+    // The runtime's log group is created by the AgentCore service, not by us,
+    // and is named after the runtime *id* + endpoint qualifier — e.g.
+    // `/aws/bedrock-agentcore/runtimes/<prefix>_agentcore_runtime-Z6D3HsHKs6-DEFAULT`.
+    //
+    // We used to declare a LogGroup at `/aws/bedrock-agentcore/runtimes/<prefix>`
+    // and point every Logs Insights widget at it. Nothing ever wrote there:
+    // measured in dev, that group held **0 bytes** while the service's own group
+    // held 229 MB, so all three widgets returned empty results and read as
+    // "no errors" / "no traffic" rather than as a broken query. Removing it also
+    // drops a retention policy that never applied to anything.
+    //
+    // ⚠️ Retention on the real group is therefore unmanaged (service-created
+    // groups can't take a CDK retention setting), which is a live cost item —
+    // dev alone carries several such groups in the hundreds of MB. Tracked as a
+    // W5 follow-up in docs/one-pagers/cost-effectiveness-roadmap.md.
+    this.runtimeLogGroupName =
+      `/aws/bedrock-agentcore/runtimes/${this.runtime.attrAgentRuntimeId}-DEFAULT`;
 
     // NOTE: X-Ray TransactionSearchConfig is an account-level singleton.
     // It cannot be created via CloudFormation if it already exists.
@@ -583,7 +603,7 @@ export class InferenceAgentCoreConstruct extends Construct {
       }),
       new cloudwatch.LogQueryWidget({
         title: 'Recent Runtime Errors',
-        logGroupNames: [runtimeLogGroup.logGroupName],
+        logGroupNames: [this.runtimeLogGroupName],
         queryLines: [
           'fields @timestamp, @message',
           'filter @message like /(?i)error|exception|traceback/',
@@ -688,7 +708,7 @@ export class InferenceAgentCoreConstruct extends Construct {
     });
 
     new cdk.CfnOutput(this, 'RuntimeLogGroupName', {
-      value: runtimeLogGroup.logGroupName,
+      value: this.runtimeLogGroupName,
       description: 'CloudWatch Log Group for AgentCore Runtime',
       exportName: `${config.projectPrefix}-AgentCoreRuntimeLogGroup`,
     });

--- a/infrastructure/lib/constructs/observability/prompt-cache-observability-construct.ts
+++ b/infrastructure/lib/constructs/observability/prompt-cache-observability-construct.ts
@@ -6,6 +6,18 @@ import { AppConfig, getResourceName } from '../../config';
 
 export interface PromptCacheObservabilityConstructProps {
   config: AppConfig;
+  /**
+   * The log group the AgentCore Runtime actually writes to, from
+   * `InferenceAgentCoreConstruct.runtimeLogGroupName`.
+   *
+   * Must be passed, not derived: the group is service-created and named
+   * after the runtime *id* (AWS-assigned suffix), which is only knowable
+   * from the runtime resource. This construct previously guessed
+   * `/aws/bedrock-agentcore/runtimes/<prefix>` — a group nothing writes to,
+   * so both Logs Insights widgets below returned empty results and read as
+   * "no traffic" rather than "wrong query".
+   */
+  runtimeLogGroupName: string;
 }
 
 /**
@@ -42,7 +54,7 @@ export class PromptCacheObservabilityConstruct extends Construct {
   ) {
     super(scope, id);
 
-    const { config } = props;
+    const { config, runtimeLogGroupName } = props;
 
     // Must match the default of EMF_NAMESPACE in emf.py.
     const namespace = 'AgentCoreStack/PromptCache';
@@ -179,12 +191,11 @@ export class PromptCacheObservabilityConstruct extends Construct {
     dashboard.addWidgets(
       new cloudwatch.LogQueryWidget({
         title: 'Model Calls by cacheStatus (inference-api)',
-        // The runtime log group is defined by the inference-api
-        // construct with this deterministic name; referenced by name
-        // (not typed ref) since a dashboard widget creates no CFN
-        // dependency. app-api's ECS log group is auto-named, so its
-        // (much smaller) share of emissions isn't queried here.
-        logGroupNames: [`/aws/bedrock-agentcore/runtimes/${config.projectPrefix}`],
+        // Referenced by name (not a typed LogGroup ref) since a dashboard
+        // widget creates no CFN dependency. app-api's ECS log group is
+        // auto-named, so its (much smaller) share of emissions isn't
+        // queried here.
+        logGroupNames: [runtimeLogGroupName],
         queryLines: [
           'filter ispresent(cacheStatus)',
           'stats count(*) as calls by cacheStatus',
@@ -198,7 +209,7 @@ export class PromptCacheObservabilityConstruct extends Construct {
     dashboard.addWidgets(
       new cloudwatch.LogQueryWidget({
         title: 'Sessions by partial-miss waste (which session did the alarm mean?)',
-        logGroupNames: [`/aws/bedrock-agentcore/runtimes/${config.projectPrefix}`],
+        logGroupNames: [runtimeLogGroupName],
         // sessionId is a log property, not a metric dimension (unbounded
         // cardinality), so the alarm says *that* a session crossed the line
         // and this widget says *which*.

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -662,13 +662,11 @@ export class PlatformStack extends cdk.Stack {
     });
 
     // ============================================================
-    // Prompt-cache observability — cross-service dashboard + alarms
-    // over the EMF metrics both APIs emit (PR #697 follow-up).
-    // Metric-namespace-based, so no typed refs are needed.
+    // Prompt-cache observability moved into the compute-wiring phase: its
+    // Logs Insights widgets need the runtime's real log group name, which
+    // only the Runtime resource knows (service-created, named after the
+    // AWS-assigned runtime id). See wireComputeLayer below.
     // ============================================================
-    new PromptCacheObservabilityConstruct(this, 'PromptCacheObservability', {
-      config,
-    });
   }
 
   /**
@@ -767,6 +765,15 @@ export class PlatformStack extends cdk.Stack {
       codeInterpreterId: this.agentCoreCodeInterpreterId,
       browserArn: this.agentCoreBrowserArn,
       browserId: this.agentCoreBrowserId,
+    });
+
+    // Cross-service dashboard + alarms over the EMF metrics both APIs emit
+    // (PR #697, extended by #838). Constructed here rather than alongside the
+    // other platform-level observability because it needs the runtime's log
+    // group name from the construct above.
+    new PromptCacheObservabilityConstruct(this, 'PromptCacheObservability', {
+      config: this._config,
+      runtimeLogGroupName: inferenceApi.runtimeLogGroupName,
     });
 
     const sagemakerPrivateSubnetIds = this.vpc.privateSubnets

--- a/infrastructure/test/prompt-cache-observability.test.ts
+++ b/infrastructure/test/prompt-cache-observability.test.ts
@@ -4,6 +4,12 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { PromptCacheObservabilityConstruct } from '../lib/constructs/observability/prompt-cache-observability-construct';
 import { createMockConfig, MOCK_ACCOUNT, MOCK_PREFIX, MOCK_REGION } from './helpers/mock-config';
 
+// The shape the AgentCore service actually uses: runtime *id* (with its
+// AWS-assigned suffix) + endpoint qualifier. Deliberately NOT the project
+// prefix — querying that name is the bug this fixture guards against.
+const MOCK_RUNTIME_LOG_GROUP =
+  `/aws/bedrock-agentcore/runtimes/${MOCK_PREFIX}_agentcore_runtime-AbC123XyZ0-DEFAULT`;
+
 function synth(production: boolean): Template {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'Test', {
@@ -12,6 +18,7 @@ function synth(production: boolean): Template {
   const config = createMockConfig({ production });
   new PromptCacheObservabilityConstruct(stack, 'PromptCacheObservability', {
     config,
+    runtimeLogGroupName: MOCK_RUNTIME_LOG_GROUP,
   });
   return Template.fromStack(stack);
 }
@@ -43,7 +50,9 @@ describe('PromptCacheObservabilityConstruct', () => {
       expect(body).toContain(metric);
     }
     expect(body).toContain('AgentCoreStack/PromptCache');
-    expect(body).toContain(`/aws/bedrock-agentcore/runtimes/${MOCK_PREFIX}`);
+    // Must be the runtime's own group, not a prefix-named one — the latter
+    // exists in no account and silently returns zero rows.
+    expect(body).toContain(MOCK_RUNTIME_LOG_GROUP);
     expect(body).toContain('cacheStatus');
     // The alarm can only say a session crossed the line; this widget says which.
     expect(body).toContain('sessionId');


### PR DESCRIPTION
Three dashboard widgets have been querying a log group that nothing writes to. Found while reading `agent_cache` lines for the #834 G1 experiment — my first query returned nothing, and the reason turned out to be in the CDK, not my filter.

## The bug

`InferenceAgentCoreConstruct` declared a LogGroup at `/aws/bedrock-agentcore/runtimes/<prefix>` and three Logs Insights widgets pointed at it:

- "Recent Runtime Errors" (inference-api dashboard)
- "Model Calls by cacheStatus" (prompt-cache dashboard, #697)
- "Sessions by partial-miss waste" (prompt-cache dashboard, #838 — I copied the pattern)

But AgentCore creates its own log group, named after the runtime **id** (with its AWS-assigned suffix) plus the endpoint qualifier. Measured in dev:

```
/aws/bedrock-agentcore/runtimes/dev-boisestateai-v2                                  0 bytes
/aws/bedrock-agentcore/runtimes/dev_boisestateai_v2_agentcore_runtime-Z6D3HsHKs6-DEFAULT  229 MB
```

**The failure mode is the dangerous kind**: a Logs Insights query against an empty group returns zero rows, not an error. "Recent Runtime Errors" showed no errors. The cacheStatus breakdown showed no calls. Both read as good news.

## The fix

The group name is only knowable from the Runtime resource, so `InferenceAgentCoreConstruct` now exposes `runtimeLogGroupName` (built from `attrAgentRuntimeId`) and `PromptCacheObservabilityConstruct` takes it as a required prop — required rather than optional so this can't silently regress to a guess. That moves the prompt-cache construct into the compute-wiring phase, which is the only place the runtime exists.

The phantom LogGroup is deleted. It was a real CFN resource carrying a `ONE_MONTH` retention policy that applied to nothing.

Verified on the synthesized template: the dashboard body now resolves the runtime id via `GetAtt`, and no prefix-named group is declared.

## A cost item this exposes

Retention on the **real** group is unmanaged — service-created groups can't take a CDK retention setting, and the deleted resource was never governing them. Dev alone is carrying several of these in the hundreds of MB (one at 615 MB). Noted in the code and worth a W5 follow-up; not fixed here because it needs a different mechanism than a `LogGroup` construct.

## Scope

Infra only. 497 infra tests pass, `tsc --noEmit` clean, `cdk synth` clean. The test fixture now uses a realistic runtime-id-shaped name with a comment saying why, so the next person doesn't "simplify" it back to the prefix.

Needs `platform.yml` to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
