### PR TITLE
feat(files): slide-deck preview card for .pptx, and stop diverted attachments vanishing on reload

### DIFF
--- a/backend/src/agents/main_agent/chat_agent.py
+++ b/backend/src/agents/main_agent/chat_agent.py
@@ -84,6 +84,7 @@ class ChatAgent(BaseAgent):
         message: str,
         session_id: Optional[str] = None,
         files: Optional[List] = None,
+        attachment_names: Optional[List[str]] = None,
         citations: Optional[List] = None,
         original_message: Optional[str] = None,
         interrupt_responses: Optional[List[Dict[str, Any]]] = None,
@@ -98,7 +99,12 @@ class ChatAgent(BaseAgent):
                 `interrupt_responses` — the paused turn already has the
                 original prompt in `_interrupt_state`.
             session_id: Session identifier (defaults to instance session_id)
-            files: Optional list of FileContent objects (with base64 bytes)
+            files: Optional list of FileContent objects (with base64 bytes).
+                Inline attachments only — diverted ones (spreadsheets, decks)
+                must not be here or they become invalid document blocks.
+            attachment_names: Every filename the user attached this turn,
+                including diverted ones, for the `[Attached files: …]` marker
+                the SPA replays to rebuild attachment cards on reload.
             citations: Optional list of citation dicts from RAG retrieval
             original_message: Original user message before RAG augmentation
             interrupt_responses: When set, resume a paused agent turn by
@@ -129,7 +135,9 @@ class ChatAgent(BaseAgent):
             # user turn, no multimodal/files.
             prompt = []
         else:
-            prompt = self.multimodal_builder.build_prompt(message, files)
+            prompt = self.multimodal_builder.build_prompt(
+                message, files, attachment_names=attachment_names
+            )
 
         async for event in self.stream_coordinator.stream_response(
             agent=self.agent,

--- a/backend/src/agents/main_agent/multimodal/prompt_builder.py
+++ b/backend/src/agents/main_agent/multimodal/prompt_builder.py
@@ -23,33 +23,52 @@ class PromptBuilder:
     def build_prompt(
         self,
         message: str,
-        files: Optional[List[Any]] = None
+        files: Optional[List[Any]] = None,
+        attachment_names: Optional[List[str]] = None,
     ) -> Union[str, List[Dict[str, Any]]]:
         """
         Build prompt for Strands Agent with multimodal support
 
         Args:
             message: User message text
-            files: Optional list of FileContent objects with base64 bytes
+            files: Optional list of FileContent objects with base64 bytes.
+                These become content blocks, so this must be the *inline*
+                set only — handing it a .pptx would produce a document block
+                in a format Bedrock's enum doesn't accept.
+            attachment_names: Optional authoritative filename list for the
+                ``[Attached files: …]`` marker. Defaults to the names in
+                ``files``. Pass this when some attachments are deliberately
+                kept out of ``files`` (spreadsheets route to the analysis
+                tools, decks to the PowerPoint tools) — the marker is what
+                the SPA replays to rebuild attachment cards on reload, so a
+                name missing here means that file's card silently disappears
+                from history even though the file itself is still in the
+                session.
 
         Returns:
             str or list[ContentBlock]: Simple string or multimodal content blocks
         """
-        # If no files, return simple text
+        marker_names = (
+            list(attachment_names)
+            if attachment_names is not None
+            else [f.filename for f in (files or []) if hasattr(f, 'filename')]
+        )
+
+        # The marker must stay at the very END of the text: the SPA's
+        # ATTACHED_FILES_PATTERN is `$`-anchored.
+        text = message
+        if marker_names:
+            text = f"{message}\n\n[Attached files: {', '.join(marker_names)}]"
+
+        # Nothing to inline — return plain text. This still carries the
+        # marker, which is the case where every attachment was diverted
+        # (e.g. a lone .pptx): previously this returned early with a bare
+        # message and the attachment vanished from restored history.
         if not files or len(files) == 0:
-            return message
+            return text
 
         # Build ContentBlock list for multimodal input
-        content_blocks = []
-
-        # Add text first (with file reference marker for session history reconstruction)
-        file_names = [f.filename for f in files if hasattr(f, 'filename')]
-        if file_names:
-            # Add file reference marker after user message for session history
-            text_with_marker = f"{message}\n\n[Attached files: {', '.join(file_names)}]"
-            content_blocks.append({"text": text_with_marker})
-        else:
-            content_blocks.append({"text": message})
+        content_blocks: List[Dict[str, Any]] = [{"text": text}]
 
         # Track sanitized document names used in this turn to prevent
         # Bedrock ValidationException: "Messages can't contain duplicate document names"

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -764,6 +764,32 @@ def _partition_attachments(
     return inline, tabular, presentations, oversized
 
 
+def _attachment_marker_names(all_files: list, oversized_inline: list) -> list:
+    """Filenames for the ``[Attached files: …]`` marker on the user message.
+
+    The SPA replays that marker on session load to rebuild attachment cards
+    (``restoreFileAttachments``): the ``fileAttachment`` content block it
+    renders from is built client-side at send time and is never persisted, so
+    the marker is the only surviving link between a file and the message it
+    was attached to.
+
+    Deliberately NOT ``files_to_send``. Diverted spreadsheets and decks are
+    still in the session and still reachable through their tools, so their
+    cards have to survive a reload too — deriving this from the inline set
+    alone is exactly what made an uploaded .pptx vanish from history while
+    the file itself remained perfectly present.
+
+    Oversized files are excluded: those were dropped from the turn entirely
+    and the guidance text already explains their absence.
+
+    Order follows ``all_files`` (how the user attached them) rather than a
+    concatenation of the partition buckets, so the text is deterministic —
+    it lands in the cacheable prefix on every later turn.
+    """
+    oversized_names = {f.filename for f in oversized_inline}
+    return [f.filename for f in all_files if f.filename not in oversized_names]
+
+
 def _build_attachment_guidance(
     diverted_tabular: list,
     diverted_presentations: list,
@@ -1354,6 +1380,8 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             f"Skipped {len(oversized_inline)} oversized file(s) (> inline limit): "
             f"{[(f.filename, _estimate_decoded_size(f)) for f in oversized_inline]}"
         )
+
+    attachment_marker_names = _attachment_marker_names(all_files, oversized_inline)
 
     # Pre-create session metadata so OAuth interrupts and other state can
     # attach to the session row from turn one. Best-effort; on failure the
@@ -2323,6 +2351,10 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             message_will_be_modified = (
                 final_message != input_data.message  # RAG augmentation / attachment guidance / inventory
                 or bool(files_to_send)               # File attachments
+                # The `[Attached files: …]` marker is appended for diverted
+                # attachments too, so the persisted text differs from what the
+                # user typed even when nothing went inline (a lone .pptx).
+                or bool(attachment_marker_names)
             )
             # Strands' resume protocol wants each entry wrapped as
             # {"interruptResponse": {...}}. The InvocationRequest schema
@@ -2338,6 +2370,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
                 final_message,
                 session_id=input_data.session_id,
                 files=files_to_send if files_to_send else None,
+                attachment_names=attachment_marker_names or None,
                 citations=citations_for_storage if citations_for_storage else None,
                 original_message=input_data.message if message_will_be_modified else None,
                 interrupt_responses=interrupt_responses_payload,

--- a/backend/tests/agents/main_agent/multimodal/test_attachment_marker.py
+++ b/backend/tests/agents/main_agent/multimodal/test_attachment_marker.py
@@ -1,0 +1,109 @@
+"""The `[Attached files: …]` marker must name every attachment, not just inline ones.
+
+The marker is the ONLY link between an uploaded file and the message it was
+attached to once a session is reloaded. The SPA renders attachment cards from
+a `fileAttachment` content block that it builds client-side at send time and
+that is never persisted; on reload it reconstructs those blocks by parsing
+this marker out of the message text and matching the names against
+`GET /files?sessionId=…` (``restoreFileAttachments`` in message-map.service.ts).
+
+So a filename missing from the marker is not a cosmetic problem — that file's
+card silently disappears from the conversation on refresh, while the file
+itself is still perfectly present in the session.
+
+That is what happened when the presentation carve-out shipped: the marker was
+derived from the inline set, decks are deliberately not in the inline set, and
+a lone .pptx even took ``build_prompt``'s "no files → return the bare message"
+early path, so it left no trace at all. Spreadsheets had the same gap from the
+tabular carve-out.
+
+Two invariants hold this together, and both are load-bearing:
+
+* the marker names diverted attachments as well as inline ones;
+* the marker stays at the very END of the text, because the SPA's
+  ``ATTACHED_FILES_PATTERN`` is ``$``-anchored — anything appended after it
+  makes the regex miss and the cards vanish just as completely.
+"""
+
+import re
+
+from agents.main_agent.multimodal.prompt_builder import PromptBuilder
+
+# Mirrors ATTACHED_FILES_PATTERN in
+# frontend/ai.client/src/app/session/services/session/message-map.service.ts
+SPA_MARKER_PATTERN = re.compile(r"\n\n\[Attached files: ([^\]]+)\]$")
+
+
+def _text_of(result):
+    """The prompt's text, whether build_prompt returned a str or blocks."""
+    return result if isinstance(result, str) else result[0]["text"]
+
+
+class TestMarkerNamesDivertedAttachments:
+    def test_lone_diverted_deck_still_produces_a_marker(self):
+        # The regression: nothing inline, so the old code returned the bare
+        # message and the deck vanished from restored history.
+        result = PromptBuilder().build_prompt(
+            "Summarize this", files=None, attachment_names=["deck.pptx"]
+        )
+        assert _text_of(result) == "Summarize this\n\n[Attached files: deck.pptx]"
+
+    def test_marker_covers_inline_and_diverted_together(self, sample_files):
+        inline = sample_files[0]
+        result = PromptBuilder().build_prompt(
+            "Compare these",
+            files=[inline],
+            attachment_names=[inline.filename, "deck.pptx", "data.xlsx"],
+        )
+        names = SPA_MARKER_PATTERN.search(_text_of(result)).group(1)
+        assert names == f"{inline.filename}, deck.pptx, data.xlsx"
+
+    def test_diverted_names_do_not_become_content_blocks(self, sample_files):
+        # The marker naming a deck must not smuggle it into the blocks — a
+        # pptx document block is a Bedrock ValidationException.
+        inline = sample_files[0]
+        result = PromptBuilder().build_prompt(
+            "Compare these",
+            files=[inline],
+            attachment_names=[inline.filename, "deck.pptx"],
+        )
+        assert isinstance(result, list)
+        # One text block + exactly one block for the single inline file.
+        assert len(result) == 2
+        assert "deck.pptx" not in str(result[1])
+
+
+class TestMarkerIsSpaParseable:
+    def test_marker_is_last_so_the_anchored_regex_matches(self):
+        result = PromptBuilder().build_prompt(
+            "Question here", files=None, attachment_names=["a.pptx", "b.xlsx"]
+        )
+        match = SPA_MARKER_PATTERN.search(_text_of(result))
+        assert match is not None
+        assert match.group(1).split(", ") == ["a.pptx", "b.xlsx"]
+
+    def test_stripping_the_marker_leaves_the_users_text(self):
+        # The SPA removes the marker before display; what's left must be the
+        # message, not a fragment of it.
+        result = PromptBuilder().build_prompt(
+            "What is in here?", files=None, attachment_names=["deck.pptx"]
+        )
+        assert SPA_MARKER_PATTERN.sub("", _text_of(result)) == "What is in here?"
+
+
+class TestBackwardCompatibility:
+    def test_omitting_attachment_names_still_derives_them_from_files(self, sample_files):
+        # Existing callers pass positionally; behaviour must not shift.
+        inline = sample_files[0]
+        result = PromptBuilder().build_prompt("Describe this", [inline])
+        assert SPA_MARKER_PATTERN.search(_text_of(result)).group(1) == inline.filename
+
+    def test_no_files_and_no_names_returns_the_bare_message(self):
+        result = PromptBuilder().build_prompt("Just talking")
+        assert result == "Just talking"
+
+    def test_empty_names_list_adds_no_marker(self):
+        result = PromptBuilder().build_prompt(
+            "Just talking", files=None, attachment_names=[]
+        )
+        assert result == "Just talking"

--- a/backend/tests/agents/main_agent/streaming/test_stream_response_signature.py
+++ b/backend/tests/agents/main_agent/streaming/test_stream_response_signature.py
@@ -40,7 +40,7 @@ class _SignatureFaithfulCoordinator:
 
 
 class _PassthroughMultimodalBuilder:
-    def build_prompt(self, message, files):
+    def build_prompt(self, message, files, attachment_names=None):
         return message
 
 

--- a/backend/tests/agents/main_agent/test_chat_agent_continue.py
+++ b/backend/tests/agents/main_agent/test_chat_agent_continue.py
@@ -25,7 +25,7 @@ class _RecordingCoordinator:
 class _ExplodingMultimodalBuilder:
     """build_prompt must never be called on the continuation path."""
 
-    def build_prompt(self, message, files):  # noqa: D401
+    def build_prompt(self, message, files, attachment_names=None):  # noqa: D401
         raise AssertionError("multimodal build_prompt called on continuation path")
 
 
@@ -59,7 +59,7 @@ async def test_normal_turn_still_uses_multimodal_builder():
     coordinator = _RecordingCoordinator()
 
     class _Builder:
-        def build_prompt(self, message, files):
+        def build_prompt(self, message, files, attachment_names=None):
             return f"built:{message}"
 
     agent = _bare_chat_agent(coordinator, _Builder())

--- a/backend/tests/apis/inference_api/test_presentation_attachment_carveout.py
+++ b/backend/tests/apis/inference_api/test_presentation_attachment_carveout.py
@@ -23,6 +23,7 @@ text ("Upload a .pptx template first") becomes a lie again.
 import pytest
 
 from apis.inference_api.chat.routes import (
+    _attachment_marker_names,
     _build_attachment_guidance,
     _partition_attachments,
 )
@@ -103,6 +104,52 @@ class TestPartitionAttachments:
         assert tabular == [sheet]
         assert presentations == [deck]
         assert oversized == []
+
+
+class TestAttachmentMarkerNames:
+    """Diverting a file must not erase it from the message it was attached to.
+
+    The `[Attached files: …]` marker is the only link the SPA can replay on
+    reload — see `_attachment_marker_names`. Deriving it from the inline set
+    is what made a diverted deck's card vanish from restored history.
+    """
+
+    def test_includes_a_diverted_deck(self):
+        pdf = _Attachment("report.pdf", "application/pdf")
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        assert _attachment_marker_names([pdf, deck], []) == [
+            "report.pdf",
+            "deck.pptx",
+        ]
+
+    def test_includes_a_diverted_spreadsheet(self):
+        sheet = _Attachment("data.xlsx", XLSX_MIME)
+        assert _attachment_marker_names([sheet], []) == ["data.xlsx"]
+
+    def test_a_lone_deck_still_yields_a_name(self):
+        # Nothing inline at all — the case that previously left no trace.
+        deck = _Attachment("deck.pptx", PPTX_MIME)
+        assert _attachment_marker_names([deck], []) == ["deck.pptx"]
+
+    def test_excludes_oversized_files(self):
+        # Dropped from the turn entirely; the guidance explains their absence,
+        # so a card promising otherwise would be misleading.
+        pdf = _Attachment("report.pdf", "application/pdf")
+        huge = _Attachment("huge.pdf", "application/pdf")
+        assert _attachment_marker_names([pdf, huge], [huge]) == ["report.pdf"]
+
+    def test_preserves_attachment_order(self):
+        # Order is deterministic because this text reaches the cacheable
+        # prefix on later turns.
+        files = [
+            _Attachment("b.pptx", PPTX_MIME),
+            _Attachment("a.pdf", "application/pdf"),
+            _Attachment("c.xlsx", XLSX_MIME),
+        ]
+        assert _attachment_marker_names(files, []) == ["b.pptx", "a.pdf", "c.xlsx"]
+
+    def test_no_attachments_yields_no_names(self):
+        assert _attachment_marker_names([], []) == []
 
 
 class TestAttachmentGuidance:

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FILE_TYPE_STYLES,
+  DEFAULT_STYLE,
+} from './file-attachment-badge.component';
+import { ALLOWED_MIME_TYPES } from '../../../../../services/file-upload';
+
+/**
+ * Every uploadable type needs its own card style.
+ *
+ * A type missing from FILE_TYPE_STYLES doesn't fail loudly — it silently
+ * falls through to DEFAULT_STYLE and the card renders a generic grey "FILE"
+ * chip. That is exactly how .pptx shipped: the upload allowlist gained the
+ * type but this map didn't, so decks arrived looking like anonymous blobs.
+ *
+ * Pinning the map against the upload allowlist means the next type added to
+ * one has to be added to the other.
+ */
+describe('file attachment card styles', () => {
+  const PPTX_MIME =
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+  it('gives .pptx its own style rather than the generic fallback', () => {
+    const style = FILE_TYPE_STYLES[PPTX_MIME];
+    expect(style).toBeDefined();
+    expect(style.label).toBe('PPTX');
+    expect(style.label).not.toBe(DEFAULT_STYLE.label);
+  });
+
+  it('uses a presentation icon for .pptx, not a plain document', () => {
+    expect(FILE_TYPE_STYLES[PPTX_MIME].icon).toBe('heroPresentationChartBar');
+    expect(FILE_TYPE_STYLES[PPTX_MIME].icon).not.toBe(DEFAULT_STYLE.icon);
+  });
+
+  it('styles every mime type the upload allowlist accepts', () => {
+    const unstyled = Object.keys(ALLOWED_MIME_TYPES).filter(
+      (mime) => !(mime in FILE_TYPE_STYLES),
+    );
+    expect(unstyled).toEqual([]);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
@@ -6,6 +6,7 @@ import {
   heroTableCells,
   heroCodeBracket,
   heroPhoto,
+  heroPresentationChartBar,
   heroArrowTopRightOnSquare,
 } from '@ng-icons/heroicons/outline';
 import { MarkdownComponent } from 'ngx-markdown';
@@ -22,14 +23,14 @@ interface FileTypeStyle {
   header_bg: string;
 }
 
-const DEFAULT_STYLE: FileTypeStyle = {
+export const DEFAULT_STYLE: FileTypeStyle = {
   icon: 'heroDocument',
   label: 'FILE',
   accent_text: 'text-gray-600 dark:text-gray-300',
   header_bg: 'bg-gray-50 dark:bg-gray-700/50',
 };
 
-const FILE_TYPE_STYLES: Record<string, FileTypeStyle> = {
+export const FILE_TYPE_STYLES: Record<string, FileTypeStyle> = {
   'application/pdf': {
     icon: 'heroDocument',
     label: 'PDF',
@@ -72,6 +73,15 @@ const FILE_TYPE_STYLES: Record<string, FileTypeStyle> = {
     accent_text: 'text-green-600 dark:text-green-300',
     header_bg: 'bg-green-50 dark:bg-green-950/40',
   },
+  // Orange is PowerPoint's brand association, which makes the chip readable
+  // at a glance. It overlaps with HTML's accent, but the label text
+  // disambiguates and the two rarely appear in the same conversation.
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': {
+    icon: 'heroPresentationChartBar',
+    label: 'PPTX',
+    accent_text: 'text-orange-600 dark:text-orange-300',
+    header_bg: 'bg-orange-50 dark:bg-orange-950/40',
+  },
   'text/markdown': {
     icon: 'heroDocumentText',
     label: 'MD',
@@ -112,6 +122,12 @@ const THUMBNAIL_PREVIEW_MIMES = new Set(['application/pdf']);
 /** Skeleton "lines of text" widths (percent), tuned to look like a paragraph. */
 const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
 
+const PRESENTATION_MIME =
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+/** Bullet-row widths (percent) inside the mock slide. */
+const SLIDE_BULLET_WIDTHS = [78, 92, 60];
+
 /**
  * Document-style preview card for a non-image file attachment.
  *
@@ -133,6 +149,7 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
       heroTableCells,
       heroCodeBracket,
       heroPhoto,
+      heroPresentationChartBar,
       heroArrowTopRightOnSquare,
     }),
   ],
@@ -247,13 +264,49 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
 
       <!-- Paper page area -->
       <div class="relative h-32 overflow-hidden bg-white dark:bg-gray-900/40">
-        <!-- Folded corner -->
-        <div
-          class="corner-fold absolute right-0 top-0"
-          aria-hidden="true"
-        ></div>
+        <!-- Folded corner. Suppressed for decks: the fold reads as a sheet of
+             paper, which fights the stacked-slides metaphor below. -->
+        @if (!isPresentation()) {
+          <div
+            class="corner-fold absolute right-0 top-0"
+            aria-hidden="true"
+          ></div>
+        }
 
-        @if (thumbnailUrl(); as url) {
+        @if (isPresentation()) {
+          <!-- Mock slide deck: two offset slides behind a 16:9 front slide
+               carrying a title bar and bullet rows. Signals "presentation"
+               at a glance, where the generic paragraph skeleton read as prose.
+               Purely decorative — the real slide text needs a server-side
+               unzip of ppt/slides/slide1.xml, which is not wired up. -->
+          <div class="flex h-full items-center justify-center" aria-hidden="true">
+            <div class="relative aspect-video h-[86px]">
+              <div
+                class="absolute -right-2 -top-2 size-full rounded-md border border-gray-200 bg-gray-100 dark:border-gray-700 dark:bg-gray-800"
+              ></div>
+              <div
+                class="absolute -right-1 -top-1 size-full rounded-md border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/80"
+              ></div>
+              <div
+                class="relative flex size-full flex-col rounded-md border border-gray-200 bg-white p-2.5 shadow-sm dark:border-gray-600 dark:bg-gray-800"
+              >
+                <div class="h-1.5 w-3/5 rounded-full bg-orange-500/80"></div>
+                <div class="mt-1.5 h-px w-2/5 bg-orange-200 dark:bg-orange-900"></div>
+                <div class="mt-2 space-y-1.5">
+                  @for (width of slideBulletWidths; track $index) {
+                    <div class="flex items-center gap-1.5">
+                      <div class="size-1 shrink-0 rounded-full bg-orange-400/70"></div>
+                      <div
+                        class="h-1 rounded-full bg-gray-200 dark:bg-gray-600"
+                        [style.width.%]="width"
+                      ></div>
+                    </div>
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+        } @else if (thumbnailUrl(); as url) {
           <img
             [src]="url"
             [alt]="'First page of ' + attachment().filename"
@@ -283,8 +336,9 @@ const SKELETON_LINE_WIDTHS = [92, 78, 88, 64, 95, 70, 84, 58];
         }
 
         <!-- Bottom fade for long text. Suppressed when a thumbnail is shown
-             so the rendered page edge stays crisp. -->
-        @if (!thumbnailUrl()) {
+             so the rendered page edge stays crisp, and for decks, where the
+             slide is fully visible and a fade would just dim its lower edge. -->
+        @if (!thumbnailUrl() && !isPresentation()) {
           <div
             class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-white to-transparent dark:from-gray-900/40"
             aria-hidden="true"
@@ -318,6 +372,7 @@ export class FileAttachmentBadgeComponent {
   private readonly fileUploadService = inject(FileUploadService);
 
   protected readonly skeletonWidths = SKELETON_LINE_WIDTHS;
+  protected readonly slideBulletWidths = SLIDE_BULLET_WIDTHS;
 
   protected readonly snippetState = signal<'idle' | 'loading' | 'ready' | 'error'>('idle');
   private readonly snippet = signal<string>('');
@@ -336,6 +391,10 @@ export class FileAttachmentBadgeComponent {
   protected readonly hasSnippet = computed(() => this.snippet().trim().length > 0);
 
   protected readonly isMarkdown = computed(() => this.attachment().mimeType === 'text/markdown');
+
+  protected readonly isPresentation = computed(
+    () => this.attachment().mimeType === PRESENTATION_MIME,
+  );
 
   /** Cap chars so very long unbroken lines don't blow out the card. */
   protected readonly truncatedSnippet = computed(() => {


### PR DESCRIPTION
Two related fixes to how `.pptx` attachments appear in a conversation. The first is cosmetic, the second is a regression I introduced in #868.

---

## 1. The card said "FILE"

A `.pptx` rendered as a generic grey **FILE** chip over paragraph skeleton lines — indistinguishable from any unrecognized binary. `FILE_TYPE_STYLES` had no entry for the type, so it fell through to `DEFAULT_STYLE`. The upload allowlist gained `.pptx` in #868; this map never did.

- **PPTX type style** — presentation icon (`heroPresentationChartBar`) on an orange tint.
- **Slide-deck body** — replaces the paragraph skeleton for presentations: a 16:9 front slide with a title bar and three bulleted rows, two offset slides stacked behind it. The generic skeleton read as *prose*, the wrong signal for a deck.
- **Suppressed the folded corner and bottom fade** for presentations — both are "sheet of paper" cues that fight the stacked-slides metaphor.

The new spec pins `FILE_TYPE_STYLES` against `ALLOWED_MIME_TYPES`, because this bug's failure mode is silence: a missing type degrades to a grey blob rather than erroring.

## 2. The card vanished entirely on reload — a #868 regression

Worse, and only visible on a refresh: an uploaded deck disappeared from the conversation completely. The file was still in the session and `/api/files` still returned it, but the card was gone.

The card renders from a `fileAttachment` content block the SPA builds client-side at send time and **never persists**. On reload it rebuilds those blocks by parsing the `[Attached files: …]` marker out of the message text and matching names against the session's file list (`restoreFileAttachments`). That marker is the only surviving link between a file and its message.

`PromptBuilder` derived the marker from the files it was turning into content blocks — the inline set. #868 deliberately keeps decks *out* of that set, so they never reached the marker. A lone `.pptx` was worse: with nothing inline, `build_prompt` took its `if not files: return message` early path and left no trace at all.

- `build_prompt` takes `attachment_names`, defaulting to the names in `files` so existing callers are unchanged; the no-inline-files path now returns text that still carries the marker.
- `chat_agent.stream_async` forwards it; the route derives it via `_attachment_marker_names`, the only place that sees every attachment.
- `message_will_be_modified` accounts for the marker, so `displayText` still holds the user's original text when nothing went inline.

**This fixes csv/xlsx cards on reload too** — spreadsheets had the identical gap from the tabular carve-out, predating #868.

### Two sharp edges worth a reviewer's eye

- **The marker must stay last.** The SPA's pattern is `$`-anchored; anything appended after it makes the regex miss and the cards vanish just as completely. The new tests mirror that regex and assert the anchor, since the two sides can drift silently.
- **Order is deterministic** — the user's attachment order, not a concatenation of partition buckets. This text reaches the cacheable prefix on later turns.
- **Oversized files are excluded** from the marker: they were dropped from the turn entirely and the guidance already explains their absence. Debatable — they *are* in the session and a card would let the user open them.

### Limits

**Existing sessions won't heal.** Their messages were persisted without a marker; this fixes conversations going forward.

## Testing

- Backend: 6004 passed, 3 skipped. 14 new tests — 8 on marker construction, 6 on which attachments it names.
- SPA: 164 files, 1860 tests.
- Three test doubles for `build_prompt` needed the new signature; they're stubs that must track the real one.

**Card verification is geometry-only.** localhost requires a sign-in I didn't perform, so I checked layout via an inline-styled overlay — an 86px slide in a 128px body, no clipping in either theme. That deliberately does *not* prove the new orange Tailwind utilities resolve in a real build. The reload fix is verified by tests, not end-to-end.

**Orange overlaps with the HTML type style.** Unlikely to co-occur and the label disambiguates, but amber or red are free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)