### PR TITLE
fix(rbac): honour isPublic in tool access checks, not just the picker

### DIFF
--- a/backend/src/apis/app_api/admin/services/tool_access.py
+++ b/backend/src/apis/app_api/admin/services/tool_access.py
@@ -33,11 +33,14 @@ class ToolAccessService:
         """
         Get the set of tool IDs the user is allowed to use.
 
+        Delegates to ``AppRoleService.get_accessible_tools`` so this surface
+        reads the same role-grant ∪ public-tool union as every other gate
+        rather than keeping a second, narrower copy of the rule.
+
         Returns:
             Set of tool IDs. Contains "*" if user has wildcard access.
         """
-        permissions = await self.app_role_service.resolve_user_permissions(user)
-        return set(permissions.tools)
+        return set(await self.app_role_service.get_accessible_tools(user))
 
     async def can_access_tool(self, user: User, tool_id: str) -> bool:
         """
@@ -50,14 +53,7 @@ class ToolAccessService:
         Returns:
             True if user has access to the tool
         """
-        allowed_tools = await self.get_user_allowed_tools(user)
-
-        # Wildcard grants access to all tools
-        if "*" in allowed_tools:
-            return True
-
-        # Check if specific tool is in allowed set
-        return tool_id in allowed_tools
+        return await self.app_role_service.can_access_tool(user, tool_id)
 
     async def filter_allowed_tools(
         self,

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -1,9 +1,30 @@
-"""AppRoleService for resolving and checking AppRole-based permissions."""
+"""AppRoleService for resolving and checking AppRole-based permissions.
+
+**A tool is granted by a role grant *or* by its own ``isPublic`` flag.**
+Both are real grants and every gate here reads both, via the one
+``_tool_grant_set`` helper. They used to disagree: ``isPublic`` was
+honoured only by the tool *picker*
+(``ToolCatalogService._compute_granted_by``) while the checks below read
+role ``grantedTools`` alone, so a public-but-ungranted tool listed for
+everyone and then failed at use — silently dropped from a scheduled run,
+and a hard block on any Agent that bound it. Non-admins hit it; anyone
+holding ``"*"`` never did. Keep the two sides reading the same flag; this
+is the tools-axis twin of the ``_grants_access`` consolidation in
+``admin/services/model_access.py``.
+
+The public set is *not* merged into ``UserEffectivePermissions``. That
+object is per-user cached and its ``tools`` list is order-sensitive
+(it reaches the model's ``toolConfig``, where a flip re-writes the
+prompt-cache prefix). Unioning at the predicate instead keeps the
+catalog's own TTL cache as the freshness boundary for an ``isPublic``
+toggle and leaves the cached permission object untouched.
+"""
 
 import logging
 from typing import List, Set, Optional
 
 from apis.shared.auth.models import User
+from apis.shared.tools.freshness import get_public_tool_ids
 from apis.shared.tools.scoped_ids import base_tool_id
 
 from .models import AppRole, UserEffectivePermissions
@@ -227,15 +248,33 @@ class AppRoleService:
             resolved_at=utc_now_iso(),
         )
 
-    async def can_access_tool(self, user: User, tool_id: str) -> bool:
-        """Check if user can access a specific tool."""
+    async def _tool_grant_set(self, user: User) -> Set[str]:
+        """The tool ids ``user`` may invoke: their role grant ∪ every public tool.
+
+        The one place the two grant sources combine. Every tool gate below
+        goes through it so they cannot drift apart again — a ``"*"`` in the
+        result still short-circuits as before.
+        """
         permissions = await self.resolve_user_permissions(user)
+        granted = set(permissions.tools)
+        if "*" in granted:
+            return granted
+        return granted | set(await get_public_tool_ids())
+
+    async def can_access_tool(self, user: User, tool_id: str) -> bool:
+        """Check if user can access a specific tool.
+
+        Exact-match on the id by design: callers pass a bare catalog id
+        (an Agent's ``binding.ref``, validated against the author's palette
+        at design time), never a scoped ``base::tool`` id.
+        """
+        allowed = await self._tool_grant_set(user)
 
         # Wildcard grants access to all
-        if "*" in permissions.tools:
+        if "*" in allowed:
             return True
 
-        return tool_id in permissions.tools
+        return tool_id in allowed
 
     async def can_access_model(self, user: User, model_id: str) -> bool:
         """Check if user can access a specific model."""
@@ -248,9 +287,12 @@ class AppRoleService:
         return model_id in permissions.models
 
     async def get_accessible_tools(self, user: User) -> List[str]:
-        """Get list of tool IDs user can access."""
-        permissions = await self.resolve_user_permissions(user)
-        return permissions.tools
+        """Get list of tool IDs user can access (role grant ∪ public tools).
+
+        Sorted, like the lists ``_merge_permissions`` builds: any tool list
+        that reaches a prompt must be deterministic across processes.
+        """
+        return sorted(await self._tool_grant_set(user))
 
     async def filter_requested_tools(
         self, user: User, requested: List[str]
@@ -267,10 +309,10 @@ class AppRoleService:
 
         A ``"*"`` grant passes everything through. A scoped id (``base::tool``)
         is allowed when its base server id is granted, so a role that grants a
-        whole MCP server still admits that server's per-tool selections.
+        whole MCP server still admits that server's per-tool selections — and
+        equally when that server is public, since a public tool is a grant.
         """
-        permissions = await self.resolve_user_permissions(user)
-        allowed = set(permissions.tools)
+        allowed = await self._tool_grant_set(user)
         if "*" in allowed:
             return list(requested)
         return [

--- a/backend/src/apis/shared/tools/freshness.py
+++ b/backend/src/apis/shared/tools/freshness.py
@@ -1,6 +1,6 @@
 """Per-process TTL caches over the tool catalog.
 
-Two caches live here, both backed by DynamoDB reads of the tool
+Three caches live here, all backed by DynamoDB reads of the tool
 catalog:
 
 1. **Per-tool freshness tokens** (`get_tool_updated_at`,
@@ -16,12 +16,19 @@ catalog:
    which tools to expand `*` into, and to validate requested tools
    against.
 
+3. **Public-tool-ids snapshot** (`get_public_tool_ids`). The set of
+   tool IDs flagged `isPublic` in the catalog — "available to every
+   authenticated user regardless of role". `AppRoleService` unions this
+   into a caller's role grant so the access *checks* honour the same
+   flag the tool *picker* already does (see the module note there).
+
 Reads are TTL-cached so the per-turn overhead is bounded to at most
 one DynamoDB read per cache key per TTL window, per process. Admin
 routes call `invalidate(tool_id)` after a write so same-process
 visibility is immediate; other processes see the change within one
-TTL window. `invalidate` clears the all-tool-ids snapshot too, since
-any create/delete shifts that set.
+TTL window. `invalidate` clears the id snapshots too, since any
+create/delete shifts those sets — and toggling `isPublic` on an
+existing tool shifts the public one.
 """
 
 import asyncio
@@ -44,12 +51,17 @@ _cache: Dict[str, Tuple[Optional[str], float]] = {}
 # reassigned), which keeps the module state easy to reason about.
 _all_tool_ids_cache: List[Optional[Tuple[FrozenSet[str], float]]] = [None]
 
+# Single-slot snapshot of (frozen_set_of_public_tool_ids, monotonic_fetched_at),
+# same shape and lifecycle as `_all_tool_ids_cache` above.
+_public_tool_ids_cache: List[Optional[Tuple[FrozenSet[str], float]]] = [None]
+
 _TTL_SECONDS = 10.0
 
 
 def _reset_for_tests() -> None:
     _cache.clear()
     _all_tool_ids_cache[0] = None
+    _public_tool_ids_cache[0] = None
 
 
 async def _fetch_updated_at(tool_id: str) -> Optional[str]:
@@ -114,8 +126,39 @@ async def get_all_tool_ids() -> FrozenSet[str]:
     an empty frozenset — never raises (auth must not break on a transient
     DB blip).
     """
+    return await _get_snapshot(_all_tool_ids_cache, "all")
+
+
+async def get_public_tool_ids() -> FrozenSet[str]:
+    """Return the set of tool IDs flagged `isPublic`, TTL-cached per process.
+
+    A public tool is "available to all authenticated users regardless of
+    role", so `AppRoleService` unions this set into a caller's role grant
+    before deciding access. Sharing one snapshot keeps every gate reading
+    the same answer within a TTL window.
+
+    Deliberately unfiltered by `status`, mirroring the listing path
+    (`ToolCatalogService._get_all_active_tools` passes no status filter):
+    enforcement and the tool picker must agree about which tools a public
+    flag reaches, and a divergence there is the bug this exists to close.
+
+    Same never-raise contract as `get_all_tool_ids`.
+    """
+    return await _get_snapshot(_public_tool_ids_cache, "public")
+
+
+async def _get_snapshot(
+    slot: List[Optional[Tuple[FrozenSet[str], float]]], which: str
+) -> FrozenSet[str]:
+    """Serve one id snapshot, refreshing both from a single catalog read.
+
+    `list_tools()` already carries the `isPublic` flag, so one read fills
+    the all-ids and public-ids slots together — half the DynamoDB traffic
+    of two independent caches, and the two sets can never disagree about
+    the catalog they were derived from.
+    """
     now = time.monotonic()
-    cached = _all_tool_ids_cache[0]
+    cached = slot[0]
     if cached is not None and now - cached[1] < _TTL_SECONDS:
         return cached[0]
 
@@ -124,21 +167,25 @@ async def get_all_tool_ids() -> FrozenSet[str]:
     try:
         repo = get_tool_catalog_repository()
         tools = await repo.list_tools()
-        ids = frozenset(t.tool_id for t in tools)
     except Exception:
-        logger.exception("Failed to list tool IDs for catalog snapshot")
+        logger.exception("Failed to list tools for the %s-ids catalog snapshot", which)
         return cached[0] if cached is not None else frozenset()
 
-    _all_tool_ids_cache[0] = (ids, now)
-    return ids
+    _all_tool_ids_cache[0] = (frozenset(t.tool_id for t in tools), now)
+    _public_tool_ids_cache[0] = (
+        frozenset(t.tool_id for t in tools if t.is_public),
+        now,
+    )
+    return slot[0][0]  # type: ignore[index]
 
 
 def invalidate(tool_id: Optional[str] = None) -> None:
     """Drop an entry (or the whole cache) from the TTL store.
 
-    Always clears the all-tool-ids snapshot too, since any create/delete
-    shifts that set (and an admin write is the only reason to invalidate
-    anyway).
+    Always clears both id snapshots too, since any create/delete shifts
+    them — and an `isPublic` toggle on an existing tool shifts the public
+    one without touching the id set (an admin write is the only reason to
+    invalidate anyway).
 
     Call this from admin write paths so changes are visible in the same
     process on the very next turn, without waiting for the TTL to lapse.
@@ -148,3 +195,4 @@ def invalidate(tool_id: Optional[str] = None) -> None:
     else:
         _cache.pop(tool_id, None)
     _all_tool_ids_cache[0] = None
+    _public_tool_ids_cache[0] = None

--- a/backend/tests/apis/app_api/admin/services/test_tool_access.py
+++ b/backend/tests/apis/app_api/admin/services/test_tool_access.py
@@ -7,8 +7,8 @@ admin-managed MCP-external and A2A tools, which only exist in
 DynamoDB.
 """
 
+from types import MethodType, SimpleNamespace
 from unittest.mock import AsyncMock, patch
-from types import SimpleNamespace
 
 import pytest
 
@@ -16,6 +16,7 @@ from apis.shared.tools import freshness
 from apis.app_api.admin.services.tool_access import ToolAccessService
 from apis.shared.auth.models import User
 from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.rbac.service import AppRoleService
 
 
 @pytest.fixture(autouse=True)
@@ -46,16 +47,32 @@ def _permissions(tools, app_roles=("admin",)) -> UserEffectivePermissions:
 
 
 def _service(permissions: UserEffectivePermissions) -> ToolAccessService:
+    """A ToolAccessService over fixed permissions but the *real* grant rule.
+
+    Only ``resolve_user_permissions`` is stubbed; the methods that decide
+    what those permissions grant are bound from the real ``AppRoleService``
+    so these tests exercise the actual role-grant ∪ public-tool union
+    instead of a hand-written copy of it.
+    """
     role_service = AsyncMock()
     role_service.resolve_user_permissions = AsyncMock(return_value=permissions)
+    role_service.get_accessible_tools = MethodType(
+        AppRoleService.get_accessible_tools, role_service
+    )
+    role_service._tool_grant_set = MethodType(
+        AppRoleService._tool_grant_set, role_service
+    )
     return ToolAccessService(app_role_service=role_service)
 
 
-def _patch_catalog(tool_ids):
+def _patch_catalog(tool_ids, public_ids=()):
     """Patch the repository.list_tools call that backs freshness snapshot."""
     repo = SimpleNamespace(
         list_tools=AsyncMock(
-            return_value=[SimpleNamespace(tool_id=tid) for tid in tool_ids]
+            return_value=[
+                SimpleNamespace(tool_id=tid, is_public=tid in public_ids)
+                for tid in tool_ids
+            ]
         )
     )
     return patch(

--- a/backend/tests/apis/app_api/tools/test_freshness.py
+++ b/backend/tests/apis/app_api/tools/test_freshness.py
@@ -21,6 +21,14 @@ def _tool(updated_at: datetime):
     return SimpleNamespace(updated_at=updated_at)
 
 
+def _catalog_tool(tool_id: str, is_public: bool = False):
+    return SimpleNamespace(tool_id=tool_id, is_public=is_public)
+
+
+def _repo_with_tools(*tools):
+    return SimpleNamespace(list_tools=AsyncMock(return_value=list(tools)))
+
+
 @pytest.mark.asyncio
 async def test_empty_tool_list_returns_empty_hash():
     assert await freshness.get_freshness_hash([]) == ""
@@ -160,6 +168,69 @@ async def test_repository_error_falls_back_to_last_known_value():
     ):
         # With invalidate cleared the cache entry, we should return None on error.
         assert await freshness.get_tool_updated_at("gmail") is None
+
+
+@pytest.mark.asyncio
+async def test_public_tool_ids_returns_only_flagged_tools():
+    repo = _repo_with_tools(
+        _catalog_tool("create_word_document", is_public=True),
+        _catalog_tool("gmail_employee", is_public=False),
+    )
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        assert await freshness.get_public_tool_ids() == {"create_word_document"}
+
+
+@pytest.mark.asyncio
+async def test_one_read_fills_both_id_snapshots():
+    """The two snapshots share a catalog read and can't disagree about it."""
+    repo = _repo_with_tools(
+        _catalog_tool("create_word_document", is_public=True),
+        _catalog_tool("gmail_employee", is_public=False),
+    )
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        public = await freshness.get_public_tool_ids()
+        every = await freshness.get_all_tool_ids()
+
+    assert repo.list_tools.await_count == 1
+    assert public == {"create_word_document"}
+    assert every == {"create_word_document", "gmail_employee"}
+
+
+@pytest.mark.asyncio
+async def test_invalidate_refetches_public_ids():
+    """An admin toggling isPublic must be visible without waiting out the TTL."""
+    repo = _repo_with_tools(_catalog_tool("create_word_document", is_public=False))
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        assert await freshness.get_public_tool_ids() == frozenset()
+
+    freshness.invalidate("create_word_document")
+
+    repo = _repo_with_tools(_catalog_tool("create_word_document", is_public=True))
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        assert await freshness.get_public_tool_ids() == {"create_word_document"}
+
+
+@pytest.mark.asyncio
+async def test_public_ids_repository_error_does_not_raise():
+    """Authorization must not break on a transient DB blip."""
+    repo = SimpleNamespace(list_tools=AsyncMock(side_effect=RuntimeError("boom")))
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        assert await freshness.get_public_tool_ids() == frozenset()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/shared/test_public_tool_grants.py
+++ b/backend/tests/shared/test_public_tool_grants.py
@@ -1,0 +1,216 @@
+"""A tool flagged ``isPublic`` must pass every gate, not just the picker.
+
+Regression cover for the divergence where ``isPublic`` was honoured only by
+``ToolCatalogService._compute_granted_by`` (which builds the tool picker) while
+every enforcement path read role ``grantedTools`` alone. A public-but-ungranted
+tool therefore listed for everyone and then failed at use: silently dropped from
+a scheduled run, and a hard block on any Agent that bound it. Only wildcard
+holders — admins — were unaffected, which is what made it look like a
+permissions misconfiguration rather than a bug.
+
+Every case here uses a role whose ``grantedTools`` is **empty**, so the public
+flag is the only thing that can grant access.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from apis.shared.tools import freshness
+
+
+PUBLIC_TOOL = "create_word_document"
+GRANTED_TOOL = "calculator"
+PRIVATE_TOOL = "gmail_employee"
+
+
+def _catalog_tool(tool_id: str, is_public: bool):
+    repo_tool = MagicMock()
+    repo_tool.tool_id = tool_id
+    repo_tool.is_public = is_public
+    return repo_tool
+
+
+@pytest.fixture(autouse=True)
+def _catalog():
+    """Serve a three-tool catalog: one public, two not."""
+    freshness._reset_for_tests()
+    repo = MagicMock()
+    repo.list_tools = AsyncMock(
+        return_value=[
+            _catalog_tool(PUBLIC_TOOL, is_public=True),
+            _catalog_tool(GRANTED_TOOL, is_public=False),
+            _catalog_tool(PRIVATE_TOOL, is_public=False),
+        ]
+    )
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        yield
+    freshness._reset_for_tests()
+
+
+@pytest.fixture
+def svc():
+    """An AppRoleService whose only role grants ``calculator`` and nothing else."""
+    from apis.shared.rbac.cache import AppRoleCache
+    from apis.shared.rbac.models import AppRole, EffectivePermissions
+    from apis.shared.rbac.service import AppRoleService
+
+    repo = AsyncMock()
+    repo.get_roles_for_jwt_role.return_value = ["student"]
+    repo.get_role.return_value = AppRole(
+        role_id="student",
+        display_name="student",
+        description="test",
+        jwt_role_mappings=["student"],
+        priority=10,
+        enabled=True,
+        effective_permissions=EffectivePermissions(
+            tools=[GRANTED_TOOL], models=["*"],
+        ),
+    )
+    return AppRoleService(repository=repo, cache=AppRoleCache())
+
+
+def _user():
+    user = MagicMock()
+    user.user_id = "u1"
+    user.email = "student@example.edu"
+    user.roles = ["student"]
+    return user
+
+
+class TestCanAccessTool:
+    """The gate an Agent's tool binding is re-resolved through (D5)."""
+
+    @pytest.mark.asyncio
+    async def test_public_tool_is_accessible_without_a_role_grant(self, svc):
+        assert await svc.can_access_tool(_user(), PUBLIC_TOOL) is True
+
+    @pytest.mark.asyncio
+    async def test_role_granted_tool_still_accessible(self, svc):
+        assert await svc.can_access_tool(_user(), GRANTED_TOOL) is True
+
+    @pytest.mark.asyncio
+    async def test_non_public_ungranted_tool_is_still_denied(self, svc):
+        """The fix widens access to public tools only — nothing else."""
+        assert await svc.can_access_tool(_user(), PRIVATE_TOOL) is False
+
+    @pytest.mark.asyncio
+    async def test_tool_absent_from_the_catalog_is_denied(self, svc):
+        assert await svc.can_access_tool(_user(), "no_such_tool") is False
+
+
+class TestFilterRequestedTools:
+    """The gate schedules and "Run now" narrow their tool list through."""
+
+    @pytest.mark.asyncio
+    async def test_public_tool_survives_the_filter(self, svc):
+        allowed = await svc.filter_requested_tools(
+            _user(), [PUBLIC_TOOL, GRANTED_TOOL, PRIVATE_TOOL]
+        )
+        assert allowed == [PUBLIC_TOOL, GRANTED_TOOL]
+
+    @pytest.mark.asyncio
+    async def test_scoped_id_of_a_public_server_survives(self, svc):
+        """A public MCP server admits its per-tool selections, as a grant does."""
+        allowed = await svc.filter_requested_tools(_user(), [f"{PUBLIC_TOOL}::sub"])
+        assert allowed == [f"{PUBLIC_TOOL}::sub"]
+
+    @pytest.mark.asyncio
+    async def test_requested_order_is_preserved(self, svc):
+        """Order is part of this contract — it reaches the model's toolConfig."""
+        allowed = await svc.filter_requested_tools(
+            _user(), [GRANTED_TOOL, PUBLIC_TOOL]
+        )
+        assert allowed == [GRANTED_TOOL, PUBLIC_TOOL]
+
+
+class TestGetAccessibleTools:
+    @pytest.mark.asyncio
+    async def test_union_of_role_grant_and_public_tools(self, svc):
+        assert await svc.get_accessible_tools(_user()) == [GRANTED_TOOL, PUBLIC_TOOL]
+
+    @pytest.mark.asyncio
+    async def test_result_is_sorted_for_prompt_cache_stability(self, svc):
+        tools = await svc.get_accessible_tools(_user())
+        assert tools == sorted(tools)
+
+
+class TestToolAccessService:
+    """The third gate — it must not keep its own narrower copy of the rule."""
+
+    @pytest.fixture
+    def tool_access(self, svc):
+        from apis.app_api.admin.services.tool_access import ToolAccessService
+
+        return ToolAccessService(app_role_service=svc)
+
+    @pytest.mark.asyncio
+    async def test_can_access_public_tool(self, tool_access):
+        assert await tool_access.can_access_tool(_user(), PUBLIC_TOOL) is True
+
+    @pytest.mark.asyncio
+    async def test_filter_keeps_public_tool(self, tool_access):
+        allowed = await tool_access.filter_allowed_tools(
+            _user(), [PUBLIC_TOOL, PRIVATE_TOOL]
+        )
+        assert allowed == [PUBLIC_TOOL]
+
+    @pytest.mark.asyncio
+    async def test_denied_list_no_longer_names_public_tools(self, tool_access):
+        allowed, denied = await tool_access.check_access_and_filter(
+            _user(), [PUBLIC_TOOL, PRIVATE_TOOL]
+        )
+        assert allowed == [PUBLIC_TOOL]
+        assert denied == [PRIVATE_TOOL]
+
+
+class TestWildcardUnaffected:
+    """Admins held ``"*"`` and never saw the bug; that path must not change."""
+
+    @pytest.fixture
+    def admin_svc(self):
+        from apis.shared.rbac.cache import AppRoleCache
+        from apis.shared.rbac.models import AppRole, EffectivePermissions
+        from apis.shared.rbac.service import AppRoleService
+
+        repo = AsyncMock()
+        repo.get_roles_for_jwt_role.return_value = ["system_admin"]
+        repo.get_role.return_value = AppRole(
+            role_id="system_admin",
+            display_name="system_admin",
+            description="test",
+            jwt_role_mappings=["system_admin"],
+            priority=100,
+            enabled=True,
+            effective_permissions=EffectivePermissions(tools=["*"], models=["*"]),
+        )
+        return AppRoleService(repository=repo, cache=AppRoleCache())
+
+    @pytest.mark.asyncio
+    async def test_wildcard_still_grants_everything(self, admin_svc):
+        assert await admin_svc.can_access_tool(_user(), PRIVATE_TOOL) is True
+
+    @pytest.mark.asyncio
+    async def test_wildcard_passes_the_whole_request_through(self, admin_svc):
+        requested = [PRIVATE_TOOL, "anything_at_all"]
+        assert await admin_svc.filter_requested_tools(_user(), requested) == requested
+
+
+class TestCatalogUnavailable:
+    """A catalog read failure must deny-as-before, never raise mid-turn."""
+
+    @pytest.mark.asyncio
+    async def test_public_grant_degrades_to_role_grant_on_error(self, svc):
+        freshness._reset_for_tests()
+        repo = MagicMock()
+        repo.list_tools = AsyncMock(side_effect=RuntimeError("dynamo down"))
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ):
+            assert await svc.can_access_tool(_user(), GRANTED_TOOL) is True
+            assert await svc.can_access_tool(_user(), PUBLIC_TOOL) is False


### PR DESCRIPTION
## Problem

Users report they can't use `create_word_document` even though it's marked public. Admins are unaffected.

`isPublic` was read by exactly one function in the backend — [`ToolCatalogService._compute_granted_by`](backend/src/apis/app_api/tools/service.py#L157), which builds the **tool picker listing**. Every path that actually *enforces* tool access resolved permissions from role `grantedTools` alone and never looked at the flag:

| Gate | Effect for a non-admin |
|---|---|
| `can_access_tool` (Agent tool bindings, D5) | **hard block** — `AgentBindingBlockedError` refuses the whole turn |
| `filter_requested_tools` (schedules, "Run now") | **silently dropped** |
| `ToolAccessService` | a second, narrower copy of the same rule |

So a public-but-ungranted tool listed for everyone and then failed at use. Only `"*"` holders — admins — were unaffected, which is what made it read as a permissions misconfiguration rather than a bug. Design-time binding validation compounds it: `_validate_tool` checks the author's palette via `get_user_accessible_tools` (which *does* honour `isPublic`), so an author can bind a tool the invoker is then denied.

No test covered `isPublic` in any access check.

## Impact in prod

Three tools are `isPublic: true` and granted by **zero** roles — `create_word_document`, `create_powerpoint_presentation`, `excalidraw`. Only `system_admin` (`grantedTools: ["*"]`) could reach them.

Live agents bind them, including PUBLIC ones every user can open:

- **Boise State Digital Accessibility Assistant** (PUBLIC) — `create_powerpoint_presentation`
- **Web to Markdown Converter** (PUBLIC) — `create_powerpoint_presentation`
- **Boise State Writing Style Guide Assistant** (PUBLIC) — both
- **Career Growth Coach** (private) — `create_word_document`

Plain chat was never affected — the chat proxy relays `enabled_tools` verbatim and inference-api's `_build_word_document_tools` gates only on that list, with no RBAC check on the path.

## Fix

- **`freshness.py`** — new `get_public_tool_ids()` TTL snapshot. Shares one `list_tools()` read with `get_all_tool_ids()` through a common `_get_snapshot` helper, so the two sets can't disagree about the catalog they came from and DynamoDB traffic is unchanged. `invalidate()` clears it too: an `isPublic` toggle shifts the public set without shifting the id set.
- **`rbac/service.py`** — one `_tool_grant_set` (role grant ∪ public tools) that `can_access_tool`, `filter_requested_tools` and `get_accessible_tools` all route through, so they can't drift apart again.
- **`tool_access.py`** — drops its private copy of the rule and delegates.

Tools-axis twin of the `_grants_access` consolidation in `admin/services/model_access.py`.

### Two deliberate calls

- **The public set is unioned at the predicate, not merged into `UserEffectivePermissions`.** That object is per-user cached and its `tools` list reaches the model's `toolConfig` — merging there would put an `isPublic` toggle inside the prompt-cache prefix and behind the permissions cache instead of the catalog's own 10s TTL.
- **`can_access_tool` keeps exact-id matching** (no scoped `base::tool` widening). Callers pass bare catalog ids validated against the author's palette at design time; adding base-id resolution there would widen access beyond this bug.

## Testing

Full backend suite: **5921 passed, 3 skipped**.

New `tests/shared/test_public_tool_grants.py` uses a role with empty `grantedTools`, so the public flag is the only thing that can grant access. Verified against the prior behaviour: **8 of 15 fail**, and the 7 that pass either way are the deny, wildcard and catalog-unavailable cases that must stay invariant — including that a catalog read failure degrades the public grant to the role grant rather than raising mid-turn.

One test-double fix: `tests/apis/app_api/admin/services/test_tool_access.py` stubbed catalog tools as `SimpleNamespace(tool_id=...)` with no `is_public`, though the real `ToolDefinition` always carries it (defaults `False`). Completed the stubs and bound the real `AppRoleService` grant methods onto the mock, so those tests exercise the actual union rule instead of a hand-written copy — rather than adding a defensive `getattr` to production code to accommodate an incomplete stub.

## Deploy notes

Backend-only, no infra or schema change — `backend.yml` covers it. No data migration required: the fix makes enforcement match the listing, so the three stranded tools work with no role edits. Behaviour change is a widening limited to tools already flagged `isPublic` in the catalog; non-public ungranted tools stay denied and `"*"` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)