### PR TITLE
fix(infra): grant app-api s3vectors:DeleteVectors and runtime user-settings read

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -624,7 +624,14 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
-  // ── S3 Vectors (RAG query) ──
+  // ── S3 Vectors (RAG query + document cleanup) ──
+  // DeleteVectors is required by documents/services/cleanup_service.py, which
+  // removes a document's (or an assistant's) chunks from the index when the
+  // document is deleted. Without it every cleanup exhausted its 3 retries and
+  // logged "Cleanup incomplete ... TTL will auto-expire", leaving orphaned
+  // vectors that stayed searchable until TTL. Note the s3vectors delete action
+  // is DeleteVectors (plural, batch); rag-ingestion's DeleteVector (singular)
+  // is a different action and does not cover this call.
   const vectorBucketName = props.refs.ragVectorBucketName;
   const vectorIndexName = props.refs.ragVectorIndexName;
   taskRole.addToPrincipalPolicy(
@@ -633,7 +640,8 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
       effect: iam.Effect.ALLOW,
       actions: ['s3vectors:GetVector', 's3vectors:GetVectors',
                 's3vectors:ListVectors', 's3vectors:QueryVectors',
-                's3vectors:GetIndex', 's3vectors:ListIndexes'],
+                's3vectors:GetIndex', 's3vectors:ListIndexes',
+                's3vectors:DeleteVectors'],
       resources: [
         `arn:aws:s3vectors:${config.awsRegion}:${config.awsAccount}:bucket/${vectorBucketName}`,
         `arn:aws:s3vectors:${config.awsRegion}:${config.awsAccount}:bucket/${vectorBucketName}/index/${vectorIndexName}`,

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -198,6 +198,25 @@ export function createRuntimeExecutionRole(
     resources: tableResources,
   }));
 
+  // ── User settings table (read-only) ──
+  // inference_api/chat/routes.py resolves the user's saved defaultModelId via
+  // UserSettingsRepository.get_settings — a GetItem on PK=USER#<id>, SK=SETTINGS.
+  // The runtime never writes settings (app-api owns that), and the table has no
+  // GSIs, so this stays a bare-ARN GetItem rather than joining the read/write
+  // bulk grant above.
+  //
+  // inference-agentcore-construct.ts injects DYNAMODB_USER_SETTINGS_TABLE_NAME,
+  // which makes the repository report itself enabled — so without this grant the
+  // GetItem AccessDenied'd and get_settings swallowed it into DEFAULT_SETTINGS.
+  // The user's chosen default model was silently ignored with no user-visible
+  // error; only a stray ERROR line in the runtime log revealed it.
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'UserSettingsTableReadAccess',
+    effect: iam.Effect.ALLOW,
+    actions: ['dynamodb:GetItem'],
+    resources: [refs.userSettingsTable.tableArn],
+  }));
+
   // ── System prompts table (read-only) ──
   // The inference path resolves the active prompt via system_prompt_resolver
   // and only ever needs GetItem. The table has no GSIs and the inference

--- a/infrastructure/test/security-policy.test.ts
+++ b/infrastructure/test/security-policy.test.ts
@@ -215,6 +215,96 @@ describe('Security policy hardening', () => {
   });
 
   // ──────────────────────────────────────────────────────────
+  // 2c. Grants proven missing by prod CloudWatch AccessDenied
+  // ──────────────────────────────────────────────────────────
+
+  // Both grants below were found the same way as SharedConversationsAccess
+  // above: the capability was wired end-to-end except for the IAM statement,
+  // so the failure only ever surfaced as an AccessDeniedException in the
+  // prod logs. Iterate AWS::IAM::Policy AND AWS::IAM::ManagedPolicy because
+  // CDK auto-splits oversized inline policies into managed overflow policies
+  // attached to the same role.
+  function statementsWithSid(sid: string): PolicyStatement[] {
+    const candidates: PolicyStatement[] = [];
+    for (const [, r] of Object.entries(template.findResources('AWS::IAM::Policy'))) {
+      const stmts = ((r.Properties as { PolicyDocument?: { Statement?: PolicyStatement[] } })?.PolicyDocument?.Statement) ?? [];
+      for (const s of stmts) candidates.push(s);
+    }
+    for (const [, r] of Object.entries(template.findResources('AWS::IAM::ManagedPolicy'))) {
+      const stmts = ((r.Properties as { PolicyDocument?: { Statement?: PolicyStatement[] } })?.PolicyDocument?.Statement) ?? [];
+      for (const s of stmts) candidates.push(s);
+    }
+    return candidates.filter((s) => s.Sid === sid);
+  }
+
+  describe('App-api S3 Vectors grant', () => {
+    // Regression guard: the grant listed read actions only, so every
+    // document-delete cleanup exhausted its 3 retries on
+    // AccessDeniedException and logged "Cleanup incomplete ... TTL will
+    // auto-expire" — orphaning the document's vectors in the index, where
+    // they stayed searchable until TTL.
+    it('app-api role can DeleteVectors as well as query the RAG index', () => {
+      const matches = statementsWithSid('S3VectorsQueryAccess');
+
+      if (matches.length === 0) {
+        throw new Error(
+          "Could not locate the app-api S3 Vectors grant. " +
+            "Looked for Sid 'S3VectorsQueryAccess'. If the Sid was renamed, update this test.",
+        );
+      }
+
+      // Both app-api and the AgentCore runtime declare this Sid; only
+      // app-api runs cleanup, so assert at least one statement carries the
+      // delete action rather than requiring it of every match.
+      const withDelete = matches.filter((s) => asArray(s.Action).includes('s3vectors:DeleteVectors'));
+      expect(withDelete.length).toBeGreaterThan(0);
+
+      for (const s of matches) {
+        const actions = asArray(s.Action);
+        // The query path is what the runtime needs; keep it intact.
+        expect(actions).toContain('s3vectors:QueryVectors');
+        // s3vectors' batch delete is DeleteVectors (plural). DeleteVector
+        // (singular, what rag-ingestion holds) is a DIFFERENT action and
+        // does not authorize the cleanup service's call.
+        expect(actions).not.toContain('s3vectors:DeleteVector');
+        const resources = asArray(s.Resource);
+        expect(resources).not.toContain('*');
+      }
+    });
+  });
+
+  describe('AgentCore runtime user-settings grant', () => {
+    // Regression guard: inference-agentcore-construct.ts injects
+    // DYNAMODB_USER_SETTINGS_TABLE_NAME, which makes UserSettingsRepository
+    // report itself enabled — but the table was absent from the runtime
+    // role's grants. get_settings swallowed the AccessDeniedException into
+    // DEFAULT_SETTINGS, silently ignoring the user's chosen default model.
+    it('runtime role can GetItem on the user-settings table', () => {
+      const matches = statementsWithSid('UserSettingsTableReadAccess');
+
+      if (matches.length === 0) {
+        throw new Error(
+          "Could not locate the runtime user-settings grant. " +
+            "Looked for Sid 'UserSettingsTableReadAccess'. Without it the user's saved " +
+            "defaultModelId is silently ignored on the inference path. " +
+            "If the Sid was renamed, update this test.",
+        );
+      }
+
+      for (const s of matches) {
+        const actions = asArray(s.Action);
+        expect(actions).toContain('dynamodb:GetItem');
+        // The runtime never writes settings — app-api owns that path.
+        expect(actions).not.toContain('dynamodb:PutItem');
+        expect(actions).not.toContain('dynamodb:UpdateItem');
+        expect(actions).not.toContain('dynamodb:DeleteItem');
+        const resources = asArray(s.Resource);
+        expect(resources).not.toContain('*');
+      }
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────
   // 3. S3 hardening (encryption + public-access-block)
   // ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Two missing IAM grants found while auditing the prod-ai CloudWatch logs. Both had the capability wired end-to-end *except* for the policy statement, so neither ever surfaced as a user-visible error — they only appeared as `AccessDeniedException` lines in the logs.

## 1. app-api can't delete vectors (`S3VectorsQueryAccess`)

```
User: .../boisestateai-v2-PlatformS-AppApiAppApiTaskDefinitio-i5ek4wrsPUph
is not authorized to perform: s3vectors:DeleteVectors on resource:
.../boisestateai-v2-rag-vector-index-v1
```

The grant listed read actions only. Every document-delete cleanup in `documents/services/cleanup_service.py` exhausted its 3 retries and logged `Cleanup incomplete ... TTL will auto-expire`. In one hour on 8/13, two bulk cleanups failed outright — `ast-87ea25f4e188` at 0/18 documents and `ast-9004b011ce30` at 0/1 — leaving those chunks orphaned in the index and **still searchable until TTL**.

⚠️ The s3vectors batch delete is `DeleteVectors` (**plural**). rag-ingestion holds `DeleteVector` (singular), which is a different action and does not authorize this call — copying that line would not have fixed it.

## 2. Runtime can't read user settings (`UserSettingsTableReadAccess`)

```
assumed-role/boisestateai-v2-agentcore-runtime-role/... is not authorized to
perform: dynamodb:GetItem on resource: table/boisestateai-v2-user-settings
```

`inference-agentcore-construct.ts:319` injects `DYNAMODB_USER_SETTINGS_TABLE_NAME`, so `UserSettingsRepository` reports itself **enabled** — but the table was absent from the runtime role's `tableArns` list. `get_settings` catches `ClientError` and returns `DEFAULT_SETTINGS`, so the failure is silent: **the user's saved `defaultModelId` was ignored and they got the system default model instead.** Only 2 log lines for what is a persistent wrong-behavior bug.

Scoped read-only on a bare ARN, following the `SystemPromptsTableReadAccess` precedent directly above it — the runtime only ever calls `get_settings` (app-api owns writes) and the table has no GSIs.

## Tests

Added to `security-policy.test.ts` beside the existing `SharedConversationsAccess` guard, which covers the identical failure mode (env var threaded, grant missing). Verified both new tests **fail** without the source change — stashing the two `lib/` edits gives `2 failed, 8 passed`.

Full suite: **505 passed** (503 + 2 new). `tsc --noEmit` and `cdk synth` clean; confirmed in the synthesized template that app-api's statement gains `DeleteVectors` while the runtime's query-only s3vectors grant is unchanged.

## Deploy

Infra-only — needs `platform.yml`. No backend image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
