### PR TITLE
feat(marketplace): submitting an agent makes it public, with a notice

### DIFF
--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
@@ -876,9 +876,9 @@ export class ShareAgentDialogComponent {
     const listing = await firstValueFrom(dialogRef.closed);
     if (listing) {
       this.listing.set(listing);
-      // Publishing widened visibility in the same write (the dialog's `makePublic`
-      // consent). Record it here or the save below derives over a stale PRIVATE and
-      // narrows the agent out from under its own live listing.
+      // Submitting widened visibility in the same write (the dialog's `makePublic`).
+      // Record it here or the save below derives over a stale PRIVATE and narrows the
+      // agent out from under its own live listing.
       this.visibility.set('PUBLIC');
     }
   }

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.spec.ts
@@ -7,9 +7,14 @@ import { AgentListingService } from '../services/agent-listing.service';
 import { ListingPreflight, SubmitListingRequest } from '../models/store.model';
 
 /**
- * The dialog owns the *consent* rule, and getting it wrong has two bad shapes: an author
- * blocked from publishing at all (the dead end this control exists to remove), or an
- * agent's visibility widened without the author having said so.
+ * The dialog owns the *disclosure* rule, and getting it wrong has two bad shapes: an
+ * author blocked from publishing at all (the dead end this replaced a checkbox to
+ * remove), or an agent's visibility widened with nothing on screen having said so.
+ *
+ * Note what is deliberately NOT asserted any more: that Submit is held until the author
+ * ticks something. The store is public-only, so that box had one valid answer and gated
+ * nothing — the guarantee worth testing is that the notice renders whenever widening will
+ * happen, and that `makePublic` is sent only then.
  *
  * DI tokens rather than vi.mock, per project convention — a shared worker pool makes
  * module mocks leak across specs.
@@ -56,43 +61,45 @@ describe('SubmitListingDialogComponent — going public', () => {
       component.category.set('Administration');
     });
 
-    it('asks for consent instead of dead-ending the author', () => {
-      // The whole point: no blockReason, so the form renders and the author can act here
-      // rather than being sent to the agent editor and back.
+    it('discloses instead of dead-ending the author', () => {
+      // The whole point: no blockReason, so the form renders and submitting resolves the
+      // visibility rather than sending the author to the agent editor and back.
       expect(component.requiresPublic()).toBe(true);
       expect(component.blockReason()).toBeNull();
     });
 
-    it('starts unticked — going public is a decision, not a default', () => {
-      expect(component.makePublic()).toBe(false);
-    });
-
-    it('holds Submit until the author consents', () => {
-      expect(component.canSubmit()).toBe(false);
-      component.makePublic.set(true);
+    it('does not hold Submit — the notice is the disclosure, not a gate', () => {
+      // Regression guard for the checkbox this replaced. There is no second answer for
+      // the author to give, so nothing here may keep Submit disabled.
       expect(component.canSubmit()).toBe(true);
     });
 
-    it('sends the consent so the backend widens in the same write', async () => {
-      component.makePublic.set(true);
+    it('sends the widening so the backend does it in the same write', async () => {
       await component.onSubmit();
 
       expect(submitted).toHaveLength(1);
       expect(submitted[0].request.makePublic).toBe(true);
     });
 
+    it('says the submission itself is what publishes it', () => {
+      // The load-bearing half of the notice: widening happens now, not at approval, so an
+      // author who withdraws tomorrow has still been public today.
+      expect(component.goingPublicNotice()).toMatch(/submitting/i);
+      expect(component.goingPublicNotice()).toMatch(/approves/i);
+    });
+
     it('says what going public changes from, per starting state', async () => {
-      expect(component.makePublicHelp()).toMatch(/only you can open it/i);
+      expect(component.goingPublicNotice()).toMatch(/only you can open it/i);
 
       const shared = build({ requiresPublic: true, reachability: 'shared_only' });
       await shared.ngOnInit();
-      expect(shared.makePublicHelp()).toMatch(/shared/i);
-      expect(shared.makePublicHelp()).not.toBe(component.makePublicHelp());
+      expect(shared.goingPublicNotice()).toMatch(/shared/i);
+      expect(shared.goingPublicNotice()).not.toBe(component.goingPublicNotice());
     });
   });
 
   describe('when the agent is already public', () => {
-    it('asks nothing and does not send a consent it never sought', async () => {
+    it('says nothing and does not send a widening it never needed', async () => {
       const component = build({ requiresPublic: false, reachability: 'everyone' });
       await component.ngOnInit();
       component.category.set('Administration');
@@ -106,7 +113,7 @@ describe('SubmitListingDialogComponent — going public', () => {
   });
 
   describe('when something really does block submission', () => {
-    it('stays a dead end — the consent checkbox must not wave it through', async () => {
+    it('stays a dead end — the going-public notice must not wave it through', async () => {
       const component = build({
         blockReason: 'This agent cannot be published while it is bound to a memory space.',
         requiresPublic: true,
@@ -114,7 +121,6 @@ describe('SubmitListingDialogComponent — going public', () => {
       });
       await component.ngOnInit();
       component.category.set('Administration');
-      component.makePublic.set(true);
 
       expect(component.canSubmit()).toBe(false);
     });

--- a/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/submit-listing-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, OnInit, computed, inject, signal } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash, heroGlobeAlt } from '@ng-icons/heroicons/outline';
 import { AgentListingService } from '../services/agent-listing.service';
 import { ListingReachability } from '../models/reachability';
 import {
@@ -40,17 +40,29 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
  *   the form is hidden and the backend's message (which names the space) explains why.
  *   The author learns this before filling in a category, not after clicking.
  * * **Going public** — the marketplace is public-only, and every Agent starts PRIVATE,
- *   so most first submissions need visibility widened. That is a *checkbox here*, not a
- *   block: `makePublic` rides the submit request and the backend widens in the same
- *   write. Sending the author to the agent editor to change a setting and come back was
- *   the whole reason this needed fixing — but it stays consent, so the box starts
- *   unticked and Submit is disabled until it is ticked.
+ *   so most first submissions need visibility widened. `makePublic` rides the submit
+ *   request and the backend widens in the same write, so the author never leaves this
+ *   dialog to change a setting on another screen.
+ *
+ *   ⚠️ It is a **disclosure, not a checkbox**. It used to be an unticked box that
+ *   disabled Submit until ticked, on the reasoning that widening access must be
+ *   consented to. The reasoning holds; the control did not serve it. There is no
+ *   submission that leaves an Agent private — the store is one public shelf — so the box
+ *   had exactly one valid answer, and a required control with one valid answer is
+ *   ceremony that trains people to click past it, not consent. What consent actually
+ *   needs is that the author *knows*, and that is the notice's job. Pressing "Submit for
+ *   review" underneath a notice saying what submitting does is the consent.
+ *
+ *   The backend gate is deliberately unchanged: `_visibility_block` still refuses a
+ *   submission whose request omits `makePublic`, so a direct API caller — who sees no
+ *   notice — cannot widen an Agent by accident. This dialog is where the notice is
+ *   shown, so this dialog is where the flag is now always set.
  */
 @Component({
   selector: 'app-submit-listing-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [DialogDismissDirective, NgIcon],
-  providers: [provideIcons({ heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash })],
+  providers: [provideIcons({ heroXMark, heroExclamationTriangle, heroEye, heroEyeSlash, heroGlobeAlt })],
   host: {
     class: 'block',
     '(keydown.escape)': 'onCancel()',
@@ -118,31 +130,28 @@ export type SubmitListingDialogResult = AgentListingBlock | undefined;
               <p>{{ reason }}</p>
             </div>
           } @else {
-            <!-- Going public. Above the form because it is the one thing here that changes
-                 who can reach the agent, and it is a *choice*, not a warning: the author
-                 acts on it in place rather than being sent to another screen. -->
+            <!-- Going public. Above the form because it is the one thing here that
+                 changes who can reach the agent, and first because a consequence
+                 disclosed after the form is one the author reads after deciding.
+
+                 A statement, not a control: submitting is what makes it public, so the
+                 notice says so plainly and the Submit button carries the consent. -->
             @if (requiresPublic()) {
               <div
                 class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-900/20"
               >
                 <div class="flex gap-3">
-                  <input
-                    id="listing-make-public"
-                    type="checkbox"
-                    [checked]="makePublic()"
-                    (change)="onMakePublicChange($event)"
-                    [attr.aria-describedby]="'listing-make-public-help'"
-                    class="mt-1 size-4 shrink-0 rounded border-gray-300 text-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                  <ng-icon
+                    name="heroGlobeAlt"
+                    class="mt-0.5 size-5 shrink-0 text-amber-700 dark:text-amber-400"
+                    aria-hidden="true"
                   />
-                  <div>
-                    <label
-                      for="listing-make-public"
-                      class="block text-sm/6 font-medium text-amber-900 dark:text-amber-200"
-                    >
-                      Make this agent public
-                    </label>
-                    <p id="listing-make-public-help" class="text-sm/6 text-amber-900 dark:text-amber-200">
-                      {{ makePublicHelp() }}
+                  <div class="min-w-0">
+                    <p class="text-sm/6 font-medium text-amber-900 dark:text-amber-200">
+                      Submitting makes this agent public
+                    </p>
+                    <p class="text-sm/6 text-amber-900 dark:text-amber-200">
+                      {{ goingPublicNotice() }}
                     </p>
                   </div>
                 </div>
@@ -300,14 +309,13 @@ export class SubmitListingDialogComponent implements OnInit {
   readonly exposedSkills = signal<SkillExposure[]>([]);
   readonly blockReason = signal<string | null>(null);
   /**
-   * This agent is not PUBLIC yet. Not a block: the checkbox below resolves it, and
-   * submitting widens visibility in the same write. The marketplace is public-only, and
-   * every agent starts PRIVATE, so this is the ordinary first-submission path.
+   * This agent is not PUBLIC yet. Not a block and no longer a question: submitting widens
+   * visibility in the same write, and this is what decides whether the notice explaining
+   * that is shown. The marketplace is public-only and every agent starts PRIVATE, so this
+   * is the ordinary first-submission path, not an edge case.
    */
   readonly requiresPublic = signal(false);
-  /** The author's consent. Starts unticked — going public is a decision, not a default. */
-  readonly makePublic = signal(false);
-  /** The current reachability, kept to word the consent copy for what it actually changes. */
+  /** The current reachability, kept to word the notice for what it actually changes. */
   private readonly reachability = signal<ListingReachability>('everyone');
   readonly loading = signal(true);
   readonly submitting = signal(false);
@@ -330,26 +338,28 @@ export class SubmitListingDialogComponent implements OnInit {
    */
   readonly isUpdate = computed(() => !!this.data.listing?.publishedVersion);
 
+  /**
+   * ⚠️ `requiresPublic` is deliberately **not** a term here any more. Needing to go public
+   * is not a reason to hold Submit — the notice above the form has already said that
+   * submitting does it, and there is no second answer for the author to give. `blockReason`
+   * is still a term, because that one really is a dead end.
+   */
   readonly canSubmit = computed(
-    () =>
-      !!this.category() &&
-      !this.submitting() &&
-      !this.blockReason() &&
-      // Consent is required, not implied: the backend refuses an omitted flag, so a
-      // Submit that looked enabled here would fail on the round trip.
-      (!this.requiresPublic() || this.makePublic()),
+    () => !!this.category() && !this.submitting() && !this.blockReason(),
   );
 
   /**
    * Says what going public actually changes *from*, so "shared with 3 people → everyone"
    * and "only me → everyone" do not read as the same sentence.
    */
-  readonly makePublicHelp = computed(() =>
+  readonly goingPublicNotice = computed(() =>
     this.reachability() === 'shared_only'
       ? 'Right now only the people it is shared with can open it. The store is public, so ' +
-        'publishing it makes it available to everyone at Boise State.'
-      : 'Right now only you can open it. The store is public, so publishing it makes it ' +
-        'available to everyone at Boise State.',
+        'submitting changes its visibility to Public — everyone at Boise State can open ' +
+        'it, starting now rather than when an admin approves it.'
+      : 'Right now only you can open it. The store is public, so submitting changes its ' +
+        'visibility to Public — everyone at Boise State can open it, starting now rather ' +
+        'than when an admin approves it.',
   );
 
   /** A resubmission is answering an admin; a first submission is introducing itself. */
@@ -400,10 +410,6 @@ export class SubmitListingDialogComponent implements OnInit {
     this.tagline.set((event.target as HTMLInputElement).value);
   }
 
-  onMakePublicChange(event: Event): void {
-    this.makePublic.set((event.target as HTMLInputElement).checked);
-  }
-
   async onSubmit(): Promise<void> {
     if (!this.canSubmit()) return;
     this.submitting.set(true);
@@ -412,9 +418,12 @@ export class SubmitListingDialogComponent implements OnInit {
       const response = await this.listings.submit(this.data.agentId, {
         category: this.category(),
         note: this.note().trim() || undefined,
-        // Sent only when it is actually being asked for, so an already-public agent's
-        // request does not carry a consent it never sought.
-        makePublic: this.requiresPublic() ? this.makePublic() : undefined,
+        // Always true when widening is needed — the notice above the form is what the
+        // author read, and pressing Submit under it is the consent the backend's flag
+        // stands for. Still omitted when the agent is already PUBLIC, so the request does
+        // not carry a widening it never needed and the backend's no-op guard is never
+        // asked to catch one.
+        makePublic: this.requiresPublic() ? true : undefined,
         // Omitted rather than blanked when empty — the backend reads `undefined` as
         // "leave the existing tagline alone".
         tagline: this.tagline().trim() || undefined,

--- a/frontend/ai.client/src/app/agents/models/reachability.ts
+++ b/frontend/ai.client/src/app/agents/models/reachability.ts
@@ -30,8 +30,8 @@ export function reachabilityIsLimited(value: ListingReachability): boolean {
 /*
  * There was a `reachabilityAuthorMessage` here. It told the author to go "set Visibility
  * to Public first" — advice that is now wrong, because the submit dialog widens
- * visibility itself via its consent checkbox. The author-facing copy lives with that
- * control (`makePublicHelp`), where it can say what going public changes *from*.
+ * visibility itself as part of submitting. The author-facing copy lives there
+ * (`goingPublicNotice`), where it can say what going public changes *from*.
  */
 
 /**

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -113,10 +113,14 @@ export interface SubmitListingRequest {
   publisherId?: string;
   note?: string;
   /**
-   * The author's explicit consent to make this agent PUBLIC as part of publishing it.
-   * The marketplace is public-only and every agent starts PRIVATE, so this is the normal
-   * path, not an edge case. Omitting it is refused by the backend — the widening is
-   * consent, never a side effect of submitting.
+   * Widen this agent to PUBLIC as part of submitting it. The marketplace is public-only
+   * and every agent starts PRIVATE, so this is the normal path, not an edge case.
+   *
+   * ⚠️ Still **required** by the backend whenever widening is needed — an omitted flag is
+   * refused, so no caller widens an agent by accident. What changed is who decides: the
+   * submit dialog sets it unconditionally, because it shows the author a notice saying
+   * submitting publishes the agent and pressing Submit under that notice is the consent.
+   * A caller that shows no such notice must not send it blindly.
    */
   makePublic?: boolean;
   /**


### PR DESCRIPTION
## What

The submit dialog asked the author to tick **Make this agent public** and held Submit until they did. This replaces that checkbox with a disclosure and lets submitting do the widening.

> **Submitting makes this agent public**
> Right now only you can open it. The store is public, so submitting changes its visibility to Public — everyone at Boise State can open it, starting now rather than when an admin approves it.

## Why

The reasoning behind the checkbox — widening access must be consented to — holds. The control did not serve it. The store is one public shelf, so there is no submission that leaves an agent private: the box had exactly one valid answer, and a required control with one valid answer is ceremony that trains people to click past it rather than consent.

What consent actually needs is that the author *knows*. Pressing Submit under a notice that says what submitting does is the consent.

Two details in the copy are deliberate:

- It varies by starting state, so `shared_only` reads "only the people it is shared with can open it" rather than the private wording.
- It says the widening happens **now, not at approval**. That is the part an author would otherwise be surprised by — and it stays true if they later withdraw (see below).

## What is deliberately unchanged

`_visibility_block` still refuses a submission whose request omits `makePublic`, so a direct API caller — who sees no notice — cannot widen an agent by accident. The dialog is where the notice is shown, so the dialog is where the flag is now always set. The request still omits the flag entirely for an already-public agent.

## Tests

Rewrote the consent specs as disclosure specs, including a regression guard that nothing holds Submit when `requiresPublic` is true. `tsc --noEmit` clean; 206 agents-feature tests pass.

## Not verified in a browser

There is no `SKIP_AUTH` here and `localhost:4200` talks to the dev backend, so reaching this dialog needs a real SSO login and an agent to submit. Types and tests pass; pixels are unverified.

## Follow-up worth deciding separately

Withdrawal is explicitly "a delisting, not a recall" — `withdraw_listing` leaves `visibility` alone because it is a separate axis. That was defensible when the author ticked a box saying "make this public"; now an author who submits and withdraws an hour later is left PUBLIC without ever having been asked, only told. The copy discloses it, but you may want withdrawal-before-first-approval to restore the prior visibility. That is a state-machine change rather than a copy tweak, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)