### PR TITLE
docs: spike AgentCore Evaluations, and scope the eval harness

### DIFF
--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -10,7 +10,9 @@ a spec, the spec wins and this page gets fixed.
 `agent-cache-extra-tools-bypass.md` (#834) · `compaction-v2-versioned-prefix.md`
 (#835) · `document-context-offload.md` + validation + evaluation (#836) ·
 `quota-cooldown-windows.md` · `tool-search-token-bloat-strategy.md` ·
-`session-workspace-tools.md` · `share-large-conversations-s3-offload.md`
+`session-workspace-tools.md` · `share-large-conversations-s3-offload.md` ·
+`agentcore-evaluations-spike-findings.md` (2026-08-12 — what the managed
+evaluation service does and does not do for the shared harness)
 
 *Fleet measurement:* `fleet-prefix-spend-anatomy.md` (2026-08-05) — the flat,
 all-conversations spend decomposition this page now ranks work against.
@@ -203,7 +205,7 @@ between sessions. **Update a row here in the PR that changes it.**
 | #834 Memory-Space tools | unbuilt | binding descriptor into cache key |
 | #835 compaction v2 | unbuilt | G2 |
 | #836 offload PRs 1–3 | unbuilt | G3 citations probe |
-| eval harness (quality veto) | **unowned** | an owner |
+| eval harness (quality veto) | **unowned** — but **smaller than the specs assumed** as of the 2026-08-12 AgentCore Evaluations spike: the managed service supplies the judges, the trajectory/tool-call scoring and the result plumbing (~a third of the build). Scope decided the same day: internal instrument, no admin feature | an owner |
 | replay harness (#833 §4.2) | partially built — `experiment_agent_cache_arms.py` + `probe_runtime_session_affinity.py` drive real arms against dev; does not yet replay a recorded session's event stream | an owner for the rest |
 | §4.1 cohort scan | ✅ **run 2026-08-05** — cohort is 49 sessions (1.63%) / $172.46 (21.9% of recorded session spend); D2 and D3 both reproduce outside the incident (a 174,952-char summary on another session; anchor≠checkpoint on 199 of 1,238 rows). Written up in #833 §4.1 | nothing |
 | fleet spend anatomy (all conversations) | ✅ **run 2026-08-05** — `fleet-prefix-spend-anatomy.md`; script committed at `backend/scripts/scan_fleet_prefix_spend.py` | nothing |
@@ -221,6 +223,34 @@ between sessions. **Update a row here in the PR that changes it.**
   said *any* W2/W3 build PR, which #839 would have violated — but #833 §4.3
   explicitly exempts changes that alter no model-visible bytes, and #839 and
   #841 are both in that class. The rule was overbroad, not the merges.)
+
+  **Scope — decided 2026-08-12, previously implicit.** The harness is an
+  **internal instrument, not a product feature.** It exists to answer ship /
+  don't-ship on the four unbuilt PRs above, and then to sit idle until the next
+  W2/W3 change needs it. There is no admin-facing evaluation feature in this
+  arc, and nothing in the three specs ever proposed one — the scope was simply
+  never written down, which is how it drifts. Concretely: no UI, no result
+  persistence beyond a run artifact, no per-tenant config, no RBAC surface.
+  Almost none of the design generalizes anyway — the corpus, the
+  citation-page-identity canary and the pinning-boundary family are built
+  around document offload and compaction specifically.
+
+  **One deliberate exception:** the *arm runner* should sit on the headless run
+  primitive (`agentic-platform-primitives.md` F1), not on a bespoke script.
+  That is the one seam a future admin-facing feature would reuse; everything
+  else is disposable to it. `experiment_agent_cache_arms.py` already drives
+  real multi-turn dev-ai sessions through the runtime gateway, so this is a
+  question of where the code lives, not extra work. Do **not** build corpus
+  generality, a config surface, or result storage now.
+
+  **Deferred, not declined — admin-facing regression checks.** Two things
+  changed the economics in the week before this decision: agent version
+  snapshots shipped (#783–#801), so "did version 4 regress against version 3?"
+  is a question the platform can nearly ask; and the AgentCore Evaluations
+  spike found managed `llmAsAJudge` evaluators need **zero** infrastructure.
+  That makes an admin feature materially cheaper than it was — size it against
+  the marketplace roadmap in a future planning cycle, not by folding it into
+  this arc, which would delay four PRs that have measured dollars behind them.
 - **The replay harness** (#833 §4.2): deterministic re-run of a session's
   event stream through an arm, asserting predicted vs. actual cache
   reads/writes per turn. Same owner as above.

--- a/docs/specs/agentcore-evaluations-spike-findings.md
+++ b/docs/specs/agentcore-evaluations-spike-findings.md
@@ -1,0 +1,193 @@
+# AgentCore Evaluations — spike findings
+
+**Date:** August 12, 2026 · **Status:** spike complete, recommendation below
+**Question:** before we write the quality-veto eval harness by hand, does the
+`bedrock_agentcore.evaluation` package in our existing pin do the job?
+
+**Verdict: adopt it for judging and trajectory scoring; build our own arm
+runner and experimental design. It removes roughly a third of the build and
+cannot satisfy one requirement at all (blinding) — which is worth knowing
+before someone designs around it.**
+
+*Context:* the harness is the shared asset described by
+`compaction-over-threshold-cache-spiral.md` §4.3, `compaction-v2-versioned-prefix.md`
+§8, and `document-offload-evaluation.md` §2. All three predate the
+`bedrock-agentcore` 1.21.0 bump (#857, merged 2026-08-11) and none mentions
+this package. It has in fact been in the SDK since at least 1.9.1.
+
+---
+
+## 1. What was verified, and how
+
+Everything below was run against **dev-ai** (`us-west-2`), not read from docs.
+
+| claim | evidence |
+|---|---|
+| The APIs exist on our pinned boto3 | boto3/botocore **1.43.68** expose `Evaluate`, `StartBatchEvaluation`, and the full evaluator CRUD on `bedrock-agentcore` / `bedrock-agentcore-control` |
+| The service is authorized for us — not preview-gated | `list_evaluators()` returns **16 built-in evaluators**, all `ACTIVE` |
+| The whole pipeline works end-to-end **today, unmodified** | Ran `EvaluationClient.run()` against a real dev conversation: 272 spans collected, 4 scored results returned, explanations quoting the actual conversation text |
+| Session correlation is already deterministic | `runtime_session_id_for()` (`apis/shared/harness/runner.py:63`) is `sid-<sha256(session_id)>` — every conversation the existing headless harness drives maps to its spans with no new plumbing |
+
+### The built-in evaluators
+
+- **TRACE, response quality (8):** Correctness, Faithfulness, Helpfulness,
+  ResponseRelevance, Conciseness, Coherence, InstructionFollowing, Refusal
+- **TRACE, safety (2):** Harmfulness, Stereotyping
+- **SESSION (4):** GoalSuccessRate, TrajectoryExactOrderMatch,
+  TrajectoryInOrderMatch, TrajectoryAnyOrderMatch
+- **TOOL_CALL (2):** ToolSelectionAccuracy, ToolParameterAccuracy
+
+Custom evaluators come in two shapes, per the `CreateEvaluator` input model:
+`llmAsAJudge` (instructions + rating scale + model config — fully managed, no
+infra) and `codeBased` (a Lambda ARN, wrapped by the SDK's
+`@custom_code_based_evaluator()` decorator).
+
+### Where the conversation content actually lives — read this before extending anything
+
+This is the part a documentation-only read gets wrong, and it nearly derailed
+this spike.
+
+`aws/spans` in dev-ai holds 117 MB of spans, and **not one of them carries
+message content.** The `strands.telemetry.tracer` spans there have token counts
+and model ids and nothing else; a query for any span with a non-empty `events`
+array across seven days returns **zero rows**. Read only that, and the obvious
+conclusion is "content capture is off, this needs observability work first."
+
+That conclusion is wrong. Content arrives as **OTLP log records**, not span
+events — emitted by `strands.telemetry.tracer` into the *runtime* log group with
+`eventName = "strands.telemetry.tracer"` and a `body` of:
+
+```
+{"input":  {"messages": [{"role": "system"|"user"|"tool", "content": …}, …]},
+ "output": {"messages": [{"role": "assistant", "content": …}]}}
+```
+
+They carry `traceId` / `spanId` / `scope`, so they duck-type past the
+collector's `_is_valid_adot_document` check and get swept up alongside real
+spans. In the session sampled: 21 content-bearing log records among 359
+documents. `CloudWatchAgentSpanCollector` queries **both** `aws/spans` and the
+runtime log group and unions them, which is why the end-to-end call works —
+the content comes entirely from the second query.
+
+Two consequences worth writing down:
+
+1. **Don't "fix" content capture.** It isn't broken. Setting
+   `OTEL_SEMCONV_STABILITY_OPT_IN` tokens to chase span events would change the
+   emission shape out from under a path that already works.
+2. The runtime log group name is the AWS-suffixed one
+   (`…_agentcore_runtime-Z6D3HsHKs6-DEFAULT`), not the prefix-derived name.
+   Querying the wrong one returns zero rows rather than an error — the same
+   trap that hid the broken dashboard widgets fixed in #843.
+
+### What a real result looks like
+
+`Builtin.Correctness` on a live dev conversation returned `value: 1.0`, label
+`"Perfectly Correct"`, `tokenUsage` of 1,728 tokens, and a paragraph of
+explanation that correctly identified that the agent's tool calls had 502'd,
+that it declined to fabricate results, and that it had accurately reported the
+failure. That is a usable judge, not a rubber stamp.
+
+---
+
+## 2. What it does not give us
+
+The harness specs ask for a specific experimental design. The SDK gives a
+runner, not that design.
+
+- **Paired A/B arms.** `OnDemandEvaluationDatasetRunner` executes one dataset
+  against one invoker. Arms, k=3 replicates at production temperature,
+  order-swapped pairwise judging, per-family reporting, McNemar — all ours.
+- **Blinding — and this one is structural, not a gap.** The offload eval
+  (§2.4) requires stripping transcripts to *final answer text only* before
+  judging, because arm C transcripts contain `document_read` calls and
+  `<document-digest>` blocks that give the arm away. AgentCore Evaluations
+  works by feeding the evaluator the whole span set — content-in-spans **is**
+  the mechanism. There is no scrubbing seam. **The blinded pairwise holistic
+  judge therefore cannot run through this service**; it needs our own judge
+  over scrubbed text. Everything else can.
+- **Programmatic ground-truth scoring.** `ReferenceInputs` carries
+  `assertions` / `expected_response` / `expected_trajectory`, but exact-match
+  scoring against planted facts, table cells, and remapped page numbers is a
+  local function. Routing it through a Lambda-backed `codeBased` evaluator is
+  infrastructure weight for something a pure function does better.
+- **Cost and token metrics.** We already read these from the `C#` rows, and
+  `partial_miss` (#838) is a better instrument than anything in the spans.
+- **The corpus.** Planted-fact document generation, the BSU public scrape, the
+  chart-only pages that make the dual-encoding question answerable — all ours,
+  and that was always where the actual thinking lived.
+
+### Operational notes
+
+- The on-demand runner sleeps `evaluation_delay_seconds` (**default 180s**) for
+  span ingestion, then the collector polls on top of that. Batch the arms;
+  don't put this in a tight loop.
+- Each `evaluate` call is billed LLM usage (~1.7k tokens for one TRACE-level
+  Correctness call). At 120 tasks × 3 replicates × 2 arms this is real but
+  modest — budget it, and prefer the free trajectory matchers where they answer
+  the question.
+- Evaluator level drives batching: SESSION sends one request, TRACE fans out
+  over trace ids, TOOL_CALL over tool span ids, capped at 10 targets per
+  request.
+
+### One scoping decision to make deliberately
+
+The `body` payload carries the **full system prompt and every user message**
+into an AWS-managed evaluator. For the synthetic corpus the harness is designed
+around, that is a non-issue — the corpus is ours and contains no user content.
+It becomes a real decision only if someone later points this at recorded
+production conversations. Decide it then, explicitly; don't let it happen as a
+side effect of reusing the same script.
+
+---
+
+## 3. Recommendation
+
+**Hybrid.** Concretely:
+
+**Use AgentCore Evaluations for**
+- the tool-trajectory families — `TrajectoryInOrderMatch` and
+  `ToolSelectionAccuracy` directly answer "did the model call `document_read`
+  when it needed to, with the right arguments", which is the
+  `document_read` health band the offload eval (§3.1) already wants
+- `GoalSuccessRate` and `InstructionFollowing` for the long-session
+  constraint-retention families in #833 §4.3
+- a **secondary, non-blinded** quality signal — useful as the second judge the
+  eval design calls for on a 20% sample
+
+**Build ourselves**
+- the arm runner, extending `experiment_agent_cache_arms.py` (already drives
+  real multi-turn dev-ai sessions through the runtime gateway; don't rebuild
+  it — and salt priming text per arm, per the G1 confound)
+- the corpus and planted-fact generation
+- programmatic lookup / citation / page-identity scoring
+- the **blinded** pairwise holistic judge plus the scrubber, which the managed
+  path cannot do
+- the statistics and the stopping rule
+
+**Net effect:** this removes roughly a third of the build — the judging
+infrastructure, tool-trajectory scoring, and result plumbing — and leaves the
+experimental design, which is the part that was always going to need care. It
+also converts one open spec question ("who writes the judges?") into a
+configuration choice.
+
+**What it does not change:** the harness is still a prerequisite for #833 PR-2,
+#833 PR-4, #835 v2, and #836 PRs 1–4, and it still needs an owner. It is now a
+smaller job than the specs assumed.
+
+---
+
+## 4. Follow-ups this spike opens
+
+1. **The three eval spec sections should be amended** to name the hybrid split
+   — otherwise the next reader re-derives it, or worse, designs the blinded
+   judge on top of a service that cannot blind.
+2. **`Builtin.Faithfulness` is worth a second look for the offload work
+   specifically.** It scores whether a response is supported by provided
+   context — which is close to the exact question "did the digest lose
+   something the document had". Not in any spec today; may be a better primary
+   than a hand-rolled rubric for the holistic family.
+3. **Online evaluation configs** (`CreateOnlineEvaluationConfig`) went
+   unexamined here. If they sample live traffic continuously, that is a
+   candidate for the "standing verification in prod" the spiral spec asks for
+   in §4.4 — but it points a managed evaluator at real user conversations, so
+   read §2's scoping note first.

--- a/docs/specs/compaction-over-threshold-cache-spiral.md
+++ b/docs/specs/compaction-over-threshold-cache-spiral.md
@@ -515,6 +515,19 @@ write volume to ≤ (prefix − previous cached prefix) + delta.
 
 ### 4.3 Quality gate — PR-2 and PR-4 change model-visible context (veto)
 
+> **Amended 2026-08-12 — build on AgentCore Evaluations, not from scratch.**
+> The harness this section describes is shared with #835 §8 and #836 eval §2,
+> and a spike (`agentcore-evaluations-spike-findings.md`) found the managed
+> `bedrock-agentcore` evaluation service supplies a usable third of it —
+> verified working end to end against dev-ai on our existing pin, with no
+> infrastructure. For **this** section specifically: `Builtin.GoalSuccessRate`
+> and `Builtin.InstructionFollowing` map onto the constraint-retention and
+> revision-continuity families below, and the trajectory matchers score tool
+> use exactly. **What must still be built by hand:** the paired arms, the k=3
+> replication, the planted-constraint corpus, and the statistics. See the
+> spike's §3 for the split, and its §2 for the one requirement the managed
+> path cannot meet — blinding.
+
 PR-2 replaces a 40k-token verbatim edit log with an ≤8k re-summary; PR-4
 freezes memory retrievals for a visit. Both are context *reductions* in
 exactly the workload where continuity matters most (a user iterating on one

--- a/docs/specs/compaction-v2-versioned-prefix.md
+++ b/docs/specs/compaction-v2-versioned-prefix.md
@@ -247,6 +247,15 @@ future compaction change ("does this mutation own its inputs?").
 
 ## 8. Evaluation
 
+> **Amended 2026-08-12.** The quality-veto harness referenced here is now
+> partly off-the-shelf: `agentcore-evaluations-spike-findings.md` verified that
+> the managed `bedrock-agentcore` evaluation service supplies the judges,
+> tool-trajectory scoring and result plumbing on our existing pin, with no
+> infrastructure. The paired arms, corpus and statistics remain ours, and the
+> **blinded** holistic judge cannot run through the managed path at all (spike
+> §2). This does not change what v2 must prove — only how much of the
+> instrument has to be written.
+
 Reuses the spiral spec's §4 machinery wholesale: arm-separated cost
 attribution (v1-triaged vs. v2 as a new arm B4 on the same `partial_miss`
 instrument and replay harness) and the **quality-veto** long-session eval

--- a/docs/specs/document-offload-evaluation.md
+++ b/docs/specs/document-offload-evaluation.md
@@ -45,6 +45,24 @@ definition of "full fidelity" from this probe, and the offload spec's
 
 ## 2. Answer quality
 
+> **Amended 2026-08-12 — what to build vs. what to adopt.** This section is the
+> base design for the harness shared with #833 §4.3 and #835 §8. A spike
+> (`agentcore-evaluations-spike-findings.md`) verified against dev-ai that the
+> managed `bedrock-agentcore` evaluation service — available on our existing
+> pin, authorized, no infrastructure — supplies a usable third of it. Read the
+> spike's §3 before writing a runner. The split, for this section:
+>
+> - **Adopt:** the tool-trajectory families (`Builtin.TrajectoryInOrderMatch`,
+>   `Builtin.ToolSelectionAccuracy`, `Builtin.ToolParameterAccuracy`) score the
+>   `document_read` health band in §3.1 directly and for free. Consider
+>   `Builtin.Faithfulness` — "is the response supported by the provided
+>   context" is close to this spec's actual question, *did the digest lose
+>   something the document had* — as a candidate primary for the holistic
+>   family, or at minimum as the second judge §2.4 asks for on the 20% sample.
+> - **Build:** the arms, the k=3 replication, the corpus and planted facts, the
+>   programmatic lookup/citation scoring, the statistics — and the blinded
+>   holistic judge, for the reason in §2.4.
+
 ### 2.1 Critique of the spec's ~30-task design, and what replaces it
 
 The shape (holistic / lookup / citation) is right and maps onto the failure
@@ -128,6 +146,16 @@ documents since >100k-token peaks are 4× more common in attachment sessions):
   transcripts to *final answer text only* before judging, and a scrubber must
   verify no digest/tool artifacts survive (grep for the digest tag and tool
   names; reject the sample into manual review if found).
+
+  ⚠️ **This requirement rules the managed evaluation service out for the
+  holistic judge — structurally, not as a gap to work around** (added
+  2026-08-12). AgentCore Evaluations works by handing the evaluator the whole
+  collected span set; content-in-spans *is* the mechanism, and there is no
+  scrubbing seam between collection and judging. The blinded pairwise judge
+  must therefore be ours, over scrubbed final-answer text. Everything else in
+  §2 can go through the service. Do not design around a `ReferenceInputs`
+  field or a custom evaluator to recover blinding — the transcript reaches the
+  judge regardless of what ground truth is attached.
 - **Consistency checks:** (1) each pair judged in both orders — an
   order-flipped verdict is recorded as a tie; (2) a second judge model on a
   20 % sample, report inter-judge agreement; (3) human (Phil or delegate)


### PR DESCRIPTION
The quality-veto eval harness is described by three specs (#833 §4.3, #835 §8, #836 eval §2) and blocked on an owner. Two things about it were undecided **in writing**: how much of it we actually have to build, and whether it is an internal instrument or the seed of an admin feature. This PR settles both.

## The spike

`docs/specs/agentcore-evaluations-spike-findings.md` — run against dev-ai, not read from docs.

`bedrock_agentcore.evaluation` has been in our pin since ≥1.9.1 and no spec mentions it. It is live and authorized in dev-ai (not preview-gated), exposes **16 built-in evaluators**, and works end to end **today, unmodified** — a real `Evaluate` call against a live dev conversation collected 272 spans and returned scored results whose explanations quote the actual conversation. Custom evaluators come as managed `llmAsAJudge` (no infrastructure) or Lambda-backed `codeBased`.

**Verdict: hybrid.** It supplies ~a third of the harness — the judges, tool-trajectory scoring, result plumbing. The arms, corpus, planted facts, statistics and one judge stay ours.

Two findings worth the write-up:

- **Content does not travel as span events.** `aws/spans` holds 117 MB in dev and *not one* span carries message content; a 7-day query for any span with a non-empty `events` array returns zero rows. Reading only that leads to the wrong conclusion that content capture is off and needs an `OTEL_SEMCONV_STABILITY_OPT_IN` fix. It isn't broken — content arrives as **OTLP log records** in the *runtime* log group, which the collector queries as a second source and unions in.
- **Blinding cannot be done through the managed path — structurally.** The offload eval requires stripping transcripts to final-answer text before judging (arm C gives itself away with `document_read` calls and digest blocks). AgentCore Evaluations hands the evaluator the whole span set; content-in-spans *is* the mechanism, so there is no scrubbing seam. Called out in §2.4 explicitly so nobody designs around a `ReferenceInputs` field trying to recover it.

## The scope decision

Recorded in the roadmap's shared-assets section: **internal instrument, no admin feature.** Nothing in the three specs ever proposed one — the scope was simply never written down, which is how it drifts. The corpus and canaries are built around document offload and compaction specifically and do not generalize.

One deliberate exception: the **arm runner sits on the headless run primitive** (`agentic-platform-primitives.md` F1), the only seam a future admin feature would reuse. No corpus generality, config surface, or result storage now.

Admin-facing regression checks are **deferred, not declined** — agent version snapshots shipped and managed judges need zero infrastructure, which made the feature materially cheaper in the last week. Size it against the marketplace roadmap, not by folding it into this arc, which would delay four PRs with measured dollars behind them.

## Changes

- **new** `docs/specs/agentcore-evaluations-spike-findings.md`
- `docs/one-pagers/cost-effectiveness-roadmap.md` — scope decision + deferred-feature note in shared assets; ledger row now records the harness is smaller than the specs assumed; spike added to companion specs
- `docs/specs/compaction-over-threshold-cache-spiral.md` §4.3, `compaction-v2-versioned-prefix.md` §8, `document-offload-evaluation.md` §2 / §2.4 — amended to name the hybrid split

Docs only; no code, no infra, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)