### PR TITLE
fix(chat): stop dropped SSE streams from bricking the next message

### DIFF
--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -15,6 +15,7 @@ access token — to inference-api, which accepts Cognito Bearer tokens via
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -40,6 +41,28 @@ def _inference_api_url() -> str:
 # Long enough to cover a full agent turn (model + tool calls), bounded so a
 # wedged upstream eventually surfaces.
 _PROXY_TIMEOUT_SECONDS = 300.0
+
+# SSE keepalive cadence. Two hops in front of this response cut an idle
+# connection at 60s — CloudFront's `OriginReadTimeout` and the ALB's
+# `idle_timeout` — while an agent turn can legitimately go quiet for longer
+# than that whenever a slow tool runs (code interpreter, a burst of MCP calls)
+# with nothing to stream. The browser then reports a network error, the
+# half-finished turn is marked `connection_lost`, and the user's resend races
+# the session lease. A comment line is the SSE no-op: a line beginning with
+# ':' carries no field, so it puts bytes on the wire — resetting both idle
+# timers — without reaching the SPA's event parser.
+#
+# Exactly ONE trailing newline, deliberately. A blank line is what *dispatches*
+# an event, and `@microsoft/fetch-event-source` dispatches on it unconditionally
+# rather than suppressing empty messages the way the SSE spec allows — so
+# `":…\n\n"` would deliver a phantom event with no name to `parseEventSourceMessage`.
+#
+# Emitted here rather than on inference-api for two reasons: both timeouts sit
+# downstream of app-api, and interposing a task on the agent stream would
+# change how client cancellation reaches that turn's interruption handling.
+# 20s leaves room for two lost frames inside a 60s window.
+_SSE_KEEPALIVE_SECONDS = 20.0
+_SSE_KEEPALIVE_FRAME = b": keepalive\n"
 
 # Canonical `/invocations` URL resolution lives in the shared harness
 # (`apis.shared.harness.runner.build_invocations_url`) — the headless
@@ -165,10 +188,44 @@ async def chat_stream(
     content_type = response.headers.get("content-type", "")
     if "text/event-stream" in content_type:
         async def stream_relay():
+            # Upstream reads run on their own task so a silent turn can be
+            # distinguished from a finished one: on timeout the read stays
+            # pending (shielded from `wait_for`'s cancellation) and is awaited
+            # again next pass, while we slip a keepalive onto the wire.
+            chunks = response.aiter_bytes()
+            pending: Optional[asyncio.Future] = None
+            # These are raw transport chunks, not parsed frames, so a chunk can
+            # end mid-frame; injecting there would corrupt it (`data: {"text":`
+            # + `: keepalive` reads as one field). Only inject once the bytes
+            # already forwarded end a frame. A stall *inside* a frame therefore
+            # goes uncovered — acceptable, since a frame is written upstream in
+            # one go, and this is never worse than sending nothing at all.
+            at_frame_boundary = True
             try:
-                async for chunk in response.aiter_bytes():
+                while True:
+                    if pending is None:
+                        pending = asyncio.ensure_future(chunks.__anext__())
+                    try:
+                        chunk = await asyncio.wait_for(
+                            asyncio.shield(pending), timeout=_SSE_KEEPALIVE_SECONDS
+                        )
+                    except asyncio.TimeoutError:
+                        if at_frame_boundary:
+                            yield _SSE_KEEPALIVE_FRAME
+                        # Deliberately keep `pending`. A chunk that lands in
+                        # the same tick as the timeout is already sitting in
+                        # that future; dropping it here to start a fresh read
+                        # would silently swallow an SSE frame.
+                        continue
+                    except StopAsyncIteration:
+                        pending = None
+                        return
+                    pending = None  # consumed — safe to read the next one
                     yield chunk
+                    at_frame_boundary = chunk.endswith(b"\n\n")
             finally:
+                if pending is not None:
+                    pending.cancel()
                 await response.aclose()
                 await client.aclose()
 

--- a/backend/src/apis/app_api/chat/proxy_routes.py
+++ b/backend/src/apis/app_api/chat/proxy_routes.py
@@ -22,7 +22,7 @@ import os
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
@@ -70,6 +70,51 @@ _SSE_KEEPALIVE_FRAME = b": keepalive\n"
 # under the historical private name so existing call sites and docstring
 # references stay valid.
 _build_invocations_url = build_invocations_url
+
+
+# Copy the SPA renders under its "Already responding" notice. Sent in place of
+# the Runtime's opaque 424 body, which carries no usable explanation once the
+# container's own 409 detail has been swallowed by the rewrite.
+_SESSION_BUSY_DETAIL = (
+    "A response is already streaming for this conversation. "
+    "Wait for it to finish before sending another message."
+)
+
+
+async def _resolve_upstream_error_status(
+    status_code: int, session_id: Optional[str], user_id: str
+) -> tuple[int, Optional[str]]:
+    """Undo the AgentCore Runtime's 424 rewrite of the single-flight 409.
+
+    The Runtime data plane maps *any* non-2xx from the inference-api container
+    to `424 Failed Dependency`, so the container's deliberate 409 — "a response
+    is already streaming for this conversation" — reaches the SPA as a fatal
+    424 and surfaces as a "Chat Request Failed" toast, instead of the soft
+    "Already responding" notice the SPA already implements for 409.
+
+    A 424 is ambiguous on its own: a genuine container 500 looks identical. So
+    the lease itself is the tiebreaker — re-map only when an unexpired turn
+    lease is actually held for this session, which is the exact fact the
+    container's 409 asserted a moment earlier. Best-effort: anything unproven
+    keeps the 424, so a real upstream failure is never disguised as a conflict.
+
+    Returns the status to relay and, when re-mapped, the detail to relay with
+    it (the Runtime's 424 body no longer explains anything useful).
+    """
+    if status_code != status.HTTP_424_FAILED_DEPENDENCY or not session_id:
+        return status_code, None
+    try:
+        from apis.shared.sessions.session_lease import is_session_lease_held
+
+        if await is_session_lease_held(session_id, user_id):
+            logger.info(
+                "Upstream 424 for a session with a live turn lease — "
+                "relaying as 409 (single-flight conflict)"
+            )
+            return status.HTTP_409_CONFLICT, _SESSION_BUSY_DETAIL
+    except Exception:  # noqa: BLE001 - explanatory lookup only, never fatal
+        logger.debug("Could not check session lease for 424 mapping", exc_info=True)
+    return status_code, None
 
 
 def _build_upstream_client() -> httpx.AsyncClient:
@@ -180,9 +225,16 @@ async def chat_stream(
         finally:
             await response.aclose()
             await client.aclose()
+        relay_status, relay_detail = await _resolve_upstream_error_status(
+            response.status_code, session_id, current_user.user_id
+        )
         raise HTTPException(
-            status_code=response.status_code,
-            detail=error_body.decode("utf-8", errors="replace"),
+            status_code=relay_status,
+            detail=(
+                relay_detail
+                if relay_detail is not None
+                else error_body.decode("utf-8", errors="replace")
+            ),
         )
 
     content_type = response.headers.get("content-type", "")

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -149,6 +149,43 @@ async def _lease_heartbeat_loop(lease, agent) -> None:
             return
 
 
+async def _release_turn_lease(heartbeat_task, lease) -> None:
+    """End the turn's lease heartbeat and release the lease. Cancellation-proof.
+
+    This runs from a stream generator's ``finally``, and the case that matters
+    is the one where cancellation is what *put us here*: on a client
+    disconnect the whole request task is being torn down, so a bare ``await``
+    in that ``finally`` is itself cancelled at the first suspension point and
+    the release never lands. The lease then survives for the rest of its 90s
+    window, and the user's resend is rejected as a duplicate turn — a 409 that
+    the AgentCore Runtime rewrites to 424 and the SPA shows as "Chat Request
+    Failed", seconds after the dropped stream already showed them a network
+    error.
+
+    Same hazard and same remedy as ``_persist_interruption`` in the stream
+    coordinator: do the work on an independent task and shield the wait on it,
+    so the release completes even when our wait for it does not.
+    """
+    async def _do() -> None:
+        if heartbeat_task is not None:
+            heartbeat_task.cancel()
+            # Await the cancelled task so its CancelledError is retrieved
+            # (never re-raised) before the lease is released.
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
+        from apis.shared.sessions.session_lease import release_session_lease
+
+        await release_session_lease(lease)
+
+    try:
+        await asyncio.shield(asyncio.ensure_future(_do()))
+    except asyncio.CancelledError:
+        # The shield was cancelled from outside while _do() ran; the inner
+        # task finishes on its own. Swallowing here cannot suppress whatever
+        # unwound the stream — that exception is still in flight and resumes
+        # propagating once this `finally` returns.
+        logger.debug("lease-release shield cancelled; inner release continues")
+
+
 def is_preview_session(session_id: str) -> bool:
     """Check if a session ID is a preview session (should skip persistence).
 
@@ -2325,13 +2362,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 async for chunk in stream_with_quota_warning():
                     yield chunk
             finally:
-                if heartbeat_task is not None:
-                    heartbeat_task.cancel()
-                    # Await the cancelled task so its CancelledError is retrieved
-                    # (never re-raised) before the lease is released.
-                    await asyncio.gather(heartbeat_task, return_exceptions=True)
-                from apis.shared.sessions.session_lease import release_session_lease
-                await release_session_lease(session_lease)
+                await _release_turn_lease(heartbeat_task, session_lease)
 
         # Stream response from agent as SSE (with optional files)
         # Note: Compression is handled by GZipMiddleware if configured in main.py

--- a/backend/src/apis/shared/sessions/session_lease.py
+++ b/backend/src/apis/shared/sessions/session_lease.py
@@ -257,6 +257,44 @@ async def release_session_lease(lease: Optional[SessionLease]) -> None:
         logger.warning("Session lease release failed for %s: %s", lease.session_id, e)
 
 
+async def is_session_lease_held(session_id: str, user_id: str) -> bool:
+    """Report whether an unexpired turn lease exists for this session.
+
+    Read-only mirror of ``acquire_session_lease``'s condition, for a caller
+    that has to *explain* a rejection it did not raise itself. The AgentCore
+    Runtime data plane rewrites every non-2xx from the container into a
+    ``424 Failed Dependency``, so app-api's chat proxy cannot tell the
+    single-flight ``409`` apart from a container crash by status alone; this
+    is the tiebreaker, asserting the same fact the container's 409 asserted.
+
+    Best-effort in the safe direction: an unconfigured table or any DynamoDB
+    error returns ``False``. A caller must never invent a conflict the guard
+    itself would not have raised.
+    """
+    table = _table()
+    if table is None:
+        return False
+
+    from botocore.exceptions import ClientError
+
+    try:
+        resp = table.get_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"LEASE#{session_id}"}
+        )
+    except ClientError as e:
+        logger.warning("Session lease lookup failed for %s: %s", session_id, e)
+        return False
+
+    item = resp.get("Item") or {}
+    expires_at = item.get("leaseExpiresAt")
+    if expires_at is None:
+        return False
+    try:
+        return int(expires_at) > int(time.time())
+    except (TypeError, ValueError):
+        return False
+
+
 async def request_session_cancel(session_id: str, user_id: str) -> bool:
     """Ask the turn currently holding this session's lease to stop.
 

--- a/backend/tests/apis/app_api/chat/test_proxy_routes.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes.py
@@ -374,3 +374,112 @@ def test_returns_502_on_unexpected_upstream_error(
 
     response = TestClient(app).post(chat_path, json={"message": "hi"})
     assert response.status_code == 502
+
+
+# ── AgentCore's 424 rewrite of the single-flight 409 ──────────────────────
+#
+# The Runtime data plane maps every non-2xx from the container to `424 Failed
+# Dependency`, so the container's deliberate 409 arrives indistinguishable
+# from a crash. The lease is the tiebreaker.
+
+
+def _patch_lease_held(monkeypatch: pytest.MonkeyPatch, held: bool) -> None:
+    import apis.shared.sessions.session_lease as session_lease
+
+    async def _is_held(session_id: str, user_id: str) -> bool:
+        assert session_id == "conv-1"
+        assert user_id == "user-sub"
+        return held
+
+    monkeypatch.setattr(session_lease, "is_session_lease_held", _is_held)
+
+
+def _upstream_424(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(424, content=b'{"message": "Failed Dependency"}')
+
+    _patch_upstream(monkeypatch, handler)
+
+
+def test_424_with_live_lease_relays_as_409(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
+    _upstream_424(monkeypatch)
+    _patch_lease_held(monkeypatch, True)
+    app = _build_app(record=_record(), user_override=_user())
+
+    response = TestClient(app).post(
+        chat_path, json={"message": "hi", "session_id": "conv-1"}
+    )
+
+    # 409 is the status the SPA renders as a soft "Already responding" notice;
+    # a relayed 424 surfaces as a fatal "Chat Request Failed" toast instead.
+    assert response.status_code == 409
+    # The Runtime's opaque body is replaced — it explains nothing to the user.
+    assert "already streaming" in response.json()["detail"]
+
+
+def test_424_without_a_lease_stays_424(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
+    _upstream_424(monkeypatch)
+    _patch_lease_held(monkeypatch, False)
+    app = _build_app(record=_record(), user_override=_user())
+
+    response = TestClient(app).post(
+        chat_path, json={"message": "hi", "session_id": "conv-1"}
+    )
+
+    # No lease means no turn is streaming, so the 424 is a real upstream
+    # failure and must not be disguised as a benign conflict.
+    assert response.status_code == 424
+    assert "Failed Dependency" in response.text
+
+
+def test_424_without_a_session_id_stays_424(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
+    _upstream_424(monkeypatch)
+    app = _build_app(record=_record(), user_override=_user())
+
+    response = TestClient(app).post(chat_path, json={"message": "hi"})
+    assert response.status_code == 424
+
+
+def test_424_keeps_its_status_when_the_lease_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
+    import apis.shared.sessions.session_lease as session_lease
+
+    async def _boom(session_id: str, user_id: str) -> bool:
+        raise RuntimeError("DynamoDB unavailable")
+
+    _upstream_424(monkeypatch)
+    monkeypatch.setattr(session_lease, "is_session_lease_held", _boom)
+    app = _build_app(record=_record(), user_override=_user())
+
+    response = TestClient(app).post(
+        chat_path, json={"message": "hi", "session_id": "conv-1"}
+    )
+    assert response.status_code == 424
+
+
+def test_non_424_errors_skip_the_lease_lookup(
+    monkeypatch: pytest.MonkeyPatch, chat_path: str
+) -> None:
+    import apis.shared.sessions.session_lease as session_lease
+
+    async def _must_not_run(session_id: str, user_id: str) -> bool:
+        raise AssertionError("lease lookup is 424-only")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b"boom")
+
+    _patch_upstream(monkeypatch, handler)
+    monkeypatch.setattr(session_lease, "is_session_lease_held", _must_not_run)
+    app = _build_app(record=_record(), user_override=_user())
+
+    response = TestClient(app).post(
+        chat_path, json={"message": "hi", "session_id": "conv-1"}
+    )
+    assert response.status_code == 500

--- a/backend/tests/apis/app_api/chat/test_proxy_routes_streaming.py
+++ b/backend/tests/apis/app_api/chat/test_proxy_routes_streaming.py
@@ -169,3 +169,163 @@ async def test_ttfb_under_200ms_with_x_accel_buffering(
     )
     assert b"oauth_required" in body
     assert b"event: done" in body
+    # A stream that never goes quiet longer than the keepalive interval must
+    # not be padded — keepalives are for silence, not for every gap.
+    assert b": keepalive" not in body
+
+
+@pytest.mark.asyncio
+async def test_silent_upstream_gets_keepalive_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn that goes quiet mid-stream keeps its connection warm.
+
+    CloudFront's `OriginReadTimeout` and the ALB's `idle_timeout` both cut an
+    idle connection at 60s, and an agent turn legitimately goes silent for
+    longer while a slow tool runs — the browser then reports a network error
+    and the half-finished turn is marked `connection_lost`. Comment frames
+    reset both timers; the SSE spec says the client ignores them, so no
+    `event:` reaches the SPA's parser that the upstream didn't send.
+    """
+    gap = 0.4
+
+    async def quiet_then_finish():
+        yield b'event: message_start\ndata: {"role": "assistant"}\n\n'
+        await asyncio.sleep(gap)  # a long tool call with nothing to stream
+        yield b"event: done\ndata: {}\n\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=quiet_then_finish(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        proxy_routes,
+        "_build_upstream_client",
+        lambda: httpx.AsyncClient(transport=transport),
+    )
+    monkeypatch.setattr(proxy_routes, "_SSE_KEEPALIVE_SECONDS", 0.1)
+
+    app = _build_app()
+    with _UvicornInThread(app) as server:
+        async with httpx.AsyncClient(base_url=server.url, timeout=10.0) as client:
+            async with client.stream(
+                "POST", "/chat/stream", json={"message": "hi"}
+            ) as response:
+                assert response.status_code == 200
+                body = b"".join([c async for c in response.aiter_bytes()])
+
+    # Several intervals fit inside the gap, so the silence is covered rather
+    # than merely interrupted once.
+    assert body.count(b": keepalive\n") >= 2
+    # Exactly one newline: a blank line is what dispatches an event, and
+    # fetch-event-source dispatches on it unconditionally — a `":…\n\n"` frame
+    # would deliver a phantom nameless event to the SPA's parser.
+    assert b": keepalive\n\n" not in body
+    # The real events still arrive, in order, unmodified.
+    assert body.index(b"event: message_start") < body.index(b"event: done")
+    assert b'data: {"role": "assistant"}' in body
+
+
+@pytest.mark.asyncio
+async def test_keepalive_is_never_injected_mid_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A keepalive spliced into a half-sent frame would corrupt it.
+
+    `aiter_bytes` yields transport chunks, not parsed frames, so a chunk can
+    end mid-frame. Injecting a comment there merges into the open field:
+    `data: {"text":` + `: keepalive` parses as one line.
+    """
+
+    async def stall_mid_frame():
+        yield b'event: message_start\ndata: {"role": "assistant"}\n\n'
+        yield b'event: content_block_delta\ndata: {"text": '  # frame left open
+        await asyncio.sleep(0.4)
+        yield b'"hi"}\n\n'
+        yield b"event: done\ndata: {}\n\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=stall_mid_frame(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        proxy_routes,
+        "_build_upstream_client",
+        lambda: httpx.AsyncClient(transport=transport),
+    )
+    monkeypatch.setattr(proxy_routes, "_SSE_KEEPALIVE_SECONDS", 0.1)
+
+    app = _build_app()
+    with _UvicornInThread(app) as server:
+        async with httpx.AsyncClient(base_url=server.url, timeout=10.0) as client:
+            async with client.stream(
+                "POST", "/chat/stream", json={"message": "hi"}
+            ) as response:
+                body = b"".join([c async for c in response.aiter_bytes()])
+
+    assert b": keepalive" not in body
+    # The frame that was open across the stall arrives intact.
+    assert b'event: content_block_delta\ndata: {"text": "hi"}\n\n' in body
+    assert b"event: done" in body
+
+
+@pytest.mark.asyncio
+async def test_frames_survive_repeated_keepalive_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No frame may be dropped by the timeout/re-await cycle.
+
+    The upstream read is a future the relay re-awaits across timeouts. An
+    earlier version abandoned that future whenever it happened to be resolved
+    at timeout time, silently swallowing the frame it held — a missing SSE
+    event with nothing logged anywhere.
+
+    Chunks are paced at exactly the keepalive interval so every read is
+    contended with its own timeout. Be honest about what this buys: the losing
+    interleaving is timing-dependent and this does NOT reproduce it on demand
+    (it passed 10/10 against the buggy relay in isolation; the bug showed as a
+    ~1-in-8 flake only under the scheduling pressure of a larger run). It is a
+    guard on the invariant, not a deterministic reproducer.
+    """
+    interval = 0.05
+    n_chunks = 12
+
+    async def paced():
+        yield b'event: message_start\ndata: {"role": "assistant"}\n\n'
+        for i in range(n_chunks):
+            await asyncio.sleep(interval)
+            yield b'event: content_block_delta\ndata: {"i": %d}\n\n' % i
+        yield b"event: done\ndata: {}\n\n"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=paced(), headers={"content-type": "text/event-stream"}
+        )
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        proxy_routes,
+        "_build_upstream_client",
+        lambda: httpx.AsyncClient(transport=transport),
+    )
+    monkeypatch.setattr(proxy_routes, "_SSE_KEEPALIVE_SECONDS", interval)
+
+    app = _build_app()
+    with _UvicornInThread(app) as server:
+        async with httpx.AsyncClient(base_url=server.url, timeout=10.0) as client:
+            async with client.stream(
+                "POST", "/chat/stream", json={"message": "hi"}
+            ) as response:
+                body = b"".join([c async for c in response.aiter_bytes()])
+
+    missing = [i for i in range(n_chunks) if b'{"i": %d}' % i not in body]
+    assert not missing, f"relay dropped chunk(s) {missing} on the keepalive tick"
+    assert b"event: done" in body

--- a/backend/tests/apis/inference_api/test_turn_lease_release.py
+++ b/backend/tests/apis/inference_api/test_turn_lease_release.py
@@ -1,0 +1,163 @@
+"""Turn-lease teardown survives the cancellation that triggers it.
+
+`_release_turn_lease` runs from the SSE stream generator's `finally`, and the
+case it exists for is the one where cancellation is what put it there: the
+browser's connection drops and Starlette tears the response down. A bare
+`await` in that `finally` never completes, so the release is abandoned — the
+lease then survives its full 90s window and the user's resend is rejected as a
+duplicate turn (409 → the Runtime's 424 rewrite → "Chat Request Failed"),
+seconds after the dropped stream already showed them a network error.
+
+The mechanism is specifically **anyio cancel scopes**, which is what Starlette
+cancels a disconnected `StreamingResponse` with. Unlike a one-shot
+`task.cancel()` — which lets a `finally` run its awaits to completion — an
+anyio scope is level-triggered: while it is cancelled, *every* checkpoint
+inside it raises `CancelledError`, including the ones in cleanup code. Tests
+that cancel a bare asyncio task therefore pass with or without the fix and
+prove nothing; these use a real cancel scope.
+
+Observed in prod-ai 2026-08-13: session 938a1e68 acquired a lease at 14:28:44,
+was interrupted (`reason=connection_lost`) at 14:30:15 with no release ever
+logged, and its resend at 14:31:16 was rejected. Twice in twelve minutes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import anyio
+import pytest
+
+import apis.shared.sessions.session_lease as session_lease_module
+from apis.inference_api.chat.routes import _release_turn_lease
+from apis.shared.sessions.session_lease import SessionLease
+
+
+def _lease() -> SessionLease:
+    return SessionLease(session_id="s1", user_id="u1", owner="owner-token")
+
+
+@pytest.fixture
+def released(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Record released leases, with a real suspension point in the release.
+
+    The suspension is the whole point: DynamoDB's round-trip is where a
+    cancelled `finally` abandons the work.
+    """
+    seen: list = []
+
+    async def _release(lease) -> None:
+        await asyncio.sleep(0.01)
+        seen.append(lease)
+
+    monkeypatch.setattr(session_lease_module, "release_session_lease", _release)
+    return seen
+
+
+async def _stream_dropped_mid_turn(lease, heartbeat_task=None) -> None:
+    """Reproduce a client disconnect the way Starlette delivers one: cancel the
+    surrounding anyio scope while the stream generator is suspended, so the
+    generator's `finally` runs inside an already-cancelled scope."""
+    with anyio.CancelScope() as scope:
+
+        async def stream():
+            try:
+                while True:
+                    yield "chunk"
+                    scope.cancel()  # the browser goes away
+                    await anyio.sleep(0.01)  # raises CancelledError here
+            finally:
+                await _release_turn_lease(heartbeat_task, lease)
+
+        async for _ in stream():
+            pass
+
+
+class TestReleaseUnderClientDisconnect:
+    @pytest.mark.asyncio
+    async def test_lease_is_released_when_the_connection_drops(self, released):
+        lease = _lease()
+        await _stream_dropped_mid_turn(lease)
+
+        # The shielded release runs on its own task, outside the cancelled
+        # scope — give the loop a beat to finish it.
+        await asyncio.sleep(0.05)
+        assert released == [lease], (
+            "lease was not released on a dropped stream — the user's resend "
+            "will be rejected as a duplicate turn"
+        )
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_is_stopped_before_release(self, released):
+        """A surviving heartbeat would keep renewing the lease we just freed."""
+        started = asyncio.Event()
+
+        async def _heartbeat() -> None:
+            started.set()
+            while True:
+                await asyncio.sleep(0.01)
+
+        heartbeat_task = asyncio.create_task(_heartbeat())
+        await started.wait()
+
+        lease = _lease()
+        await _stream_dropped_mid_turn(lease, heartbeat_task)
+        await asyncio.sleep(0.05)
+
+        assert heartbeat_task.cancelled()
+        assert released == [lease]
+
+
+class TestReleaseUnderTaskCancellation:
+    @pytest.mark.asyncio
+    async def test_cancellation_still_propagates(self, released):
+        """Swallowing CancelledError in the teardown must not swallow the
+        cancellation that unwound the stream — the coordinator's interruption
+        arm and Starlette's teardown both depend on it propagating."""
+        lease = _lease()
+
+        async def consume():
+            async def stream():
+                try:
+                    while True:
+                        yield "chunk"
+                        await asyncio.sleep(0.01)
+                finally:
+                    await _release_turn_lease(None, lease)
+
+            async for _ in stream():
+                pass
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.03)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        await asyncio.sleep(0.05)
+        assert released == [lease]
+
+
+class TestReleaseOnNormalCompletion:
+    @pytest.mark.asyncio
+    async def test_lease_is_released_when_the_stream_ends_normally(self, released):
+        lease = _lease()
+
+        async def stream():
+            try:
+                yield "chunk"
+            finally:
+                await _release_turn_lease(None, lease)
+
+        async for _ in stream():
+            pass
+
+        assert released == [lease]
+
+    @pytest.mark.asyncio
+    async def test_no_lease_is_a_noop(self, released):
+        # Preview sessions and the local no-DynamoDB path never take a lease;
+        # release_session_lease is itself a no-op on None.
+        await _release_turn_lease(None, None)
+        assert released == [None]

--- a/backend/tests/shared/test_session_lease.py
+++ b/backend/tests/shared/test_session_lease.py
@@ -17,6 +17,7 @@ from apis.shared.sessions.session_lease import (
     SessionBusyError,
     SessionLease,
     acquire_session_lease,
+    is_session_lease_held,
     release_session_lease,
     renew_session_lease,
     request_session_cancel,
@@ -163,6 +164,52 @@ class TestRelease:
     @pytest.mark.asyncio
     async def test_release_none_is_noop(self, sessions_metadata_table):
         await release_session_lease(None)  # must not raise
+
+
+class TestIsHeld:
+    """The read-only probe app-api uses to explain a Runtime 424 rewrite."""
+
+    @pytest.mark.asyncio
+    async def test_reports_held_while_a_turn_owns_the_lease(
+        self, sessions_metadata_table
+    ):
+        await acquire_session_lease("s1", "u1")
+        assert await is_session_lease_held("s1", "u1") is True
+
+    @pytest.mark.asyncio
+    async def test_reports_free_when_no_lease_exists(self, sessions_metadata_table):
+        assert await is_session_lease_held("s1", "u1") is False
+
+    @pytest.mark.asyncio
+    async def test_reports_free_after_release(self, sessions_metadata_table):
+        lease = await acquire_session_lease("s1", "u1")
+        await release_session_lease(lease)
+        assert await is_session_lease_held("s1", "u1") is False
+
+    @pytest.mark.asyncio
+    async def test_expired_lease_reads_as_free(self, sessions_metadata_table):
+        # Matches acquire's condition: a lapsed lease is not a conflict, so it
+        # must never be reported as one (that would turn a container crash's
+        # 424 into a misleading "already responding" notice).
+        now = int(time.time())
+        sessions_metadata_table.put_item(
+            Item={
+                "PK": "USER#u1",
+                "SK": "LEASE#s1",
+                "leaseOwner": "dead-owner",
+                "leaseExpiresAt": now - 1,
+                "ttl": now + 3600,
+            }
+        )
+        assert await is_session_lease_held("s1", "u1") is False
+
+    @pytest.mark.asyncio
+    async def test_is_scoped_to_the_named_session_and_user(
+        self, sessions_metadata_table
+    ):
+        await acquire_session_lease("s1", "u1")
+        assert await is_session_lease_held("s2", "u1") is False
+        assert await is_session_lease_held("s1", "u2") is False
 
 
 class TestCancel:


### PR DESCRIPTION
## What users saw

A "Network error" mid-response, and then — on resending — **"Chat Request Failed"**. Reported in prod against boisestate.ai.

It's one causal chain, not two bugs:

1. The SSE stream to the browser drops mid-turn → the container marks the turn `interrupted_turn … reason=connection_lost`. **That's the "Network error."**
2. The interrupted turn **never released its single-flight session lease**.
3. The user resends ~60s later, the stale lease is still valid (90s window) → the container returns **409**.
4. The AgentCore Runtime rewrites *any* container non-2xx to **424**, so the SPA's existing soft path for 409 ("Already responding") never fires and it shows the fatal **"Chat Request Failed"** toast.

From the runtime log, session `938a1e68`, twice in twelve minutes:

```
14:28:44  Acquired session lease for 938a1e68… (owner=d893fdab…)
14:30:15  Interruption for session 938a1e68… (reason=connection_lost)
          ← no "Released session lease" ever logged
14:31:16  Rejected duplicate concurrent invocation for session 938a1e68… (409)
```

Over 24h: **433 lease acquires, 413 releases** — the 20 leaked leases exactly account for 20 × 409, matching the 19 × 424 app-api logged.

## The three commits

**1. Release the turn lease when a dropped stream cancels teardown.** The release sat behind an `await` in the stream generator's `finally`. Starlette cancels a disconnected `StreamingResponse` with an **anyio cancel scope**, which is level-triggered — while cancelled, *every* checkpoint inside it raises, cleanup included. So the case that ran the `finally` was the case that guaranteed it never finished. Shielded, same idiom `_persist_interruption` already uses.

> A regression test that cancels a plain asyncio task **passes with and without the fix** — `task.cancel()` is one-shot and lets a `finally` run its awaits to completion. The test here uses a real `anyio.CancelScope`; mutation-checked, it fails 2/5 against the unfixed code.

**2. SSE keepalive.** CloudFront's `OriginReadTimeout` and the ALB's `idle_timeout` are both **60s**, with no keepalive anywhere in the chat path. Of 47 dropped turns measured over 5 days, **11 died in a 62–67s band** — that spike is the 60s cut.

**3. Relay the 424 back to 409.** Translated in the proxy, not the SPA, because a 424 is genuinely ambiguous — a container crash looks identical. The lease is the tiebreaker (`is_session_lease_held`), so the re-map only fires when a turn really is streaming; anything unproven keeps the 424.

## How it was introduced

Drops went from **0/day** (07-30 → 08-02) to **5–13/day** from 08-03. The instrumentation predates that by a month, so those zeros are real.

Release 1.13.0 shipped that night and armed the AgentCore idle reaper — tempting, but **the obvious mechanism is disproven**: dropped turns start on containers of median age **1060s** vs **1001s** for turns that completed, and **0%** of the 60s-band drops were cold starts. What did change on 08-03 is brave-search usage, up ~5x. Best-supported reading: **a workload change, not a code change** — the timeouts and the missing keepalive were always there, and heavy MCP turns exposed them. Not proven; day-by-day brave volume doesn't track drops tightly.

## Note for reviewers

Writing the keepalive tests surfaced a **data-loss race in the relay itself**: a chunk resolving in the same tick as the keepalive timeout was discarded when the read restarted. In prod that would have been an SSE event that simply never arrived, with nothing logged. Fixed by keeping the pending read across a timeout. Buggy: 1 failure in 8 runs. Fixed: **0 in 34**.

The frame is `": keepalive\n"` — one newline. A blank line is what *dispatches* an event, and `@microsoft/fetch-event-source` dispatches on it unconditionally rather than suppressing empty messages the way the SSE spec allows, so `":…\n\n"` would push a phantom nameless event into the SPA's parser on every keepalive.

## Testing

- `2581 passed` (`tests/apis`, `tests/shared`), `2026 passed` (`tests/routes`, `tests/architecture`, `tests/agents/main_agent`)
- New: 5 lease-release (anyio cancel scope), 5 `is_session_lease_held`, 5 424-mapping, 3 streaming/keepalive

## Not addressed

- ~~app-api stopped shipping logs to CloudWatch.~~ **Retracted — this was my error, not a defect.** app-api's log delivery is healthy: ingestion lag measured over 640 events is p50 **2.3s**, max **5.0s**, and the group is currently ~15s behind live. The "gap" came from my own epoch arithmetic — I queried a window that was in the *future* at the time and read the empty result as an outage. `describe-log-streams`' `lastEventTimestamp` appeared to corroborate it, but that field is eventually consistent by design (AWS: may take up to an hour) and is not a freshness instrument.
- Why the sockets drop in the first place is only explained for the 60s cluster. The short cluster (14 drops at 4–14s) is most likely users stopping or refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

