### PR TITLE
docs: where the model spend actually goes, across all conversations (+ #833 §4.1 scan)

### DIFF
--- a/backend/scripts/scan_fleet_prefix_spend.py
+++ b/backend/scripts/scan_fleet_prefix_spend.py
@@ -1,0 +1,408 @@
+"""Where does the model spend actually go, across ALL conversations?
+
+Read-only, content-free projection over the sessions-metadata table. Produces
+the numbers in ``docs/one-pagers/fleet-prefix-spend-anatomy.md`` and the §4.1
+cohort scan in ``docs/specs/compaction-over-threshold-cache-spiral.md``.
+
+Every cost investigation on this platform so far sized *its own cohort* —
+attachments (#836), the compaction spiral (#833), the agent-cache bypass
+(#834). This asks the flat question instead: across every conversation, short
+and long, what share of the dollars is cache writes, how often does the
+cacheable prefix mutate mid-session, and what would #838's ``partial_miss``
+classifier have said?
+
+**Content-free by construction.** Compaction summaries and message text are
+*measured* (length, presence) and never printed, logged, or written to disk.
+The only projections requested are cost, token usage, prefix fingerprint
+hashes, and compaction coordinates.
+
+**Denominator rule** (from the #836 validation, and it matters — 10.8% of
+call rows and 20.0% of session rows carry no cost): rows without a cost are
+counted and excluded, never treated as $0. Every printed share names the
+universe it is against.
+
+Usage:
+
+    cd backend
+    AWS_PROFILE=prod-ai uv run python scripts/scan_fleet_prefix_spend.py \
+        --table boisestateai-v2-sessions-metadata --region us-west-2
+
+    # Just the §4.1 cohort half:
+    ... scripts/scan_fleet_prefix_spend.py --table <t> --sections cohort
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+from collections import Counter, defaultdict
+from datetime import datetime
+from typing import Any, Dict, Iterator, List, Optional
+
+import boto3
+
+# apis/shared/observability/prompt_cache.py
+CACHE_TTL_SECONDS = 300
+PARTIAL_MISS_WRITE_READ_RATIO = 3
+# agents/main_agent/config/constants.py
+COMPACTION_TOKEN_THRESHOLD = 100_000
+# #833 PR-2's proposed budget, for the "how many summaries are over it" read.
+SUMMARY_TOKEN_BUDGET = 8_000
+CHARS_PER_TOKEN = 4
+
+
+# ── DynamoDB helpers ─────────────────────────────────────────────────────
+
+
+def scan_all(table, **kwargs) -> Iterator[Dict[str, Any]]:
+    """Paginate a scan, yielding raw items."""
+    start_key = None
+    while True:
+        if start_key:
+            kwargs["ExclusiveStartKey"] = start_key
+        response = table.scan(**kwargs)
+        for item in response.get("Items", []):
+            yield item
+        start_key = response.get("LastEvaluatedKey")
+        if not start_key:
+            break
+
+
+def to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def cost_total(raw: Any) -> Optional[float]:
+    """Cost is a breakdown map on the streaming path, a bare number on the
+    legacy path. Returns None when absent — *unknown*, never 0."""
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return to_float(raw.get("total"))
+    return to_float(raw)
+
+
+def cost_parts(raw: Any) -> Dict[str, float]:
+    if not isinstance(raw, dict):
+        return {}
+    return {k: to_float(v) or 0.0 for k, v in raw.items() if k != "total"}
+
+
+def parse_ts(value: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat((value or "").replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ── Section 1: fleet spend anatomy + prefix stability ────────────────────
+
+
+def scan_calls(table) -> List[Dict[str, Any]]:
+    projection = (
+        "sessionId, #ts, #cost, tokenUsage, prefixFingerprints, cacheStatus, "
+        "agentSwitched"
+    )
+    rows = scan_all(
+        table,
+        FilterExpression="begins_with(GSI_SK, :c)",
+        ExpressionAttributeValues={":c": "C#"},
+        ProjectionExpression=projection,
+        ExpressionAttributeNames={"#ts": "timestamp", "#cost": "cost"},
+    )
+
+    calls: List[Dict[str, Any]] = []
+    skipped = 0
+    for item in rows:
+        total = cost_total(item.get("cost"))
+        if total is None:
+            skipped += 1
+            continue
+        usage = item.get("tokenUsage") or {}
+        fingerprints = item.get("prefixFingerprints") or {}
+        calls.append({
+            "session_id": item.get("sessionId", ""),
+            "timestamp": item.get("timestamp", ""),
+            "cost": total,
+            "parts": cost_parts(item.get("cost")),
+            "cache_read": to_float(usage.get("cacheReadInputTokens")) or 0.0,
+            "cache_write": to_float(usage.get("cacheWriteInputTokens")) or 0.0,
+            "system_hash": fingerprints.get("systemPromptHash"),
+            "tool_hash": fingerprints.get("toolConfigHash"),
+            "status": item.get("cacheStatus"),
+            "agent_switched": bool(item.get("agentSwitched")),
+        })
+    calls.sort(key=lambda c: (c["session_id"], c["timestamp"]))
+    print(f"  call rows with a cost (the universe): {len(calls):,}")
+    print(f"  call rows without one (excluded):     {skipped:,} "
+          f"({skipped / max(1, skipped + len(calls)) * 100:.1f}%)")
+    return calls
+
+
+def report_spend_anatomy(calls: List[Dict[str, Any]]) -> None:
+    spend = sum(c["cost"] for c in calls)
+    buckets: Counter = Counter()
+    for c in calls:
+        for key in ("cacheWriteCost", "outputCost", "cacheReadCost", "inputCost"):
+            buckets[key] += c["parts"].get(key, 0.0)
+    broken = sum(buckets.values()) or 1.0
+
+    print(f"\ntotal recorded model spend: ${spend:,.2f}")
+    for key, label in (
+        ("cacheWriteCost", "cache WRITE"),
+        ("outputCost", "output"),
+        ("inputCost", "input (uncached)"),
+        ("cacheReadCost", "cache read"),
+    ):
+        print(f"  {label:<18} ${buckets[key]:>9,.2f}   "
+              f"{buckets[key] / broken * 100:>5.1f}%")
+
+    read = sum(c["cache_read"] for c in calls)
+    write = sum(c["cache_write"] for c in calls)
+    if read:
+        print(f"  cache tokens: read {read:,.0f} / write {write:,.0f} "
+              f"→ write:read {write / read:.2f}  "
+              f"(tokens; the DOLLARS above are what matter — a written token "
+              f"costs ~12x a read one)")
+
+
+def group_sessions(calls: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for c in calls:
+        grouped[c["session_id"]].append(c)
+    return grouped
+
+
+def report_prefix_mutation(sessions: Dict[str, List[Dict[str, Any]]]) -> None:
+    multi = {k: v for k, v in sessions.items() if len(v) > 1}
+    transitions = sys_flips = tool_flips = 0
+    sys_sessions = tool_sessions = 0
+    flip_write_cost = 0.0
+
+    for calls in multi.values():
+        sf = tf = 0
+        for prev, cur in zip(calls, calls[1:]):
+            transitions += 1
+            if prev["system_hash"] and cur["system_hash"] and prev["system_hash"] != cur["system_hash"]:
+                sf += 1
+                flip_write_cost += cur["parts"].get("cacheWriteCost", 0.0)
+            if prev["tool_hash"] and cur["tool_hash"] and prev["tool_hash"] != cur["tool_hash"]:
+                tf += 1
+        sys_flips += sf
+        tool_flips += tf
+        sys_sessions += 1 if sf else 0
+        tool_sessions += 1 if tf else 0
+
+    if not transitions:
+        return
+    print(f"\nsessions with >1 model call: {len(multi):,}   "
+          f"transitions: {transitions:,}")
+    print(f"  systemPromptHash changed: {sys_flips:,} "
+          f"({sys_flips / transitions * 100:.1f}% of transitions) in "
+          f"{sys_sessions:,} sessions ({sys_sessions / len(multi) * 100:.1f}%)")
+    print(f"  toolConfigHash changed:   {tool_flips:,} "
+          f"({tool_flips / transitions * 100:.1f}%) in {tool_sessions:,} "
+          f"sessions ({tool_sessions / len(multi) * 100:.1f}%)")
+    print(f"  cache-write $ on calls following a system-prompt flip: "
+          f"${flip_write_cost:,.2f}")
+
+
+def report_offline_partial_miss(
+    sessions: Dict[str, List[Dict[str, Any]]], total_spend: float
+) -> Dict[str, float]:
+    """What #838's predicate would have said, applied to historical rows.
+
+    A FLOOR, deliberately: compares each call to its immediate predecessor
+    only (the shipped classifier uses a 10-row same-prefix lookback), and
+    keeps #838's TTL gate so a legitimately expired entry is never booked as
+    waste — the #753 mistake.
+    """
+    hits: List[tuple] = []
+    waste_total = 0.0
+    for session_id, calls in sessions.items():
+        for prev, cur in zip(calls, calls[1:]):
+            if cur["cache_read"] <= 0:
+                continue
+            if cur["cache_write"] <= PARTIAL_MISS_WRITE_READ_RATIO * cur["cache_read"]:
+                continue
+            before, after = parse_ts(prev["timestamp"]), parse_ts(cur["timestamp"])
+            if not before or not after:
+                continue
+            if (after - before).total_seconds() > CACHE_TTL_SECONDS:
+                continue
+            write_cost = cur["parts"].get("cacheWriteCost", 0.0)
+            read_cost = cur["parts"].get("cacheReadCost", 0.0)
+            waste = 0.0
+            if write_cost and read_cost and cur["cache_write"] and cur["cache_read"]:
+                premium = (write_cost / cur["cache_write"]) - (read_cost / cur["cache_read"])
+                waste = max(0.0, (cur["cache_write"] - cur["cache_read"]) * premium)
+            waste_total += waste
+            hits.append((session_id, cur["status"], waste))
+
+    print(f"\ncalls classified partial_miss: {len(hits):,}")
+    if total_spend:
+        print(f"estimated avoidable waste:     ${waste_total:,.2f} "
+              f"({waste_total / total_spend * 100:.1f}% of total model spend)")
+    print(f"sessions touched:              {len({h[0] for h in hits}):,}")
+    print(f"  status those rows carry today: {dict(Counter(h[1] for h in hits))}")
+    per_session: Dict[str, float] = defaultdict(float)
+    for session_id, _, waste in hits:
+        per_session[session_id] += waste
+    for session_id, waste in sorted(per_session.items(), key=lambda x: -x[1])[:5]:
+        print(f"    {session_id}  ${waste:>8,.2f}")
+    return per_session
+
+
+def report_by_length(
+    sessions: Dict[str, List[Dict[str, Any]]],
+    partial_miss_by_session: Optional[Dict[str, float]] = None,
+) -> None:
+    """Is this only a long-conversation problem? (It is not — see the
+    one-pager's §4: 43% of spend sits in sessions of 15 calls or fewer.)"""
+    waste = partial_miss_by_session or {}
+    print(f"\n{'calls in session':<18}{'sessions':>9}{'spend':>11}"
+          f"{'w:r':>8}{'sysflips/1k':>13}{'pm waste $':>12}"
+          f"{'write-no-read $':>17}")
+    for lo, hi, label in ((1, 2, "1"), (2, 6, "2-5"), (6, 16, "6-15"),
+                          (16, 41, "16-40"), (41, 10 ** 9, "41+")):
+        group = [c for c in sessions.values() if lo <= len(c) < hi]
+        if not group:
+            continue
+        spend = sum(c["cost"] for calls in group for c in calls)
+        read = sum(c["cache_read"] for calls in group for c in calls)
+        write = sum(c["cache_write"] for calls in group for c in calls)
+        transitions = sum(len(calls) - 1 for calls in group)
+        flips = sum(
+            1
+            for calls in group
+            for prev, cur in zip(calls, calls[1:])
+            if prev["system_hash"] and cur["system_hash"]
+            and prev["system_hash"] != cur["system_hash"]
+        )
+        unread = sum(
+            c["parts"].get("cacheWriteCost", 0.0)
+            for calls in group
+            if sum(x["cache_read"] for x in calls) == 0
+            for c in calls
+        )
+        pm = sum(waste.get(calls[0]["session_id"], 0.0) for calls in group)
+        print(f"{label:<18}{len(group):>9,}{spend:>11,.2f}"
+              f"{(write / read if read else float('nan')):>8.2f}"
+              f"{(flips / transitions * 1000 if transitions else 0):>13.0f}"
+              f"{pm:>12,.2f}{unread:>17,.2f}")
+
+
+# ── Section 2: §4.1 cohort scan ──────────────────────────────────────────
+
+
+def report_cohort(table) -> None:
+    """The #833 §4.1 questions: how big is the over-threshold cohort, how long
+    are persisted compaction summaries, and does the checkpoint/anchor
+    coordinate mismatch (D3) reproduce outside the incident session?"""
+    projection = (
+        "sessionId, userId, totalCost, lastContextTokens, "
+        "totalCacheReadTokens, totalCacheWriteTokens, partialMissCount, "
+        "partialMissUsd, wastedUsd, compaction"
+    )
+    rows = list(scan_all(
+        table,
+        FilterExpression="GSI_SK = :meta",
+        ExpressionAttributeValues={":meta": "META"},
+        ProjectionExpression=projection,
+    ))
+
+    priced = [r for r in rows if to_float(r.get("totalCost")) is not None]
+    print(f"\nsession rows: {len(rows):,}   with totalCost (universe): "
+          f"{len(priced):,}   without: {len(rows) - len(priced):,} "
+          f"({(len(rows) - len(priced)) / max(1, len(rows)) * 100:.1f}%)")
+
+    fleet = sum(to_float(r["totalCost"]) for r in priced)
+    over = [r for r in priced
+            if (to_float(r.get("lastContextTokens")) or 0) > COMPACTION_TOKEN_THRESHOLD]
+    over_cost = sum(to_float(r["totalCost"]) for r in over)
+    print(f"over-threshold sessions (> {COMPACTION_TOKEN_THRESHOLD:,} tokens): "
+          f"{len(over):,} ({len(over) / max(1, len(priced)) * 100:.2f}%), "
+          f"${over_cost:,.2f} ({over_cost / max(fleet, 1e-9) * 100:.1f}% of "
+          f"${fleet:,.2f})")
+
+    # Summary length — measured, never printed.
+    lengths = []
+    coords = []
+    for r in rows:
+        state = r.get("compaction") or {}
+        summary = state.get("summary") or ""
+        if isinstance(summary, str) and summary:
+            lengths.append(len(summary))
+        checkpoint = to_float(state.get("checkpoint"))
+        anchor = to_float(state.get("truncationAnchor"))
+        if checkpoint is not None and anchor is not None:
+            coords.append((checkpoint, anchor))
+
+    if lengths:
+        lengths.sort()
+        budget_chars = SUMMARY_TOKEN_BUDGET * CHARS_PER_TOKEN
+        over_budget = [n for n in lengths if n > budget_chars]
+        print(f"persisted summaries: {len(lengths):,}   "
+              f"median {int(statistics.median(lengths)):,} chars   "
+              f"max {lengths[-1]:,} (~{lengths[-1] // CHARS_PER_TOKEN:,} tokens)")
+        print(f"  over PR-2's {SUMMARY_TOKEN_BUDGET:,}-token budget "
+              f"({budget_chars:,} chars): {len(over_budget):,} "
+              f"({len(over_budget) / len(lengths) * 100:.1f}%)")
+
+    if coords:
+        mismatched = [c for c in coords if c[0] != c[1]]
+        ahead = [c for c in coords if c[1] > c[0]]
+        print(f"checkpoint/truncationAnchor pairs: {len(coords):,}   "
+              f"mismatched {len(mismatched):,} "
+              f"({len(mismatched) / len(coords) * 100:.1f}%)   "
+              f"anchor > checkpoint: {len(ahead):,}")
+
+
+# ── Entry point ──────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", required=True, help="sessions-metadata table name")
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument(
+        "--sections",
+        default="all",
+        choices=["all", "spend", "cohort"],
+        help="'spend' = fleet anatomy + prefix stability; 'cohort' = #833 §4.1",
+    )
+    args = parser.parse_args()
+
+    table = boto3.resource("dynamodb", region_name=args.region).Table(args.table)
+
+    if args.sections in ("all", "spend"):
+        print("=" * 74)
+        print("FLEET SPEND ANATOMY — every conversation, short and long")
+        print("=" * 74)
+        calls = scan_calls(table)
+        report_spend_anatomy(calls)
+        sessions = group_sessions(calls)
+        report_prefix_mutation(sessions)
+        waste = report_offline_partial_miss(sessions, sum(c["cost"] for c in calls))
+        report_by_length(sessions, waste)
+
+    if args.sections in ("all", "cohort"):
+        print()
+        print("=" * 74)
+        print("§4.1 COHORT SCAN — over-threshold sessions, summaries, D3 coords")
+        print("=" * 74)
+        report_cohort(table)
+
+    print("\nCAVEATS: the partial_miss figure is an offline reimplementation of "
+          "#838's predicate over historical rows — a FLOOR, not the shipped "
+          "classifier's output. Fingerprints exist only on rows written since "
+          "#697. Rows without a cost are excluded everywhere, never zeroed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -12,6 +12,9 @@ a spec, the spec wins and this page gets fixed.
 `quota-cooldown-windows.md` · `tool-search-token-bloat-strategy.md` ·
 `session-workspace-tools.md` · `share-large-conversations-s3-offload.md`
 
+*Fleet measurement:* `fleet-prefix-spend-anatomy.md` (2026-08-05) — the flat,
+all-conversations spend decomposition this page now ranks work against.
+
 ---
 
 ## The tenet, restated as a plan
@@ -19,31 +22,71 @@ a spec, the spec wins and this page gets fixed.
 CLAUDE.md's token-cost tenet says: engineer against **waste**, never against
 context, and verify — don't guess. The 2026 investigations turned that tenet
 into measured findings: attachment conversations are 31% of model spend,
-cold prefix re-writes ~25%, the fleet writes 2× what it reads from cache, and
-one compaction spiral spent 90% of a user's monthly quota on cache re-writes.
-Meanwhile the AICC platform report found **AgentCore Runtime memory is ~73% of
-the total AWS bill** — the model-token arc below optimizes the *minority* of
-spend, and the plan has to hold both levers in frame.
+cold prefix re-writes ~25%, and one compaction spiral spent 90% of a user's
+monthly quota on cache re-writes. Meanwhile the AICC platform report found
+**AgentCore Runtime memory is ~73% of the total AWS bill** — the model-token
+arc below optimizes the *minority* of spend, and the plan has to hold both
+levers in frame.
+
+**Correction, 2026-08-05:** this paragraph previously read "the fleet writes 2×
+what it reads from cache." That is inverted. The 2026-07-27 measurement was
+write:read **1:2**, and the fleet scan confirms it (289.9M read / 186.4M
+written = 0.64). §4.4's "target ≤ 1:4" only parses that way.
+
+## The spend anatomy — every conversation, measured 2026-08-05
+
+Each investigation so far entered through its own door and sized its own
+cohort. `fleet-prefix-spend-anatomy.md` asks the flat question, and the answer
+reorganizes this page: **55.2% of all model spend is cache *writes*.**
+
+| component | share of $888.35 | the workstream that owns it |
+|---|---|---|
+| **cache write** | **55.2%** | W2 prefix stability (+ the new W2b below) |
+| output | 19.8% | artifacts / edit-in-place (deferred in #833) |
+| input (uncached) | 17.5% | W3 payload boundedness |
+| cache read | 7.5% | — this is the *cheap* line; more of it is the goal |
+
+Caching is still net-positive fleet-wide (a prefix breaks even after ~0.3
+reads and the fleet reads 1.6× what it writes) — the target is fewer
+**re**-writes, never fewer cachePoints. Two findings from that scan changed
+how the backlog below is ranked:
+
+- **The system prompt mutates mid-session in 12.3% of multi-turn
+  conversations** (#833 D4 / PR-4). Filed as "small next to D2/D3" because it
+  was ranked inside one incident; fleet-wide it is the most general defect in
+  the epic and the cheapest to fix.
+- **$383 of $888 — 43% — sits in conversations of 15 calls or fewer**, which
+  nothing in this arc addresses. 700 sessions wrote cache and never read any
+  back ($33.92, 7.3% of all write spend, returning nothing).
 
 ## North-star metrics (proposed — ratify at first review)
 
 1. **Unexplained-waste share of model spend** = (partial-miss + avoidable-miss
-   dollars, net of `agentSwitched` re-writes) ÷ total model spend. Today:
-   still unknown, but no longer unmeasurable — #833 PR-1 built the instrument
-   (`partial_miss` on every `C#` row, `PartialMiss`/`PartialMissUsd` EMF,
-   `partialMissCount`/`partialMissUsd` session rollups). Baseline is the first
-   full week of prod traffic after it deploys; note the numerator only counts
-   calls written *after* deploy — nothing is backfilled, so the incident's own
-   56 rows still read `hit`. Provisional target: **< 5%**. This is the number
-   that says the *prefix-stability* and *payload* work is done.
-2. **Cost per weekly-active-user, trend** — flat-or-down while usage grows.
+   dollars, net of `agentSwitched` re-writes) ÷ total model spend. #833 PR-1
+   built the instrument (`partial_miss` on every `C#` row,
+   `PartialMiss`/`PartialMissUsd` EMF, `partialMissCount`/`partialMissUsd`
+   session rollups). Provisional target: **< 5%**. This is the number that says
+   the *prefix-stability* and *payload* work is done.
+   **First reading: 5.9% ($52.14 of $888.35), 2026-08-05** — obtained by
+   running the predicate *offline* over historical rows, so it does not clear
+   G0 (that still needs a prod baseline week after #838 releases, and nothing
+   is backfilled). It is a **floor**: immediate-predecessor comparison only,
+   no fingerprints before #697, and 10.8% of call rows carry no cost at all.
+   206 of the 215 rows it flags say `hit` today — which is the blind spot #838
+   exists to close, now quantified rather than assumed.
+2. **Cache-write share of model spend** (added 2026-08-05). The anatomy above
+   makes this the single most legible number on the page: **55.2% today**.
+   Unlike metric 1 it needs no classifier and no release — it is a straight
+   sum over `cost.cacheWriteCost`, computable from the first day of any
+   period. Every W2 item should move it; nothing else on this page will.
+3. **Cost per weekly-active-user, trend** — flat-or-down while usage grows.
    This is the number that says the platform scales. (Absolute totals are
    understated ~20% by legacy missing-cost rows — see the #836 validation —
    so trend, not level, is the signal.)
-3. **Runtime-memory minutes per active session** — the infra lever's
+4. **Runtime-memory minutes per active session** — the infra lever's
    equivalent of metric 1. Baseline exists from the reaper work (post-#827
    microVM lifetimes 18–50 min vs 480–520 before).
-4. **p50/p95 turn latency** (added 2026-08-05, when W6 appeared). Not
+5. **p50/p95 turn latency** (added 2026-08-05, when W6 appeared). Not
    originally here because this page was scoped to spend — but G1 found the
    platform paying a full `initialize()` on ~76% of turns, and cost-only
    metrics are blind to that. Dev baseline: ~7.5–8.1s unpinned vs ~3.1s
@@ -53,8 +96,9 @@ spend, and the plan has to hold both levers in frame.
 
 | # | workstream | what it protects | authority | state |
 |---|---|---|---|---|
-| W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, dashboards #699/#700 | **PR-1 merged (#838) and live in dev**; prod awaits a release, and that is when the baseline clock starts. Cohort scan §4.1 next |
-| W2 | **Prefix stability** | don't rewrite what didn't change | #833 PR-2/3/4 → #835 v2 (gated) | #833 PR-2/3/4 unbuilt. ⚠️ **#834 has left this row** — G1 disproved its prefix-cost thesis; it is a latency fix and now lives in W6 |
+| W1 | **Measurement** | every other row of this table | #833 PR-1 (`partial_miss`), cohort scan §4.1, fleet anatomy scan, dashboards #699/#700 | **PR-1 merged (#838) and live in dev**; prod awaits a release, and that is when the G0 clock starts. §4.1 cohort scan **run 2026-08-05**; fleet anatomy **run 2026-08-05** (`scan_fleet_prefix_spend.py`, reproducible) |
+| W2 | **Prefix stability** | don't rewrite what didn't change — 55.2% of spend | #833 PR-2/3/4 → #835 v2 (gated) | #833 PR-2/3/4 unbuilt. ⚠️ **PR-4 re-ranked 2026-08-05**: the system prompt mutates mid-session in 12.3% of multi-turn conversations, making it the most *general* item here, not a footnote to D2/D3. ⚠️ **#834 has left this row** — G1 disproved its prefix-cost thesis; it is a latency fix and now lives in W6 |
+| W2b | **Short-conversation cache economics** (new 2026-08-05) | the 43% of spend in sessions of ≤15 calls, which no item in this arc touches | **un-specced — gap** | 700 sessions wrote cache and read none back ($33.92, 7.3% of all write spend). Single-call sessions are 29% of all sessions and spend 67% of their money on writes they can never use. Needs a cachePoint-policy spec for first/short turns |
 | W6 | **Turn latency** | time-to-answer, not tokens | #834 (bypass narrowing + family promotion) · #841 (runtime session affinity) | **#841 merged and verified in dev** — steady-state turns ~7.6s → ~3.9s. Split: warm container ~7.6→4.8s (all sessions), reused Agent ~4.8→3.9s (cacheable only). #839's treatment arm now equals the ceiling |
 | W3 | **Payload boundedness** | nothing unbounded enters the prefix | #836 offload · tool-search strategy · workspace tools (PR-1 built) · S3 share-offload | offload PRs unbuilt; citations baseline probe required first |
 | W4 | **Demand governance** | bound the blast radius of any failure | quota-cooldown spec · #833 PR-5 (earlier warnings, per-session notice) | **PR-5 built 2026-08-05** — 50%/75% rungs, `quota_session_notice`, admin top-sessions view; cooldown-windows spec still drafted only |
@@ -109,6 +153,21 @@ Gate summary — each is a *measurement with a decision attached*, not a date:
 - **G2** — #835 §7 lists the falsifiable go criteria (cohort >3% of sessions
   or >15% of spend, or residual waste >$50/mo post-triage). Defer is a
   respectable outcome: the invariants persist as review criteria.
+  **Inputs now measured (2026-08-05), and they split:** cohort is **1.63%** of
+  sessions (below the bar) but **21.9%** of recorded session spend (above it);
+  residual waste is not readable until #838 reaches prod.
+  ⚠️ **Read the gate carefully before firing it.** "Is the cohort >3% of
+  sessions" is a *volume* test, and the two defects behind it are not volume-
+  driven: the summary ratchet is monotonic in a conversation's **age** (it only
+  grows, and no prod session has yet exceeded 19 summarized turns), and prefix
+  mutation is per-turn behavior present at every conversation length. At the
+  lowest traffic this platform will ever see, a volume test will say defer for
+  a mechanism that is already reaching users — **five distinct users have been
+  quota-blocked, and a sixth was granted a manual limit raise on 2026-08-04
+  with the reason "bug caused quota to be reached."** Prefer the conditional
+  rate: *of conversations that get long enough to compact at all, 32% already
+  exceed PR-2's proposed budget.* That rate does not shrink with growth; the
+  population it applies to grows.
 - **G3** — no citations config is sent in prod today, so we don't know what
   the current document path can even see. Every offload quality comparison
   inherits its baseline from this probe.
@@ -135,7 +194,7 @@ between sessions. **Update a row here in the PR that changes it.**
 | #833 PR-1 `partial_miss` | ✅ merged #838, live in dev | prod release for the baseline |
 | #833 PR-2 summary cap | unbuilt | eval-harness owner (changes model-visible context) |
 | #833 PR-3 byte stability | unbuilt | investigation first, then G2 |
-| #833 PR-4 memory pinning | unbuilt | eval-harness owner (changes model-visible context) |
+| #833 PR-4 memory pinning | unbuilt — **promoted 2026-08-05**: 12.3% of multi-turn conversations, the most general defect in the epic | eval-harness owner (changes model-visible context). ⚠️ its arm is the cheapest of the three to design — worth splitting from PR-2's harness rather than waiting on one owner for both |
 | #833 PR-5 quota runway | ✅ built 2026-08-05 — earlier rungs + `quota_session_notice` + admin top-sessions; acceptance replay in CI over the incident's own rows | prod release. ⚠️ the replay moved the spec's own number: the extra rungs buy ~6h, the **session notice** is what buys the 3.9 days |
 | #834 arm 1 (artifacts) | ✅ merged #839 — **live and hitting** since #841 | nothing |
 | #841 runtime session affinity | ✅ merged, verified in dev | prod read; hot-spotting under load still unproven |
@@ -146,7 +205,9 @@ between sessions. **Update a row here in the PR that changes it.**
 | #836 offload PRs 1–3 | unbuilt | G3 citations probe |
 | eval harness (quality veto) | **unowned** | an owner |
 | replay harness (#833 §4.2) | partially built — `experiment_agent_cache_arms.py` + `probe_runtime_session_affinity.py` drive real arms against dev; does not yet replay a recorded session's event stream | an owner for the rest |
-| §4.1 cohort scan | not run | nothing — cheap, read-only |
+| §4.1 cohort scan | ✅ **run 2026-08-05** — cohort is 49 sessions (1.63%) / $172.46 (21.9% of recorded session spend); D2 and D3 both reproduce outside the incident (a 174,952-char summary on another session; anchor≠checkpoint on 199 of 1,238 rows). Written up in #833 §4.1 | nothing |
+| fleet spend anatomy (all conversations) | ✅ **run 2026-08-05** — `fleet-prefix-spend-anatomy.md`; script committed at `backend/scripts/scan_fleet_prefix_spend.py` | nothing |
+| W2b cachePoint policy for short/first turns | **un-specced** | needs a spec — no gate blocks it |
 | prompt-cache dashboard Logs Insights widgets | ✅ fixed (#843) | platform.yml deploy to take effect |
 
 ## Shared assets — build once, name an owner

--- a/docs/one-pagers/fleet-prefix-spend-anatomy.md
+++ b/docs/one-pagers/fleet-prefix-spend-anatomy.md
@@ -1,0 +1,154 @@
+# Where the model spend actually goes — fleet-wide, all conversations
+
+**Measured:** 2026-08-05, prod (`boisestateai-v2-sessions-metadata`, account
+897729136999) · **Method:** `backend/scripts/scan_fleet_prefix_spend.py`
+(read-only, content-free) · **Owner:** Phil Merrell
+
+**Why this exists.** Every cost investigation on this platform so far entered
+through a specific door — attachment conversations (#836), one compaction
+spiral (#833), the agent-cache bypass (#834) — and each one sized *its own
+cohort*. None of them ever asked the flat question: across **all**
+conversations, short and long, where do the dollars go? This is that question,
+answered once, so the roadmap can rank work against a spend anatomy instead of
+against whichever cohort was measured most recently.
+
+**Denominator, stated once and used throughout:** 18,907 model-call (`C#`)
+rows carrying a cost, across 3,505 sessions. A further **2,299 rows (10.8%)
+carry no cost attribute at all** — they are *unknown*, not $0, and are
+excluded from every figure below. (Session rows show the same gap: 760 of
+3,808, 20.0%.) This is the understatement the #836 validation caught; it has
+not been fixed, so treat every absolute total here as a floor.
+
+---
+
+## 1. The anatomy
+
+| component | spend | share |
+|---|---|---|
+| **cache write** | **$461.57** | **55.2%** |
+| output | $165.49 | 19.8% |
+| input (uncached) | $146.64 | 17.5% |
+| cache read | $63.03 | 7.5% |
+
+Total recorded model spend: **$888.35** (17,820 of 18,907 rows carry a cost
+breakdown; the rest carry only a total).
+
+**More than half of every dollar is spent writing cache entries.** In *tokens*
+the ratio looks benign — 289.9M read against 186.4M written, a 1.6:1
+read:write — but a written token costs roughly 12× a read one, so the dollar
+picture is governed by how often the prefix is re-written rather than by how
+much of it is read.
+
+⚠️ **55% is not 55% waste.** At Bedrock's pricing a cached prefix breaks even
+after roughly 0.3 reads, and the fleet reads 1.6× what it writes, so prompt
+caching is net-positive overall. The waste is in the *re-writing*, quantified
+in §3.
+
+## 2. Prefix mutation happens in ordinary conversations
+
+Across 2,483 sessions with more than one model call (15,402 call-to-call
+transitions):
+
+| prefix component | transitions where it changed | sessions affected |
+|---|---|---|
+| `systemPromptHash` | 703 (4.6%) | **305 (12.3%)** |
+| `toolConfigHash` | 96 (0.6%) | 69 (2.8%) |
+
+`toolConfigHash` holding at 0.6% says the prompt-cache ordering contract is
+largely working. The mover is the **memory-augmented system prompt**, which
+re-retrieves UserPreference / SemanticFact records per turn — including
+records extracted from the conversation in progress. $53.39 of cache-write
+spend landed on the call immediately following such a flip.
+
+That is `#833` **D4 / PR-4**, which the spec ranks as "small next to D2/D3"
+because it was judged inside a single incident. Fleet-wide it touches **one
+multi-turn conversation in eight**, and it is the cheapest fix in that epic.
+
+## 3. The north-star metric, measured for the first time
+
+Running #838's `partial_miss` predicate offline over historical rows:
+
+- **215 calls classified, $52.14 of avoidable waste — 5.9% of total model
+  spend**, across 63 sessions.
+- **206 of those 215 rows say `hit` today.** This is exactly the blind spot
+  #838 was built to close, quantified before #838 has reached prod.
+- Concentration: `c94a3172…` (the compaction-spiral incident) is $25.56 of the
+  $52.14. The remaining $26.58 is spread across 62 other sessions.
+
+The roadmap's provisional target for unexplained-waste share is **< 5%**. This
+reads **5.9%**, and it is a **floor** for three reasons:
+
+1. It compares each call only to its immediate predecessor, where the shipped
+   classifier uses a 10-row same-prefix lookback.
+2. Rows written before #697 carry no fingerprints and cannot be classified
+   either way.
+3. The 10.8% of rows with no cost contribute nothing.
+
+**This does not clear G0.** It is an offline reimplementation over historical
+rows, not a reading of the shipped instrument. G0 still clears on a prod
+baseline week after #838 releases — but "we cannot know until then" is no
+longer true, and the direction is now evidence rather than assumption.
+
+## 4. Cost is not concentrated where the arc has been looking
+
+| calls in session | sessions | spend | write:read (tokens) | sys-prompt flips /1k transitions | partial-miss waste |
+|---|---|---|---|---|---|
+| 1 | 1,022 | $35.17 | **5.23** | — | $0.00 |
+| 2–5 | 1,588 | $138.02 | 0.82 | 31 | $0.98 |
+| 6–15 | 656 | $209.93 | 0.49 | 39 | $3.73 |
+| 16–40 | 202 | $279.25 | 0.53 | 51 | $7.35 |
+| 41+ | 37 | $225.96 | 0.72 | 69 | $40.08 |
+
+Two readings, and they point in different directions on purpose:
+
+- **$383 of $888 — 43% — sits in conversations of 15 calls or fewer**, which
+  no item in the current arc addresses.
+- **Prefix instability rises monotonically with length** (31 → 69 flips per
+  1,000 transitions) and partial-miss waste concentrates almost entirely in
+  the 41+ bucket. The long-conversation work is where the *concentration* is;
+  it is not where the *generality* is.
+
+### 4a. Cache written and never read
+
+**700 sessions wrote cache tokens and read none back — $33.92, or 7.3% of all
+cache-write spend, returning nothing.** Single-call sessions are 29% of all
+sessions and spend **67% of their money on cache writes they can never use**
+($23.49 of $35.17).
+
+It is almost entirely a short-conversation cost: $22.68 of it in single-call
+sessions, $10.73 in 2–5-call sessions, and $0.51 in everything longer. The
+mirror image of the partial-miss column, which is $40.08 of $52.14 in the 41+
+bucket — the two failure shapes sit at opposite ends of the length
+distribution, and an arc that only looks at long conversations sees one of
+them.
+
+Some of this is structural: a conversation that ends after one turn cannot
+amortize a write, and nothing knows in advance that it will end. But nothing
+in the arc has ever examined **cachePoint policy for first or short turns**,
+and at 29% of sessions it is not a rounding error. This is a *new* work item,
+not a re-ranking of an existing one.
+
+## 5. What this changes
+
+1. **PR-4 (memory-prompt pinning) is a general lever, not a footnote.** One
+   multi-turn conversation in eight; cheapest fix in #833.
+2. **cachePoint policy for short/first turns is unowned and unspecced.**
+   ~$34 returning nothing at this traffic level.
+3. **Cohort share is the wrong ranking function.** #835 §7's G2 criteria ask
+   "is the cohort >3% of sessions" — a volume test for defects that are driven
+   by conversation *age* and by per-turn prefix behavior. Applied to the
+   numbers above, that gate would defer work whose mechanism is fleet-wide.
+4. **The missing-cost gap (10.8% of calls, 20.0% of sessions) is now load-
+   bearing.** Every total on this page is a floor because of it. Worth its own
+   fix before the next round of numbers gets quoted.
+
+## Caveats
+
+- Offline reimplementation of #838's predicate; not the shipped classifier's
+  output. Treat §3 as directional and as a floor.
+- Fingerprints exist only on rows written since #697.
+- Single point in time, and — per Phil, 2026-08-05 — **this is the lowest
+  traffic the platform will ever see**. Rates (share of transitions, share of
+  sessions) generalize; absolute dollars do not.
+- Prompt caching remains net-positive fleet-wide. Nothing here argues for
+  fewer cachePoints in long conversations.

--- a/docs/specs/compaction-over-threshold-cache-spiral.md
+++ b/docs/specs/compaction-over-threshold-cache-spiral.md
@@ -1,9 +1,10 @@
 # Compaction over-threshold cache spiral — stop paying a full prefix re-write on every turn
 
-**Status:** PR-1 shipped (#838, merged 2026-08-05 — see "As shipped" under §3
-PR-1, which differs from what this section originally specified). PR-5 built
-2026-08-05 (quota runway — see "As shipped" under §3 PR-5; its acceptance
-replay moved one of §3's own numbers). PR-2 through PR-4 unbuilt.
+**Status:** PR-1 shipped (#838). PR-5 shipped (#845 — see "As shipped" under
+§3 PR-5; its acceptance replay moved one of §3's own numbers). PR-2 through
+PR-4 unbuilt. **§4.1's adversarial re-scan is run** (2026-08-05, results
+inline below): D2 and D3 both reproduce on sessions other than the incident's,
+and the harm is already multi-user.
 **Motivating incident:** prod, 2026-08-05 analysis. One faculty user exhausted
 their $30/month quota in 5 days on a **single conversation** (session
 `c94a3172-e1fb-4a1d-b375-6e51a56c75ad`, an essay-editing session created
@@ -88,6 +89,10 @@ incident is its worst single-session expression.
 
 ### D2 — the compaction summary is a log, not a compression, and is unbounded
 
+*Confirmed fleet-wide 2026-08-05 (§4.1): 15 sessions already exceed the budget
+PR-2 proposes, and the largest summary in prod — 174,952 chars — belongs to a
+different user's conversation, not this incident's.*
+
 `_retrieve_session_summaries`
 ([turn_based_session_manager.py:612](../../backend/src/agents/main_agent/session/turn_based_session_manager.py:612))
 fetches up to `maxResults=100` LTM records and `update_after_turn` joins **all
@@ -101,6 +106,11 @@ under — the session can *never* compact below 100k, so `Threshold exceeded`
 fires every turn forever.
 
 ### D3 — the restored prefix is not byte-stable turn-to-turn
+
+*Confirmed fleet-wide 2026-08-05 (§4.1): the checkpoint/anchor coordinate
+mismatch appears on 199 of 1,238 rows carrying both, never in the opposite
+direction — so it is a coordinate-system defect, not this session's history
+shape.*
 
 Proven by the token accounting (11k reads at 60s gaps, same tool/system
 hashes), not yet root-caused to the byte. Two anomalies point the way:
@@ -126,14 +136,29 @@ on genuine cold starts. The bypass converts a cold-start-only defect into an
 every-turn tax. Both fixes are needed: the bypass fix makes instability *rare*,
 the byte-stability fix makes it *harmless*.
 
-### D4 — a secondary buster: the system prompt mutates mid-session
+### D4 — the system prompt mutates mid-session — **the most general defect here**
 
 `systemPromptHash` changed between each day's visit *and* twice mid-burst
 (cache read dropped 11,278 → 8,929 both times). The memory-augmented system
 prompt (UserPreference / SemanticFact retrievals, 10 records each, per turn)
 re-writes the system+history segments whenever extraction lands new records —
-including records extracted *from the very conversation in progress*. Small
-next to D2/D3, but it breaks the prefix at an earlier cachePoint when it fires.
+including records extracted *from the very conversation in progress*.
+
+**Re-ranked 2026-08-05.** This section previously read "small next to D2/D3."
+That judgement was made *inside* one incident, where it was true. Measured
+across all 2,483 multi-call prod conversations
+(`docs/one-pagers/fleet-prefix-spend-anatomy.md`), `systemPromptHash` changes
+on **4.6% of call-to-call transitions, affecting 12.3% of multi-turn
+conversations** — against 0.6% / 2.8% for `toolConfigHash`, which says the
+ordering contract is holding and the memory retrieval is what moves. $53.39 of
+cache-write spend landed on the call immediately after such a flip.
+
+D2 and D3 are bounded to conversations long enough to compact. **D4 is not
+bounded at all** — it applies to every conversation belonging to a user with
+extracted memories, at any length. It is also the cheapest fix in this
+document (freeze the retrieved blocks for the visit; PR-4). Rank it
+accordingly: it is not a footnote to the spiral, it is the one defect here
+that every conversation pays.
 
 ### D5 — quota warnings gave the user no runway — FIXED (PR-5)
 
@@ -409,6 +434,59 @@ the offload validation doc) must:
   conditional-TTL-policy magnitudes from the first pass. Assume some §1
   numbers will move; the plan survives if the *shape* (writes dominate,
   history segment never hits) survives.
+
+#### Results — run 2026-08-05
+
+Method: `backend/scripts/scan_fleet_prefix_spend.py --sections cohort`
+(read-only, content-free; summary text is measured, never printed or
+persisted). The fleet-wide half of the same scan is written up separately in
+`docs/one-pagers/fleet-prefix-spend-anatomy.md`.
+
+**Denominator, stated once:** 3,048 session rows carry a `totalCost`; **760
+(20.0%) do not** and are excluded as *unknown*, never as $0 — the exact
+understatement the offload validation warned about, still unfixed. Recorded
+session spend: $786.83.
+
+| question | answer |
+|---|---|
+| sessions over `COMPACTION_TOKEN_THRESHOLD` | **49 (1.63%)**, $172.46 — **21.9%** of recorded session spend |
+| …median over-threshold session | $1.22 (the cohort's spend is carried by ~5 conversations) |
+| …**and** write:read > 3 (the spiral's actual shape) | **2 sessions, $43.98 (5.6%)** |
+| persisted summaries, non-empty | 47 · median 20,118 chars · **max 174,952 (~43.7k tokens)** |
+| …over PR-2's 8k-token budget | **15 (31.9%)**, holding $137.20 |
+| `truncationAnchor` ≠ `checkpoint` | **199 of 1,238 rows (16.1%)**; 8 of 23 over-threshold sessions |
+
+**D2 reproduces, and the incident is not the worst case.** Session
+`3a8f3b20…` carries a **174,952-char** summary — larger than the incident's
+164,991 — on a $20.37 conversation belonging to a different user. The ratchet
+is visible in the data: median summary length rises from ~20k chars at 0–9
+summarized turns to 34k at 10–19, and max from 34k → 175k (correlation 0.46,
+n=47 — directional, small buckets). Note the floor: even at **zero**
+summarized turns the median summary is 20,534 chars. It starts large and only
+grows.
+
+**D3 reproduces and is not session-specific.** The anchor exceeds the
+checkpoint on 199 rows and is *never* below it — consistent with §2's reading
+that one coordinate is window-relative and the other absolute. The three
+largest over-threshold sessions sit at 34/68, 32/62, 32/57.
+
+**The harm is already multi-user.** Five distinct users have `block` events
+recorded (11 of 12 blocks in July 2026), and four of those five appear in the
+top six over-threshold spenders. The incident user has **no** `block` event
+because an admin granted a **$30 → $60 override on 2026-08-04, reason "bug
+caused quota to be reached"** — so §3's "Deferred: quota credit for the
+affected user" was already actioned in prod, by hand, and this document did
+not know it. D5's phrase "the same day the `block` landed" should read *the
+day the quota was exhausted*: that session kept spending into 2026-08-05 and
+reached $35.43 against a $30 limit.
+
+**What did not survive.** Nothing in §1's shape. What moved is the *framing*:
+sized as a share of today's sessions the cohort is 1.63%, which reads small —
+but the platform is at its lowest traffic ever, the ratchet is monotonic in
+conversation age rather than in fleet volume, and the conditional rate is the
+honest one: **of conversations that get long enough to compact at all, 32%
+already exceed the budget PR-2 proposes.** Ranking this epic on cohort share
+would defer a mechanism that has already cost six users their quota.
 
 ### 4.2 Cost outcome: arm-separated attribution, not a before/after blur
 


### PR DESCRIPTION
Answers a question no document in this arc had asked: **across all conversations, short and long, where do the dollars actually go?** Every investigation so far entered through its own door and sized its own cohort — attachments (#836), the compaction spiral (#833), the agent cache (#834) — so the plan of record was ranked on whichever cohort was measured most recently.

## The answer

**55.2% of all model spend is cache writes.**

| component | share of $888.35 |
|---|---|
| **cache write** | **55.2%** |
| output | 19.8% |
| input (uncached) | 17.5% |
| cache read | 7.5% |

In *tokens* the ratio looks benign (289.9M read / 186.4M written) — but a written token costs ~12× a read one, so the dollar picture is governed by how often the prefix is **re**-written. Caching remains net-positive fleet-wide; nothing here argues for fewer cachePoints.

## Three findings that re-rank the backlog

1. **#833 PR-4 is the most general defect in that epic, not a footnote.** The system prompt mutates mid-session in **12.3% of multi-turn conversations** (4.6% of transitions) — against 0.6% / 2.8% for `toolConfigHash`, which says the ordering contract is holding and the *memory retrieval* is what moves. D2 and D3 are bounded to conversations long enough to compact; **D4 is not bounded at all**, and it is the cheapest fix in the document. D4's own section and the roadmap are re-ranked.
2. **43% of spend ($383 of $888) sits in conversations of ≤15 calls** — which nothing in this arc addresses. 700 sessions wrote cache and read none back ($33.92, **7.3% of all cache-write spend, returning nothing**); single-call sessions are 29% of all sessions and spend **67% of their money on writes they can never use**. Filed as a new un-specced workstream row (**W2b**).
3. **The north-star metric has a first reading: 5.9%** ($52.14), against its <5% target — and **206 of the 215 calls it flags say `hit` today**, which is exactly the blind spot #838 exists to close. ⚠️ Obtained by running the predicate *offline* over historical rows, so it **does not clear G0** (that still needs a prod baseline week after #838 releases) and it is a **floor**.

## Also: #833 §4.1's adversarial re-scan

The only ledger item blocked on nothing. Run, and written into the spec:

- cohort is **49 sessions (1.63%) / $172.46 (21.9%** of recorded session spend); narrowed to the spiral's actual shape (over-threshold **and** write:read > 3) it is **2 sessions**
- **D2 reproduces with a worse case than the incident** — a **174,952-char** summary on a *different user's* conversation; 15 sessions exceed PR-2's proposed budget, and even at zero summarized turns the median summary is 20,534 chars
- **D3 reproduces and is not session-specific** — `truncationAnchor` ≠ `checkpoint` on **199 of 1,238** rows, and never in the opposite direction
- **the harm is already multi-user** — **5 users quota-blocked**, four of whom are in the top six over-threshold spenders, and a **6th granted a manual $30 → $60 override on 2026-08-04, reason "bug caused quota to be reached."** So §3's deferred "quota credit for the affected user" was already actioned in prod by hand, and the spec didn't know it

## Two corrections to the plan of record

- The tenet paragraph read *"the fleet writes 2× what it reads from cache."* **Inverted** — measured 0.64, and the 2026-07-27 reading was 1:2. §4.4's "target ≤ 1:4" only parses the other way.
- **G2's criteria are a volume test for defects that aren't volume-driven.** The summary ratchet is monotonic in a conversation's *age* (no prod session has yet exceeded 19 summarized turns) and prefix mutation is per-turn behavior at every length. At the lowest traffic this platform will ever see, "is the cohort >3% of sessions" would defer a mechanism that has already cost six users their quota. The gate now carries that caveat and the conditional rate to prefer instead: *of conversations that get long enough to compact at all, 32% already exceed PR-2's budget.*

## Method

`backend/scripts/scan_fleet_prefix_spend.py` — read-only, content-free (compaction summaries are *measured*, never printed or persisted), denominator rule enforced throughout (rows without a cost are excluded as unknown, never zeroed — 10.8% of call rows, 20.0% of session rows). Verified to reproduce **every published figure exactly** by replaying the same prod rows through the committed code path.

Docs only — no application code, no CI-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
