### PR TITLE
fix(agents): hydrate the saved reasoning-effort value into the Designer's select

### DIFF
--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -314,15 +314,24 @@
             @for (p of enumParams(); track p.key) {
               <div>
                 <label [attr.for]="'param-' + p.key" class="block text-xs/5 font-medium text-gray-700 dark:text-gray-300">{{ p.label }}</label>
+                <!--
+                  Bind [selected] on each <option>, never [value] on the <select>.
+                  `select.value` is a one-time DOM property write applied before
+                  @for has mounted the options in the same change-detection tick,
+                  so the browser drops the unmatched value and falls back to the
+                  first option ("Default") — and Angular never re-applies it,
+                  because the bound value itself never changed. A saved
+                  `reasoning_effort: high` then reads as the model's default
+                  forever. Same failure this pattern caused in chat preferences (#161).
+                -->
                 <select
                   [id]="'param-' + p.key"
                   [disabled]="isViewer()"
-                  [value]="paramValue(p.key)"
                   (change)="onEnumParam(p.key, $any($event.target).value)"
                   class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-xs transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white">
-                  <option value="">Default{{ p.spec.default != null ? ' (' + p.spec.default + ')' : '' }}</option>
+                  <option value="" [selected]="paramValue(p.key) === ''">Default{{ p.spec.default != null ? ' (' + p.spec.default + ')' : '' }}</option>
                   @for (opt of p.spec.allowed ?? []; track opt) {
-                    <option [value]="opt">{{ opt }}</option>
+                    <option [value]="opt" [selected]="opt === paramValue(p.key)">{{ opt }}</option>
                   }
                 </select>
               </div>

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.spec.ts
@@ -241,3 +241,140 @@ describe('AgentFormPage — loading state', () => {
     expect(fixture.nativeElement.querySelector('form')).toBeTruthy();
   });
 });
+
+/**
+ * A saved enum param (reasoning effort) must still be the one selected when the
+ * author reopens the agent. The select's options are rendered by `@for` from the
+ * model's `supportedParams`, so binding the saved value on the <select> loses it:
+ * `select.value` is written before the options mount, the browser drops it, and
+ * Angular never re-applies a binding whose value did not change — a saved `high`
+ * silently reads back as the model's default. Same defect as #161.
+ */
+describe('AgentFormPage — saved enum param on reopen', () => {
+  let fixture: ComponentFixture<AgentFormPage>;
+  let component: AgentFormPage;
+
+  const MODEL_WITH_EFFORT = {
+    kind: 'model',
+    ref: 'openai.gpt-5.4',
+    label: 'GPT-5.4',
+    description: '',
+    meta: {
+      provider: 'mantle',
+      supportedParams: {
+        params: {
+          reasoning_effort: {
+            supported: true,
+            allowed: ['low', 'medium', 'high'],
+            default: 'medium',
+            locked: false,
+          },
+        },
+      },
+    },
+  };
+
+  const mockAgentService = {
+    loadBindable: vi
+      .fn()
+      .mockImplementation((kind: string) =>
+        Promise.resolve(kind === 'model' ? [MODEL_WITH_EFFORT] : []),
+      ),
+    getAgent: vi.fn().mockResolvedValue({
+      agentId: 'agt-1',
+      name: 'Research Assistant',
+      description: 'A short summary of the agent',
+      instructions: 'You are a helpful assistant that answers questions.',
+      visibility: 'PRIVATE',
+      userPermission: 'owner',
+      modelConfig: {
+        modelId: 'openai.gpt-5.4',
+        provider: 'mantle',
+        params: { reasoning_effort: 'high' },
+      },
+      bindings: [],
+    }),
+    updateAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+  };
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      providers: [
+        provideRouter([{ path: 'agents', children: [] }]),
+        { provide: AgentService, useValue: mockAgentService },
+        {
+          provide: ToastService,
+          useValue: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+        },
+        { provide: SidenavService, useValue: { hide: vi.fn(), show: vi.fn() } },
+        { provide: ThemeService, useValue: { isDark: () => false } },
+        // Edit mode: the route carries the agent id.
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => 'agt-1' } } } },
+      ],
+    });
+
+    TestBed.overrideComponent(AgentFormPage, {
+      remove: { imports: [AgentPreviewComponent, KnowledgeBaseSectionComponent] },
+      add: { imports: [StubPreviewComponent, StubKnowledgeBaseComponent] },
+    });
+
+    fixture = TestBed.createComponent(AgentFormPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await settle(fixture);
+  });
+
+  function effortSelect(): HTMLSelectElement {
+    return fixture.nativeElement.querySelector('select#param-reasoning_effort');
+  }
+
+  it('hydrates the saved param into component state', () => {
+    expect(component.paramValue('reasoning_effort')).toBe('high');
+  });
+
+  it('renders the saved value as the selected option, not the model default', () => {
+    const select = effortSelect();
+    expect(select).toBeTruthy();
+    expect([...select.options].map((o) => o.value)).toEqual(['', 'low', 'medium', 'high']);
+    expect(select.value).toBe('high');
+  });
+
+  it('still round-trips a change back through the form state', () => {
+    const select = effortSelect();
+    select.value = 'low';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(component.paramValue('reasoning_effort')).toBe('low');
+    expect(effortSelect().value).toBe('low');
+  });
+
+  it('still sends the saved value on a save that never touched the control', async () => {
+    // The regression was display-only: `modelParams` kept `high` even while the
+    // select showed the default, so reopening and saving never rewrote the record.
+    await component.onSubmit();
+
+    expect(mockAgentService.updateAgent).toHaveBeenCalledWith(
+      'agt-1',
+      expect.objectContaining({
+        modelConfig: expect.objectContaining({ params: { reasoning_effort: 'high' } }),
+      }),
+    );
+  });
+
+  it('falls back to the Default option when the param is cleared', () => {
+    const select = effortSelect();
+    select.value = '';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(component.paramValue('reasoning_effort')).toBe('');
+    expect(effortSelect().value).toBe('');
+  });
+});


### PR DESCRIPTION
## What

An agent saved with `reasoning_effort: high` came back showing **Default (medium)** when reopened for editing. User-reported on boisestate.ai.

Fixes the Agent Designer's enum-param `<select>` so the saved value is the one selected on load.

## Why

[`agent-form.page.html`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html#L320) bound the saved value on the `<select>` itself, while the options come from `@for` over the model's `supportedParams.allowed`:

```html
<select [value]="paramValue(p.key)">
  <option value="">Default…</option>
  @for (opt of p.spec.allowed ?? []; track opt) { <option [value]="opt"> }
</select>
```

`select.value` is a one-time DOM property write. Angular applies it *before* the `@for` mounts the options in the same change-detection tick, so the browser finds no matching `<option>`, discards the value, and settles on the first one once the options arrive. It never resyncs, because the bound value itself never changed.

Reproduced with a failing test before touching anything:

```
OPTIONS: [ '', 'low', 'medium', 'high' ]   DOM value: ""   selectedIndex: 0
```

Component state held `'high'`; the rendered control showed option 0 — `Default (medium)`.

This is the same defect as #161, already fixed once in [`chat-preferences-settings.page.ts`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/frontend/ai.client/src/app/settings/pages/chat-preferences/chat-preferences-settings.page.ts#L54), which carries a comment describing exactly this failure mode. The Designer's params picker reintroduced the pattern.

## How

Bind `[selected]` on each `<option>` rather than `[value]` on the `<select>`, so the binding fires as each option mounts. Matches the existing in-repo fix, with a comment so the pattern doesn't come back a third time.

## Reviewer notes

**No agent lost its setting — this was display-only.** `modelParams` kept `high` throughout, and `persist()` reads that same signal, so reopening and re-saving never rewrote the record. Affected agents have been running at their saved effort all along; only the editor misreported it. There's a test asserting the save payload still carries `reasoning_effort: high` after an untouched reopen, so the reassurance is pinned down rather than just claimed.

The backend was checked and is not implicated: `modelConfig.params` persists through `_update_assistant_cloud` and is projected back by `to_agent_view`, and `_validate_model_params` rejects rather than silently drops.

I also checked the other `[value]`-on-`<select>` sites (`sync-policy-control`, `usage-settings`, `rollback-dialog`, `listings`). They share the pattern, but their initial bound value is `''`, which matches their placeholder option — fragile rather than broken, so they're left alone here.

## Testing

13/13 pass in `agent-form.page.spec.ts` (`npx ng test --include="**/agent-form.page.spec.ts"`) — four new regression tests covering hydration, the rendered selection, round-tripping a change, and clearing back to Default, plus the save-payload assertion.

Not verified in a browser: the local SPA on :4200 came up on the admin-account bootstrap screen (pointed at a local backend with no account), so there was no authenticated session to drive. The tests assert the actual rendered DOM (`select.value` and the full options list), which is the exact surface that was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)