### PR TITLE
docs: post-merge verification splits the latency win in two

### DIFF
--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -79,12 +79,23 @@ async def chat_stream(
         "Authorization": f"Bearer {current_user.raw_token}",
     }
 
-    # Pin this conversation to one microVM so inference-api's in-process caches
-    # survive between turns. Measured in dev: without it every turn is an agent
-    # cache miss and pays a full `initialize()` (~7.5-8.1s/turn); with it, turns
-    # after the first hit and run ~3.1s. It does NOT change the prompt-cache
-    # token split — that was already stable — so this is a latency fix, not a
-    # cost one (docs/specs/agent-cache-extra-tools-bypass.md §6 read).
+    # Pin this conversation to one microVM so the container it lands on stays
+    # warm across turns. Measured in dev, steady-state turns:
+    #
+    #   no pinning, agent-cache miss     ~7.6s
+    #   pinned, agent-cache miss         ~4.8s   ← warm container alone
+    #   pinned, agent-cache hit          ~3.9s   ← + a reused Agent
+    #
+    # Note what that split means: most of the win is the **warm container**,
+    # which every session gets, not the agent-cache hit, which only cacheable
+    # ones get. An earlier note here credited the whole ~7.6→~3.9s to the
+    # cache; that conflated the two, and the honest read is that this header
+    # helps 100% of traffic while the agent cache adds ~19% on top for the
+    # subset that can use it.
+    #
+    # It does NOT change the prompt-cache token split — that was already
+    # stable — so this is a latency fix, not a cost one
+    # (docs/specs/agent-cache-extra-tools-bypass.md §8).
     #
     # This is the one place that has to look inside the body, which the proxy
     # otherwise relays verbatim. Read-only and best-effort: a body that isn't

--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -55,7 +55,7 @@ spend, and the plan has to hold both levers in frame.
 |---|---|---|---|---|
 | W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, dashboards #699/#700 | **PR-1 merged (#838) and live in dev**; prod awaits a release, and that is when the baseline clock starts. Cohort scan §4.1 next |
 | W2 | **Prefix stability** | don't rewrite what didn't change | #833 PR-2/3/4 → #835 v2 (gated) | #833 PR-2/3/4 unbuilt. ⚠️ **#834 has left this row** — G1 disproved its prefix-cost thesis; it is a latency fix and now lives in W6 |
-| W6 | **Turn latency** | time-to-answer, not tokens | #834 (bypass narrowing + family promotion) · #841 (runtime session affinity) | #841 open — ~60%/turn measured; #834 arm 1 merged (#839) but inert until #841 lands |
+| W6 | **Turn latency** | time-to-answer, not tokens | #834 (bypass narrowing + family promotion) · #841 (runtime session affinity) | **#841 merged and verified in dev** — steady-state turns ~7.6s → ~3.9s. Split: warm container ~7.6→4.8s (all sessions), reused Agent ~4.8→3.9s (cacheable only). #839's treatment arm now equals the ceiling |
 | W3 | **Payload boundedness** | nothing unbounded enters the prefix | #836 offload · tool-search strategy · workspace tools (PR-1 built) · S3 share-offload | offload PRs unbuilt; citations baseline probe required first |
 | W4 | **Demand governance** | bound the blast radius of any failure | quota-cooldown spec · #833 PR-5 (earlier warnings, per-session notice) | drafted; PR-5 unbuilt |
 | W5 | **Infrastructure economics** | the 73% of the bill that isn't tokens | reaper #827 (shipped) + open follow-ups: ~~session-id forwarding~~, `StopRuntimeSession` | session-id forwarding **done for a different reason** (#841, W6) — it was filed here as a reaper follow-up and turned out to be the binding constraint on the agent cache; `StopRuntimeSession` still un-specced — **gap** |
@@ -130,9 +130,9 @@ between sessions. **Update a row here in the PR that changes it.**
 | #833 PR-3 byte stability | unbuilt | investigation first, then G2 |
 | #833 PR-4 memory pinning | unbuilt | eval-harness owner (changes model-visible context) |
 | #833 PR-5 quota runway | **ready — unblocked by every gate** | nothing |
-| #834 arm 1 (artifacts) | ✅ merged #839 — correct but inert | #841 |
-| #841 runtime session affinity | PR open | review; hot-spotting under load unproven |
-| #834 four more families | held | #841 landing **+ a prod read**; justified on latency now, not cost |
+| #834 arm 1 (artifacts) | ✅ merged #839 — **live and hitting** since #841 | nothing |
+| #841 runtime session affinity | ✅ merged, verified in dev | prod read; hot-spotting under load still unproven |
+| #834 four more families | held | a prod read. ⚠️ marginal value is now measured at **~19%** (the reused-Agent share), not the full latency win — re-judge whether it earns the risk |
 | #834 spreadsheets | unbuilt | `assistant_id` into cache key + `PausedTurnSnapshot` |
 | #834 Memory-Space tools | unbuilt | binding descriptor into cache key |
 | #835 compaction v2 | unbuilt | G2 |
@@ -140,7 +140,7 @@ between sessions. **Update a row here in the PR that changes it.**
 | eval harness (quality veto) | **unowned** | an owner |
 | replay harness (#833 §4.2) | partially built — `experiment_agent_cache_arms.py` + `probe_runtime_session_affinity.py` drive real arms against dev; does not yet replay a recorded session's event stream | an owner for the rest |
 | §4.1 cohort scan | not run | nothing — cheap, read-only |
-| prompt-cache dashboard Logs Insights widgets | **broken** | one-line CDK fix: they query `/aws/bedrock-agentcore/runtimes/{prefix}`, but the real group is named by runtime *id* + `-DEFAULT`. Never returned data since #697; #838 copied the bug |
+| prompt-cache dashboard Logs Insights widgets | ✅ fixed (#843) | platform.yml deploy to take effect |
 
 ## Shared assets — build once, name an owner
 

--- a/docs/specs/agent-cache-extra-tools-bypass.md
+++ b/docs/specs/agent-cache-extra-tools-bypass.md
@@ -295,3 +295,39 @@ does not clear #833 PR-3**. And the first affinity probe appeared to show a
 cost win too — that was run-order confound (both arms primed with identical
 bytes, so the second inherited the first's Bedrock entry), caught only by
 re-running with salted priming. Any future arm comparison must salt.
+
+### 8.4 Post-merge verification (2026-08-05, after #839 + #841 deployed to dev)
+
+Re-ran the arm experiment through the **shipped** code path rather than a
+hand-rolled probe. The arms separate exactly as designed:
+
+| arm | tools | agent_cache | steady-state turns |
+|---|---|---|---|
+| control | `create_word_document` (unpromoted) | miss/miss/miss/miss | 4.8s, 5.0s, 4.7s |
+| treatment | `create_artifact` (promoted) | miss/**hit/hit/hit** | 4.0s, 4.0s, 3.7s |
+| ceiling | none | miss/**hit/hit/hit** | 3.7s, 3.8s, 4.1s |
+
+**Treatment now equals ceiling.** A session carrying a promoted injected tool
+performs identically to one carrying no injected tools at all — arm 1 delivers
+its full theoretical benefit, and the bypass predicate still correctly excludes
+the unpromoted family.
+
+**The attribution splits, and the earlier headline was too generous to the
+agent cache.** §8.2 reported ~7.6s → ~3.1s and credited it to pinning. With a
+control arm that has affinity but *no* cache hit, the two mechanisms separate:
+
+- **warm container alone**: ~7.6s → ~4.8s — the larger share, and every
+  session gets it, cacheable or not
+- **reused Agent on top**: ~4.8s → ~3.9s — roughly 19% more, only for
+  sessions the predicate admits
+
+That is better news overall (most of the win is fleet-wide) and *worse* news
+for the remaining #834 work: **promoting the other four families buys the ~19%
+marginal delta, not the whole win.** Still worth doing; no longer headline.
+
+*Rigour note:* the control-vs-treatment comparison is within a single run and
+is solid. The ~7.6s figure comes from a different run at a different time, so
+treat the warm-container share as indicative rather than measured to the tenth
+of a second. Prod numbers will differ again — dev has essentially no
+concurrency, which is precisely the condition under which microVM pinning
+looks best.


### PR DESCRIPTION
Re-ran the G1 arm experiment now that #839 and #841 are live in dev — through the **shipped** code path, not the hand-rolled probe. Records the result, corrects an attribution I got wrong, and syncs the ledger rows that three sequential merges left stale.

## The arms now separate exactly as designed

| arm | tools | agent_cache | steady-state turns |
|---|---|---|---|
| control | `create_word_document` (unpromoted) | miss/miss/miss/miss | 4.8s, 5.0s, 4.7s |
| treatment | `create_artifact` (promoted) | miss/**hit/hit/hit** | 4.0s, 4.0s, 3.7s |
| ceiling | none | miss/**hit/hit/hit** | 3.7s, 3.8s, 4.1s |

**Treatment equals ceiling.** A session carrying a promoted injected tool now performs identically to one carrying none — #839 delivers its full theoretical benefit — while the predicate still correctly excludes the unpromoted family. That's both PRs verified end to end in one run.

## The correction

I reported ~7.6s → ~3.1s and credited it to pinning. That conflated two mechanisms, and a control arm with affinity but *no* cache hit separates them:

- **warm container alone**: ~7.6s → ~4.8s — the larger share, and **every session gets it**
- **reused Agent on top**: ~4.8s → ~3.9s — roughly 19% more, only for sessions the predicate admits

Better news overall, since most of the win turns out to be fleet-wide rather than limited to the cacheable cohort. Worse news for the remaining #834 work: **promoting the other four families buys the ~19% marginal delta, not the headline.** Still worth doing, but it should be re-judged against its risk rather than waved through on the earlier number — the ledger row now says so.

The same over-claim was in the chat proxy's comment; fixed there too, since a comment that oversells a mechanism is how the next person mis-prioritises.

## Rigour note, stated in the spec

The control-vs-treatment comparison is within a single run and is solid. The ~7.6s baseline comes from a different run at a different time, so the warm-container share is indicative, not measured to the tenth of a second. And dev has essentially no concurrency — precisely the condition under which microVM pinning looks best, which is why the hot-spotting question stays open until prod.

## Ledger sync

#841 open → merged; #834 arm 1 "inert" → live and hitting; dashboard widgets "broken" → fixed by #843. Those rows went stale because the three PRs merged in sequence, each written before the others landed — exactly the drift the ledger exists to catch, caught by the ledger.

971 backend tests pass in the touched areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
