### PR TITLE
feat: make mid-stream disconnects attributable

### DIFF
--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -647,22 +647,32 @@ async def signal_turn_interrupted_endpoint(
     body: SessionInterruptRequest,
     current_user: User = Depends(get_current_user_from_session),
 ):
-    """Record that the user deliberately stopped the session's in-flight turn.
+    """Record a client-attested reason for the session's turn being interrupted.
 
-    This is the AUTHORITATIVE carrier of stop intent for the interrupted-turn
-    flow: the transport cannot distinguish a Stop click from a dropped socket
-    (both surface as a cancelled stream), so the SPA signals intent here
-    out-of-band when the user clicks Stop — via ``fetch(..., {keepalive:
+    This is the AUTHORITATIVE carrier of client intent for the
+    interrupted-turn flow: the transport cannot distinguish a Stop click from
+    a refresh from a dropped socket (all three surface as a cancelled
+    stream), so the SPA signals out-of-band — via ``fetch(..., {keepalive:
     true})`` with the ``X-CSRF-Token`` header (NOT ``navigator.sendBeacon``,
     which cannot set headers and would be rejected by CSRFMiddleware).
+
+    Two reasons are accepted, and they mean different things:
+
+      * ``user_stopped``   — the Stop button. Deliberate: the user rejected
+        the response in flight, so the turn is cancelled server-side too.
+      * ``navigated_away`` — the page was hidden or unloaded mid-turn. The
+        user left; they did not reject anything. **Recorded only** — the
+        running turn is deliberately left alone, matching today's behaviour
+        where a refresh lets the turn finish server-side and the reload
+        offers to continue it.
 
     Lives on app-api, not inference-api: the AgentCore Runtime data plane
     only proxies ``/invocations`` + ``/ping``, so a custom inference-api
     route would 404 in cloud.
 
-    ``user_stopped`` takes precedence over the ``connection_lost`` fallback
-    that inference-api's cancellation backstop may race against this write
-    (see ``set_interrupted_turn``). No-op for missing sessions — and the GSI
+    Both take precedence over the ``connection_lost`` fallback that
+    inference-api's cancellation backstop may race against this write (see
+    ``set_interrupted_turn``). No-op for missing sessions — and the GSI
     lookup inside ``set_interrupted_turn`` is user-scoped, so a session
     owned by someone else is also a no-op. Returns 204 either way (the
     user's intent is recorded best-effort; the client never waits on it).
@@ -685,11 +695,19 @@ async def signal_turn_interrupted_endpoint(
         # so the user's resend isn't rejected with 409 and stopping wasted
         # model/tool work. Owner-scoped, so a stale Stop can't kill a later
         # turn. Best-effort: never fail the Stop signal on this.
-        try:
-            from apis.shared.sessions.session_lease import request_session_cancel
-            await request_session_cancel(session_id, user_id)
-        except Exception:
-            logger.warning("Failed to arm session cancel on stop", exc_info=True)
+        #
+        # Deliberate Stop ONLY. `navigated_away` is an attribution signal, not
+        # an instruction: cancelling on it would make every refresh kill the
+        # turn it interrupted, discarding work the reload is about to offer to
+        # continue. Leaving the turn running preserves exactly today's
+        # behaviour for a departure — this endpoint's reason set widened, the
+        # side effects did not.
+        if body.reason == "user_stopped":
+            try:
+                from apis.shared.sessions.session_lease import request_session_cancel
+                await request_session_cancel(session_id, user_id)
+            except Exception:
+                logger.warning("Failed to arm session cancel on stop", exc_info=True)
         return Response(status_code=204)
     except Exception:
         logger.error("Error recording turn interruption", exc_info=True)

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -2843,6 +2843,20 @@ async def clear_truncated_turn(session_id: str, user_id: str) -> None:
         logger.error("Failed to clear truncated_turn: %s", e, exc_info=True)
 
 
+# Interrupt-reason precedence, strongest first. Rank = how much the reason
+# actually tells us, which is why the client-attested ones outrank the
+# server's fallback: `connection_lost` is stamped whenever a stream is torn
+# down and nothing said why, so a refresh, a dead socket and a platform-side
+# idle timeout are indistinguishable under it. A reason may only overwrite a
+# same-or-weaker one (see `set_interrupted_turn`).
+_REASON_RANK = {
+    "unknown": 0,
+    "connection_lost": 1,
+    "navigated_away": 2,
+    "user_stopped": 3,
+}
+
+
 async def set_interrupted_turn(
     session_id: str,
     user_id: str,
@@ -2852,22 +2866,34 @@ async def set_interrupted_turn(
     """Mark that the last turn was interrupted before completion.
 
     Interruptions come from two racing sources that write the same session
-    record: the client stop signal (app-api ``POST /sessions/{id}/interrupt``,
-    ``reason="user_stopped"``) and the stream cancellation backstop
-    (inference-api, ``reason="connection_lost"`` fallback). ``user_stopped``
-    is the stronger signal, so a ``user_stopped`` write is unconditional
-    while a fallback write is guarded by a condition so it can never
-    downgrade an already-recorded ``user_stopped`` — whichever source lands
-    first, the final reason is correct. Idempotent. Best-effort: a write
-    failure logs but never breaks the live flow. No-op when the session
-    record is missing or the table env var is unset.
+    record: the client signal (app-api ``POST /sessions/{id}/interrupt`` —
+    ``user_stopped`` from the Stop button, ``navigated_away`` from the
+    page-lifecycle handler) and the stream cancellation backstop
+    (inference-api, ``connection_lost`` fallback).
+
+    Precedence is by ``_REASON_RANK``: a write only lands if no *stronger*
+    reason is already recorded, enforced as a DynamoDB condition against the
+    pre-update item, so the outcome is correct regardless of which source
+    wins the race. The ranking is by how much the reason actually tells us —
+    a client-attested reason outranks the server's fallback, which is
+    literally "the stream died and nothing told us why".
+
+    Note this used to protect only ``user_stopped``, which meant the
+    ``connection_lost`` backstop could overwrite any other reason it raced.
+    That was harmless while ``user_stopped`` was the only client reason;
+    with ``navigated_away`` it would silently erase the attribution this
+    exists to capture.
+
+    Idempotent. Best-effort: a write failure logs but never breaks the live
+    flow. No-op when the session record is missing or the table env var is
+    unset.
     """
     sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
     if not sessions_metadata_table:
         logger.warning("DYNAMODB_SESSIONS_METADATA_TABLE_NAME not set; skipping interrupted_turn persistence")
         return
 
-    if reason not in ("user_stopped", "connection_lost", "unknown"):
+    if reason not in _REASON_RANK:
         reason = "unknown"
 
     try:
@@ -2904,13 +2930,21 @@ async def set_interrupted_turn(
             },
         }
 
-        # A fallback (non-user_stopped) write must not clobber a stronger
-        # user_stopped reason the beacon may have already landed. The
-        # condition is evaluated against the pre-update item, so this is
-        # race-safe regardless of which source writes first.
-        if reason != "user_stopped":
-            update_kwargs["ConditionExpression"] = "attribute_not_exists(#ltr) OR #ltr <> :user_stopped"
-            update_kwargs["ExpressionAttributeValues"][":user_stopped"] = "user_stopped"
+        # A write must not clobber a reason that says more than this one
+        # does. Guard against every strictly-stronger reason; evaluated
+        # against the pre-update item, so it is race-safe regardless of
+        # which source writes first. The strongest reason has no stronger
+        # peers, so it writes unconditionally.
+        stronger = [r for r, rank in _REASON_RANK.items() if rank > _REASON_RANK[reason]]
+        if stronger:
+            clauses = []
+            for i, r in enumerate(stronger):
+                placeholder = f":stronger{i}"
+                clauses.append(f"#ltr <> {placeholder}")
+                update_kwargs["ExpressionAttributeValues"][placeholder] = r
+            update_kwargs["ConditionExpression"] = (
+                "attribute_not_exists(#ltr) OR (" + " AND ".join(clauses) + ")"
+            )
 
         try:
             table.update_item(**update_kwargs)

--- a/backend/src/apis/shared/sessions/models.py
+++ b/backend/src/apis/shared/sessions/models.py
@@ -241,10 +241,17 @@ class SessionMetadata(BaseModel):
         alias="lastTurnInterrupted",
         description="True when the last turn was interrupted before completion (user Stop, refresh, or dropped connection). Lets a reload show the 'response interrupted' state. Cleared at the start of any new (non-interrupt-resume) turn",
     )
-    last_turn_interrupt_reason: Optional[Literal["user_stopped", "connection_lost", "unknown"]] = Field(
+    last_turn_interrupt_reason: Optional[
+        Literal["user_stopped", "navigated_away", "connection_lost", "unknown"]
+    ] = Field(
         default=None,
         alias="lastTurnInterruptReason",
-        description="Why the last turn was interrupted. 'user_stopped' (deliberate Stop, from the client beacon) wins over the 'connection_lost' cancellation fallback",
+        description=(
+            "Why the last turn was interrupted, strongest client-attested reason first: "
+            "'user_stopped' (deliberate Stop) > 'navigated_away' (page hidden/unloaded) > "
+            "'connection_lost' (the server-side cancellation fallback) > 'unknown'. "
+            "A weaker reason can never overwrite a stronger one — see set_interrupted_turn"
+        ),
     )
     last_turn_interrupted_at: Optional[str] = Field(
         default=None,
@@ -321,14 +328,29 @@ class UpdateSessionMetadataRequest(BaseModel):
 class SessionInterruptRequest(BaseModel):
     """Request body for the client stop signal (POST /sessions/{id}/interrupt).
 
-    Only `user_stopped` is accepted from the client — it is the one reason
-    that requires user attestation. `connection_lost` is never client-sent;
-    it is inferred server-side by the stream-cancellation backstop and would
-    otherwise let a client downgrade a deliberate stop.
+    Only client-*attested* reasons are accepted here — the ones the browser
+    is the sole witness to:
+
+      * `user_stopped`    — the Stop button. Deliberate rejection of the
+                            in-flight response.
+      * `navigated_away`  — the page was hidden or unloaded (refresh, tab
+                            close, navigation) while a turn was streaming.
+                            NOT a rejection: the user left, they didn't say
+                            "stop". Sent from a `pagehide` handler.
+
+    `connection_lost` is never client-sent. It is the server-side
+    cancellation backstop's fallback — literally "the stream died and nothing
+    told us why" — and accepting it from a client would let a caller
+    downgrade an attested reason.
+
+    The distinction exists because `connection_lost` is otherwise
+    unattributable: a refresh, a dropped socket, and a platform-side idle
+    timeout all reach the container as an identical cancellation. Labelling
+    departures at the source is what makes the remainder diagnosable.
     """
 
-    reason: Literal["user_stopped"] = Field(
-        description="Interruption reason. Only the deliberate Stop is client-attested",
+    reason: Literal["user_stopped", "navigated_away"] = Field(
+        description="Interruption reason. Only client-attested reasons are accepted",
     )
 
 
@@ -380,7 +402,7 @@ class SessionMetadataResponse(BaseModel):
     last_turn_interrupt_reason: Optional[str] = Field(
         default=None,
         alias="lastTurnInterruptReason",
-        description="Why the last turn was interrupted: 'user_stopped' (deliberate Stop) or 'connection_lost' (refresh / dropped connection). Drives whether a 'Continue' affordance is offered on reload",
+        description="Why the last turn was interrupted: 'user_stopped' (deliberate Stop), 'navigated_away' (page hidden/unloaded mid-turn), or 'connection_lost' (the unattributable server-side fallback). Only 'user_stopped' suppresses the 'Continue' affordance on reload",
     )
     last_turn_interrupted_at: Optional[str] = Field(
         default=None,

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -862,6 +862,56 @@ class TestSignalTurnInterrupted:
         assert resp.status_code == 422
         recorder.assert_not_awaited()
 
+    def test_returns_204_and_records_navigated_away(self, app, make_user, authenticated_client):
+        """A departure (refresh / tab close / navigation) is client-attested
+        too — it is the one interruption cause only the browser witnesses."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        recorder = AsyncMock()
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            recorder,
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "navigated_away"},
+            )
+
+        assert resp.status_code == 204
+        recorder.assert_awaited_once_with(
+            "sess-001",
+            user.user_id,
+            reason="navigated_away",
+            source="client_signal",
+        )
+
+    def test_navigated_away_does_not_cancel_the_turn(self, app, make_user, authenticated_client):
+        """Attribution, not instruction.
+
+        Cancelling on a departure would make every refresh kill the turn it
+        interrupted — discarding work the reload is about to offer to
+        continue. Only a deliberate Stop arms the distributed cancel.
+        """
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        cancel = AsyncMock(return_value=True)
+        with patch(
+            "apis.app_api.sessions.routes.set_interrupted_turn",
+            AsyncMock(),
+        ), patch(
+            "apis.shared.sessions.session_lease.request_session_cancel",
+            cancel,
+        ):
+            resp = client.post(
+                "/sessions/sess-001/interrupt",
+                json={"reason": "navigated_away"},
+            )
+
+        assert resp.status_code == 204
+        cancel.assert_not_awaited()
+
     def test_returns_401_for_unauthenticated(self, app, unauthenticated_client):
         client = unauthenticated_client(app)
         resp = client.post(

--- a/backend/tests/shared/test_sessions_metadata.py
+++ b/backend/tests/shared/test_sessions_metadata.py
@@ -141,6 +141,73 @@ class TestInterruptedTurnMarker:
         assert result.last_turn_interrupt_reason == "user_stopped"
 
     @pytest.mark.asyncio
+    async def test_navigated_away_wins_over_connection_lost(self, sessions_metadata_table):
+        # The whole point of attesting departures: the cancellation backstop
+        # races the pagehide signal and must not erase it. Before the rank
+        # generalisation the condition only protected `user_stopped`, so this
+        # write order silently reverted to the unattributable reason.
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i5", user_id="u1", session_metadata=_make_session_metadata(session_id="i5"))
+
+        await set_interrupted_turn("i5", "u1", reason="navigated_away", source="client_signal")
+        await set_interrupted_turn("i5", "u1", reason="connection_lost", source="cancellation")
+
+        result = await get_session_metadata("i5", "u1")
+        assert result.last_turn_interrupt_reason == "navigated_away"
+
+    @pytest.mark.asyncio
+    async def test_navigated_away_upgrades_connection_lost(self, sessions_metadata_table):
+        # Reverse order: the backstop lands first and the departure signal
+        # arrives late (the keepalive fetch outliving the page), upgrading it.
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i6", user_id="u1", session_metadata=_make_session_metadata(session_id="i6"))
+
+        await set_interrupted_turn("i6", "u1", reason="connection_lost", source="cancellation")
+        await set_interrupted_turn("i6", "u1", reason="navigated_away", source="client_signal")
+
+        result = await get_session_metadata("i6", "u1")
+        assert result.last_turn_interrupt_reason == "navigated_away"
+
+    @pytest.mark.asyncio
+    async def test_navigated_away_never_downgrades_user_stopped(self, sessions_metadata_table):
+        # Stop, then the user closes the tab. The deliberate rejection is the
+        # stronger statement and must survive.
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i7", user_id="u1", session_metadata=_make_session_metadata(session_id="i7"))
+
+        await set_interrupted_turn("i7", "u1", reason="user_stopped", source="client_signal")
+        await set_interrupted_turn("i7", "u1", reason="navigated_away", source="client_signal")
+
+        result = await get_session_metadata("i7", "u1")
+        assert result.last_turn_interrupt_reason == "user_stopped"
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_reason_falls_back_to_unknown(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            get_session_metadata,
+            set_interrupted_turn,
+        )
+        await store_session_metadata(session_id="i8", user_id="u1", session_metadata=_make_session_metadata(session_id="i8"))
+
+        await set_interrupted_turn("i8", "u1", reason="something_new", source="cancellation")
+
+        result = await get_session_metadata("i8", "u1")
+        assert result.last_turn_interrupt_reason == "unknown"
+
+    @pytest.mark.asyncio
     async def test_set_noop_when_session_missing(self, sessions_metadata_table):
         from apis.shared.sessions.metadata import set_interrupted_turn, get_session_metadata
         # No store first — must not raise, and nothing to read back.

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -127,6 +127,12 @@ export class MessageListComponent {
     ) {
       return null;
     }
+    // Two UI outcomes, not one per reason: only a deliberate Stop withholds
+    // the Continue affordance. Every other reason — `navigated_away`,
+    // `connection_lost`, `unknown` — means the user never rejected the
+    // answer, so Continue is offered. New reasons bucket here by default,
+    // which is the safe direction: offering Continue on a turn the user
+    // abandoned is recoverable; withholding it on one they still want is not.
     return this.chatStateService.lastTurnInterruptReason() === 'user_stopped'
       ? 'user_stopped'
       : 'connection_lost';

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.spec.ts
@@ -31,7 +31,7 @@ describe('ChatHttpService', () => {
         { provide: BffSessionService, useValue: { csrfHeaders: vi.fn().mockReturnValue({}), handleUnauthorized: vi.fn() } },
         { provide: SessionService, useValue: { currentSession: signal({ sessionId: 's1' }), updateSessionTitleInCache: vi.fn(), getSessionMetadata: vi.fn().mockResolvedValue({}) } },
         { provide: StreamParserService, useValue: { getCurrentStreamId: vi.fn().mockReturnValue('stream-1'), parseEventSourceMessage: vi.fn() } },
-        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), setLastTurnInterrupted: vi.fn(), seedSessionAggregates: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()) } },
+        { provide: ChatStateService, useValue: { abortRequest: vi.fn(), setChatLoading: vi.fn(), setLastTurnInterrupted: vi.fn(), seedSessionAggregates: vi.fn(), createAbortController: vi.fn().mockReturnValue(new AbortController()), streamingSessionIds: vi.fn().mockReturnValue([]) } },
         { provide: MessageMapService, useValue: { endStreaming: vi.fn() } },
         { provide: ErrorService, useValue: { handleHttpError: vi.fn(), addError: vi.fn() } },
       ],
@@ -188,5 +188,68 @@ describe('ChatHttpService', () => {
     const [, message] = errorSvc.addError.mock.calls[0];
     expect(message).toBe('This conversation is busy generating a response.');
     vi.restoreAllMocks();
+  });
+
+  describe('page-departure attribution', () => {
+    // A refresh / tab close / navigation is the one interruption cause only
+    // the browser witnesses. Unattested it lands server-side as
+    // `connection_lost` — indistinguishable from a dropped socket or a
+    // platform-side idle timeout — which is what made the remaining drops
+    // undiagnosable in the first place.
+
+    interface InterruptCall {
+      url: string;
+      body: { reason: string };
+      keepalive: boolean | undefined;
+    }
+
+    function interruptCalls(fetchSpy: any): InterruptCall[] {
+      return fetchSpy.mock.calls
+        .filter(([url]: [string]) => String(url).includes('/interrupt'))
+        .map(([url, init]: [string, RequestInit]) => ({
+          url: String(url),
+          body: JSON.parse(String(init.body)),
+          keepalive: init.keepalive,
+        }));
+    }
+
+    it('signals navigated_away for each streaming session on pagehide', () => {
+      chatStateService.streamingSessionIds.mockReturnValue(['s1', 's2']);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+      window.dispatchEvent(new Event('pagehide'));
+
+      const calls = interruptCalls(fetchSpy);
+      expect(calls).toHaveLength(2);
+      expect(calls.map((c: InterruptCall) => c.body.reason)).toEqual(['navigated_away', 'navigated_away']);
+      expect(calls[0].url).toContain('/sessions/s1/interrupt');
+      expect(calls[1].url).toContain('/sessions/s2/interrupt');
+      // `keepalive` is what lets the request outlive the page being torn down.
+      expect(calls.every((c: InterruptCall) => c.keepalive)).toBe(true);
+      vi.restoreAllMocks();
+    });
+
+    it('signals nothing when no turn is in flight', () => {
+      chatStateService.streamingSessionIds.mockReturnValue([]);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+      window.dispatchEvent(new Event('pagehide'));
+
+      expect(interruptCalls(fetchSpy)).toHaveLength(0);
+      vi.restoreAllMocks();
+    });
+
+    it('does not abort the stream — attribution must not intervene', () => {
+      // Aborting on page-hide would kill turns for a bfcache navigation the
+      // user may come back from, and the server turn is meant to keep running
+      // so a reload can offer to continue it.
+      chatStateService.streamingSessionIds.mockReturnValue(['s1']);
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+      window.dispatchEvent(new Event('pagehide'));
+
+      expect(chatStateService.abortRequest).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-http.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { DestroyRef, inject, Injectable } from '@angular/core';
 import { EventSourceMessage, fetchEventSource } from '@microsoft/fetch-event-source';
 import { StreamParserService } from './stream-parser.service';
 import { ChatStateService } from './chat-state.service';
@@ -73,6 +73,14 @@ async function parseConflictMessage(response: Response): Promise<string> {
   }
 }
 
+/**
+ * Client-attested interruption reasons — the causes only the browser can
+ * witness. The server's `connection_lost` fallback is deliberately not here:
+ * it means "the stream died and nothing told us why", and the point of
+ * attesting these is to shrink that unattributable population.
+ */
+type InterruptReason = 'user_stopped' | 'navigated_away';
+
 interface GenerateTitleRequest {
   session_id: string;
   input: string;
@@ -95,6 +103,11 @@ export class ChatHttpService {
   private sessionService = inject(SessionService);
   private bffSession = inject(BffSessionService);
   private errorService = inject(ErrorService);
+  private destroyRef = inject(DestroyRef);
+
+  constructor() {
+    this.registerPageLifecycleAttribution();
+  }
 
   async sendChatRequest(requestObject: any): Promise<void> {
     const sessionId = requestObject.session_id as string;
@@ -332,7 +345,7 @@ export class ChatHttpService {
     // unlike `navigator.sendBeacon`, can carry the `X-CSRF-Token` header the
     // app-api CSRFMiddleware requires on unsafe cookie-authenticated methods.
     // Best-effort / fire-and-forget — the user's Stop must never block on it.
-    this.signalUserStopped(sessionId);
+    this.signalInterrupt(sessionId, 'user_stopped');
     // Reflect the interruption locally right away so the reload chip also
     // shows within the same session, without waiting for a refresh. The
     // backend marker (raced with the cancellation backstop) is the
@@ -384,8 +397,8 @@ export class ChatHttpService {
     }
   }
 
-  /** Fire-and-forget POST to app-api recording deliberate stop intent. */
-  private signalUserStopped(sessionId: string): void {
+  /** Fire-and-forget POST to app-api recording a client-attested interrupt reason. */
+  private signalInterrupt(sessionId: string, reason: InterruptReason): void {
     try {
       const appApiUrl = this.config.appApiUrl();
       if (!appApiUrl) return;
@@ -398,14 +411,52 @@ export class ChatHttpService {
           'Content-Type': 'application/json',
           ...this.bffSession.csrfHeaders(),
         },
-        body: JSON.stringify({ reason: 'user_stopped' }),
+        body: JSON.stringify({ reason }),
       }).catch(() => {
         // Best-effort: a failed signal degrades to the server-side
         // connection_lost backstop (or nothing if the turn completed).
       });
     } catch {
-      // Never let intent signalling interfere with the Stop action.
+      // Never let intent signalling interfere with the caller's action.
     }
+  }
+
+  /**
+   * Attribute a page departure to whatever turns it interrupts.
+   *
+   * Without this, a refresh / tab close / navigation lands server-side as
+   * `connection_lost` — the backstop's "the stream died and nothing told us
+   * why" — indistinguishable from a dropped socket or a platform-side idle
+   * timeout. Departures are the one cause only the browser can witness, so
+   * labelling them here is what makes the remaining `connection_lost`
+   * population diagnosable.
+   *
+   * `pagehide` rather than `beforeunload` or `unload`: it is the event that
+   * still fires reliably on mobile Safari and for bfcache navigations, where
+   * `unload` does not. `keepalive: true` on the fetch is what lets the
+   * request outlive the page — the same property the Stop path already
+   * relies on.
+   *
+   * Deliberately does NOT abort the stream. Aborting on page-hide would kill
+   * turns for a bfcache navigation the user may return from, and the server
+   * turn is meant to keep running so a reload can offer to continue it. This
+   * records; it does not intervene.
+   */
+  private registerPageLifecycleAttribution(): void {
+    // SSR / non-browser render pass has no window to listen on.
+    if (typeof window === 'undefined') return;
+    const onPageHide = () => {
+      for (const sessionId of this.chatStateService.streamingSessionIds()) {
+        this.signalInterrupt(sessionId, 'navigated_away');
+      }
+    };
+    window.addEventListener('pagehide', onPageHide);
+    // The root service outlives everything in the app, so this matters for
+    // tests rather than production: without it each TestBed instance leaves
+    // a live listener bound to the shared window, and the suite runs with
+    // `isolate: false`, so a later `pagehide` would fan out across every
+    // stale instance and its torn-down mocks.
+    this.destroyRef.onDestroy(() => window.removeEventListener('pagehide', onPageHide));
   }
 
   /**

--- a/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-state.service.ts
@@ -234,6 +234,20 @@ export class ChatStateService {
         return controller;
     }
 
+    /**
+     * Session ids with a stream in flight right now.
+     *
+     * Read at page-hide time to attribute a departure to the turns it
+     * actually interrupted. A live controller is the truthful test: it is
+     * created per request and nulled on abort, so it tracks the transport
+     * rather than the `loading` flag, which other code also drives.
+     */
+    streamingSessionIds(): string[] {
+        return [...this.states().entries()]
+            .filter(([, state]) => state.abortController !== null)
+            .map(([sessionId]) => sessionId);
+    }
+
     /** Abort a session's in-flight request (Stop button), if any. */
     abortRequest(sessionId: string): void {
         const state = this.states().get(sessionId);

--- a/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
+++ b/frontend/ai.client/src/app/session/services/models/session-metadata.model.ts
@@ -55,7 +55,11 @@ export interface SessionMetadata {
   /** Why the last turn was interrupted. 'user_stopped' (deliberate Stop) →
    *  no Continue; 'connection_lost' (refresh / dropped connection) → offer
    *  Continue. */
-  lastTurnInterruptReason?: 'user_stopped' | 'connection_lost' | 'unknown';
+  lastTurnInterruptReason?:
+    | 'user_stopped'
+    | 'navigated_away'
+    | 'connection_lost'
+    | 'unknown';
   /** ISO 8601 timestamp when the interruption was detected. */
   lastTurnInterruptedAt?: string;
   /** True when an unattended (scheduled) run left a response the user hasn't

--- a/infrastructure/lib/constructs/network/alb-construct.ts
+++ b/infrastructure/lib/constructs/network/alb-construct.ts
@@ -1,9 +1,18 @@
+import * as cdk from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
-import { AppConfig, getResourceName } from '../../config';
+import { AppConfig, getRemovalPolicy, getResourceName } from '../../config';
+
+/**
+ * How long ALB access logs are kept. Long enough to investigate a pattern
+ * across a couple of weeks of traffic, short enough that a high-volume log
+ * of every request doesn't accumulate cost indefinitely.
+ */
+const ACCESS_LOG_RETENTION_DAYS = 30;
 
 export interface AlbConstructProps {
   config: AppConfig;
@@ -16,6 +25,9 @@ export interface AlbConstructProps {
  * Provisions:
  *   - ALB security group permitting :80 and :443 from anywhere
  *   - Internet-facing ALB in the VPC's public subnets
+ *   - Access-log bucket (30-day expiry) with delivery enabled, which is
+ *     what makes a mid-stream SSE disconnect attributable to the client,
+ *     the network, or the ALB's own idle timeout
  *   - Primary listener: HTTPS on :443 if `config.certificateArn` is set,
  *     plus a redirect-to-HTTPS HTTP listener on :80; otherwise HTTP on :80
  *     with a fixed 404 response
@@ -33,6 +45,7 @@ export class AlbConstruct extends Construct {
   public readonly alb: elbv2.ApplicationLoadBalancer;
   public readonly albListener: elbv2.ApplicationListener;
   public readonly albSecurityGroup: ec2.SecurityGroup;
+  public readonly accessLogBucket: s3.Bucket;
 
   constructor(scope: Construct, id: string, props: AlbConstructProps) {
     super(scope, id);
@@ -71,6 +84,38 @@ export class AlbConstruct extends Construct {
         subnetType: ec2.SubnetType.PUBLIC,
       },
     });
+
+    // Access logs: the only record of who ENDED a connection.
+    //
+    // The chat path is SSE, and a stream that dies mid-turn reaches the
+    // backend as an indistinguishable cancellation — a client going away, a
+    // dropped socket, and the ALB's own 60s idle timeout all look identical
+    // from inside the container. The access log is the one place that
+    // separates them: `elb_status_code`, the `-`/`connection` termination
+    // fields, and `request_processing_time` name the terminator and how long
+    // the request had run. Without it, that attribution is guesswork.
+    //
+    // SSE-S3 rather than KMS deliberately — the ALB log delivery service
+    // only supports SSE-S3 (or none) and silently fails to deliver against
+    // an SSE-KMS bucket. `logAccessLogs` writes the bucket policy that
+    // grants the regional ELB log-delivery principal.
+    this.accessLogBucket = new s3.Bucket(this, 'AlbAccessLogBucket', {
+      bucketName: getResourceName(config, 'alb-access-logs'),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      lifecycleRules: [
+        {
+          id: 'expire-access-logs',
+          expiration: cdk.Duration.days(ACCESS_LOG_RETENTION_DAYS),
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(7),
+        },
+      ],
+      removalPolicy: getRemovalPolicy(config),
+      autoDeleteObjects: !config.retainDataOnDelete,
+    });
+
+    this.alb.logAccessLogs(this.accessLogBucket);
 
 
 

--- a/infrastructure/test/network-and-scripts.test.ts
+++ b/infrastructure/test/network-and-scripts.test.ts
@@ -92,6 +92,54 @@ describe('AlbConstruct — detailed', () => {
     });
   });
 
+  // Access logs are the only record of who ENDED a connection. A mid-stream
+  // SSE disconnect is indistinguishable inside the container — client gone,
+  // socket dropped, and the ALB's own idle timeout all arrive as the same
+  // cancellation — so losing this attribute re-blinds that investigation.
+  it('access logging is enabled on the ALB', () => {
+    t.hasResourceProperties('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      LoadBalancerAttributes: Match.arrayWith([
+        Match.objectLike({ Key: 'access_logs.s3.enabled', Value: 'true' }),
+      ]),
+    });
+  });
+
+  it('access-log bucket uses SSE-S3, not KMS', () => {
+    // The ELB log-delivery service cannot write to an SSE-KMS bucket; it
+    // fails silently, leaving an empty bucket and no logs.
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: Match.stringLikeRegexp('alb-access-logs'),
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          { ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } },
+        ],
+      },
+    });
+  });
+
+  it('access logs expire so a per-request log cannot grow unbounded', () => {
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: Match.stringLikeRegexp('alb-access-logs'),
+      LifecycleConfiguration: {
+        Rules: Match.arrayWith([
+          Match.objectLike({ ExpirationInDays: 30, Status: 'Enabled' }),
+        ]),
+      },
+    });
+  });
+
+  it('access-log bucket blocks public access', () => {
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      BucketName: Match.stringLikeRegexp('alb-access-logs'),
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    });
+  });
+
   it('HTTP listener returns 404 by default (no cert)', () => {
     t.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
       Port: 80,

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -107,6 +107,11 @@ describe('PlatformStack', () => {
             clientId: 'example-client',
           },
         }),
+        // A concrete region is required: the ALB's access logging resolves
+        // the regional ELB log-delivery principal for the bucket policy, and
+        // CDK refuses to synth it against an env-agnostic stack. Every real
+        // deploy passes env (see bin/infrastructure.ts); this matches.
+        env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
       });
       const optIn = Template.fromStack(optInStack);
 
@@ -155,8 +160,9 @@ describe('PlatformStack', () => {
       // file-uploads, SPA static, mcp-sandbox, rag-documents, fine-tuning-data,
       // artifacts-content, skill-resources (admin-managed Skills reference files),
       // memory-spaces (Memory Spaces feature content bucket),
-      // shared-conversations (share snapshot-body offload)
-      template.resourceCountIs('AWS::S3::Bucket', 9);
+      // shared-conversations (share snapshot-body offload),
+      // alb-access-logs (who terminated a connection — SSE disconnect attribution)
+      template.resourceCountIs('AWS::S3::Bucket', 10);
     });
   });
 


### PR DESCRIPTION
Follow-up to [#863](https://github.com/Boise-State-Development/agentcore-public-stack/pull/863). That PR made a dropped stream *recoverable*; this one makes it *diagnosable*.

## The problem

`connection_lost` is a fallback label, not a diagnosis. The container stamps it whenever a stream task is torn down and no client signal arrived — so a refresh, a dead socket, and a platform-side idle timeout are recorded identically.

Prod over 14 days:

```
connection_lost   64  (62%)
user_stopped      40  (38%)
```

Of 47 dropped turns sampled in detail, only the **11 in the 62–67s band** could be attributed to anything (the 60s CloudFront/ALB idle cut, which #863 addresses). The remaining ~36 aren't merely unexplained — they're unexplainable with the signals we currently record.

## Two instruments

**1. `navigated_away` — attest page departures (SPA + backend).**

A departure is the one interruption cause *only the browser witnesses*, and the SPA had **no `beforeunload`, `pagehide`, or `unload` handler anywhere** — `cancelChatRequest` is reached solely from the Stop button. Every refresh, tab close, and navigation was landing in the unattributable bucket with nothing able to label it.

Adds a `pagehide` handler signalling `navigated_away` for each session with a stream in flight. `pagehide` rather than `unload` (still fires on mobile Safari and for bfcache navigations); `keepalive: true` is what lets the request outlive the page — the same property the Stop path already relies on.

Deliberately does **not** abort the stream, and **not** arm the distributed turn cancel. Cancelling on a departure would make every refresh discard work the reload is about to offer to continue. The endpoint's reason set widened; its side effects did not.

**2. ALB access logs (infra).** Currently disabled, and they're the only record of who *ended* a connection — `elb_status_code`, the termination-reason field, and `request_processing_time` name the terminator and how long the request ran. Bucket is SSE-S3 because the ELB log-delivery service cannot write to SSE-KMS and fails *silently*; 30-day expiry bounds the cost of a per-request log.

## Bug found along the way

Interrupt-reason precedence protected only `user_stopped`, so the `connection_lost` backstop could overwrite any other reason it raced. Harmless while `user_stopped` was the only client reason — with `navigated_away` it would have silently erased the very attribution this PR exists to capture, and the failure would have looked like "the pagehide handler doesn't work." Generalised to a rank: a reason may only overwrite a same-or-weaker one.

```
user_stopped (3) > navigated_away (2) > connection_lost (1) > unknown (0)
```

## Behaviour that does not change

The Continue affordance buckets on "was this a deliberate rejection?", so `navigated_away` is offered Continue like any other non-rejection. That was already the shape of the gate; I made it explicit rather than incidental, since the safe direction is to offer Continue on a turn the user abandoned rather than withhold it on one they still want.

## Note for reviewers

`logAccessLogs` makes a concrete region **required** to synth the ALB construct — CDK resolves the regional ELB log-delivery principal for the bucket policy and refuses on an env-agnostic stack. Every real deploy passes `env` (`bin/infrastructure.ts`); one PlatformStack test did not, and now does.

The SPA listener is unregistered via `DestroyRef`. In production the root service outlives everything, so this is for tests: the suite runs with `isolate: false`, and without cleanup each TestBed instance would leave a live listener on the shared `window`, fanning a later `pagehide` across every stale instance and its torn-down mocks.

## Testing

- Backend `3584 passed`, SPA `1845 passed` (163 files), infra `503 passed` (27 suites)
- New: 4 precedence tests (including the race this PR's rank fixes), 2 endpoint tests (`navigated_away` records but does not cancel), 3 SPA departure tests, 4 infra access-log tests

## Still open

This changes nothing about *how often* streams drop — it makes the drops answerable. Once it has run for a few days, `lastTurnInterruptReason` plus the ALB log should partition the 47 into departures, platform cuts, and genuine network loss.

The remaining analysis item from #863 is unchanged: **9 of 47 drops fall in a 206–244s band**, which may be a second timeout I haven't identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
