### PR TITLE
fix(attachments): re-mint expired preview URLs instead of showing a broken image

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/file-attachment-badge.component.ts
@@ -313,6 +313,8 @@ const SLIDE_BULLET_WIDTHS = [78, 92, 60];
             class="size-full object-cover object-top"
             loading="lazy"
             decoding="async"
+            (load)="onThumbnailLoaded()"
+            (error)="onThumbnailError()"
           />
         } @else if (snippetState() === 'ready' && hasSnippet()) {
           @if (isMarkdown()) {
@@ -382,6 +384,9 @@ export class FileAttachmentBadgeComponent {
       unsupported types or render failure — caller falls back to skeleton. */
   protected readonly thumbnailUrl = signal<string | null>(null);
 
+  /** True while a re-minted thumbnail URL is unproven; see `onThumbnailError`. */
+  private readonly thumbnailReminted = signal(false);
+
   protected readonly formattedSize = computed(() => formatBytes(this.attachment().sizeBytes));
 
   protected readonly style = computed<FileTypeStyle>(
@@ -428,6 +433,27 @@ export class FileAttachmentBadgeComponent {
   private async loadThumbnail(uploadId: string): Promise<void> {
     const result = await this.fileUploadService.getThumbnail(uploadId);
     this.thumbnailUrl.set(result.status === 'ready' ? result.response.url : null);
+  }
+
+  /**
+   * The thumbnail failed to load. Its presigned URL only lives ~10 minutes and
+   * the `<img>` is lazy, so a card scrolled back into view later in a long
+   * conversation asks S3 with a dead signature. Re-mint once, then fall back
+   * to the skeleton rather than leaving a broken image in the card.
+   */
+  protected onThumbnailError(): void {
+    if (this.thumbnailReminted()) {
+      this.thumbnailUrl.set(null);
+      return;
+    }
+    this.thumbnailReminted.set(true);
+    this.thumbnailUrl.set(null);
+    void this.loadThumbnail(this.attachment().uploadId);
+  }
+
+  /** A URL that rendered is proven good, so it earns a fresh retry budget. */
+  protected onThumbnailLoaded(): void {
+    this.thumbnailReminted.set(false);
   }
 
   protected async openFile(): Promise<void> {

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.spec.ts
@@ -1,0 +1,139 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ImageAttachmentGroupComponent } from './image-attachment-group.component';
+import { FileUploadService, PreviewUrlResponse } from '../../../../../services/file-upload';
+import { FileAttachmentData } from '../../../../services/models/message.model';
+
+const ATTACHMENT: FileAttachmentData = {
+  uploadId: 'upload-1',
+  filename: 'screenshot.png',
+  mimeType: 'image/png',
+  sizeBytes: 1024,
+};
+
+function previewResponse(url: string, expiresInMs = 10 * 60 * 1000): PreviewUrlResponse {
+  return {
+    uploadId: ATTACHMENT.uploadId,
+    url,
+    expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
+    mimeType: ATTACHMENT.mimeType,
+    filename: ATTACHMENT.filename,
+  };
+}
+
+/** Let the constructor's queueMicrotask and the awaited fetch chain settle. */
+async function settle(fixture: ComponentFixture<ImageAttachmentGroupComponent>): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  fixture.detectChanges();
+}
+
+/**
+ * Preview URLs are presigned for ~10 minutes and the tiles are `loading="lazy"`,
+ * so an image scrolled back into view later in a long conversation asks S3 with
+ * a dead signature. Before this, nothing listened for the `<img>` error and the
+ * browser's broken-image glyph sat in the message with the filename as alt text.
+ */
+describe('ImageAttachmentGroupComponent expired preview URLs', () => {
+  let fixture: ComponentFixture<ImageAttachmentGroupComponent>;
+  let getPreviewUrl: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    getPreviewUrl = vi.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [ImageAttachmentGroupComponent],
+      providers: [{ provide: FileUploadService, useValue: { getPreviewUrl } }],
+    }).compileComponents();
+
+  });
+
+  /**
+   * Build after the mock is primed — the component fetches from its
+   * constructor, so creating it in `beforeEach` would burn the first
+   * `mockResolvedValueOnce` on a bare `vi.fn()`.
+   */
+  async function create(): Promise<void> {
+    fixture = TestBed.createComponent(ImageAttachmentGroupComponent);
+    fixture.componentRef.setInput('attachments', [ATTACHMENT]);
+    fixture.detectChanges();
+    await settle(fixture);
+  }
+
+  function img(): HTMLImageElement | null {
+    return fixture.nativeElement.querySelector('img');
+  }
+
+  it('re-mints a fresh URL when the tile fails to load', async () => {
+    getPreviewUrl
+      .mockResolvedValueOnce(previewResponse('https://s3/expired'))
+      .mockResolvedValueOnce(previewResponse('https://s3/fresh'));
+
+    await create();
+    expect(img()?.getAttribute('src')).toBe('https://s3/expired');
+
+    img()?.dispatchEvent(new Event('error'));
+    await settle(fixture);
+
+    expect(getPreviewUrl).toHaveBeenCalledTimes(2);
+    expect(img()?.getAttribute('src')).toBe('https://s3/fresh');
+    expect(fixture.nativeElement.textContent).not.toContain('Preview unavailable');
+  });
+
+  it('gives up after one retry so a dead object cannot loop', async () => {
+    getPreviewUrl.mockResolvedValue(previewResponse('https://s3/gone'));
+
+    await create();
+
+    img()?.dispatchEvent(new Event('error'));
+    await settle(fixture);
+    img()?.dispatchEvent(new Event('error'));
+    await settle(fixture);
+
+    expect(getPreviewUrl).toHaveBeenCalledTimes(2);
+    expect(img()).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Preview unavailable');
+  });
+
+  it('restores the retry budget once an image actually loads', async () => {
+    getPreviewUrl.mockResolvedValue(previewResponse('https://s3/ok'));
+
+    await create();
+
+    img()?.dispatchEvent(new Event('error'));
+    await settle(fixture);
+    // The re-minted URL rendered, so a later expiry earns its own retry.
+    img()?.dispatchEvent(new Event('load'));
+    await settle(fixture);
+    img()?.dispatchEvent(new Event('error'));
+    await settle(fixture);
+
+    expect(getPreviewUrl).toHaveBeenCalledTimes(3);
+    expect(fixture.nativeElement.textContent).not.toContain('Preview unavailable');
+  });
+
+  it('refreshes a stale URL before opening the lightbox', async () => {
+    getPreviewUrl
+      .mockResolvedValueOnce(previewResponse('https://s3/stale', -1000))
+      .mockResolvedValueOnce(previewResponse('https://s3/fresh'));
+
+    await create();
+
+    fixture.nativeElement.querySelector('button')?.click();
+    await settle(fixture);
+
+    expect(getPreviewUrl).toHaveBeenCalledTimes(2);
+    expect(fixture.nativeElement.querySelector('app-image-lightbox')).not.toBeNull();
+  });
+
+  it('leaves a still-valid URL alone when the lightbox opens', async () => {
+    getPreviewUrl.mockResolvedValue(previewResponse('https://s3/fresh'));
+
+    await create();
+
+    fixture.nativeElement.querySelector('button')?.click();
+    await settle(fixture);
+
+    expect(getPreviewUrl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-attachment-group.component.ts
@@ -15,7 +15,18 @@ import { ImageLightboxComponent, LightboxImage } from './image-lightbox.componen
 interface PreviewState {
   url: string | null;
   status: 'idle' | 'loading' | 'ready' | 'error';
+  /** Epoch ms the presigned URL stops working; null when unknown. */
+  expiresAt: number | null;
+  /**
+   * True while a re-minted URL is unproven. Set when a failed load triggers a
+   * re-mint, cleared once an `<img>` actually loads — so a genuinely dead
+   * object fails after one retry instead of looping.
+   */
+  reminted: boolean;
 }
+
+/** Treat a URL as expired this far ahead of its stated expiry. */
+const EXPIRY_SKEW_MS = 30_000;
 
 /**
  * iMessage-style group renderer for one or more image attachments.
@@ -57,6 +68,8 @@ interface PreviewState {
               class="size-full object-cover transition-transform duration-200 group-hover:scale-[1.02]"
               loading="lazy"
               decoding="async"
+              (load)="onImageLoaded(item.attachment.uploadId)"
+              (error)="onImageError(item.attachment.uploadId)"
             />
           } @else if (item.state.status === 'error') {
             <div
@@ -90,6 +103,7 @@ interface PreviewState {
       <app-image-lightbox
         [images]="lightboxImages()"
         [startIndex]="lightboxOpenAt() ?? 0"
+        (imageError)="onLightboxImageError($event)"
         (close)="closeLightbox()"
       />
     }
@@ -114,7 +128,9 @@ export class ImageAttachmentGroupComponent {
     const map = this.previews();
     return visible.map((attachment) => ({
       attachment,
-      state: map.get(attachment.uploadId) ?? { url: null, status: 'idle' as const },
+      state:
+        map.get(attachment.uploadId) ??
+        ({ url: null, status: 'idle', expiresAt: null, reminted: false } as PreviewState),
     }));
   });
 
@@ -173,7 +189,66 @@ export class ImageAttachmentGroupComponent {
     if (!attachment) return;
     const state = map.get(attachment.uploadId);
     if (state?.status !== 'ready') return;
+    // The tile's own URL may have been minted well before this click. The
+    // lightbox has no error tile of its own, so refresh a stale one up front
+    // rather than showing a full-screen broken image.
+    if (this.isStale(state)) {
+      void this.mintPreview(attachment.uploadId, false);
+    }
     this.lightboxOpenAt.set(visibleIndex);
+  }
+
+  /**
+   * A tile failed to load. Presigned GET URLs expire after ~10 minutes, and
+   * these tiles are `loading="lazy"` — so a message scrolled back into view
+   * later in a long conversation fetches an already-dead signature. Re-mint
+   * once; only call the preview unavailable if the fresh URL fails too.
+   */
+  protected onImageError(uploadId: string): void {
+    const state = this.previews().get(uploadId);
+    if (state?.reminted) {
+      this.updatePreview(uploadId, {
+        url: null,
+        status: 'error',
+        expiresAt: null,
+        reminted: true,
+      });
+      return;
+    }
+    this.updatePreview(uploadId, {
+      url: state?.url ?? null,
+      status: 'loading',
+      expiresAt: state?.expiresAt ?? null,
+      reminted: true,
+    });
+    void this.mintPreview(uploadId, true);
+  }
+
+  /** A URL that rendered is proven good, so it earns a fresh retry budget. */
+  protected onImageLoaded(uploadId: string): void {
+    const state = this.previews().get(uploadId);
+    if (!state?.reminted) return;
+    this.updatePreview(uploadId, { ...state, reminted: false });
+  }
+
+  /** Same one-shot re-mint for a failure surfaced by the lightbox. */
+  protected onLightboxImageError(index: number): void {
+    const attachment = this.attachments()[index];
+    if (!attachment) return;
+    const state = this.previews().get(attachment.uploadId);
+    if (state?.reminted) return;
+    this.updatePreview(attachment.uploadId, {
+      url: state?.url ?? null,
+      status: state?.status ?? 'ready',
+      expiresAt: state?.expiresAt ?? null,
+      reminted: true,
+    });
+    void this.mintPreview(attachment.uploadId, true);
+  }
+
+  private isStale(state: PreviewState): boolean {
+    if (state.expiresAt === null) return false;
+    return Date.now() >= state.expiresAt - EXPIRY_SKEW_MS;
   }
 
   protected closeLightbox(): void {
@@ -186,7 +261,7 @@ export class ImageAttachmentGroupComponent {
     const next = new Map(current);
     for (const a of all) {
       if (!next.has(a.uploadId)) {
-        next.set(a.uploadId, { url: null, status: 'loading' });
+        next.set(a.uploadId, { url: null, status: 'loading', expiresAt: null, reminted: false });
       }
     }
     this.previews.set(next);
@@ -194,14 +269,35 @@ export class ImageAttachmentGroupComponent {
     await Promise.all(
       all.map(async (a) => {
         if (current.get(a.uploadId)?.status === 'ready') return;
-        try {
-          const response = await this.fileUploadService.getPreviewUrl(a.uploadId);
-          this.updatePreview(a.uploadId, { url: response.url, status: 'ready' });
-        } catch {
-          this.updatePreview(a.uploadId, { url: null, status: 'error' });
-        }
+        await this.mintPreview(a.uploadId, false);
       }),
     );
+  }
+
+  /**
+   * Fetch a presigned GET URL and record when it dies.
+   *
+   * `reminted` carries through so the retry budget survives the round trip:
+   * a first mint resets it, a re-mint keeps it spent until an `<img>` loads.
+   */
+  private async mintPreview(uploadId: string, reminted: boolean): Promise<void> {
+    try {
+      const response = await this.fileUploadService.getPreviewUrl(uploadId);
+      const expiresAt = Date.parse(response.expiresAt);
+      this.updatePreview(uploadId, {
+        url: response.url,
+        status: 'ready',
+        expiresAt: Number.isNaN(expiresAt) ? null : expiresAt,
+        reminted,
+      });
+    } catch {
+      this.updatePreview(uploadId, {
+        url: null,
+        status: 'error',
+        expiresAt: null,
+        reminted,
+      });
+    }
   }
 
   private updatePreview(uploadId: string, state: PreviewState): void {

--- a/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-lightbox.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/file-attachment/image-lightbox.component.ts
@@ -66,12 +66,20 @@ export interface LightboxImage {
       }
 
       <figure class="flex max-h-full max-w-full flex-col items-center gap-3">
-        <img
-          [src]="currentImage().url"
-          [alt]="currentImage().filename"
-          class="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
-          (click)="$event.stopPropagation()"
-        />
+        @if (currentImage().url) {
+          <img
+            [src]="currentImage().url"
+            [alt]="currentImage().filename"
+            class="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+            (click)="$event.stopPropagation()"
+            (error)="imageError.emit(activeIndex())"
+          />
+        } @else {
+          <div class="flex size-40 items-center justify-center rounded-lg bg-white/10 text-white/70">
+            <div class="size-8 animate-pulse rounded-full bg-white/40" aria-hidden="true"></div>
+            <span class="sr-only">Loading {{ currentImage().filename }}</span>
+          </div>
+        }
         <figcaption class="max-w-full truncate text-sm text-white/80">
           {{ currentImage().filename }}
           @if (hasMultiple()) {
@@ -86,6 +94,11 @@ export class ImageLightboxComponent {
   readonly images = input.required<LightboxImage[]>();
   readonly startIndex = input<number>(0);
   readonly close = output<void>();
+  /**
+   * The image at this index failed to load — almost always an expired
+   * presigned URL. The owner re-mints and pushes a new `images` value.
+   */
+  readonly imageError = output<number>();
 
   protected readonly activeIndex = signal(0);
 


### PR DESCRIPTION
## What

Uploaded images in a conversation could render as the browser's broken-image glyph — the filename as alt text on a grey tile — even though the upload succeeded and the model read the file fine.

## Why

Image tiles are `loading="lazy"` and their `src` is a presigned S3 GET URL minted **once**, when the message first renders, with a **10-minute** lifetime (`preview_url_expiration`, `apis/app_api/files/service.py:186`). In a long turn the attachment scrolls out of view before the browser ever fetches it, so the lazy load fires against an already-expired signature.

Nothing listened for the `<img>` error event, so the failure fell through to the browser's default rendering. The component's designed "Preview unavailable" tile was unreachable — from its point of view the URL *fetch* had succeeded; only the *image load* failed.

`expiresAt` is already on every one of these API responses and was **not read anywhere in the SPA**. No code tracked or refreshed an expiring URL.

The backend and the model were never involved, which is why the agent could read content the user saw as broken.

## What changed

Three components render a presigned image and all three had the identical defect:

- **`image-attachment-group`** — `(error)` re-mints a fresh URL once; only a second failure shows "Preview unavailable". `(load)` restores the retry budget, so a proven URL that later expires gets its own retry while a genuinely dead object can't loop. Opening the lightbox proactively refreshes a URL within 30s of expiry, since the lightbox has no error state of its own.
- **`image-lightbox`** — new `imageError` output so the owner re-mints, plus a guard against `<img src="">` when arrowing to an image past the four visible tiles that hasn't loaded yet (pre-existing bug, same family).
- **`file-attachment-badge`** — same one-shot re-mint for PDF page-1 thumbnails, falling back to the skeleton rather than leaving a broken image inside the card.

## Reviewer notes

- **The retry budget is the part worth a careful read.** `reminted` is set when a failed load triggers a re-mint and cleared only when an `<img>` actually loads. That's what keeps a permanently-403 object from looping while still letting a long-lived session recover from a *second* expiry an hour later.
- **This fixes the display path, not a hard S3 failure.** If a presigned GET fails for another reason (bucket policy, KMS), the tile now shows "Preview unavailable" instead of a broken glyph — better, but still a real failure worth chasing separately.
- **`preview_url_expiration` is left at 10 minutes.** The retry makes that survivable; raising it would cut re-mint round trips but widens the signature window, so it felt like a separate decision rather than something to fold in here.

## Testing

- 5 new specs in `image-attachment-group.component.spec.ts`: error→re-mint, give-up-after-one-retry, budget restore on load, and both lightbox freshness paths.
- Full SPA suite green: **165 files / 1875 tests**.
- `ng build` passes (template typechecking).
- Not reproduced live in a browser — that needs a 10-minute wait against dev. The specs drive the error path directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
