### PR TITLE
docs: run the G3 citations probe — the premise was wrong

### DIFF
--- a/backend/scripts/probe_document_citations.py
+++ b/backend/scripts/probe_document_citations.py
@@ -1,0 +1,423 @@
+"""G3 baseline probe — what does today's document path actually see?
+
+`docs/specs/document-offload-evaluation.md` §1 requires this before any offload
+quality scoring: the validation pass found we send no citations config in
+production, and assumed that on Bedrock the visual (page-image) PDF path is
+tied to citations-enabled document handling. If that were true, production
+would be blind to charts today and every offload comparison would inherit a
+degraded baseline.
+
+This probe settles it. It builds a self-contained corpus, then asks each
+question twice against Bedrock Converse:
+
+  arm "bare"  — the document block exactly as `DocumentHandler` builds it
+                today (format / name / source.bytes, no citations)
+  arm "cited" — the same block with `citations: {enabled: True}` added,
+                nothing else changed
+
+Four of the five documents are image-only (PIL writes no text layer), so a
+correct answer proves the model saw pixels. `text_layer.pdf` is the probe's
+own canary: if it fails, the probe is broken rather than the model. The mixed
+document is the realistic production shape — prose plus a figure.
+
+Usage:
+    cd backend
+    AWS_PROFILE=dev-ai uv run python scripts/probe_document_citations.py
+    AWS_PROFILE=dev-ai uv run python scripts/probe_document_citations.py \
+        us.anthropic.claude-haiku-4-5-20251001-v1:0 us.anthropic.claude-sonnet-5
+
+Findings as of 2026-08-12 are recorded in
+`docs/specs/document-citations-probe-findings.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3
+from PIL import Image, ImageDraw, ImageFont
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("g3-probe")
+
+REGION = "us-west-2"
+DEFAULT_MODELS = ["us.anthropic.claude-haiku-4-5-20251001-v1:0"]
+
+FONT_CANDIDATES = [
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+]
+
+REFUSAL_MARKERS = [
+    "unable to", "cannot see", "can't see", "no image", "not able to see",
+    "don't have access", "do not have access", "unable to view", "cannot view",
+    "not visible", "cannot read", "can't read",
+]
+
+
+# --------------------------------------------------------------------- corpus
+
+def _font(size: int) -> Any:
+    for path in FONT_CANDIDATES:
+        if os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _chart_image() -> Image.Image:
+    """Bar chart whose values exist only as pixel heights against an axis."""
+    width, height = 1200, 900
+    img = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(img)
+    draw.text((60, 40), "Quarterly Enrollment, Department of Ceramics",
+              font=_font(34), fill="black")
+
+    bars = [("Fall 2023", 412), ("Spring 2024", 268), ("Fall 2024", 631), ("Spring 2025", 349)]
+    base_y, left, bar_w, gap, top_val = 780, 140, 150, 90, 700
+    scale = (base_y - 160) / top_val
+
+    draw.line([(left - 40, base_y), (width - 60, base_y)], fill="black", width=3)
+    draw.line([(left - 40, base_y), (left - 40, 150)], fill="black", width=3)
+    for grid in range(0, top_val + 1, 100):
+        y = base_y - grid * scale
+        draw.line([(left - 48, y), (left - 40, y)], fill="black", width=3)
+        draw.text((left - 120, y - 14), str(grid), font=_font(24), fill="black")
+
+    for i, (label, value) in enumerate(bars):
+        x0 = left + i * (bar_w + gap)
+        draw.rectangle([x0, base_y - value * scale, x0 + bar_w, base_y], fill=(41, 84, 143))
+        draw.text((x0 + 6, base_y + 14), label, font=_font(22), fill="black")
+    return img
+
+
+def _table_image() -> Image.Image:
+    width, height = 1200, 800
+    img = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(img)
+    draw.text((60, 40), "Table 3. Course Fees by Program (2025-26)", font=_font(32), fill="black")
+    rows = [
+        ["Program", "Lab Fee", "Materials", "Total"],
+        ["Ceramics", "$145", "$310", "$455"],
+        ["Printmaking", "$92", "$188", "$280"],
+        ["Metalsmithing", "$237", "$401", "$638"],
+        ["Photography", "$118", "$264", "$382"],
+    ]
+    x0, y0, col_w, row_h = 70, 130, 265, 76
+    for r, row in enumerate(rows):
+        for c, cell in enumerate(row):
+            x, y = x0 + c * col_w, y0 + r * row_h
+            draw.rectangle([x, y, x + col_w, y + row_h], outline="black", width=2)
+            if r == 0:
+                draw.rectangle([x + 2, y + 2, x + col_w - 2, y + row_h - 2], fill=(230, 230, 235))
+            draw.text((x + 16, y + 24), cell, font=_font(26), fill="black")
+    return img
+
+
+def _scan_image() -> Image.Image:
+    width, height = 1200, 1000
+    img = Image.new("RGB", (width, height), (252, 251, 246))
+    draw = ImageDraw.Draw(img)
+    lines = [
+        "MEMORANDUM", "", "To all department chairs:", "",
+        "Effective the start of the spring term, the equipment replacement",
+        "reserve will be held at eleven percent of each department's annual",
+        "operating allocation. Requests to draw against the reserve must be",
+        "filed with the facilities office no later than the fourteenth day of",
+        "the month preceding the intended purchase.", "",
+        "The prior threshold of six percent is retired and should not be used",
+        "in any budget projection after this date.", "",
+        "  -- Office of the Provost, document reference PR-2291",
+    ]
+    y = 90
+    for line in lines:
+        draw.text((100, y), line, font=_font(30), fill=(28, 28, 32))
+        y += 56
+    img = img.rotate(-0.7, expand=False, fillcolor=(252, 251, 246))
+    ImageDraw.Draw(img).rectangle([0, 0, width - 1, height - 1], outline=(205, 203, 197), width=6)
+    return img
+
+
+def _assemble_pdf(objects: Dict[int, bytes]) -> bytes:
+    """Serialize numbered PDF objects into a valid single-file PDF."""
+    out = b"%PDF-1.4\n"
+    offsets: Dict[int, int] = {}
+    for num in sorted(objects):
+        offsets[num] = len(out)
+        out += f"{num} 0 obj\n".encode("latin-1") + objects[num] + b"\nendobj\n"
+    xref_at = len(out)
+    out += f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n".encode("latin-1")
+    for num in sorted(objects):
+        out += f"{offsets[num]:010d} 00000 n \n".encode("latin-1")
+    out += (f"trailer\n<< /Size {len(objects)+1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_at}\n%%EOF\n").encode("latin-1")
+    return out
+
+
+def _text_layer_pdf() -> bytes:
+    body = (
+        "BT /F1 16 Tf 60 720 Td (Facilities Standards Handbook, Section 9) Tj ET\n"
+        "BT /F1 12 Tf 60 690 Td (The freight elevator in the Liberal Arts building has a rated) Tj ET\n"
+        "BT /F1 12 Tf 60 672 Td (capacity of 3,400 pounds and is inspected twice per year.) Tj ET\n"
+        "BT /F1 12 Tf 60 654 Td (The passenger elevators are inspected annually.) Tj ET\n"
+    )
+    return _assemble_pdf({
+        1: b"<< /Type /Catalog /Pages 2 0 R >>",
+        2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+           b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        4: f"<< /Length {len(body)} >>\nstream\n{body}endstream".encode("latin-1"),
+        5: b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    })
+
+
+def _mixed_pdf() -> bytes:
+    """Page 1 real text layer, page 2 chart image — the production shape."""
+    img = _chart_image()
+    buf = io.BytesIO()
+    img.save(buf, "JPEG", quality=88)
+    jpg, iw, ih = buf.getvalue(), img.width, img.height
+
+    text = (
+        "BT /F1 16 Tf 60 720 Td (Annual Report: Department of Ceramics) Tj ET\n"
+        "BT /F1 12 Tf 60 690 Td (The department operates a shared kiln facility rated for) Tj ET\n"
+        "BT /F1 12 Tf 60 672 Td (cone 10 reduction firing. The replacement cost of the) Tj ET\n"
+        "BT /F1 12 Tf 60 654 Td (primary kiln is estimated at 47,500 dollars as of this year.) Tj ET\n"
+        "BT /F1 12 Tf 60 624 Td (Quarterly enrollment is shown in the figure on page 2.) Tj ET\n"
+    )
+    disp_w = 512.0
+    disp_h = disp_w * ih / iw
+    stream = f"q {disp_w:.2f} 0 0 {disp_h:.2f} 50 400 cm /Im0 Do Q\n"
+
+    return _assemble_pdf({
+        1: b"<< /Type /Catalog /Pages 2 0 R >>",
+        2: b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>",
+        3: b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+           b"/Resources << /Font << /F1 7 0 R >> >> /Contents 5 0 R >>",
+        4: b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+           b"/Resources << /XObject << /Im0 8 0 R >> >> /Contents 6 0 R >>",
+        5: f"<< /Length {len(text)} >>\nstream\n{text}endstream".encode("latin-1"),
+        6: f"<< /Length {len(stream)} >>\nstream\n{stream}endstream".encode("latin-1"),
+        7: b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        8: (f"<< /Type /XObject /Subtype /Image /Width {iw} /Height {ih} "
+            f"/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode "
+            f"/Length {len(jpg)} >>\nstream\n").encode("latin-1") + jpg + b"\nendstream",
+    })
+
+
+def build_corpus(out_dir: str) -> Dict[str, Tuple[str, str]]:
+    """Write the corpus, returning {key: (path, bedrock document name)}."""
+    def image_pdf(img: Image.Image, name: str) -> str:
+        path = os.path.join(out_dir, name)
+        img.convert("RGB").save(path, "PDF", resolution=150.0)
+        return path
+
+    def raw_pdf(data: bytes, name: str) -> str:
+        path = os.path.join(out_dir, name)
+        with open(path, "wb") as fh:
+            fh.write(data)
+        return path
+
+    corpus = {
+        "chart": (image_pdf(_chart_image(), "chart_only.pdf"), "chart only"),
+        "table": (image_pdf(_table_image(), "table_in_image.pdf"), "table in image"),
+        "scan": (image_pdf(_scan_image(), "scanned_page.pdf"), "scanned page"),
+        "canary": (raw_pdf(_text_layer_pdf(), "text_layer.pdf"), "text layer canary"),
+        "mixed": (raw_pdf(_mixed_pdf(), "mixed_text_and_chart.pdf"), "annual report"),
+    }
+    for key, (path, _) in corpus.items():
+        logger.info("corpus %-7s %-26s %8d bytes", key, os.path.basename(path),
+                    os.path.getsize(path))
+    return corpus
+
+
+# ------------------------------------------------------------------ questions
+# accept:     any listed substring present -> correct
+# accept_all: every listed substring must be present
+# num:        any integer in the answer inside (lo, hi) -> correct
+#             (chart bars carry no printed labels, so values are read off an
+#             axis and an exact-match bar would be unfair)
+QUESTIONS: List[Dict[str, Any]] = [
+    dict(id="c1", doc="chart", family="chart-value", num=(600, 660), truth="631",
+         q="What is the value of the Fall 2024 bar in this chart? Answer with the number only."),
+    dict(id="c2", doc="chart", family="chart-compare", accept=["spring 2024"], truth="Spring 2024",
+         q="Which period in this chart has the lowest enrollment? Answer with the period label only."),
+    dict(id="c3", doc="chart", family="chart-value", num=(300, 430), truth="~363",
+         q="Approximately how much higher is the Fall 2024 bar than the Spring 2024 bar? "
+           "Answer with a number only."),
+    dict(id="c4", doc="chart", family="chart-structure",
+         accept_all=["fall 2023", "spring 2024", "fall 2024", "spring 2025"],
+         truth="all four labels",
+         q="List the four period labels along the horizontal axis, left to right."),
+    dict(id="t1", doc="table", family="table-cell", accept=["401"], truth="$401",
+         q="What is the Materials fee for Metalsmithing? Answer with the amount only."),
+    dict(id="t2", doc="table", family="table-compare", accept=["printmaking"], truth="Printmaking",
+         q="Which program has the lowest Total? Answer with the program name only."),
+    dict(id="t3", doc="table", family="table-cell", accept=["118"], truth="$118",
+         q="What is the Lab Fee for Photography? Answer with the amount only."),
+    dict(id="s1", doc="scan", family="scan-fact", accept=["eleven", "11%", "11 percent"],
+         truth="eleven percent",
+         q="What percentage of each department's annual operating allocation is the "
+           "equipment replacement reserve held at?"),
+    dict(id="s2", doc="scan", family="scan-fact", accept=["pr-2291", "pr 2291", "pr2291"],
+         truth="PR-2291",
+         q="What is the document reference identifier shown on this memo?"),
+    dict(id="k1", doc="canary", family="text-layer-canary", accept=["3,400", "3400"],
+         truth="3,400 lb",
+         q="What is the rated capacity of the freight elevator? Answer with the number only."),
+    dict(id="m1", doc="mixed", family="mixed-text", accept=["47,500", "47500"], truth="$47,500 (p1)",
+         q="What is the estimated replacement cost of the primary kiln? Answer with the amount only."),
+    dict(id="m2", doc="mixed", family="mixed-chart", num=(600, 660), truth="631 (p2 image)",
+         q="In the figure, what is the value of the Fall 2024 bar? Answer with the number only."),
+    dict(id="m3", doc="mixed", family="mixed-chart", accept=["spring 2024"],
+         truth="Spring 2024 (p2)",
+         q="In the figure, which period has the lowest enrollment? Answer with the label only."),
+    dict(id="m4", doc="mixed", family="mixed-cross", accept_all=["yes"], truth="yes / yes",
+         q="Does the report state a kiln replacement cost, and does the figure show Fall 2024 "
+           "above 600? Answer yes/no to each."),
+]
+
+
+# -------------------------------------------------------------------- runner
+
+def document_block(corpus, doc_key: str, citations: bool) -> Dict[str, Any]:
+    """Mirror `DocumentHandler.create_content_block`, optionally + citations."""
+    path, label = corpus[doc_key]
+    with open(path, "rb") as fh:
+        data = fh.read()
+    block: Dict[str, Any] = {
+        "document": {"format": "pdf", "name": label, "source": {"bytes": data}}
+    }
+    if citations:
+        block["document"]["citations"] = {"enabled": True}
+    return block
+
+
+def extract(blocks: List[Dict[str, Any]]) -> Tuple[str, bool]:
+    """Pull answer text out of a response.
+
+    With citations enabled the answer moves INSIDE ``citationsContent`` and the
+    top-level ``text`` blocks go empty — a consumer reading only ``text`` sees
+    nothing. Returns (text, response carried citation blocks).
+    """
+    parts: List[str] = []
+    cited = False
+    for block in blocks:
+        if "text" in block:
+            parts.append(block["text"])
+        if "citationsContent" in block:
+            cited = True
+            parts += [c.get("text", "") for c in block["citationsContent"].get("content", [])]
+    return " ".join(parts).strip(), cited
+
+
+def score(question: Dict[str, Any], answer: str) -> bool:
+    lowered = answer.lower()
+    if "num" in question:
+        lo, hi = question["num"]
+        found = [int(n.replace(",", "")) for n in re.findall(r"\d[\d,]*", lowered)]
+        return any(lo <= n <= hi for n in found)
+    if "accept_all" in question:
+        return all(token in lowered for token in question["accept_all"])
+    return any(token in lowered for token in question["accept"])
+
+
+def ask(client, model_id: str, corpus, question, citations: bool) -> Dict[str, Any]:
+    message = {
+        "role": "user",
+        "content": [document_block(corpus, question["doc"], citations), {"text": question["q"]}],
+    }
+    started = time.time()
+    error: Optional[str] = None
+    # Claude 5-family models reject `temperature` outright; fall back rather
+    # than scoring a 400 as a wrong answer.
+    for config in ({"maxTokens": 500, "temperature": 0}, {"maxTokens": 500}):
+        try:
+            response = client.converse(modelId=model_id, messages=[message],
+                                       inferenceConfig=config)
+            break
+        except Exception as exc:  # noqa: BLE001 - probe reports, never raises
+            error = f"{type(exc).__name__}: {exc}"
+            if "temperature" not in str(exc):
+                return dict(error=error, answer="", cited=False)
+    else:
+        return dict(error=error, answer="", cited=False)
+
+    text, cited = extract(response["output"]["message"]["content"])
+    return dict(
+        error=None,
+        answer=text,
+        cited=cited,
+        refused=any(m in text.lower() for m in REFUSAL_MARKERS),
+        usage=response.get("usage", {}),
+        ms=int((time.time() - started) * 1000),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("models", nargs="*", default=None,
+                        help=f"Bedrock model ids (default: {DEFAULT_MODELS[0]})")
+    parser.add_argument("--out", default=None, help="directory for corpus + results JSON")
+    args = parser.parse_args()
+
+    models = args.models or DEFAULT_MODELS
+    out_dir = args.out or tempfile.mkdtemp(prefix="g3-probe-")
+    os.makedirs(out_dir, exist_ok=True)
+    logger.info("corpus + results -> %s", out_dir)
+
+    corpus = build_corpus(out_dir)
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    results: List[Dict[str, Any]] = []
+
+    for model_id in models:
+        print(f"\n{'=' * 86}\nMODEL {model_id}\n{'=' * 86}")
+        for question in QUESTIONS:
+            row: Dict[str, Any] = dict(model=model_id, id=question["id"],
+                                       doc=question["doc"], family=question["family"],
+                                       truth=question["truth"])
+            for arm, citations in (("bare", False), ("cited", True)):
+                res = ask(client, model_id, corpus, question, citations)
+                res["correct"] = (not res["error"]) and score(question, res["answer"])
+                row[arm] = res
+            bare, cited = row["bare"], row["cited"]
+            marker = "" if bare["correct"] == cited["correct"] else "   <-- ARMS DIVERGE"
+            print(f"[{question['id']:>3}] {question['family']:<20} "
+                  f"truth={question['truth']:<18} "
+                  f"bare={'PASS' if bare['correct'] else 'fail'}  "
+                  f"cited={'PASS' if cited['correct'] else 'fail'}"
+                  f"{'+cit' if cited['cited'] else '    '}{marker}")
+            if bare["error"] or cited["error"]:
+                print(f"       ERROR bare={bare['error']} cited={cited['error']}")
+            results.append(row)
+
+    results_path = os.path.join(out_dir, "results.json")
+    with open(results_path, "w") as fh:
+        json.dump(results, fh, indent=2, default=str)
+
+    print(f"\n{'=' * 86}\nSUMMARY\n{'=' * 86}")
+    for model_id in models:
+        rows = [r for r in results if r["model"] == model_id]
+        bare_ok = sum(r["bare"]["correct"] for r in rows)
+        cited_ok = sum(r["cited"]["correct"] for r in rows)
+        with_cit = sorted(r["id"] for r in rows if r["cited"]["cited"])
+        print(f"{model_id}")
+        print(f"  bare  {bare_ok}/{len(rows)} correct")
+        print(f"  cited {cited_ok}/{len(rows)} correct")
+        print(f"  responses carrying citation blocks: {len(with_cit)} {with_cit}")
+    print(f"\nresults -> {results_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/one-pagers/cost-effectiveness-roadmap.md
+++ b/docs/one-pagers/cost-effectiveness-roadmap.md
@@ -168,9 +168,25 @@ Gate summary — each is a *measurement with a decision attached*, not a date:
   rate: *of conversations that get long enough to compact at all, 32% already
   exceed PR-2's proposed budget.* That rate does not shrink with growth; the
   population it applies to grows.
-- **G3** — no citations config is sent in prod today, so we don't know what
-  the current document path can even see. Every offload quality comparison
-  inherits its baseline from this probe.
+- **G3 — CLEARED 2026-08-12, by falsifying its own premise**
+  (`document-citations-probe-findings.md`). The gate existed because no
+  citations config is sent in prod and the #836 validation reasoned Bedrock's
+  visual PDF path was *tied to* citations-enabled handling — which would have
+  made prod blind to figures. It is not. Probed with 14 questions over 5
+  documents on two models: **14/14 correct in both arms, both models**,
+  including bar values read off an unlabeled axis, cells in a table that exists
+  only as pixels, and a rotated scan. **Citations turn out to be a text-layer
+  feature**: with citations explicitly enabled, every image-only document
+  returned none at all, while text-layer and mixed-document page-1 prose
+  questions returned them with a usable `documentPage` location.
+  Consequences: the offload baseline is **full visual fidelity, uncited**; the
+  spec's "native blocks, never flattened text" rule is now measured rather than
+  precautionary; and offloading an image-only document costs no citations,
+  because there were never any. ⚠️ One migration cost surfaced — with citations
+  on, the answer text moves *inside* `citationsContent` and top-level `text`
+  blocks go empty, so every consumer must handle both shapes first. "Should we
+  enable citations?" is now a standalone product question about attribution,
+  **not a prerequisite for the offload arc**.
 
 Independent of all gates: #833 PR-5 (quota runway — **built 2026-08-05**) and
 the W5 follow-ups — cheap, and they don't wait on measurement. PR-5 also
@@ -202,7 +218,8 @@ between sessions. **Update a row here in the PR that changes it.**
 | #834 spreadsheets | unbuilt | `assistant_id` into cache key + `PausedTurnSnapshot` |
 | #834 Memory-Space tools | unbuilt | binding descriptor into cache key |
 | #835 compaction v2 | unbuilt | G2 |
-| #836 offload PRs 1–3 | unbuilt | G3 citations probe |
+| #836 offload PRs 1–3 | unbuilt | ~~G3 citations probe~~ — **G3 cleared 2026-08-12**; baseline is full visual fidelity, uncited. Now blocked only on the eval harness owner (PRs 1–3 change model-visible context) |
+| G3 citations probe | ✅ **run 2026-08-12** — `document-citations-probe-findings.md`; script committed at `backend/scripts/probe_document_citations.py` | nothing |
 | eval harness (quality veto) | **unowned** | an owner |
 | replay harness (#833 §4.2) | partially built — `experiment_agent_cache_arms.py` + `probe_runtime_session_affinity.py` drive real arms against dev; does not yet replay a recorded session's event stream | an owner for the rest |
 | §4.1 cohort scan | ✅ **run 2026-08-05** — cohort is 49 sessions (1.63%) / $172.46 (21.9% of recorded session spend); D2 and D3 both reproduce outside the incident (a 174,952-char summary on another session; anchor≠checkpoint on 199 of 1,238 rows). Written up in #833 §4.1 | nothing |

--- a/docs/specs/document-citations-probe-findings.md
+++ b/docs/specs/document-citations-probe-findings.md
@@ -1,0 +1,158 @@
+# G3 — the citations baseline probe, run
+
+**Date:** August 12, 2026 · **Gate:** G3 (`cost-effectiveness-roadmap.md`)
+**Required by:** `document-offload-evaluation.md` §1
+**Script:** `backend/scripts/probe_document_citations.py` (self-contained;
+builds its own corpus, no fixtures, no user content)
+
+**Result: G3 clears, and it clears by falsifying the premise it was built on.
+Production already reads charts, image tables and scanned pages at full
+fidelity, with no citations config. Citations are a *text-layer* feature, not
+the switch that turns on visual understanding.**
+
+---
+
+## 1. What the gate was for
+
+The #836 validation pass established that we send **no citations config in
+production** — `DocumentHandler.create_content_block` emits `format` / `name` /
+`source.bytes` and nothing else. It then reasoned that on Bedrock the visual
+(page-image) PDF path is *tied to* citations-enabled document handling, and
+concluded we did not know whether production could see charts at all.
+
+That mattered because every offload quality comparison inherits its baseline
+from arm A. If arm A were blind to figures, "the digest lost the chart" would
+be unmeasurable — you cannot lose what was never there.
+
+## 2. Method
+
+Five documents, fourteen questions, each asked twice — once with the document
+block exactly as production builds it, once with `citations: {enabled: True}`
+added and **nothing else changed**.
+
+| document | construction | what a correct answer proves |
+|---|---|---|
+| `chart_only.pdf` | bar chart, image-only | values read off an axis from pixels |
+| `table_in_image.pdf` | table rendered as an image | cell lookup with no text layer |
+| `scanned_page.pdf` | memo text rasterized, rotated 0.7° | OCR-equivalent reading |
+| `text_layer.pdf` | real PDF text object, no image | **canary** — if this fails the probe is broken |
+| `mixed_text_and_chart.pdf` | p1 real text layer, p2 embedded JPEG chart | the realistic production shape |
+
+The four image-only PDFs were verified to carry **no extractable text**
+(`strings` over the raw bytes finds none of the ground-truth values), so a
+correct answer cannot come from a text layer. Chart-value questions are scored
+with a tolerance band because the bars carry no printed labels — reading them
+means estimating against the axis, and an exact-match bar would be unfair.
+
+Models: `us.anthropic.claude-haiku-4-5-20251001-v1:0` (the dev default) and
+`us.anthropic.claude-sonnet-5`.
+
+## 3. Results
+
+**Both models, both arms: 14/14 correct.**
+
+| family | bare | cited |
+|---|---|---|
+| chart-value (2) · chart-compare · chart-structure | 4/4 | 4/4 |
+| table-cell (2) · table-compare | 3/3 | 3/3 |
+| scan-fact (2) | 2/2 | 2/2 |
+| text-layer canary | 1/1 | 1/1 |
+| mixed: text · chart (2) · cross-page | 4/4 | 4/4 |
+
+Nothing diverged between arms on correctness. The model read 631 off an
+unlabeled bar, found `$401` in a table that exists only as pixels, and pulled
+`PR-2291` off a rotated scan.
+
+### Where citations actually fired
+
+This is the finding with teeth. Of the 14 responses in the **cited** arm,
+exactly three carried `citationsContent` — and *the same three on both models*:
+
+| id | document | question draws on | cited |
+|---|---|---|---|
+| `k1` | `text_layer.pdf` | the text layer | ✅ |
+| `m1` | `mixed_text_and_chart.pdf` | page-1 prose | ✅ |
+| `m4` | `mixed_text_and_chart.pdf` | page-1 prose **and** page-2 figure | ✅ |
+| `m2`, `m3` | `mixed_text_and_chart.pdf` | page-2 figure only | ❌ |
+| `c1`–`c4`, `t1`–`t3`, `s1`–`s2` | the three image-only PDFs | pixels only | ❌ |
+
+Every image-only document returned plain `text` blocks and **no citations at
+all**, in both models, with citations explicitly enabled. The mixed document is
+the clean demonstration: same request, same document, citations on — the two
+questions answerable only from the figure came back uncited, while the two that
+touch the prose came back cited.
+
+**Citations require a text layer to cite.** They are not a visual-fidelity
+switch, and enabling them does not make the model see more. Both capabilities
+coexist happily in one document: page-1 prose answers arrive cited with a page
+location, page-2 figure answers arrive correct and uncited.
+
+### The citation block's shape
+
+```
+citationsContent:
+  content:   [{text: "3,400 pounds"}]          <- the answer
+  citations: [{title: "text layer canary",
+               sourceContent: [{text: "...verbatim source excerpt..."}],
+               location: {documentPage: {documentIndex: 0, start: 1, end: 2}}}]
+```
+
+Two things follow.
+
+⚠️ **With citations enabled the answer text moves *inside* `citationsContent`
+and the top-level `text` blocks go empty.** Any consumer that reads only
+`text` sees a blank answer. This probe hit it directly — a correct answer
+scored as a miss until the extractor was fixed. Anything that would consume a
+citations-enabled response (the SSE content path, the eval harness scorer,
+`_BEDROCK_CONTENT_BLOCK_KEYS`) has to handle both shapes before citations
+could be turned on anywhere.
+
+✅ `location.documentPage` gives `{documentIndex, start, end}` — which is
+exactly the page-identity primitive `document-offload-evaluation.md` §2.3 needs
+for the `document_read(page_range=…)` remapping test. That family is buildable
+against a real page number rather than an inferred one.
+
+## 4. What this changes
+
+**For the offload work (#836):**
+
+1. **The G3 baseline is "full visual fidelity, uncited."** Arms B and C are
+   measured against a model that today reads charts, image tables and scans.
+   The bar is higher than the spec assumed.
+2. **The spec's "native blocks, never flattened text" rule is now empirically
+   justified**, not precautionary. A text-only digest demonstrably discards
+   capability the current path has — we measured the capability rather than
+   assuming it.
+3. **The citation-loss concern narrows sharply.** Offloading an *image-only*
+   document costs no citations, because there were never any. It is only
+   text-layer documents where offload trades away attribution — and since the
+   product does not send the citations config today, that trade currently costs
+   nothing at all.
+4. **The dual-encoding premise is confirmed but re-attributed.** PDFs do get
+   visual understanding. It simply is not gated on the citations config, which
+   is what the spec had wrong.
+
+**For the product, separately:** "should we enable citations?" is now a clean,
+independent question about answer attribution — worth asking on its own merits,
+with the response-shape migration in §3 as its real cost. It is **not** a
+prerequisite for anything in the offload arc, and the offload arc should stop
+treating it as one.
+
+## 5. Corrections to existing documents
+
+- `document-context-offload.md` §1 / `document-context-offload-validation.md`:
+  the claim that the visual PDF path is tied to citations-enabled handling is
+  **disproven**. Visual understanding is unconditional.
+- `document-offload-evaluation.md` §1: the required baseline experiment is
+  **run**; §2.3's note that "arm A scores here reflect the §1 baseline probe"
+  resolves to *arm A is at full fidelity*, so the citation family gates B and C
+  against each other, as that section anticipated.
+
+## 6. Loose end worth knowing
+
+`us.anthropic.claude-sonnet-5` rejects `temperature` outright
+(`ValidationException: temperature is deprecated for this model`). Our main
+chat path only sends it when a value is explicitly set, and the Nova Micro
+title path is unaffected — so this is **latent, not a live defect**. But an
+admin pinning `temperature` on a Claude-5-family model via the inference-params
+surface would 400 the turn. Worth a guard when someone is next in that code.

--- a/docs/specs/document-context-offload-validation.md
+++ b/docs/specs/document-context-offload-validation.md
@@ -242,6 +242,18 @@ Related code findings that sharpen PR-6:
    processing is tied to the citations-enabled document path. The evaluation
    must establish the *current* fidelity baseline before scoring the digest
    against it (see the evaluation spec §2).
+
+   > **Superseded 2026-08-12 — the second half of this item is wrong.** The
+   > first half stands: no citations config is sent, and the
+   > `_BEDROCK_CONTENT_BLOCK_KEYS` reasoning does conflate response-side with
+   > request-side. But "full visual PDF processing is tied to the
+   > citations-enabled document path" is **false**, and the G3 probe
+   > (`document-citations-probe-findings.md`) measured it: 14/14 correct in the
+   > *bare* arm on two models, including unlabeled bar values, image-only table
+   > cells, and a rotated scan. Visual understanding is unconditional.
+   > Citations are a **text-layer** feature — enabled explicitly, they produced
+   > no citations at all on image-only documents. The current fidelity baseline
+   > is therefore **full visual fidelity, uncited**, and it is established.
 2. **The bypass spec's §6 isolating experiment is not clean — it is nearly
    powerless.** 921 of 974 `create_artifact` sessions *also* have spreadsheet
    tools enabled, so "enable caching for `create_artifact` only" changes the

--- a/docs/specs/document-context-offload.md
+++ b/docs/specs/document-context-offload.md
@@ -457,6 +457,24 @@ emits only `format`/`name`/`source.bytes`), so enabling citations is new work
 in PR-1, and the evaluation's §1 baseline probe must establish current PDF
 visual fidelity before any digest comparison is scored.
 
+> **G3 probe run 2026-08-12 — `document-citations-probe-findings.md`.** The
+> baseline is established: **full visual fidelity, uncited.** Today's bare
+> document block reads unlabeled chart bars, image-only table cells and
+> rotated scans — 14/14 on two models — so the §3 "quality tension" is real
+> and this spec's *offload as native blocks, never flattened text* rule is now
+> measured rather than precautionary.
+>
+> Two revisions follow. **Citations are a text-layer feature**, not a visual
+> one: enabled explicitly, image-only documents returned none at all. So
+> "citations stay enabled on it" (§4 lifecycle, and the reassembly note) is
+> not a quality requirement for image-heavy documents — there is nothing to
+> preserve — and **enabling citations is no longer part of PR-1**. It is a
+> standalone product question about attribution, with a real migration cost:
+> with citations on, the answer text moves *inside* `citationsContent` and
+> top-level `text` blocks go empty, so every consumer must handle both shapes.
+> Where citations *do* apply — text-layer documents — `location.documentPage`
+> supplies the page identity the evaluation's reassembly test needs.
+
 ---
 
 ## 7. Non-goals


### PR DESCRIPTION
G3 gated every offload quality comparison on an unknown: we send no citations config in production, and the #836 validation reasoned that Bedrock's visual (page-image) PDF path is **tied to** citations-enabled document handling. If that were true, production is blind to charts today and arm A is a degraded baseline — you cannot measure "the digest lost the chart" if the chart was never visible.

**It is not true. G3 clears by falsifying its own premise.**

## Method

14 questions over 5 documents, each asked twice — once with the document block exactly as `DocumentHandler.create_content_block` builds it today, once with `citations: {enabled: true}` added and *nothing else changed*. Models: `claude-haiku-4-5` (the dev default) and `claude-sonnet-5`.

Four of the five PDFs are image-only and verified to carry **no extractable text**, so a correct answer can only have come from pixels. The fifth is a real text layer — the probe's canary, so a total failure is distinguishable from a broken harness. The fifth document is the realistic production shape: page 1 prose, page 2 an embedded chart.

## Result: 14/14 correct, both arms, both models

The model read **631** off an unlabeled bar, found **$401** in a table that exists only as pixels, and pulled **PR-2291** off a rotated scan. Nothing diverged between arms.

**Citations are a text-layer feature, not a visual-fidelity switch.** With citations explicitly enabled, exactly three responses carried `citationsContent` — the same three on both models — and all three draw on a text layer. In the mixed document, same request, citations on: the two questions answerable only from the figure came back **uncited**, the two touching the prose came back **cited** with a usable `documentPage` location.

## What changes

- The offload baseline is **full visual fidelity, uncited**. Arms B and C are measured against a higher bar than the spec assumed.
- The spec's *"offload as native blocks, never flattened text"* rule is now **measured**, not precautionary — a text-only digest demonstrably discards capability the current path has.
- **Offloading an image-only document costs no citations**, because there were never any. Only text-layer documents trade attribution — and since we don't send the config today, that trade currently costs nothing.
- **Enabling citations drops out of PR-1** into a standalone product question about attribution. ⚠️ It carries a real migration cost: with citations on, the answer text moves *inside* `citationsContent` and top-level `text` blocks go empty. Every consumer must handle both shapes first. This probe hit it directly — a correct answer scored as a miss until the extractor was fixed.

## Changes

- **new** `backend/scripts/probe_document_citations.py` — self-contained and reproducible; builds its own corpus, touches no user content, `ruff` clean
- **new** `docs/specs/document-citations-probe-findings.md`
- `docs/one-pagers/cost-effectiveness-roadmap.md` — G3 marked cleared with the finding; ledger rows updated (#836 PRs 1–3 now blocked only on the eval-harness owner)
- `docs/specs/document-context-offload.md` + `-validation.md` — the disproven claim marked superseded in place, with the original reasoning left readable

Docs + one script; no product code, no infra, no deploy.

**Note:** touches the same roadmap file as #862 (eval-harness scope + AgentCore Evaluations spike), but different sections — should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)