### PR TITLE
fix(mcp): only treat an auth failure as an OAuth consent gap

### DIFF
--- a/backend/src/agents/main_agent/integrations/external_mcp_client.py
+++ b/backend/src/agents/main_agent/integrations/external_mcp_client.py
@@ -15,7 +15,7 @@ OAuth Support:
 
 import logging
 import re
-from typing import Any, Callable, Optional, List, Set
+from typing import Any, Callable, Iterator, Optional, List, Set
 from urllib.parse import urlparse
 
 from mcp.client.streamable_http import streamablehttp_client
@@ -124,6 +124,64 @@ def detect_aws_service_from_url(url: str) -> Optional[str]:
             url,
         )
         return None
+
+
+# HTTP statuses that mean "this caller is not authorized" — the only kind of
+# pre-flight failure that completing an OAuth consent flow can actually fix.
+_AUTH_STATUS_CODES = frozenset({401, 403})
+
+# Fallback for transports that stringify the status instead of raising an
+# httpx error carrying a `.response` (an MCP server may surface the refusal as
+# a protocol-level message). Deliberately narrow: matching bare digits would
+# fire on any URL or port that happens to contain them.
+_AUTH_TEXT_RE = re.compile(
+    r"\b(?:401|403)\b|\bunauthorized\b|\bforbidden\b", re.IGNORECASE
+)
+
+
+def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield `exc` and everything reachable through its cause/context chain
+    and any ExceptionGroup members, each exactly once.
+
+    The exception we catch is never the interesting one: Strands wraps the
+    real failure twice (`ToolProviderException` around
+    `MCPClientInitializationError`), and the transport or HTTP error
+    underneath arrives inside an anyio `ExceptionGroup`.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        e = stack.pop()
+        if id(e) in seen:
+            continue
+        seen.add(id(e))
+        yield e
+        for nxt in (e.__cause__, e.__context__):
+            if nxt is not None:
+                stack.append(nxt)
+        stack.extend(getattr(e, "exceptions", ()) or ())  # ExceptionGroup
+
+
+def _is_auth_failure(exc: BaseException) -> bool:
+    """True when `exc`'s chain carries an HTTP 401/403.
+
+    Used to decide whether a failed pre-flight is plausibly a *consent* gap.
+    A connection refusal, DNS failure, or timeout is not: the server simply
+    isn't answering, and no amount of authorizing will change that. Treating
+    those as consent gaps prompts the user to connect a server that isn't
+    there, on every single turn, with no way for the prompt to succeed.
+    """
+    for e in _iter_exception_chain(exc):
+        response = getattr(e, "response", None)
+        for code in (
+            getattr(response, "status_code", None),
+            getattr(e, "status_code", None),
+        ):
+            if isinstance(code, int) and code in _AUTH_STATUS_CODES:
+                return True
+        if _AUTH_TEXT_RE.search(str(e)):
+            return True
+    return False
 
 
 def create_external_mcp_client(
@@ -344,7 +402,13 @@ class ExternalMCPIntegration:
         cache: the tool stayed missing for the life of the process even for
         a user whose token was sitting in the AgentCore vault the whole time.
 
-        So on failure we ask the vault directly:
+        Only an *auth* failure qualifies. A pre-flight that failed because the
+        server is unreachable, timed out, or resolved to nothing is not a
+        consent gap — asking the vault there would answer "no token, here's an
+        authorization URL" for a server that isn't listening, and the user
+        would be told to connect it on every turn with no way to succeed.
+
+        So on an auth failure we ask the vault directly:
           * token  -> warm the cache and retry the pre-flight once. This is
             the consented-user path, and it is why the tool comes back by
             itself after the user completes consent in the popup.
@@ -369,6 +433,17 @@ class ExternalMCPIntegration:
             logger.warning(
                 f"Skipping external MCP tool {tool_id}: failed to start client "
                 f"with a cached {provider_id} token ({exc})"
+            )
+            return False
+
+        # Consent can only fix a refusal to authorize. Anything else — the
+        # server is down, the URL is wrong, the host doesn't resolve — keeps
+        # the pre-recovery behaviour of dropping the tool quietly.
+        if not _is_auth_failure(exc):
+            logger.warning(
+                f"Skipping external MCP tool {tool_id}: pre-flight failed without "
+                f"an auth error, so this is not a {provider_id} consent gap "
+                f"({exc})"
             )
             return False
 

--- a/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
+++ b/backend/tests/agents/main_agent/integrations/test_external_mcp_client.py
@@ -12,13 +12,55 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
+from strands.types.exceptions import (
+    MCPClientInitializationError,
+    ToolProviderException,
+)
 
 from agents.main_agent.integrations.external_mcp_client import (
     ExternalMCPIntegration,
+    _is_auth_failure,
     detect_aws_service_from_url,
     extract_region_from_url,
 )
+
+
+def _wrapped_preflight_failure(inner: BaseException) -> Exception:
+    """Rebuild the exception `client.load_tools()` actually raises.
+
+    Strands opens the MCP session on a background thread, so the real cause
+    surfaces inside an anyio `ExceptionGroup`, wrapped by
+    `MCPClientInitializationError` (raised by `start()`), wrapped again by
+    `ToolProviderException` (raised by `load_tools()`). Neither wrapper's
+    message carries the status, so a classifier that only looks at the
+    exception it caught sees nothing — which is the whole point of these
+    tests using the real shape instead of a bare `RuntimeError`.
+    """
+    group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [inner])
+    init_exc = MCPClientInitializationError(
+        f"the client initialization failed: {group}"
+    )
+    init_exc.__cause__ = group
+    outer = ToolProviderException(f"Failed to start MCP client: {init_exc}")
+    outer.__cause__ = init_exc
+    return outer
+
+
+def _http_status_error(
+    status: int, message: str = "the server rejected the request"
+) -> httpx.HTTPStatusError:
+    """The error `response.raise_for_status()` raises inside the MCP transport.
+
+    `message` defaults to text with no status in it, so tests using this
+    exercise the *structural* check (`.response.status_code`) rather than
+    accidentally passing on httpx's usual "Client error '401 Unauthorized'"
+    wording.
+    """
+    request = httpx.Request("POST", "https://api.example.com/mcp")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(message, request=request, response=response)
 
 
 class TestExtractRegionFromUrl:
@@ -505,6 +547,85 @@ class TestGetClientResolvesScopedBindings:
         assert integration.get_client("canvas") is None
 
 
+def _status_code_error(status: int) -> Exception:
+    """An exception carrying the status directly, with no httpx `.response`."""
+    exc = RuntimeError("request rejected")
+    exc.status_code = status
+    return exc
+
+
+class TestIsAuthFailure:
+    """Only a refusal to authorize can be fixed by consenting. Everything
+    else — server down, host doesn't resolve, request timed out — must not be
+    read as a consent gap, or an unconsented user is asked to connect a
+    server that isn't there, on every turn, forever."""
+
+    def test_wrapped_401_is_an_auth_failure(self):
+        """The status lives three wrappers down, in an ExceptionGroup, and
+        never appears in the outermost message."""
+        exc = _wrapped_preflight_failure(_http_status_error(401))
+
+        assert "401" not in str(exc)
+        assert _is_auth_failure(exc) is True
+
+    def test_wrapped_403_is_an_auth_failure(self):
+        assert _is_auth_failure(_wrapped_preflight_failure(_http_status_error(403)))
+
+    def test_wrapped_connect_error_is_not_an_auth_failure(self):
+        """The dev `canvas_faculty` case: `serverUrl` points at a localhost
+        port that the AgentCore Runtime container cannot reach."""
+        exc = _wrapped_preflight_failure(
+            httpx.ConnectError("All connection attempts failed")
+        )
+
+        assert _is_auth_failure(exc) is False
+
+    def test_wrapped_timeout_is_not_an_auth_failure(self):
+        exc = _wrapped_preflight_failure(httpx.ConnectTimeout("timed out"))
+
+        assert _is_auth_failure(exc) is False
+
+    def test_dns_failure_is_not_an_auth_failure(self):
+        exc = _wrapped_preflight_failure(
+            httpx.ConnectError("[Errno 8] nodename nor servname provided")
+        )
+
+        assert _is_auth_failure(exc) is False
+
+    def test_server_error_is_not_an_auth_failure(self):
+        """A 500 is the server's problem, not the user's authorization."""
+        exc = _wrapped_preflight_failure(_http_status_error(500))
+
+        assert _is_auth_failure(exc) is False
+
+    def test_plain_status_code_attribute_is_an_auth_failure(self):
+        """Not every client wraps the response; some carry the status directly."""
+        assert _is_auth_failure(_status_code_error(403)) is True
+
+    def test_message_only_unauthorized_is_an_auth_failure(self):
+        """A server that reports the refusal as protocol text rather than an
+        HTTP error still gets the user a consent prompt."""
+        assert _is_auth_failure(RuntimeError("Unauthorized: missing bearer token"))
+
+    def test_digits_inside_a_url_do_not_read_as_a_status(self):
+        """The text fallback must not fire on a port or path that merely
+        contains the digits — that would resurrect the bug it guards."""
+        assert not _is_auth_failure(
+            httpx.ConnectError("connection to localhost:8403 failed")
+        )
+        assert not _is_auth_failure(RuntimeError("cannot reach https://x/v1/4010/mcp"))
+
+    def test_self_referential_chain_terminates(self):
+        """`__context__` cycles are possible when exceptions are re-raised;
+        the walk must not spin."""
+        first = RuntimeError("boom")
+        second = RuntimeError("bang")
+        first.__context__ = second
+        second.__context__ = first
+
+        assert _is_auth_failure(first) is False
+
+
 class TestOAuthPreflightRecovery:
     """An OAuth-gated MCP server that requires auth even for `tools/list`
     (GitHub's does) 401s whenever the in-process token cache is cold — which
@@ -609,11 +730,13 @@ class TestOAuthPreflightRecovery:
     @pytest.mark.asyncio
     async def test_no_prompt_when_vault_cannot_be_reached(self):
         """A hard error is "couldn't ask", NOT "user must consent". Prompting
-        here would nag a connected user every turn the server is down."""
+        here would nag a connected user every turn the vault is unhappy."""
         integration = ExternalMCPIntegration()
         repo = SimpleNamespace(get_tool=AsyncMock(return_value=self._oauth_tool()))
+        # 401 so the pre-flight really does reach the vault — the vault
+        # itself is what fails here.
         client = SimpleNamespace(
-            load_tools=AsyncMock(side_effect=RuntimeError("connection refused"))
+            load_tools=AsyncMock(side_effect=RuntimeError("401 Unauthorized"))
         )
 
         p1, p2, p3 = self._patches(client, repo, None)
@@ -624,6 +747,75 @@ class TestOAuthPreflightRecovery:
 
         assert result == []
         assert integration.take_pending_consents("alice") == {}
+
+    @pytest.mark.asyncio
+    async def test_unreachable_server_never_prompts_for_consent(self):
+        """The dev `canvas_faculty` regression: an OAuth-gated server whose
+        URL the runtime cannot reach failed pre-flight with a ConnectError,
+        the vault correctly answered "no token, here is an authorization
+        URL", and the user was shown a connect prompt on every turn that
+        completing consent could never satisfy — the server simply is not
+        there. Classify before asking."""
+        integration = ExternalMCPIntegration()
+        repo = SimpleNamespace(
+            get_tool=AsyncMock(return_value=self._oauth_tool(tool_id="canvas_faculty"))
+        )
+        client = SimpleNamespace(
+            load_tools=AsyncMock(
+                side_effect=_wrapped_preflight_failure(
+                    httpx.ConnectError("All connection attempts failed")
+                )
+            )
+        )
+        resolve_mock = AsyncMock(
+            return_value={"token": None, "url": "https://consent.example/authorize"}
+        )
+
+        with patch(
+            "apis.shared.tools.repository.get_tool_catalog_repository",
+            return_value=repo,
+        ), patch(
+            "agents.main_agent.integrations.external_mcp_client."
+            "create_external_mcp_client",
+            return_value=client,
+        ), patch(
+            "apis.shared.oauth.token_resolution.resolve_token_or_consent_url",
+            resolve_mock,
+        ):
+            result = await integration.load_external_tools(
+                ["canvas_faculty"], user_id="alice"
+            )
+
+        assert result == []
+        # Never even asked — the vault would have said "not consented" and
+        # that answer is meaningless for a server that isn't listening.
+        resolve_mock.assert_not_awaited()
+        assert integration.take_pending_consents("alice") == {}
+
+    @pytest.mark.asyncio
+    async def test_wrapped_401_still_records_consent(self):
+        """The real production shape, not a bare `RuntimeError`: a 401 buried
+        under Strands' two wrappers and an anyio ExceptionGroup must still
+        reach the vault, or classifying would undo the recovery it guards."""
+        integration = ExternalMCPIntegration()
+        repo = SimpleNamespace(get_tool=AsyncMock(return_value=self._oauth_tool()))
+        client = SimpleNamespace(
+            load_tools=AsyncMock(
+                side_effect=_wrapped_preflight_failure(_http_status_error(401))
+            )
+        )
+        resolved = {"token": None, "url": "https://consent.example/authorize"}
+
+        p1, p2, p3 = self._patches(client, repo, resolved)
+        with p1, p2, p3:
+            result = await integration.load_external_tools(
+                ["github_issues"], user_id="alice"
+            )
+
+        assert result == []
+        assert integration.take_pending_consents("alice") == {
+            self.PROVIDER: "https://consent.example/authorize"
+        }
 
     @pytest.mark.asyncio
     async def test_skips_vault_when_cached_token_already_present(self):


### PR DESCRIPTION
## Problem

`ExternalMCPIntegration._recover_oauth_preflight` asked the AgentCore vault on **any** pre-flight failure for an OAuth-gated tool with a cold token cache. It never distinguished *why* the pre-flight failed, so a server that is simply unreachable looked identical to one refusing an unauthorized caller:

1. `client.load_tools()` fails with an httpx `ConnectError`.
2. The recovery path asks the vault anyway.
3. The vault correctly answers "this user has no token, here is an authorization URL".
4. The turn emits a pre-flight `oauth_required`.
5. The user is shown **Connect** on every turn — and completing consent will never fix it, because the server is not there.

Found in dev while verifying #872: `canvas_faculty` has `serverUrl = http://localhost:8026/mcp`, unreachable from the AgentCore Runtime container. Verified impact is dev-only today (it is the only OAuth-gated tool and it is misconfigured), but the same path runs in prod for any OAuth-gated MCP server during an outage — every unconsented user gets an unsatisfiable prompt for the duration.

#872 already reasoned about this class of problem: `resolve_token_or_consent_url` returning `None` deliberately stays silent, because prompting on a transport error would nag a connected user every time the server blips. That guard covers *the vault call* failing; it does not cover *the MCP server itself* being unreachable.

## Fix

Classify the exception before consulting the vault. Only a 401/403 counts as a possible consent gap; connect / DNS / timeout / 5xx failures keep the pre-recovery silent-skip behaviour.

**The status is not on the exception we catch.** `MCPClient.load_tools()` raises `ToolProviderException` wrapping `MCPClientInitializationError` wrapping an anyio `ExceptionGroup` — the real `httpx.HTTPStatusError` (from `response.raise_for_status()` in the MCP streamable-http transport) is three levels down, and the outermost message carries no status at all (the `ExceptionGroup` stringifies as `unhandled errors in a TaskGroup`). So `_is_auth_failure` walks `__cause__` / `__context__` / `ExceptionGroup.exceptions` — the same shape `mcp_apps._is_transient_connect_error` already had to solve — and reads `.response.status_code` / `.status_code`, with a deliberately narrow text fallback (`\b401\b|\b403\b|unauthorized|forbidden`) for servers that report the refusal as protocol text rather than an HTTP error.

Gating the **whole** recovery rather than just the consent-recording is safe: on a transport error the vault's token would only feed a retry that fails the same way, so the consented-user path loses nothing.

## Tests

New `TestIsAuthFailure` covers the predicate against the real wrapped chain: 401/403, `ConnectError`, `ConnectTimeout`, DNS failure, 500, a bare `.status_code` attribute, text-only "Unauthorized", a `:8403` port that must **not** read as a status, and a self-referential `__context__` cycle.

At the `load_external_tools` level:
- `test_unreachable_server_never_prompts_for_consent` — the `canvas_faculty` regression; asserts the vault is never awaited. Confirmed to fail with the guard disabled.
- `test_wrapped_401_still_records_consent` — a 401 in the real production shape still reaches the vault, so classifying does not undo the recovery it guards.

`test_no_prompt_when_vault_cannot_be_reached` used `RuntimeError("connection refused")` to reach the vault-unreachable branch; under the new gate it would never reach the vault and would have passed vacuously, so it now uses a 401.

Existing tests that stub a bare `RuntimeError("401 Unauthorized")` pass on the text fallback alone — the new tests build the wrapped chain so the structural path is actually exercised.

## Verification

- `tests/agents/main_agent/integrations/` — 154 passed
- `tests/agents/main_agent/session/test_oauth_consent_hook.py` — 61 passed
- Full backend suite — 6022 passed. Five failures in `test_async_persistence.py` / `test_cancellation_state.py` are pre-existing and unrelated: they assert against installed SDK source, and the local venv has strands 1.48.0 while the repo pins 1.51.0 (`cancel_signal` exists only in 1.51). CI installs the pinned version.

Follow-up to #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)