### PR TITLE
fix(rbac): allow spaces in JWT role mappings and name the failing entry

### DIFF
--- a/backend/src/apis/shared/rbac/role_constraints.py
+++ b/backend/src/apis/shared/rbac/role_constraints.py
@@ -9,9 +9,18 @@ mistake:
    protected role's ``jwt_role_mappings``, which would silently grant that
    role's permissions to every authenticated user.
 2. Storing free-form text in ``jwt_role_mappings`` that doesn't look like
-   a real group identifier (whitespace, HTML, control characters, etc.) —
-   typically indicates a mis-typed or attacker-shaped payload rather than
-   a legitimate IdP claim value.
+   a real group identifier (HTML, control characters, invisible Unicode,
+   etc.) — typically indicates a mis-typed or attacker-shaped payload
+   rather than a legitimate IdP claim value.
+
+   Internal spaces *are* legitimate: Entra security groups are routinely
+   named as display names (``"PSEmeriti Entra Sync"``), and we do not
+   control those names. What stays rejected is anything that cannot round
+   trip through the claim: a comma (the ``custom:roles`` claim is
+   comma-separated, so a comma-bearing group name is unrepresentable),
+   and leading/trailing whitespace (both claim parsers ``.strip()`` every
+   entry, so an edge-padded mapping could never match an incoming claim —
+   it would look granted and grant nothing).
 3. Granting an admin scope that must never be delegated, or one that does
    not exist — see :func:`validate_admin_scopes`.
 """
@@ -32,6 +41,13 @@ PROTECTED_ROLE_IDS: frozenset[str] = frozenset({"system_admin"})
 # (``"default"`` is the universal group every authenticated user holds in
 # the standard Cognito setup; the rest are common synonyms or wildcards
 # we never want to accept on a protected role).
+#
+# Compared after :func:`_normalize_for_forbidden_check`, which folds case
+# and treats space/hyphen/underscore as the same separator. That matters
+# now that spaces are accepted: ``"Authenticated Users"`` and
+# ``"All Users"`` are real Entra/AD display names for exactly the
+# populations this set exists to keep off a protected role, and before
+# normalization only the hyphenated spelling was caught.
 _FORBIDDEN_PROTECTED_MAPPINGS: frozenset[str] = frozenset(
     {
         "default",
@@ -45,14 +61,46 @@ _FORBIDDEN_PROTECTED_MAPPINGS: frozenset[str] = frozenset(
         "all",
         "any",
         "public",
+        "all-users",
+        "domain-users",
     }
 )
 
 # Conservative pattern for a JWT group identifier: alphanumerics, underscore,
-# and hyphen, 2–64 characters. Real-world IdP groups (Entra, Okta, Cognito
-# Cognito groups, custom claims) all conform to this shape; values that
-# don't are almost certainly malformed.
-_JWT_MAPPING_PATTERN = re.compile(r"^[A-Za-z0-9_-]{2,64}$")
+# and hyphen, plus *single internal* ASCII spaces. Entra security groups are
+# commonly named as display names ("PSEmeriti Entra Sync"), and the tenant
+# owner — not this platform — chooses those names, so a space has to be
+# accepted verbatim.
+#
+# The alternation (rather than adding " " to the character class) is what
+# forbids leading, trailing, and doubled spaces. Both shapes end the same
+# way -- a mapping that looks granted and matches nothing. A stored value
+# has to match the incoming claim byte for byte, and the claim parsers
+# ``.strip()`` every entry, so an edge-padded value can never match; a
+# doubled space is indistinguishable from a single one in the admin's
+# comma-separated field and is far likelier to be a typo than a real group.
+#
+# Deliberately still rejected: commas (the delimiter in a ``custom:roles``
+# claim and in the admin form, so a comma-bearing name is unrepresentable),
+# and every non-space whitespace or invisible character — tabs, newlines,
+# NBSP (U+00A0), zero-width space (U+200B). JavaScript ``trim()`` does not
+# strip U+200B, so a name pasted out of Entra or Teams can carry one into
+# the payload; it must fail loudly rather than be stored as a mapping that
+# looks granted and matches nothing.
+_JWT_MAPPING_PATTERN = re.compile(r"^[A-Za-z0-9_-]+(?: [A-Za-z0-9_-]+)*$")
+
+# Length bounds, checked separately from the pattern so an out-of-range value
+# gets an error that says so.
+_JWT_MAPPING_MIN_LENGTH = 2
+_JWT_MAPPING_MAX_LENGTH = 64
+
+# Characters reproduced literally by :func:`_describe_mapping`. Everything
+# else — control characters, ``<``, NBSP, zero-width characters, any
+# non-ASCII — is escaped to a visible ``<U+XXXX>`` token before it reaches an
+# error body or a log line. The set is the accepted charset plus the three
+# punctuation marks an admin plausibly typed by mistake (``,``, ``.``,
+# ``/``); none of them carry an injection shape.
+_ECHO_SAFE_CHAR = re.compile(r"[A-Za-z0-9 _,./-]")
 
 # Shape of an admin scope id (``admin.tools``). Deliberately length-bounded:
 # this pattern is the gate that decides whether a rejected value is safe to
@@ -77,12 +125,62 @@ class RoleMutationForbidden(Exception):
     """
 
 
+def _normalize_for_forbidden_check(value: str) -> str:
+    """Fold a mapping to the form compared against the forbidden set.
+
+    Case-insensitive, and space/hyphen/underscore are treated as the same
+    separator, so ``"Authenticated Users"``, ``"authenticated_users"`` and
+    ``"authenticated-users"`` all collapse to one entry.
+    """
+    return re.sub(r"[ _-]+", "-", value.strip().lower())
+
+
 def _is_forbidden_for_protected(value: str) -> bool:
-    return value.strip().lower() in _FORBIDDEN_PROTECTED_MAPPINGS
+    normalized = _normalize_for_forbidden_check(value)
+    return (
+        value.strip().lower() in _FORBIDDEN_PROTECTED_MAPPINGS
+        or normalized in _FORBIDDEN_PROTECTED_MAPPINGS
+    )
+
+
+def _describe_mapping(entry: str) -> str:
+    """Render ``entry`` for an error message and a log line.
+
+    Two jobs. First, make the invisible visible: every character outside
+    :data:`_ECHO_SAFE_CHAR` is replaced by a ``<U+XXXX>`` token, so an admin
+    who pasted a group name out of Entra or Teams can see *that* there is a
+    zero-width space or an NBSP in it — echoing the raw value would render
+    identically to a correct one and tell them nothing.
+
+    Second, bound the output. The result is length-capped, so a malformed
+    payload cannot ride an arbitrarily long string into the 400 body or the
+    ``Role update failed:`` log line.
+    """
+    truncated = entry[:_JWT_MAPPING_MAX_LENGTH]
+    rendered = "".join(
+        ch if _ECHO_SAFE_CHAR.fullmatch(ch) else f"<U+{ord(ch):04X}>"
+        for ch in truncated
+    )
+    ellipsis = "..." if len(entry) > _JWT_MAPPING_MAX_LENGTH else ""
+    return f"'{rendered}{ellipsis}'"
 
 
 def validate_jwt_role_mappings(role_id: str, mappings: Iterable[str]) -> None:
     """Validate ``jwt_role_mappings`` content for ``role_id``.
+
+    Entries may contain single internal spaces (Entra security groups are
+    routinely named as display names) but must otherwise be alphanumerics,
+    underscore and hyphen, 2-64 characters. See :data:`_JWT_MAPPING_PATTERN`
+    for why each excluded shape is excluded.
+
+    Like :func:`validate_admin_scopes`, the errors here name the offending
+    entry. The same reasoning applies verbatim: only a ``system_admin`` can
+    reach this code path (the roles admin is non-delegable), so there is no
+    untrusted caller to withhold detail from — and a bare "Invalid role
+    configuration." on a comma-separated field turns a one-character typo
+    into a CloudWatch expedition. The value is echoed only after
+    :func:`_describe_mapping` has bounded its length and escaped anything
+    outside a conservative charset.
 
     Args:
         role_id: The role being mutated.
@@ -97,13 +195,54 @@ def validate_jwt_role_mappings(role_id: str, mappings: Iterable[str]) -> None:
         return
 
     for entry in mappings:
-        if not isinstance(entry, str) or not _JWT_MAPPING_PATTERN.fullmatch(entry):
-            raise RoleConstraintError("Invalid role configuration.")
+        if not isinstance(entry, str):
+            raise RoleConstraintError("Each JWT role mapping must be a string.")
+
+        described = _describe_mapping(entry)
+
+        if not (
+            _JWT_MAPPING_MIN_LENGTH <= len(entry) <= _JWT_MAPPING_MAX_LENGTH
+        ):
+            raise RoleConstraintError(
+                f"JWT role mapping {described} must be between "
+                f"{_JWT_MAPPING_MIN_LENGTH} and {_JWT_MAPPING_MAX_LENGTH} "
+                "characters."
+            )
+
+        if "," in entry:
+            raise RoleConstraintError(
+                f"JWT role mapping {described} must not contain a comma. "
+                "Commas separate one mapping from the next."
+            )
+
+        if entry != entry.strip(" "):
+            raise RoleConstraintError(
+                f"JWT role mapping {described} must not start or end with a "
+                "space. The claim is read with leading and trailing "
+                "whitespace stripped, so a padded mapping would never match."
+            )
+
+        if "  " in entry:
+            raise RoleConstraintError(
+                f"JWT role mapping {described} must not contain consecutive "
+                "spaces."
+            )
+
+        if not _JWT_MAPPING_PATTERN.fullmatch(entry):
+            raise RoleConstraintError(
+                f"JWT role mapping {described} contains unsupported "
+                "characters. Allowed: letters, digits, underscore, hyphen, "
+                "and single spaces between words."
+            )
 
     if role_id in PROTECTED_ROLE_IDS:
         for entry in mappings:
             if _is_forbidden_for_protected(entry):
-                raise RoleConstraintError("Invalid role configuration.")
+                raise RoleConstraintError(
+                    f"JWT role mapping {_describe_mapping(entry)} is held by "
+                    "every authenticated user and cannot be mapped to the "
+                    f"protected role '{role_id}'."
+                )
 
 
 def is_protected_role(role_id: str) -> bool:

--- a/backend/tests/rbac/test_role_mutation_constraints.py
+++ b/backend/tests/rbac/test_role_mutation_constraints.py
@@ -6,6 +6,13 @@ common JWT group claims, and that ``jwtRoleMappings`` entries follow a
 strict format. These checks are enforced at the service layer so they apply
 regardless of whether the call originates from the admin REST API, a CLI
 script, or future automation.
+
+On the format axis: single *internal* spaces are accepted, because real Entra
+security groups are named as display names ("PSEmeriti Entra Sync") and the
+tenant owner picks those names. Everything that cannot round trip through the
+``custom:roles`` claim stays rejected -- commas (the claim delimiter), edge
+whitespace (both claim parsers ``.strip()`` every entry, so a padded mapping
+could never match), and every non-space whitespace or invisible character.
 """
 
 from __future__ import annotations
@@ -39,7 +46,25 @@ def service(mock_app_role_repo, mock_app_role_cache) -> AppRoleAdminService:
 
 @pytest.mark.parametrize(
     "forbidden",
-    ["default", "DEFAULT", "Default", "*", "user", "users", "everyone", "anyone", "authenticated", "all"],
+    [
+        "default",
+        "DEFAULT",
+        "Default",
+        "*",
+        "user",
+        "users",
+        "everyone",
+        "anyone",
+        "authenticated",
+        "all",
+        # Now that spaces are accepted, the ubiquitous groups have a spelling
+        # that could not previously be typed at all. "All Users" and
+        # "Authenticated Users" are real Entra/AD display names for exactly
+        # the populations this rule exists to keep off a protected role.
+        "All Users",
+        "Authenticated Users",
+        "domain users",
+    ],
 )
 @pytest.mark.asyncio
 async def test_protected_role_rejects_ubiquitous_jwt_mapping(service, mock_app_role_repo, make_app_role, admin, forbidden: str) -> None:
@@ -69,11 +94,14 @@ async def test_protected_role_accepts_specific_group_mapping(service, mock_app_r
     mock_app_role_repo.get_role.return_value = system_admin_role
     mock_app_role_repo.update_role.return_value = system_admin_role
 
-    updates = AppRoleUpdate(jwt_role_mappings=["system_admin", "platform_admin"])
+    updates = AppRoleUpdate(
+        jwt_role_mappings=["system_admin", "platform_admin", "Platform Admins Entra Sync"]
+    )
 
     result = await service.update_role("system_admin", updates, admin)
     assert result is not None
     assert "platform_admin" in result.jwt_role_mappings
+    assert "Platform Admins Entra Sync" in result.jwt_role_mappings
 
 
 # ---------------------------------------------------------------------------
@@ -115,12 +143,33 @@ async def test_non_protected_role_can_have_default_mapping(service, mock_app_rol
         "",  # empty
         "x",  # too short
         "a" * 65,  # too long
-        "has spaces",
+        "a" * 62 + " bb",  # 65 chars: the length bound still holds with a space
         "has/slash",
         "has.dot",
+        # A comma is the delimiter in a comma-separated ``custom:roles`` claim
+        # and in the admin form, so a comma-bearing group name is
+        # unrepresentable and must stay rejected even now that spaces are not.
         "has,comma",
         "<script>",
         "name\nwithnewline",
+        "name\twithtab",
+        # Edge whitespace: both claim parsers ``.strip()`` every entry, so a
+        # mapping stored like this could never match an incoming claim. It
+        # must be rejected, not silently trimmed -- the stored value has to
+        # match the claim byte for byte.
+        " leading space",
+        "trailing space ",
+        "\tleading tab",
+        "trailing newline\n",
+        # Invisible characters. JS ``trim()`` does not strip U+200B, so one of
+        # these can be pasted out of Entra or Teams straight into the payload.
+        "nbsp\u00a0inside",
+        "zero\u200bwidth",
+        "\u200bleading zero width",
+        "trailing nbsp\u00a0",
+        # A doubled internal space is invisible in the comma-separated admin
+        # field and is far likelier to be a typo than a real group name.
+        "double  space",
     ],
 )
 @pytest.mark.asyncio
@@ -151,11 +200,125 @@ async def test_role_mapping_accepts_valid_format(service, mock_app_role_repo, ma
     mock_app_role_repo.get_role.return_value = role
     mock_app_role_repo.update_role.return_value = role
 
-    updates = AppRoleUpdate(jwt_role_mappings=["valid_group", "Group-Name", "abc123", "_under_score"])
+    updates = AppRoleUpdate(
+        jwt_role_mappings=[
+            "valid_group",
+            "Group-Name",
+            "abc123",
+            "_under_score",
+            # Entra security groups are named as display names, and Boise
+            # State does not control those names.
+            "has spaces",
+            "PSEmeriti Entra Sync",
+            "Faculty",
+            "a" * 62 + " b",  # exactly 64 chars, space included
+        ]
+    )
 
     result = await service.update_role("standard_user", updates, admin)
     assert result is not None
-    assert set(result.jwt_role_mappings) >= {"valid_group", "Group-Name", "abc123"}
+    assert set(result.jwt_role_mappings) >= {
+        "valid_group",
+        "Group-Name",
+        "abc123",
+        "has spaces",
+        "PSEmeriti Entra Sync",
+    }
+
+
+@pytest.mark.asyncio
+async def test_role_mapping_accepts_real_world_entra_group(service, mock_app_role_repo, make_app_role, admin) -> None:
+    """The value from the prod incident this constraint was widened for.
+
+    ``PATCH /api/admin/roles/faculty`` with ``["Faculty", "PSEmeriti Entra
+    Sync"]`` returned 400, and because one bad entry rejects the whole
+    payload, even the untouched ``Faculty`` mapping failed to save.
+    """
+    role = make_app_role(
+        role_id="faculty",
+        display_name="Faculty",
+        is_system_role=False,
+        jwt_role_mappings=["Faculty"],
+    )
+    mock_app_role_repo.get_role.return_value = role
+    mock_app_role_repo.update_role.return_value = role
+
+    updates = AppRoleUpdate(jwt_role_mappings=["Faculty", "PSEmeriti Entra Sync"])
+
+    result = await service.update_role("faculty", updates, admin)
+    assert result is not None
+    assert "PSEmeriti Entra Sync" in result.jwt_role_mappings
+
+
+@pytest.mark.parametrize(
+    "bad_value,expected_fragment",
+    [
+        ("trailing space ", "start or end with a space"),
+        ("double  space", "consecutive spaces"),
+        ("has,comma", "comma"),
+        ("x", "between 2 and 64"),
+        ("zero\u200bwidth", "<U+200B>"),
+        ("nbsp\u00a0inside", "<U+00A0>"),
+        ("name\twithtab", "<U+0009>"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_role_mapping_error_names_the_offending_entry(
+    service, mock_app_role_repo, make_app_role, admin, bad_value: str, expected_fragment: str
+) -> None:
+    """A rejection has to say *which* entry failed and why.
+
+    A bare "Invalid role configuration." is what turned the prod incident
+    into a CloudWatch expedition. Invisible characters are escaped to a
+    visible ``<U+XXXX>`` token, because echoing them raw would render
+    identically to a correct value.
+    """
+    role = make_app_role(
+        role_id="standard_user",
+        display_name="Standard User",
+        is_system_role=False,
+        jwt_role_mappings=["standard_user"],
+    )
+    mock_app_role_repo.get_role.return_value = role
+    mock_app_role_repo.update_role.return_value = role
+
+    updates = AppRoleUpdate(jwt_role_mappings=[bad_value])
+
+    with pytest.raises(ValueError) as excinfo:
+        await service.update_role("standard_user", updates, admin)
+
+    assert expected_fragment in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_role_mapping_error_does_not_echo_raw_unsafe_characters(
+    service, mock_app_role_repo, make_app_role, admin
+) -> None:
+    """The echoed value is bounded and escaped before it reaches the 400 body.
+
+    Mirrors the reasoning in ``validate_admin_scopes``: detail is safe to
+    return here because only a ``system_admin`` can reach the route, but a
+    malformed payload still must not ride an arbitrarily long or
+    control-character-bearing string into the response or the log line.
+    """
+    role = make_app_role(
+        role_id="standard_user",
+        display_name="Standard User",
+        is_system_role=False,
+        jwt_role_mappings=["standard_user"],
+    )
+    mock_app_role_repo.get_role.return_value = role
+    mock_app_role_repo.update_role.return_value = role
+
+    updates = AppRoleUpdate(jwt_role_mappings=["<script>alert(1)</script>" + "A" * 200])
+
+    with pytest.raises(ValueError) as excinfo:
+        await service.update_role("standard_user", updates, admin)
+
+    message = str(excinfo.value)
+    assert "<script>" not in message
+    assert "<U+003C>" in message
+    assert len(message) < 300
 
 
 # ---------------------------------------------------------------------------
@@ -164,11 +327,29 @@ async def test_role_mapping_accepts_valid_format(service, mock_app_role_repo, ma
 
 
 @pytest.mark.asyncio
+async def test_create_role_accepts_space_bearing_mapping(service, mock_app_role_repo, admin) -> None:
+    role_data = AppRoleCreate(
+        role_id="emeriti",
+        display_name="Emeriti",
+        jwt_role_mappings=["PSEmeriti Entra Sync"],
+    )
+    mock_app_role_repo.get_role.return_value = None
+
+    await service.create_role(role_data, admin)
+
+    # The repository mock returns an AsyncMock, so assert on what the service
+    # handed it rather than on the round-tripped result.
+    mock_app_role_repo.create_role.assert_awaited_once()
+    created = mock_app_role_repo.create_role.await_args.args[0]
+    assert "PSEmeriti Entra Sync" in created.jwt_role_mappings
+
+
+@pytest.mark.asyncio
 async def test_create_role_rejects_invalid_mapping_format(service, mock_app_role_repo, admin) -> None:
     role_data = AppRoleCreate(
         role_id="badrole",
         display_name="Bad",
-        jwt_role_mappings=["has spaces"],
+        jwt_role_mappings=["has,comma"],
     )
     mock_app_role_repo.get_role.return_value = None
 

--- a/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
+++ b/frontend/ai.client/src/app/admin/roles/pages/role-form.page.ts
@@ -208,11 +208,17 @@ interface RoleFormGroup {
                   type="text"
                   id="jwtRoleMappings"
                   formControlName="jwtRoleMappings"
-                  placeholder="e.g., User, Admin, DotNetDevelopers"
+                  placeholder="e.g., User, Admin, PSEmeriti Entra Sync"
                   class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-500/50 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
                 />
                 <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-                  Enter JWT role names separated by commas. These are the roles from your identity provider.
+                  Enter the group names exactly as your identity provider sends them,
+                  separated by commas. Group names may contain spaces
+                  (<span class="font-medium">PSEmeriti Entra Sync</span>) &mdash; only the
+                  comma separates one name from the next, so a name cannot itself contain
+                  one. Surrounding spaces are trimmed; a name that still fails to save is
+                  usually carrying an invisible character from a copy&#8209;paste, and the
+                  error will point at it.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## The bug

In prod, `PATCH /api/admin/roles/faculty` returned 400 when an admin set the JWT Role Mappings to `Faculty, PSEmeriti Entra Sync`. From the prod app-api log group:

```
2026-08-25 19:08:27 - apis.app_api.admin.roles.routes - WARNING - Role update failed: Invalid role configuration.
```

`PSEmeriti Entra Sync` failed `_JWT_MAPPING_PATTERN` (`^[A-Za-z0-9_-]{2,64}$`) in `backend/src/apis/shared/rbac/role_constraints.py`. `validate_jwt_role_mappings` raises `RoleConstraintError` (a `ValueError`), which the roles route maps to 400. One bad entry rejects the whole PATCH, so even the untouched `Faculty` mapping didn't save.

The module docstring and the pattern comment both asserted that real-world IdP groups never contain spaces. That premise is false for Entra security groups named as display names, and **Boise State does not control those names**.

## The change

Pattern widened to `^[A-Za-z0-9_-]+(?: [A-Za-z0-9_-]+)*$` — single internal ASCII spaces accepted, 2–64 characters, rest of the charset unchanged. The alternation (rather than adding `" "` to the character class) is what keeps leading, trailing, and doubled spaces out.

## Parsing constraints — verified, not assumed

Each of these was checked in the code before the pattern changed.

**1. Internal spaces are safe downstream. ✅** `user.roles` is the verbatim claim (`apis/shared/auth/dependencies.py:353`); matching is exact string equality on the GSI key value `JWT_ROLE#{jwt_role}` (`apis/shared/rbac/repository.py:228`); the mapping cache key is a plain dict key `f"jwt:{jwt_role}"` (`apis/shared/rbac/cache.py:146`); and `roles_fingerprint` joins with `\x00`, not a printable delimiter (`apis/shared/rbac/cache.py:33`). Nothing breaks on a space.

**2. Commas stay rejected. ✅** The `custom:roles` claim is split on `,` at `cognito_jwt_validator.py:127` and `bff/token_exchange.py:86`, and the admin form field is comma-separated. A comma-bearing group name is unrepresentable in that claim form. Commas now get a dedicated error message explaining that.

**3. Edge whitespace rejected, not trimmed. ✅** Both claim parsers `.strip()` every entry, so a mapping stored with edge whitespace could never match an incoming claim — it would look granted and grant nothing. Rejected with an explicit message rather than silently normalized: the stored value has to match the claim byte-for-byte, so rewriting what the admin typed is the more dangerous option.

**4. Non-space whitespace and invisible characters fail loudly. ✅** Tab, newline, NBSP (U+00A0), and zero-width space (U+200B) are all rejected. Confirmed in `node`: JS `trim()` strips NBSP but **not** U+200B, so a name pasted out of Entra or Teams can carry an invisible character straight into the payload. The error escapes it to a visible `<U+200B>` token — echoing it raw would render identically to a correct value and tell the admin nothing.

**5. URL surfaces. ✅ No fix needed.** The JWT role *name* never appears in a URL path (admin roles routes key on the internal `role_id` slug, e.g. `faculty`). It appears in one query parameter, `roles` at `apis/app_api/admin/quota/routes.py:424`, built by Angular `HttpParams` at `quota-http.service.ts:189`. Verified end-to-end rather than assumed:

- Angular's `standardEncoding` (`@angular/common` `_module-chunk.mjs:256`) runs `encodeURIComponent` and then decodes back only `@ : $ , ; = ? /`. `%20` is **not** in that table, so a space is sent as `%20` and the comma delimiter survives literal. Ran it: `['Faculty','PSEmeriti Entra Sync'].join(',')` → `Faculty,PSEmeriti%20Entra%20Sync`.
- Starlette decodes it correctly: `QueryParams('roles=Faculty,PSEmeriti%20Entra%20Sync')['roles']` → `'Faculty,PSEmeriti Entra Sync'`, and the route's `split(",")` + `strip()` yields `['Faculty', 'PSEmeriti Entra Sync']`.

### Doubled internal spaces — rejected, and why

Unlike edge whitespace, a doubled internal space *could* match byte-for-byte (Python `.strip()` only touches the edges), so the "can never match" argument doesn't carry over. I rejected it anyway on risk asymmetry:

- **Accept a typo'd double space** → the mapping saves, grants nothing, silently. That's the exact failure mode this validator exists to prevent, and it's another CloudWatch expedition to diagnose.
- **Reject a genuine double-space group** → the admin gets an error naming the entry, and we widen the pattern. Bounded and visible.

A doubled space is indistinguishable from a single one in a comma-separated text field, and a real Entra group with one is vanishingly rare. If a real one turns up, this is a one-character pattern change.

## Error message

`validate_jwt_role_mappings` returned a bare `"Invalid role configuration."` with no indication of which entry failed or why — that's what turned this into a CloudWatch expedition. It now names the offending entry and says what's wrong, mirroring `validate_admin_scopes` ~40 lines below in the same file. That function's docstring reasoning applies verbatim: only a `system_admin` can reach this route (the roles router is non-delegable, keeping bare `require_admin` on purpose), so there is no untrusted caller to withhold detail from.

The value is echoed only after `_describe_mapping` bounds its length and escapes every character outside a conservative charset, so a malformed payload can't ride into the 400 body or the `Role update failed:` log line:

```
JWT role mapping 'PSEmeriti<U+200B>Entra Sync' contains unsupported characters.
  Allowed: letters, digits, underscore, hyphen, and single spaces between words.
JWT role mapping 'Faculty ' must not start or end with a space. The claim is read
  with leading and trailing whitespace stripped, so a padded mapping would never match.
JWT role mapping 'a,b' must not contain a comma. Commas separate one mapping from the next.
```

`<script>alert(1)</script>` comes back as `'<U+003C>script<U+003E>alert(1)...'` — there's a test asserting the raw form never appears.

## Protected-role rule — a hole the widening re-opened

`_FORBIDDEN_PROTECTED_MAPPINGS` exists to stop a ubiquitous group being mapped to `system_admin`. It already contained `authenticated-users` (hyphenated), but `"Authenticated Users"` and `"All Users"` — the actual Entra/AD display names for exactly those populations — previously couldn't be typed at all, and after this change they can. The comparison now folds case and treats space/hyphen/underscore as one separator, and `all-users` / `domain-users` are added to the set. Only affects `PROTECTED_ROLE_IDS` (`{system_admin}`).

## Tests

`backend/tests/rbac/test_role_mutation_constraints.py`: the parametrized case asserting `"has spaces"` is rejected is now wrong and has been flipped into the accepted set. Added:

- `PSEmeriti Entra Sync` accepted, plus a dedicated test replaying the prod incident (`faculty` + `["Faculty", "PSEmeriti Entra Sync"]`)
- leading/trailing space rejected; leading tab and trailing newline rejected
- tab, newline, NBSP, and zero-width space rejected — including a leading zero-width and a trailing NBSP
- doubled internal space rejected
- comma still rejected (the create-path test now uses `has,comma`, since its old `has spaces` value is legal)
- 2–64 bound still enforced with a space in the value: `"a"*62 + " b"` (64) accepted, `"a"*62 + " bb"` (65) rejected
- protected-role rule unaffected, plus the new space-separated ubiquitous spellings, and `Platform Admins Entra Sync` still accepted on `system_admin`
- error-message tests: each rejection names the entry, and the escaped form is asserted for the invisible characters

Grepped for other assertions on the old shape (`grep -rn "has spaces\|_JWT_MAPPING_PATTERN\|validate_jwt_role_mappings" backend/`) — only this test file and the two `admin_service.py` call sites, no seed scripts.

```
cd backend && uv run python -m pytest tests/rbac tests/auth tests/shared -v
```
**1887 passed.**

## Frontend

Helper text under the JWT Roles field in `role-form.page.ts` now says group names may contain spaces, that only the comma separates entries, and that a name which still won't save is usually carrying an invisible character from a copy-paste. Placeholder updated to show a space-bearing example.

Round-trip confirmed in `node`: `join(', ')` on load → `split(',') → trim() → filter(length > 0)` on save gives back `["Faculty", "PSEmeriti Entra Sync"]` unchanged. `src/version.ts` was not left dirty.

```
npm test   # in frontend/ai.client, via ng test
```
**1870 passed / 164 files.**

## ⚠️ Needs a deploy

This needs a `backend.yml` deploy before the prod `faculty` role can be saved with the `PSEmeriti Entra Sync` mapping — that mapping is currently absent from the role because the Role form 400s on it. Nothing was deployed and no prod AWS resource was written from this branch.

## Claim value — confirmed

**Resolved.** Phil confirms `PSEmeriti Entra Sync` is the literal value in the claim, so once this deploys the mapping will match. It has not been added to the `faculty` app role yet — the 400 from the Role form is precisely what has been blocking it.

That closes the "saves cleanly but silently never matches" risk this PR was otherwise carrying. The deploy above is now the only thing standing between this and the mapping working in prod.

## Note for later

Dots, parentheses, and ampersands can be widened the same way if a real group needs them — same alternation shape, one character class. They stay rejected here because widening to spaces is the scoped ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

