### PR TITLE
feat(files): accept .pptx uploads and route them to the PowerPoint tools

### DIFF
--- a/backend/src/apis/app_api/files/routes.py
+++ b/backend/src/apis/app_api/files/routes.py
@@ -62,10 +62,11 @@ async def request_presigned_url(
     2. Use the returned presignedUrl to PUT the file directly to S3
     3. Call POST /files/{uploadId}/complete to finalize
 
-    **Supported file types:** PDF, DOCX, TXT, HTML, CSV, XLS, XLSX, MD
+    **Supported file types:** PDF, DOCX, TXT, HTML, CSV, XLS, XLSX, PPTX, MD
 
     **Limits:**
-    - Maximum file size: 4MB
+    - Maximum file size: 4MB (25MB for PPTX — decks never go inline to
+      Bedrock, so the inline-document ceiling doesn't bound them)
     - Maximum files per message: 5
     - User storage quota: 1GB
     """

--- a/backend/src/apis/app_api/files/service.py
+++ b/backend/src/apis/app_api/files/service.py
@@ -32,6 +32,7 @@ from apis.shared.files.models import (
     FileListResponse,
     QuotaResponse,
     is_allowed_mime_type,
+    is_presentation_file,
     ALLOWED_MIME_TYPES,
 )
 from .thumbnails import (
@@ -125,6 +126,7 @@ class FileUploadService:
         s3_client=None,
         bucket_name: Optional[str] = None,
         max_file_size: Optional[int] = None,
+        presentation_max_file_size: Optional[int] = None,
         max_files_per_message: Optional[int] = None,
         user_quota_bytes: Optional[int] = None,
         thumbnail_renderer: Optional[ThumbnailRenderer] = None,
@@ -156,6 +158,22 @@ class FileUploadService:
         self.max_file_size = max_file_size or int(
             os.environ.get("FILE_UPLOAD_MAX_SIZE_BYTES", 4 * 1024 * 1024)  # 4MB
         )
+        # Presentations get a larger cap than the general limit. The general
+        # 4MB is sized for what Bedrock will accept as an inline document
+        # block; a .pptx never goes inline (Bedrock has no pptx document
+        # format — see `is_presentation_file`), so that ceiling does not
+        # apply to it. What does apply is the Code Interpreter hop in the
+        # PowerPoint tools: `_ci_write_bytes` base64-encodes the whole deck
+        # into a single writeFiles `text` field, inflating it ~4/3. That
+        # field is a MaxLenString (100MB), so 25MB of deck → ~33MB of base64
+        # stays well inside it. Real-world corporate templates with imagery
+        # routinely exceed 4MB, which is what made the template workflow
+        # unusable at the general cap.
+        self.presentation_max_file_size = presentation_max_file_size or int(
+            os.environ.get(
+                "FILE_UPLOAD_MAX_SIZE_BYTES_PRESENTATION", 25 * 1024 * 1024  # 25MB
+            )
+        )
         self.max_files_per_message = max_files_per_message or int(
             os.environ.get("FILE_UPLOAD_MAX_FILES_PER_MESSAGE", 5)
         )
@@ -166,6 +184,18 @@ class FileUploadService:
         # Pre-signed URL expiration
         self.presign_expiration = 15 * 60  # 15 minutes
         self.preview_url_expiration = 10 * 60  # 10 minutes for GET previews
+
+    def max_size_for(self, filename: str, mime_type: str) -> int:
+        """Return the upload size cap that applies to this file.
+
+        Presentations get their own (larger) cap; everything else gets the
+        general limit. Callers must use this rather than reading
+        `max_file_size` directly, or a .pptx under the presentation cap gets
+        rejected by whichever gate was missed.
+        """
+        if is_presentation_file(filename, mime_type):
+            return self.presentation_max_file_size
+        return self.max_file_size
 
     # =========================================================================
     # Pre-signed URL Flow
@@ -200,9 +230,10 @@ class FileUploadService:
         if not is_allowed_mime_type(request.mime_type):
             raise InvalidFileTypeError(request.mime_type)
 
-        # Validate file size
-        if request.size_bytes > self.max_file_size:
-            raise FileTooLargeError(request.size_bytes, self.max_file_size)
+        # Validate file size against the cap for this file's class
+        size_limit = self.max_size_for(request.filename, request.mime_type)
+        if request.size_bytes > size_limit:
+            raise FileTooLargeError(request.size_bytes, size_limit)
 
         # Check quota
         quota = await self.repository.get_user_quota(user_id)

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -714,26 +714,42 @@ def _estimate_decoded_size(file: "FileContent") -> int:
 
 def _partition_attachments(
     all_files: list,
-) -> tuple[list, list, list]:
-    """Split attachments into (inline_for_bedrock, tabular, oversized_non_tabular).
+) -> tuple[list, list, list, list]:
+    """Split attachments into
+    (inline_for_bedrock, tabular, presentations, oversized_non_tabular).
 
     - Tabular files (csv/xlsx) are never sent inline — they route through
       the spreadsheet analysis tools. Keeps Bedrock's 4.5MB document limit
       from exploding on XLSX files that expand during internal parsing.
+    - Presentations (pptx) are never sent inline either, but for a harder
+      reason: Bedrock's document-block format enum has no `pptx`, so an
+      inline deck is a guaranteed ValidationException. They route through
+      the PowerPoint tools (see `is_presentation_file`).
     - Non-tabular files larger than INLINE_DOCUMENT_MAX_BYTES are dropped
       from the inline set with a user-facing note, to prevent mid-stream
       ValidationException on the raw AWS error path.
     - Everything else rides along as a regular document/image content block.
+
+    Both diverted classes are checked before the size gate: they never go
+    inline at any size, so an oversized note would misdescribe them.
     """
-    from apis.shared.files.models import INLINE_DOCUMENT_MAX_BYTES, is_tabular_file
+    from apis.shared.files.models import (
+        INLINE_DOCUMENT_MAX_BYTES,
+        is_presentation_file,
+        is_tabular_file,
+    )
 
     inline: list = []
     tabular: list = []
+    presentations: list = []
     oversized: list = []
 
     for file in all_files:
         if is_tabular_file(file.filename, file.content_type):
             tabular.append(file)
+            continue
+        if is_presentation_file(file.filename, file.content_type):
+            presentations.append(file)
             continue
         # Only size-gate non-image documents. Images have their own Bedrock
         # limits (much larger) and the prompt builder reroutes them as
@@ -745,11 +761,12 @@ def _partition_attachments(
             continue
         inline.append(file)
 
-    return inline, tabular, oversized
+    return inline, tabular, presentations, oversized
 
 
 def _build_attachment_guidance(
     diverted_tabular: list,
+    diverted_presentations: list,
     oversized_inline: list,
     enabled_tools: list | None,
 ) -> str:
@@ -777,6 +794,27 @@ def _build_attachment_guidance(
                 f"this size. To analyze them, enable **Spreadsheet Analysis** "
                 f"in the Tools section of the settings panel (gear icon next "
                 f"to the message input), then re-send your message._"
+            )
+
+    if diverted_presentations:
+        names = ", ".join(f"`{f.filename}`" for f in diverted_presentations)
+        tool_is_enabled = bool(enabled_tools) and bool(
+            POWERPOINT_PRESENTATION_TOOL_IDS.intersection(enabled_tools)
+        )
+        if tool_is_enabled:
+            parts.append(
+                f"_Attached presentation(s) {names} are available through the "
+                f"PowerPoint Presentations tool rather than inline — use "
+                f"`read_powerpoint_presentation` to read a deck's slide text "
+                f"and speaker notes, or pass it as `template_name` to "
+                f"`create_powerpoint_presentation` to build on its layouts._"
+            )
+        else:
+            parts.append(
+                f"_Attached presentation(s) {names} can't be read inline. To "
+                f"work with them, enable **PowerPoint Presentations** in the "
+                f"Tools section of the settings panel (gear icon next to the "
+                f"message input), then re-send your message._"
             )
 
     if oversized_inline:
@@ -1238,6 +1276,11 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     #     (1.4MB zipped → >4.5MB internal, triggering ValidationException).
     #     They remain available to the agent via list_spreadsheets /
     #     analyze_spreadsheet, which run pandas on the real file. See #206.
+    #   - presentation_files: pptx, also never sent inline — Bedrock's
+    #     document-block format enum has no `pptx` member at all, so an
+    #     inline deck is an unconditional ValidationException. They remain
+    #     available via list/read_powerpoint_presentation, which extract
+    #     slide text with python-pptx in Code Interpreter.
     #   - oversized_files: non-tabular docs that exceed our inline size
     #     budget; we skip them inline and surface a note instead of
     #     letting Bedrock reject the turn.
@@ -1289,11 +1332,22 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             )
         all_files = deduped_files
 
-    files_to_send, diverted_tabular, oversized_inline = _partition_attachments(all_files)
+    (
+        files_to_send,
+        diverted_tabular,
+        diverted_presentations,
+        oversized_inline,
+    ) = _partition_attachments(all_files)
     if diverted_tabular:
         logger.info(
             f"Diverted {len(diverted_tabular)} tabular file(s) from inline document blocks; "
             f"available via spreadsheet tools: {[f.filename for f in diverted_tabular]}"
+        )
+    if diverted_presentations:
+        logger.info(
+            f"Diverted {len(diverted_presentations)} presentation(s) from inline document "
+            f"blocks (Bedrock has no pptx document format); available via PowerPoint tools: "
+            f"{[f.filename for f in diverted_presentations]}"
         )
     if oversized_inline:
         logger.warning(
@@ -2217,7 +2271,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             # The original text becomes the single source of truth for UI display,
             # while the full augmented prompt stays in AgentCore Memory for the LLM.
             attachment_guidance = _build_attachment_guidance(
-                diverted_tabular, oversized_inline, effective_enabled_tools
+                diverted_tabular,
+                diverted_presentations,
+                oversized_inline,
+                effective_enabled_tools,
             )
             # When multiple spreadsheets are visible, ship the full inventory
             # up front so the agent can disambiguate intentionally instead of

--- a/backend/src/apis/shared/files/__init__.py
+++ b/backend/src/apis/shared/files/__init__.py
@@ -19,10 +19,13 @@ from .models import (
     ALLOWED_EXTENSIONS,
     TABULAR_MIME_TYPES,
     TABULAR_EXTENSIONS,
+    PRESENTATION_MIME_TYPES,
+    PRESENTATION_EXTENSIONS,
     INLINE_DOCUMENT_MAX_BYTES,
     get_file_format,
     is_allowed_mime_type,
     is_tabular_file,
+    is_presentation_file,
 )
 
 from .repository import (
@@ -64,10 +67,13 @@ __all__ = [
     "ALLOWED_EXTENSIONS",
     "TABULAR_MIME_TYPES",
     "TABULAR_EXTENSIONS",
+    "PRESENTATION_MIME_TYPES",
+    "PRESENTATION_EXTENSIONS",
     "INLINE_DOCUMENT_MAX_BYTES",
     "get_file_format",
     "is_allowed_mime_type",
     "is_tabular_file",
+    "is_presentation_file",
     # Repository
     "FileUploadRepository",
     "get_file_upload_repository",

--- a/backend/src/apis/shared/files/models.py
+++ b/backend/src/apis/shared/files/models.py
@@ -112,6 +112,49 @@ def is_tabular_file(filename: str, mime_type: str) -> bool:
     return False
 
 
+# =============================================================================
+# Presentation File Detection
+# =============================================================================
+
+# PowerPoint files are routed to the PowerPoint presentation tools
+# (list_powerpoint_presentations, read_powerpoint_presentation) instead of
+# being sent inline as Bedrock document content blocks. Unlike the tabular
+# carve-out below, this one is not a size optimization — it is mandatory:
+# Bedrock's Converse `DocumentFormat` enum has no `pptx` member (pdf, csv,
+# doc, docx, xls, xlsx, html, txt, md are the only accepted values), so an
+# inline .pptx fails the whole turn with a ValidationException. The tools are
+# the only path that works.
+#
+# read_powerpoint_presentation extracts slide text, tables and speaker notes
+# with python-pptx inside Code Interpreter, which is also far cheaper in
+# tokens than shipping raw OOXML bytes would be even if Bedrock accepted them.
+#
+# Uploads are gated to keep this reachable: `.pptx` is in ALLOWED_MIME_TYPES
+# above, and the frontend allowlist in `file-upload.service.ts` must stay in
+# sync — drift there is what made .pptx un-uploadable while the create-deck
+# tool's own error text told users to "upload a .pptx template first".
+
+PRESENTATION_MIME_TYPES = frozenset({
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+})
+
+PRESENTATION_EXTENSIONS = frozenset({".pptx"})
+
+
+def is_presentation_file(filename: str, mime_type: str) -> bool:
+    """Return True when the file should be handled by the PowerPoint tools
+    rather than sent inline as a Bedrock document block.
+    """
+    if mime_type and mime_type.lower() in PRESENTATION_MIME_TYPES:
+        return True
+    if filename:
+        lower = filename.lower()
+        for ext in PRESENTATION_EXTENSIONS:
+            if lower.endswith(ext):
+                return True
+    return False
+
+
 # Bedrock's /ConverseStream imposes a 4.5MB hard limit on each document
 # content block's *internal* representation. Non-tabular formats (PDF, docx,
 # txt, md) don't inflate much, but we leave margin for per-request overhead

--- a/backend/tests/apis/app_api/test_presentation_upload_size_cap.py
+++ b/backend/tests/apis/app_api/test_presentation_upload_size_cap.py
@@ -1,0 +1,117 @@
+"""Presentations upload under a larger cap than everything else.
+
+The general 4MB limit is sized for Bedrock's *inline* document budget — it is
+the point past which a document block starts risking a ValidationException
+mid-stream. A .pptx never enters that path (Bedrock's document-format enum has
+no `pptx`; it routes to the PowerPoint tools instead), so the ceiling that
+justifies 4MB simply does not apply to it. Corporate templates with imagery
+clear 4MB routinely, which made `create_powerpoint_presentation`'s
+``template_name`` argument unusable for exactly the files it exists to accept.
+
+The cap that *does* bind a deck is the Code Interpreter hop:
+``_ci_write_bytes`` base64-encodes the whole file into a single ``writeFiles``
+``text`` field (~4/3 inflation). That field is a MaxLenString (100MB), so 25MB
+of deck → ~33MB of base64 sits well inside it.
+
+Both size gates must agree on which cap applies. Historically they were one
+constant read from two places; now that the cap depends on the file, a gate
+that reads ``max_file_size`` directly rejects a deck the other gate allowed —
+so ``max_size_for`` is the single decision point and this pins it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.app_api.files.service import FileTooLargeError, FileUploadService
+from apis.shared.files.models import PresignRequest
+
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+GENERAL_CAP = 4 * 1024 * 1024
+PRESENTATION_CAP = 25 * 1024 * 1024
+
+
+@pytest.fixture
+def service():
+    repository = MagicMock()
+    repository.get_user_quota = AsyncMock(
+        return_value=SimpleNamespace(total_bytes=0)
+    )
+    repository.create_file = AsyncMock()
+
+    s3_client = MagicMock()
+    s3_client.generate_presigned_url.return_value = "https://example.invalid/put"
+
+    return FileUploadService(
+        repository=repository,
+        s3_client=s3_client,
+        bucket_name="test-bucket",
+        max_file_size=GENERAL_CAP,
+        presentation_max_file_size=PRESENTATION_CAP,
+    )
+
+
+class TestMaxSizeFor:
+    def test_ordinary_documents_get_the_general_cap(self, service):
+        assert service.max_size_for("report.pdf", "application/pdf") == GENERAL_CAP
+
+    def test_presentations_get_the_presentation_cap(self, service):
+        assert service.max_size_for("deck.pptx", PPTX_MIME) == PRESENTATION_CAP
+
+    def test_extension_alone_is_enough(self, service):
+        # Some clients send octet-stream for pptx; the cap must not depend on
+        # the browser getting the MIME right.
+        assert (
+            service.max_size_for("deck.pptx", "application/octet-stream")
+            == PRESENTATION_CAP
+        )
+
+    def test_defaults_match_the_documented_values(self):
+        # Constructed with no overrides — these are the values the frontend
+        # constants mirror, and the frontend must never be the larger side.
+        default = FileUploadService(
+            repository=MagicMock(), s3_client=MagicMock(), bucket_name="b"
+        )
+        assert default.max_file_size == GENERAL_CAP
+        assert default.presentation_max_file_size == PRESENTATION_CAP
+
+
+class TestPresignSizeEnforcement:
+    @pytest.mark.asyncio
+    async def test_rejects_ordinary_document_above_general_cap(self, service):
+        request = PresignRequest(
+            sessionId="s1",
+            filename="big.pdf",
+            mimeType="application/pdf",
+            sizeBytes=GENERAL_CAP + 1,
+        )
+        with pytest.raises(FileTooLargeError) as exc:
+            await service.request_presigned_url("u1", request)
+        assert exc.value.max_size == GENERAL_CAP
+
+    @pytest.mark.asyncio
+    async def test_accepts_deck_above_general_cap(self, service):
+        # The regression this whole change exists to prevent.
+        request = PresignRequest(
+            sessionId="s1",
+            filename="template.pptx",
+            mimeType=PPTX_MIME,
+            sizeBytes=GENERAL_CAP + 1,
+        )
+        response = await service.request_presigned_url("u1", request)
+        assert response.upload_id
+
+    @pytest.mark.asyncio
+    async def test_rejects_deck_above_presentation_cap(self, service):
+        request = PresignRequest(
+            sessionId="s1",
+            filename="huge.pptx",
+            mimeType=PPTX_MIME,
+            sizeBytes=PRESENTATION_CAP + 1,
+        )
+        with pytest.raises(FileTooLargeError) as exc:
+            await service.request_presigned_url("u1", request)
+        # The 400 detail is built from max_size, so the user is told 25MB —
+        # not the 4MB that does not apply to their file.
+        assert exc.value.max_size == PRESENTATION_CAP

--- a/backend/tests/apis/inference_api/test_presentation_attachment_carveout.py
+++ b/backend/tests/apis/inference_api/test_presentation_attachment_carveout.py
@@ -1,0 +1,147 @@
+"""A .pptx attachment must never reach Bedrock as an inline document block.
+
+This is not the same kind of rule as the tabular carve-out it sits next to.
+Spreadsheets are diverted as an *optimization* — an xlsx would technically be
+accepted inline, it just inflates past the 4.5MB internal limit and analyzes
+worse than pandas would. A pptx is diverted because Bedrock's Converse
+``DocumentFormat`` enum has no ``pptx`` member at all:
+
+    pdf | csv | doc | docx | xls | xlsx | html | txt | md
+
+So an inline deck is an unconditional ValidationException that kills the turn,
+at any size, forever — not a threshold we tune. That is why
+``is_presentation_file`` is checked BEFORE the size gate: routing a small deck
+to the "oversized" bucket would produce a note that misdescribes why it was
+skipped, and routing it to `inline` at all is simply broken.
+
+The upload path and this carve-out are one feature. `.pptx` is in the backend
+and frontend upload allowlists only because these tools can receive it; if a
+future change re-narrows either allowlist, the create-deck tool's own error
+text ("Upload a .pptx template first") becomes a lie again.
+"""
+
+import pytest
+
+from apis.inference_api.chat.routes import (
+    _build_attachment_guidance,
+    _partition_attachments,
+)
+from apis.shared.files.models import ALLOWED_MIME_TYPES, is_presentation_file
+
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+class _Attachment:
+    """Minimal stand-in for FileContent — the partition only reads these three."""
+
+    def __init__(self, filename: str, content_type: str, bytes_: str = ""):
+        self.filename = filename
+        self.content_type = content_type
+        self.bytes = bytes_
+
+
+class TestIsPresentationFile:
+    def test_detects_by_mime_type(self):
+        assert is_presentation_file("anything", PPTX_MIME) is True
+
+    def test_detects_by_extension_when_mime_is_missing(self):
+        # Browsers and some clients send "" or application/octet-stream for
+        # pptx; the extension is the fallback, same as the tabular helper.
+        assert is_presentation_file("deck.pptx", "") is True
+        assert is_presentation_file("deck.PPTX", "application/octet-stream") is True
+
+    def test_does_not_claim_other_documents(self):
+        assert is_presentation_file("report.pdf", "application/pdf") is False
+        assert is_presentation_file("data.xlsx", XLSX_MIME) is False
+
+    def test_legacy_ppt_is_not_claimed(self):
+        # .ppt (binary, pre-2007) is not in the upload allowlist and
+        # python-pptx cannot open it — don't silently divert it.
+        assert is_presentation_file("old.ppt", "application/vnd.ms-powerpoint") is False
+
+    def test_pptx_is_uploadable(self):
+        # The carve-out is unreachable if the upload gate rejects the file.
+        assert ALLOWED_MIME_TYPES.get(PPTX_MIME) == "pptx"
+
+
+class TestPartitionAttachments:
+    def test_pptx_is_diverted_not_inlined(self):
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        inline, tabular, presentations, oversized = _partition_attachments([deck])
+
+        assert presentations == [deck]
+        assert inline == []
+        assert tabular == []
+        assert oversized == []
+
+    def test_tiny_pptx_still_diverted_never_oversized(self):
+        # The size gate must not get a vote: a 12-byte deck is still a deck,
+        # and "too big" would be the wrong explanation for skipping it.
+        deck = _Attachment("small.pptx", PPTX_MIME, bytes_="AAAA")
+        inline, _, presentations, oversized = _partition_attachments([deck])
+
+        assert presentations == [deck]
+        assert oversized == []
+        assert inline == []
+
+    def test_ordinary_documents_still_inline(self):
+        pdf = _Attachment("report.pdf", "application/pdf", bytes_="AAAA")
+        _, _, presentations, _ = _partition_attachments([pdf])
+        assert presentations == []
+
+    def test_mixed_batch_lands_in_the_right_buckets(self):
+        pdf = _Attachment("report.pdf", "application/pdf", bytes_="AAAA")
+        sheet = _Attachment("data.xlsx", XLSX_MIME)
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+
+        inline, tabular, presentations, oversized = _partition_attachments(
+            [pdf, sheet, deck]
+        )
+
+        assert inline == [pdf]
+        assert tabular == [sheet]
+        assert presentations == [deck]
+        assert oversized == []
+
+
+class TestAttachmentGuidance:
+    def test_names_the_deck_and_the_read_tool_when_enabled(self):
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        guidance = _build_attachment_guidance(
+            [], [deck], [], ["create_powerpoint_presentation"]
+        )
+
+        assert "`deck.pptx`" in guidance
+        assert "read_powerpoint_presentation" in guidance
+
+    def test_tells_the_user_which_toggle_to_flip_when_disabled(self):
+        # A diverted deck with no tool to read it is a dead end unless the
+        # note names the toggle — the file is neither inline nor reachable.
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        guidance = _build_attachment_guidance([], [deck], [], ["some_other_tool"])
+
+        assert "PowerPoint Presentations" in guidance
+        assert "read_powerpoint_presentation" not in guidance
+
+    @pytest.mark.parametrize("enabled_tools", [None, []])
+    def test_no_enabled_tools_is_treated_as_disabled(self, enabled_tools):
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        guidance = _build_attachment_guidance([], [deck], [], enabled_tools)
+        assert "PowerPoint Presentations" in guidance
+
+    def test_silent_when_nothing_was_diverted(self):
+        assert _build_attachment_guidance([], [], [], ["create_powerpoint_presentation"]) == ""
+
+    def test_spreadsheet_and_deck_notes_coexist(self):
+        # Both carve-outs can fire on one turn; neither may swallow the other.
+        sheet = _Attachment("data.xlsx", XLSX_MIME)
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        guidance = _build_attachment_guidance(
+            [sheet], [deck], [], ["analyze_spreadsheet", "create_powerpoint_presentation"]
+        )
+
+        assert "`data.xlsx`" in guidance
+        assert "`deck.pptx`" in guidance
+        assert "analyze_spreadsheet" in guidance
+        assert "read_powerpoint_presentation" in guidance

--- a/frontend/ai.client/src/app/services/file-upload/file-upload.service.spec.ts
+++ b/frontend/ai.client/src/app/services/file-upload/file-upload.service.spec.ts
@@ -6,12 +6,15 @@ import { signal } from '@angular/core';
 import { 
   FileUploadService, 
   formatBytes, 
-  isAllowedMimeType, 
+  isAllowedMimeType,
   getFileExtension,
+  resolveMimeType,
   FileTooLargeError,
   InvalidFileTypeError,
   QuotaExceededError,
   MAX_FILE_SIZE_BYTES,
+  PPTX_MAX_FILE_SIZE_BYTES,
+  maxFileSizeFor,
   ALLOWED_EXTENSIONS
 } from './file-upload.service';
 import { ConfigService } from '../config.service';
@@ -138,8 +141,25 @@ describe('FileUploadService', () => {
       });
 
       it('should throw FileTooLargeError for oversized file', () => {
-        const file = new File(['x'.repeat(MAX_FILE_SIZE_BYTES + 1)], 'large.pdf', { 
-          type: 'application/pdf' 
+        const file = new File(['x'.repeat(MAX_FILE_SIZE_BYTES + 1)], 'large.pdf', {
+          type: 'application/pdf'
+        });
+        expect(() => service.validateFile(file)).toThrow(FileTooLargeError);
+      });
+
+      // A deck never goes inline to Bedrock, so the 4MB inline-document
+      // ceiling doesn't bound it. Corporate templates with imagery clear
+      // 4MB routinely — capping them there is what broke `template_name`.
+      it('should allow a .pptx above the general cap', () => {
+        const file = new File(['x'.repeat(MAX_FILE_SIZE_BYTES + 1)], 'deck.pptx', {
+          type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        });
+        expect(() => service.validateFile(file)).not.toThrow();
+      });
+
+      it('should still reject a .pptx above the presentation cap', () => {
+        const file = new File(['x'.repeat(PPTX_MAX_FILE_SIZE_BYTES + 1)], 'huge.pptx', {
+          type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
         });
         expect(() => service.validateFile(file)).toThrow(FileTooLargeError);
       });
@@ -151,6 +171,22 @@ describe('FileUploadService', () => {
 
       it('should allow unknown MIME with valid extension', () => {
         const file = new File(['content'], 'test.pdf', { type: '' });
+        expect(() => service.validateFile(file)).not.toThrow();
+      });
+
+      // .pptx uploads feed the PowerPoint tools (read a deck, or pass one as
+      // a template to create_powerpoint_presentation). The backend has always
+      // allowed the MIME type; this list was the only thing blocking it, and
+      // the create-deck tool's error text tells users to upload a template.
+      it('should allow .pptx by MIME type', () => {
+        const file = new File(['content'], 'deck.pptx', {
+          type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        });
+        expect(() => service.validateFile(file)).not.toThrow();
+      });
+
+      it('should allow .pptx by extension when MIME is empty', () => {
+        const file = new File(['content'], 'deck.pptx', { type: '' });
         expect(() => service.validateFile(file)).not.toThrow();
       });
     });
@@ -429,11 +465,70 @@ describe('FileUploadService', () => {
         });
       });
 
+      describe('maxFileSizeFor', () => {
+        it('should return the general cap for ordinary files', () => {
+          const file = new File(['c'], 'doc.pdf', { type: 'application/pdf' });
+          expect(maxFileSizeFor(file)).toBe(MAX_FILE_SIZE_BYTES);
+        });
+
+        it('should return the presentation cap by MIME type', () => {
+          const file = new File(['c'], 'deck.pptx', {
+            type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+          });
+          expect(maxFileSizeFor(file)).toBe(PPTX_MAX_FILE_SIZE_BYTES);
+        });
+
+        it('should return the presentation cap by extension when MIME is empty', () => {
+          const file = new File(['c'], 'deck.pptx', { type: '' });
+          expect(maxFileSizeFor(file)).toBe(PPTX_MAX_FILE_SIZE_BYTES);
+        });
+
+        it('should not exceed the backend presentation cap', () => {
+          // The backend is the enforcing side; if the UI cap were larger it
+          // would accept decks that presign then rejects with a 400.
+          expect(PPTX_MAX_FILE_SIZE_BYTES).toBe(25 * 1024 * 1024);
+        });
+      });
+
+      describe('resolveMimeType', () => {
+        it('should keep an allowed MIME the browser reported', () => {
+          const file = new File(['c'], 'doc.pdf', { type: 'application/pdf' });
+          expect(resolveMimeType(file)).toBe('application/pdf');
+        });
+
+        it('should resolve .pptx from the extension when MIME is empty', () => {
+          // Presign would otherwise receive application/octet-stream, which
+          // the backend allowlist rejects — and a deck stored under the wrong
+          // MIME is invisible to read_powerpoint_presentation, which matches
+          // the stored type exactly.
+          const file = new File(['c'], 'deck.pptx', { type: '' });
+          expect(resolveMimeType(file)).toBe(
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+          );
+        });
+
+        it('should override a generic octet-stream MIME using the extension', () => {
+          const file = new File(['c'], 'data.xlsx', { type: 'application/octet-stream' });
+          expect(resolveMimeType(file)).toBe(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+          );
+        });
+
+        it('should pass through an unknown type it cannot resolve', () => {
+          // validateFile is the gate for rejection; this helper must not
+          // invent a MIME for something the allowlist never accepted.
+          const file = new File(['c'], 'thing.exe', { type: 'application/exe' });
+          expect(resolveMimeType(file)).toBe('application/exe');
+        });
+      });
+
       describe('getAcceptedFileTypes equivalent', () => {
         it('should return allowed extensions', () => {
           expect(ALLOWED_EXTENSIONS).toContain('.pdf');
           expect(ALLOWED_EXTENSIONS).toContain('.png');
           expect(ALLOWED_EXTENSIONS).toContain('.docx');
+          // Drives the file picker's `accept` filter in chat-input.
+          expect(ALLOWED_EXTENSIONS).toContain('.pptx');
           expect(ALLOWED_EXTENSIONS.length).toBeGreaterThan(0);
         });
       });

--- a/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
+++ b/frontend/ai.client/src/app/services/file-upload/file-upload.service.ts
@@ -8,7 +8,14 @@ import { ConfigService } from '../config.service';
 export type FileStatus = 'pending' | 'ready' | 'failed';
 
 /**
- * Allowed MIME types for file uploads (Bedrock-compliant)
+ * Allowed MIME types for file uploads.
+ *
+ * Must stay in sync with `ALLOWED_MIME_TYPES` in
+ * `backend/src/apis/shared/files/models.py` — the backend is the enforcing
+ * side, this list drives the picker's `accept` filter and the drop/paste
+ * check. Not every entry is sent to Bedrock as a document block: csv/xls/xlsx
+ * route to the spreadsheet tools and pptx routes to the PowerPoint tools
+ * (Bedrock's document-format enum has no `pptx`). See `_partition_attachments`.
  */
 export const ALLOWED_MIME_TYPES: Record<string, string> = {
   // Documents
@@ -19,6 +26,7 @@ export const ALLOWED_MIME_TYPES: Record<string, string> = {
   'text/csv': 'csv',
   'application/vnd.ms-excel': 'xls',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
   'text/markdown': 'md',
   // Images (Bedrock-supported)
   'image/png': 'png',
@@ -32,7 +40,7 @@ export const ALLOWED_MIME_TYPES: Record<string, string> = {
  */
 export const ALLOWED_EXTENSIONS = [
   // Documents
-  '.pdf', '.docx', '.txt', '.html', '.csv', '.xls', '.xlsx', '.md',
+  '.pdf', '.docx', '.txt', '.html', '.csv', '.xls', '.xlsx', '.pptx', '.md',
   // Images
   '.png', '.jpg', '.jpeg', '.gif', '.webp'
 ];
@@ -41,6 +49,34 @@ export const ALLOWED_EXTENSIONS = [
  * Maximum file size in bytes (4MB)
  */
 export const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Maximum .pptx size in bytes (25MB).
+ *
+ * Decks get a larger cap because the general limit exists to keep documents
+ * under what Bedrock accepts as an inline content block, and a .pptx is
+ * never sent inline — it routes to the PowerPoint tools instead. Corporate
+ * templates with imagery routinely clear 4MB, which is what made the
+ * `template_name` workflow unusable.
+ *
+ * Must match `FILE_UPLOAD_MAX_SIZE_BYTES_PRESENTATION` on the backend
+ * (`files/service.py`), which is the enforcing side — if this is the larger
+ * of the two, the UI accepts a deck that presign then rejects.
+ */
+export const PPTX_MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Resolve the size cap that applies to a given file. Use this rather than
+ * `MAX_FILE_SIZE_BYTES` directly at any gate, or a legitimate deck gets
+ * rejected by whichever check was missed.
+ */
+export function maxFileSizeFor(file: File): number {
+  const isPptx =
+    file.name.toLowerCase().endsWith('.pptx') ||
+    file.type ===
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  return isPptx ? PPTX_MAX_FILE_SIZE_BYTES : MAX_FILE_SIZE_BYTES;
+}
 
 /**
  * Maximum files per message
@@ -232,6 +268,48 @@ export function getFileExtension(filename: string): string {
 }
 
 /**
+ * Extension → MIME map, mirroring `ALLOWED_EXTENSIONS` in
+ * `backend/src/apis/shared/files/models.py`.
+ */
+const EXTENSION_TO_MIME_TYPE: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.csv': 'text/csv',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.md': 'text/markdown',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/**
+ * Resolve the MIME type to send with a presign request.
+ *
+ * Browsers do not always populate `File.type` — an OS with no handler
+ * registered for the extension reports `''`, and some file managers report
+ * `application/octet-stream`. `validateFile` accepts those by extension, so
+ * sending the browser's value verbatim would hand the backend a MIME its
+ * own allowlist rejects, 400-ing an upload the UI just accepted.
+ *
+ * Resolving from the extension also keeps files reachable by the tools that
+ * route them, which match on the stored MIME *exactly*: a deck stored as
+ * octet-stream is invisible to `read_powerpoint_presentation`, and a
+ * spreadsheet stored that way never reaches the analysis tools.
+ */
+export function resolveMimeType(file: File): string {
+  if (isAllowedMimeType(file.type)) {
+    return file.type;
+  }
+  return EXTENSION_TO_MIME_TYPE[getFileExtension(file.name)] ?? file.type;
+}
+
+/**
  * Service for managing file uploads via pre-signed URLs.
  *
  * Upload flow:
@@ -313,9 +391,10 @@ export class FileUploadService {
    * @throws FileUploadError if validation fails
    */
   validateFile(file: File): void {
-    // Check size
-    if (file.size > MAX_FILE_SIZE_BYTES) {
-      throw new FileTooLargeError(file.size, MAX_FILE_SIZE_BYTES);
+    // Check size (pptx has its own, larger cap)
+    const sizeLimit = maxFileSizeFor(file);
+    if (file.size > sizeLimit) {
+      throw new FileTooLargeError(file.size, sizeLimit);
     }
 
     // Check MIME type
@@ -346,7 +425,7 @@ export class FileUploadService {
     const presignRequest: PresignRequest = {
       sessionId,
       filename: file.name,
-      mimeType: file.type || 'application/octet-stream',
+      mimeType: resolveMimeType(file),
       sizeBytes: file.size,
     };
 

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -30,7 +30,7 @@ import {
   FileUploadService,
   PendingUpload,
   ALLOWED_EXTENSIONS,
-  MAX_FILE_SIZE_BYTES,
+  maxFileSizeFor,
   MAX_FILES_PER_MESSAGE,
   formatBytes
 } from '../../../services/file-upload';
@@ -647,11 +647,12 @@ export class ChatInputComponent {
 
     // Validate and upload each file
     for (const file of newFiles) {
-      // Check file size
-      if (file.size > MAX_FILE_SIZE_BYTES) {
+      // Check file size (pptx has its own, larger cap — see maxFileSizeFor)
+      const sizeLimit = maxFileSizeFor(file);
+      if (file.size > sizeLimit) {
         this.toastService.error(
           'File Too Large',
-          `${file.name} exceeds maximum size of ${formatBytes(MAX_FILE_SIZE_BYTES)}.`
+          `${file.name} exceeds maximum size of ${formatBytes(sizeLimit)}.`
         );
         continue;
       }

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -245,6 +245,11 @@ export function buildAppApiEnvironment(
     DYNAMODB_USER_FILES_TABLE_NAME: params.userFilesTableName,
     S3_USER_FILES_BUCKET_NAME: params.userFilesBucketName,
     FILE_UPLOAD_MAX_SIZE_BYTES: String(4194304),
+    // Decks route to the PowerPoint tools instead of Bedrock document blocks,
+    // so the inline-document ceiling that sets the 4MB general cap does not
+    // bound them. Keep in sync with PPTX_MAX_FILE_SIZE_BYTES in the SPA's
+    // file-upload.service.ts — the backend must never be the smaller of the two.
+    FILE_UPLOAD_MAX_SIZE_BYTES_PRESENTATION: String(26214400), // 25MB
     FILE_UPLOAD_MAX_FILES_PER_MESSAGE: String(5),
     FILE_UPLOAD_USER_QUOTA_BYTES: String(1073741824),
     S3_ASSISTANTS_DOCUMENTS_BUCKET_NAME: params.ragDocumentsBucketName,


### PR DESCRIPTION
## Why

`.pptx` was un-uploadable. The frontend allowlist omitted it while the backend's `ALLOWED_MIME_TYPES` has included it since the PowerPoint toolset landed (`65a5a6df`) — so the two had drifted, with the frontend as the stricter side. Meanwhile `create_powerpoint_presentation`'s own error text tells users to *"Upload a .pptx template first"*, advice the UI made impossible to follow.

## Why the one-line fix doesn't work

Bedrock's Converse `DocumentFormat` enum has no `pptx` member:

```
pdf | csv | doc | docx | xls | xlsx | html | txt | md
```

(verified against the botocore service model). Non-tabular attachments go inline as document blocks, so simply adding `.pptx` to the frontend list would presign fine, upload fine, then kill the turn with a `ValidationException` on `format: "pptx"`.

## What this does

Adds the carve-out that makes the upload useful, mirroring the existing tabular one:

- `is_presentation_file()` in `apis/shared/files/models.py`
- `_partition_attachments()` returns a 4-tuple, diverting decks **before** the size gate — they never go inline at any size, so an "oversized" note would misdescribe why they were skipped
- `_build_attachment_guidance()` names the deck and points at `read_powerpoint_presentation` / `template_name`, or names the **PowerPoint Presentations** toggle when the tool is off

The tools needed no changes — `_find_powerpoint_presentation` already resolves any READY `.pptx` in the session, so an uploaded deck is reachable as-is.

## Two things found along the way

**A latent MIME bug.** `validateFile` accepts a file by extension when the browser reports no MIME, but `uploadFile` then sent `file.type || 'application/octet-stream'` — a MIME the backend allowlist rejects, 400-ing an upload the UI had just accepted. This affects *every* type, not just pptx. It bites decks twice over, since `_find_powerpoint_presentation` matches the stored MIME **exactly**, so a deck saved as octet-stream would upload and then be silently invisible to the tool. `resolveMimeType()` now resolves from the extension, leaving `validateFile` as the only rejection gate.

**Presentation-only size cap, raised to 25MB.** The general 4MB limit is sized for Bedrock's inline-document budget, which no longer bounds a deck. The constraint that *does* is the Code Interpreter hop: `_ci_write_bytes` base64-encodes the whole file into a single `writeFiles` `text` field (~4/3 inflation), and that field is a `MaxLenString` capped at 100MB — so 25MB of deck → ~33MB of base64 sits well inside. Corporate templates with imagery routinely clear 4MB, which is what made `template_name` unusable. Both size gates now read `max_size_for()` / `maxFileSizeFor()` so they cannot disagree about which cap applies.

## Worth a reviewer's attention

- **Deploy ordering.** `backend.yml` and `frontend-deploy.yml` both trigger on merge to develop and run in parallel, so there's a brief window where the SPA accepts a `.pptx` that the old inference-api still tries to send inline. Minutes, self-healing.
- **Quota math changed.** Storage quota is untouched at 1GB/user, but five 25MB decks is 125MB — a heavy template user now consumes quota an order of magnitude faster. Nothing breaks; may be worth revisiting that number separately.
- **The general 4MB cap is unchanged** (pptx-only was the ask). Note it's also below Bedrock's actual 4.5MB inline ceiling, so there's headroom there if wanted — separate call.

## Testing

- 22 new tests: 15 covering the carve-out (`test_presentation_attachment_carveout.py`), 7 covering the per-type cap (`test_presentation_upload_size_cap.py`), plus SPA specs for the allowlist, `resolveMimeType`, and `maxFileSizeFor`
- Backend full suite: 5984 passed, 3 skipped
- SPA: 1854 passed
- Infra: `tsc --noEmit` clean, 499 jest passed

**Not verified end-to-end** — the real path (upload a deck in dev, have the agent read it) needs this deployed; dev's inference-api still has the old partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)