### PR TITLE
chore: remove unused Any import from cache-arms experiment script

### DIFF
--- a/backend/scripts/experiment_agent_cache_arms.py
+++ b/backend/scripts/experiment_agent_cache_arms.py
@@ -56,7 +56,7 @@ import sys
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 logging.getLogger("httpx").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary

Removes the unused `Any` from the `typing` import in [`backend/scripts/experiment_agent_cache_arms.py:59`](backend/scripts/experiment_agent_cache_arms.py#L59).

## Why

CodeQL alert #796 (`py/unused-import`, note severity) surfaced this on release PR #853 (`release/1.14.0` → `main`). It was the only genuine finding of the six CodeQL raised there — the other five were verified false positives or deliberate and have been dismissed.

It was deliberately **not** fixed on the release branch: per the repo's `cutting-a-release` skill, a release branch carries only the version bump and release documents, not application code. So the fix lands here, on `develop`.

## Verification

- `grep` confirms `Any` appears exactly once in the file (the import itself); `Dict`, `List`, and `Optional` are each still referenced (lines 118, 134–156, 300, 381).
- `python3 -m py_compile` on the modified file passes.

One line changed, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)