### PR TITLE
fix(infra): stop exceeding the AgentCore Runtime 50-env-var limit (develop is red)

### DIFF
--- a/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-agentcore-construct.ts
@@ -398,11 +398,21 @@ export class InferenceAgentCoreConstruct extends Construct {
         // Authentication
         ENABLE_QUOTA_ENFORCEMENT: 'true',
 
-        // Quota runway (#833 PR-5): earlier warning rungs (50%/75%) plus the
-        // per-session `quota_session_notice`. Default ON — set to 'false' to
-        // fall back to the soft-limit/90% pair and silence the session
-        // notice, which is the kill switch for both halves at once.
-        QUOTA_RUNWAY_ENABLED: 'true',
+        // ⚠️ NO ROOM FOR NEW VARIABLES HERE — see the assertion in
+        // test/inference-agentcore-construct.test.ts. `AWS::BedrockAgentCore::Runtime`
+        // caps EnvironmentVariables at 50 and this construct is AT the cap.
+        // Adding one more fails CloudFormation's *changeset validation* — after
+        // synth, after tsc, after jest, after CI is green. It broke the dev
+        // Platform Stack deploy on 2026-08-05 (`maximum size: [50], found: [51]`,
+        // adding QUOTA_RUNWAY_ENABLED for #833 PR-5).
+        //
+        // To add a flag you must first free a slot: retire a dead variable, or
+        // fold several booleans into one delimited FEATURE_FLAGS value. A
+        // code-level flag that reads `os.environ` and defaults ON needs no entry
+        // here at all — that is why QUOTA_RUNWAY_ENABLED is absent and the quota
+        // runway is still on. Setting such a flag to a non-default value in a
+        // deployed environment requires an out-of-band Runtime update until a
+        // slot is freed.
 
         // Directories
         UPLOAD_DIR: '/tmp/uploads',

--- a/infrastructure/test/runtime-env-var-limit.test.ts
+++ b/infrastructure/test/runtime-env-var-limit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * `AWS::BedrockAgentCore::Runtime` env-var ceiling guard.
+ *
+ * The Runtime resource accepts at most **50** EnvironmentVariables. That limit
+ * is enforced by CloudFormation when it validates the changeset — *not* by
+ * `cdk synth`, and not by anything else that runs before a deploy. So a PR that
+ * adds the 51st variable passes `tsc`, passes `jest`, passes CI, merges, and
+ * then fails the Platform Stack deploy with:
+ *
+ *     🛑 #/EnvironmentVariables: maximum size: [50], found: [51]
+ *
+ * That is exactly what happened on 2026-08-05: #833 PR-5 added
+ * `QUOTA_RUNWAY_ENABLED` to the inference construct and broke the dev platform
+ * deploy. Nothing caught it earlier because nothing looked.
+ *
+ * This test looks. It is deliberately a *ceiling* assertion rather than an
+ * exact-count snapshot: removing a variable should never fail a build, and
+ * pinning the exact number would turn every legitimate removal into a test
+ * edit. The failure message is the important part — it has to tell the next
+ * person what to do, because "add an env var" is an obvious-looking change with
+ * a non-obvious limit.
+ *
+ * Freeing a slot means retiring a dead variable or folding several booleans
+ * into one delimited value. A code-level feature flag that reads `os.environ`
+ * and defaults ON does not need an entry here at all.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+/** Hard AWS limit on AWS::BedrockAgentCore::Runtime EnvironmentVariables. */
+const RUNTIME_ENV_VAR_LIMIT = 50;
+
+describe('AgentCore Runtime environment variable ceiling', () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const cert = 'arn:aws:acm:us-east-1:123456789012:certificate/test';
+    // WORST CASE, on purpose. Some variables are spread in conditionally, so a
+    // minimal config under-counts and the guard would report headroom that no
+    // real environment has. `tokenExchange` alone adds three
+    // (TOKEN_EXCHANGE_URL / _CLIENT_ID / _SECRET_ID) — without it this test
+    // counts 47 while prod and dev deploy 50. Any future conditional block
+    // must be enabled here too, or this guard quietly stops guarding.
+    const config = createMockConfig({
+      domainName: 'example.com',
+      infrastructureHostedZoneDomain: 'example.com',
+      certificateArn: cert,
+      frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
+      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
+      fineTuning: {},
+      tokenExchange: {
+        url: 'https://tokens.example.com/v2/oauth/token',
+        clientId: 'test-client',
+      },
+    });
+    const app = new cdk.App();
+    mockSsmContext(app, config);
+    const stack = new PlatformStack(app, 'TestPlatformStack', {
+      config,
+      env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+    });
+    stack.wireCompute();
+    template = Template.fromStack(stack);
+  });
+
+  it('stays at or under the 50-variable limit CloudFormation enforces', () => {
+    const runtimes = template.findResources('AWS::BedrockAgentCore::Runtime');
+    const entries = Object.entries(runtimes);
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const [logicalId, resource] of entries) {
+      const env = (resource.Properties?.EnvironmentVariables ?? {}) as Record<string, unknown>;
+      const count = Object.keys(env).length;
+
+      // Thrown rather than asserted so the guidance travels with the failure —
+      // Jest's expect() carries no message argument.
+      if (count > RUNTIME_ENV_VAR_LIMIT) {
+        throw new Error(
+          `${logicalId} declares ${count} environment variables; ` +
+            `AWS::BedrockAgentCore::Runtime allows ${RUNTIME_ENV_VAR_LIMIT}. ` +
+            `CloudFormation rejects the changeset at deploy time, so synth and CI both look ` +
+            `green while the Platform Stack deploy fails. Free a slot before adding another: ` +
+            `retire a dead variable, or fold booleans into one delimited FEATURE_FLAGS value. ` +
+            `A flag that reads os.environ and defaults ON needs no entry here at all.`,
+        );
+      }
+      expect(count).toBeLessThanOrEqual(RUNTIME_ENV_VAR_LIMIT);
+    }
+  });
+
+  it('reports the remaining headroom, so the next PR knows what it has', () => {
+    const runtimes = template.findResources('AWS::BedrockAgentCore::Runtime');
+    for (const [logicalId, resource] of Object.entries(runtimes)) {
+      const env = (resource.Properties?.EnvironmentVariables ?? {}) as Record<string, unknown>;
+      const count = Object.keys(env).length;
+      // Not an assertion — a visible number in the test output. The ceiling
+      // above is the gate; this is the early warning.
+      console.log(
+        `[env-var headroom] ${logicalId}: ${count}/${RUNTIME_ENV_VAR_LIMIT} used, ` +
+          `${RUNTIME_ENV_VAR_LIMIT - count} free`,
+      );
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
**`develop`'s Platform Stack deploy is currently failing, and this fixes it.** My #845 added the 51st environment variable to the AgentCore Runtime.

```
🛑 #/EnvironmentVariables: maximum size: [50], found: [51]
   AWS::BedrockAgentCore::Runtime InferenceApiAgentCoreRuntime42085C46
```

`AWS::BedrockAgentCore::Runtime` caps EnvironmentVariables at **50**, and this construct was at exactly 50. The limit is enforced by CloudFormation at **changeset validation** — not by `cdk synth` — so `tsc`, `jest`, and CI were all green on the PR that broke it. Backend and Frontend deploys succeeded; only Platform Stack failed, and it failed at validation, so nothing was applied and dev was not rolled back.

## The fix

Removes `QUOTA_RUNWAY_ENABLED`. **The kill switch is unaffected** — `quota_runway_enabled()` reads `os.environ` and defaults ON, so the quota runway stays enabled with no entry here. Setting it to a non-default value now needs an out-of-band Runtime update until a slot is freed; that's recorded in a comment where the variable used to be.

## The part that matters more than the fix

**We are at the ceiling — 0 slots free.** The next feature flag anyone adds breaks the platform deploy exactly the same way, and today nothing warns them.

`test/runtime-env-var-limit.test.ts` (sibling to the existing `gsi-update-limit.test.ts`, same class of AWS-limit guard):

- asserts the count stays ≤ 50, throwing a message that says how to free a slot rather than just failing
- logs headroom on every run — currently **`50/50 used, 0 free`**
- synthesizes the **worst case** on purpose: `tokenExchange` is enabled in the test config because it spreads in three more variables. Without it the test counts 47 while prod and dev deploy 50 — a guard that reports headroom no real environment has is worse than no guard. Any future conditional block has to be enabled there too, and the test says so.

Verified both directions: added a 51st variable and confirmed the guard fails with the intended message, then removed it and confirmed green. Full infra suite: **499 passed**.

## Follow-up worth filing separately

Freeing slots is now a real constraint, not housekeeping. Options are a dead-variable audit or folding the booleans (`MEMORY_SPACES_ENABLED`, `SKILLS_ENABLED`, `AGENTS_API_ENABLED`, `ENABLE_QUOTA_ENFORCEMENT`, …) into one delimited `FEATURE_FLAGS` value. Not done here — this PR is scoped to turning `develop` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
