### PR TITLE
feat(marketplace): let admins read, test-drive and decline a submission

### DIFF
--- a/backend/src/apis/app_api/admin/agents/routes.py
+++ b/backend/src/apis/app_api/admin/agents/routes.py
@@ -26,6 +26,7 @@ from apis.app_api.agent_designer.services.listing_service import (
     review_listing,
     decide_withdrawal,
     diff_pending_version,
+    read_submission_for_review,
     takedown_listing,
 )
 from apis.shared.assistants.categories import (
@@ -50,6 +51,7 @@ from apis.shared.assistants.models import (
     AdminReportRow,
     AdminReportsResponse,
     AdminStoreFrontResponse,
+    AdminSubmissionReview,
     AgentCategoriesResponse,
     AgentCategory,
     AgentCategoryCreateRequest,
@@ -143,6 +145,37 @@ async def list_listings(
     except Exception as e:
         logger.error(f"Error listing agent listings: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list listings: {str(e)}")
+
+
+@router.get("/{agent_id}/submission", response_model=AdminSubmissionReview)
+async def get_agent_submission_review(
+    agent_id: str,
+    admin: User = Depends(require_marketplace_admin),
+):
+    """The full reviewer read of a listing — instructions, capabilities, model (D2).
+
+    The queue could name a submission but not show one. ``instructions`` is gated to
+    owner/editor on ``GET /agents/{id}``, and that read refuses a non-owner outright when
+    the Agent is PRIVATE — so the person deciding whether to publish could not read the
+    system prompt or see what the Agent binds, and on a first submission the review diff
+    (their only other window onto it) is empty by construction.
+
+    Serves the **frozen snapshot**, not the live record. See ``AdminSubmissionReview`` for
+    why that distinction is the design rather than an implementation detail: the live record
+    is the author's draft, and approval promotes ``submittedVersion``.
+
+    Deliberately a separate endpoint rather than a widened ``GET /agents/{id}``. That route
+    is the store's detail read *and* the Agent Designer's form loader; teaching it an admin
+    bypass would put an access exception on the busiest read in the feature, to serve the
+    wrong version anyway.
+    """
+    try:
+        return await read_submission_for_review(agent_id, admin)
+    except ListingError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+    except Exception as e:
+        logger.error(f"Error reading submission for review: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to read submission: {str(e)}")
 
 
 @router.get("/{agent_id}/diff", response_model=AgentVersionDiffResponse)

--- a/backend/src/apis/app_api/agent_designer/services/listing_service.py
+++ b/backend/src/apis/app_api/agent_designer/services/listing_service.py
@@ -54,11 +54,13 @@ from apis.shared.assistants.version_repository import (
     list_versions,
     set_version_index,
 )
+from apis.shared.assistants.version_resolution import resolve_review_agent
 from apis.shared.assistants.versions import snapshot_of
 from apis.shared.assistants.models import (
     AdminEdit,
     AdminListingPatchRequest,
     AdminListingRow,
+    AdminSubmissionReview,
     AgentListing,
     AgentVersionDiffResponse,
     AgentVersionSummary,
@@ -81,6 +83,7 @@ from apis.shared.assistants.service import (
 from apis.shared.auth.models import User
 from apis.shared.feature_flags import skills_enabled
 from apis.shared.memory.service import MemorySpaceService
+from apis.shared.security.log_sanitize import scrub_log
 from apis.shared.skills.repository import get_skill_catalog_repository
 from apis.shared.timestamps import utc_now_iso
 
@@ -764,20 +767,36 @@ async def review_listing(
     category: Optional[str] = None,
     publisher_id: Optional[str] = None,
 ) -> AgentListing:
-    """Approve a submission, or return it with a reason (D2).
+    """Approve a submission, return it with a reason, or decline it (D2).
 
     Approval is where an attribution becomes authoritative, so the reviewer may adjust
     category and publisher in the same act (D12) without a second round trip.
+
+    ``reject`` is the third decision and it is not a synonym for ``request_changes``: it
+    answers a submission that should not be in the store at all, rather than one that needs
+    work. Both carry a required reason for the same reason — a decision the author cannot
+    read is one they cannot act on — and the state machine's note on ``rejected`` records
+    why both let the author come back.
     """
     assistant = await _load_any(agent_id)
     if not assistant.listing:
         raise ListingError("This agent has no marketplace listing to review.", status_code=404)
 
-    target = "published" if decision == "approve" else "changes_requested"
-    if decision == "request_changes" and not (note or "").strip():
+    # Mapped rather than branched, so adding a fourth decision cannot silently fall through
+    # to ``changes_requested`` the way an ``if/else`` on ``approve`` did.
+    targets = {
+        "approve": "published",
+        "request_changes": "changes_requested",
+        "reject": "rejected",
+    }
+    target = targets.get(decision)
+    if target is None:
+        raise ListingError(f"Unknown review decision '{decision}'.", status_code=400)
+    if target != "published" and not (note or "").strip():
+        verb = "Declining a submission" if decision == "reject" else "Requesting changes"
         raise ListingError(
-            "Requesting changes needs a reason — it renders on the author's card so they "
-            "never have to ask what happened.",
+            f"{verb} needs a reason — it renders on the author's card so they never have "
+            "to ask what happened.",
             status_code=400,
         )
 
@@ -1167,6 +1186,101 @@ async def diff_pending_version(agent_id: str) -> AgentVersionDiffResponse:
         instructions_diff=instructions_diff(published, pending),
     )
 
+
+
+async def read_submission_for_review(agent_id: str, admin: User) -> AdminSubmissionReview:
+    """The reviewer's full read of a listing — instructions, bindings, model and all (D2).
+
+    **Which version this reads is the entire correctness question**, and it is answered the
+    same way ``review_listing`` answers "which version does approval promote?": the snapshot
+    named by the listing, never "the latest" and never the live draft.
+
+    * ``in_review`` → ``submitted_version``. That is the artifact approval promotes, so it
+      is the artifact the reviewer must read. The live record is the author's draft and they
+      can edit it while the row sits in the queue; reading it would show one configuration
+      and publish another.
+    * anything else → ``published_version``. ``submitted_version`` is a high-water mark that
+      deliberately survives a decision, so on a ``withdrawal_requested`` row — where nothing
+      is pending and the question is whether to pull what is *live* — it would name a stale
+      snapshot the store never served.
+
+    Falls back to the live record, flagged, when neither pointer resolves. See
+    ``AdminSubmissionReview.snapshot_unavailable`` for why that is reported rather than
+    refused.
+
+    ``admin`` is threaded through only to resolve **memory-space labels**, which have no
+    unfiltered name lookup (see ``agent_detail._memory_labels``). It is not an access
+    decision — the route's ``admin.marketplace`` scope already made that one — and nothing
+    here filters by what this particular admin can reach.
+    """
+    # Imported here rather than at module scope: ``agent_detail`` pulls in the whole
+    # bindable catalog (five per-primitive services), and every other caller of this module
+    # — the author paths, the submit dialog's preflight — needs none of it.
+    from apis.app_api.agent_designer.services.agent_detail import (
+        resolve_capabilities,
+        resolve_listing_display,
+    )
+
+    assistant = await _load_any(agent_id)
+    listing = assistant.listing
+    if not listing:
+        raise ListingError("This agent has no marketplace listing to review.", status_code=404)
+
+    # ⚠️ The which-version rule lives in ``version_resolution``, not here, and that is
+    # load-bearing: the reviewer's *test drive* (``inference_api.chat.routes``) has to
+    # resolve the same snapshot this page shows, and inference-api cannot import from
+    # app_api. A second copy of the rule is a page and a preview that disagree about what
+    # is under review — which is exactly the failure snapshots exist to prevent, one level
+    # up.
+    reviewed, review_version = await resolve_review_agent(assistant)
+
+    publisher = await get_publisher(listing.publisher_id)
+    try:
+        capabilities, model_label = await resolve_capabilities(reviewed, admin)
+    except Exception:
+        # Presentation, exactly as on the user-facing detail read: a catalog hiccup must not
+        # turn a reviewable submission into a 500 and strand the queue.
+        logger.warning(
+            f"Failed to resolve capabilities for review of {scrub_log(agent_id)}", exc_info=True
+        )
+        capabilities, model_label = [], None
+    try:
+        _, category_label = await resolve_listing_display(reviewed)
+    except Exception:
+        logger.warning(f"Failed to resolve category label for {scrub_log(agent_id)}", exc_info=True)
+        category_label = None
+
+    return AdminSubmissionReview(
+        agent_id=agent_id,
+        name=reviewed.name,
+        description=reviewed.description,
+        tagline=reviewed.tagline,
+        instructions=reviewed.instructions,
+        starters=list(reviewed.starters or []),
+        emoji=reviewed.emoji,
+        icon_url=icon_url(agent_id, reviewed.icon_key),
+        owner_name=assistant.owner_name,
+        publisher=publisher,
+        category=listing.category,
+        category_label=category_label,
+        state=listing.state,
+        capabilities=capabilities,
+        model_label=model_label,
+        review_version=review_version,
+        published_version=listing.published_version,
+        snapshot_unavailable=review_version is None,
+        submitted_at=listing.submitted_at,
+        withdrawal_requested_at=(
+            listing.withdrawal_requested_at if listing.state == "withdrawal_requested" else None
+        ),
+        reviewed_at=listing.reviewed_at,
+        review_note=listing.review_note,
+        # ⚠️ Derived from the **live** record, never the snapshot. ``visibility`` is
+        # deliberately absent from ``AgentVersion`` (fusing it with listing state is the
+        # trap that class docstring names), and the question here is "can people reach this
+        # right now?" — a fact about now, which a frozen artifact cannot answer.
+        reachability=_reachability(assistant),
+    )
 
 
 async def list_admin_listings(state: Optional[str] = None) -> Tuple[List[AdminListingRow], int]:

--- a/backend/src/apis/inference_api/chat/models.py
+++ b/backend/src/apis/inference_api/chat/models.py
@@ -117,6 +117,23 @@ class InvocationRequest(BaseModel):
     # `get_assistant_with_access_check` still gates the Agent itself, so the
     # worst a forged flag can do is decline to persist a binding.
     agent_mention: Optional[bool] = None
+    # Marketplace D2: this turn is a marketplace **reviewer** test-driving a submission
+    # before deciding on it. Two things change, and nothing else does.
+    #
+    # 1. The Agent resolves to the snapshot under review (`submittedVersion` while one is
+    #    pending, `publishedVersion` otherwise) rather than to the published-or-draft rule
+    #    every other caller gets. A reviewer who test-drove the author's live draft would
+    #    be testing something approval is not going to publish.
+    # 2. The PRIVATE access check is bypassed, because a PRIVATE Agent can be — and often
+    #    is — sitting in the review queue, and `get_assistant_with_access_check` refuses a
+    #    non-owner outright on one.
+    #
+    # ⚠️ Unlike `agent_mention`, this is NOT merely a claim about intent, so it cannot be
+    # treated like one: it widens access. The route re-checks `admin.marketplace` against
+    # the caller's own roles before honoring it, and a caller without the scope gets a 403
+    # rather than a quietly-ignored flag — a silently downgraded preview would run the
+    # wrong configuration and report it as the reviewed one.
+    review_preview: Optional[bool] = None
     # When set, the route resumes a paused agent turn instead of starting a
     # new one. `message` is ignored in that case — the original prompt is
     # already in the agent's interrupt context.

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1553,6 +1553,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         from apis.shared.assistants.version_resolution import (
             AgentVersionUnavailableError,
             resolve_invocation_agent,
+            resolve_review_agent,
         )
         from apis.shared.sessions.messages import get_messages
         from apis.shared.sessions.metadata import (
@@ -1624,13 +1625,54 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             )
 
         # 2. Load assistant with access check
-        logger.info("Loading assistant with access check...")
-        assistant, _ = await get_assistant_with_access_check(
-            assistant_id=input_data.rag_assistant_id, user_id=user_id, user_email=current_user.email
-        )
+        #
+        # ⚠️ The reviewer preview is the ONE path that does not go through the visibility
+        # gate, and it earns that by proving the scope first. A PRIVATE Agent can be sitting
+        # in the review queue — approval refuses one, but submission does not — and
+        # ``get_assistant_with_access_check`` refuses a non-owner outright on PRIVATE, so a
+        # reviewer could not test-drive exactly the submissions most worth testing.
+        #
+        # The scope is re-resolved here against the caller's own roles rather than trusted
+        # from the request, and a caller without it is refused rather than quietly demoted
+        # to an ordinary turn: a silent downgrade would run the published snapshot (or the
+        # author's draft) and report it to the reviewer as the version under review.
+        is_review_preview = bool(input_data.review_preview)
+        if is_review_preview:
+            import os
+
+            from apis.shared.auth import has_admin_scope
+            from apis.shared.assistants.service import (
+                _get_assistant_cloud_without_ownership_check,
+            )
+
+            if not await has_admin_scope(current_user, "admin.marketplace"):
+                logger.warning("review_preview requested without the marketplace scope")
+                raise HTTPException(
+                    status_code=403,
+                    detail="Reviewing an agent requires marketplace admin access.",
+                )
+            table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+            if not table_name:
+                # Explicit, because the alternative is a confusing failure several frames
+                # down inside boto3 rather than a message naming the missing variable.
+                raise RuntimeError(
+                    "DYNAMODB_ASSISTANTS_TABLE_NAME environment variable is required"
+                )
+            assistant = await _get_assistant_cloud_without_ownership_check(
+                input_data.rag_assistant_id, table_name
+            )
+        else:
+            logger.info("Loading assistant with access check...")
+            assistant, _ = await get_assistant_with_access_check(
+                assistant_id=input_data.rag_assistant_id,
+                user_id=user_id,
+                user_email=current_user.email,
+            )
 
         if not assistant:
-            logger.warning("get_assistant_with_access_check returned None")
+            logger.warning(
+                "Assistant lookup returned None (review_preview=%s)", is_review_preview
+            )
             # Check if assistant exists at all to provide better error message
             from apis.shared.assistants.service import assistant_exists
 
@@ -1667,7 +1709,14 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         # ⚠️ Ordered *before* the access check's side effects below on purpose: it is not an
         # access decision and must not be read as one. The caller was already admitted.
         try:
-            assistant, resolved_version = await resolve_invocation_agent(assistant, user_id)
+            if is_review_preview:
+                # The submitted snapshot, not the published one and not the author's draft —
+                # the artifact the reviewer's decision is actually about. Shares its rule
+                # with the admin submission read, so the page and the test drive can never
+                # disagree about what is under review.
+                assistant, resolved_version = await resolve_review_agent(assistant)
+            else:
+                assistant, resolved_version = await resolve_invocation_agent(assistant, user_id)
         except AgentVersionUnavailableError as unavailable:
             # A published Agent whose snapshot is missing fails the turn rather than
             # falling back to the draft — the fallback would serve unreviewed instructions
@@ -1688,22 +1737,31 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             f"published version {resolved_version}" if resolved_version else "live record / draft",
         )
 
-        # Mark as viewed if this is a shared assistant (not owned)
-        if assistant.owner_id != user_id:
-            await mark_share_as_interacted(assistant_id=input_data.rag_assistant_id, user_email=current_user.email)
+        # ⚠️ Both bookkeeping writes below are skipped for a reviewer preview, because a
+        # review is not use. ``mark_share_as_interacted`` would stamp a share record the
+        # reviewer does not have, and ``bump_last_used_at`` feeds the KB-sync inactivity
+        # pause — a reviewer poking a submission once would read as the Agent being live
+        # and wake sync policies that were correctly dormant. Persistence of the turn
+        # itself is already handled by the ``preview-`` session id the reviewer's client
+        # sends (``PREVIEW_SESSION_PREFIX``), which is what keeps the test drive out of the
+        # author's conversation history.
+        if not is_review_preview:
+            # Mark as viewed if this is a shared assistant (not owned)
+            if assistant.owner_id != user_id:
+                await mark_share_as_interacted(assistant_id=input_data.rag_assistant_id, user_email=current_user.email)
 
-        # KB sync inactivity signal: any user's chat use counts. Throttled
-        # to one write/day inside bump_last_used_at (conditional update);
-        # the winning bump also wakes any inactivity-paused sync policies.
-        # Best-effort — a bookkeeping failure must never break a chat turn.
-        try:
-            from apis.shared.assistants.service import bump_last_used_at
-            from apis.shared.sync_policies.service import resume_inactive_policies
+            # KB sync inactivity signal: any user's chat use counts. Throttled
+            # to one write/day inside bump_last_used_at (conditional update);
+            # the winning bump also wakes any inactivity-paused sync policies.
+            # Best-effort — a bookkeeping failure must never break a chat turn.
+            try:
+                from apis.shared.assistants.service import bump_last_used_at
+                from apis.shared.sync_policies.service import resume_inactive_policies
 
-            if await bump_last_used_at(input_data.rag_assistant_id):
-                await resume_inactive_policies(input_data.rag_assistant_id)
-        except Exception as bump_err:
-            logger.warning(f"lastUsedAt bump failed for assistant {input_data.rag_assistant_id}: {bump_err}")
+                if await bump_last_used_at(input_data.rag_assistant_id):
+                    await resume_inactive_policies(input_data.rag_assistant_id)
+            except Exception as bump_err:
+                logger.warning(f"lastUsedAt bump failed for assistant {input_data.rag_assistant_id}: {bump_err}")
 
         # 2b. Agent Designer Phase 3 — resolve the Agent's governed capabilities
         # for the INVOKING user (D5), before the expensive KB search. v1 blocks

--- a/backend/src/apis/shared/assistants/listing.py
+++ b/backend/src/apis/shared/assistants/listing.py
@@ -52,6 +52,7 @@ LISTING_STATES: Tuple[str, ...] = (
     "changes_requested",
     "taken_down",
     "withdrawal_requested",
+    "rejected",
 )
 
 # The transition table. ``None`` is the pre-state of a record that has never been
@@ -69,6 +70,9 @@ LISTING_STATES: Tuple[str, ...] = (
 #                                          which returns the record to what was already serving
 #   in_review         → changes_requested  admin requests changes, with a reason — or the author
 #                                          cancels an update submitted while one was outstanding
+#   in_review         → rejected           admin declines it for the store, with a reason
+#   rejected          → in_review          author revises and submits again
+#   rejected          → private            author shelves a declined agent (so it can be deleted)
 #   published         → taken_down         admin delists, with a reason
 #   published         → changes_requested  admin requests changes on a live listing
 #   taken_down        → changes_requested  admin annotates an already-delisted listing
@@ -138,6 +142,32 @@ LISTING_STATES: Tuple[str, ...] = (
 # snapshot keeps serving; approval of the new one is still the only thing that changes what
 # users get. What it does open is the reverse edge — see ``author_cancel_target``.
 #
+# ⚠️ ``rejected`` is the answer to a submission that should not be in the store *at all*,
+# and it exists because the only two decisions before it were "approve" and "request
+# changes". An admin who thought a submission did not belong had to either publish it or
+# say "fix this" — which promises a review they do not intend to give, leaves the author
+# revising toward an approval that is not coming, and leaves the admin re-reading the same
+# submission every time it comes back.
+#
+# **The difference from ``changes_requested`` is intent, not mechanics, and that is
+# deliberate.** Both carry a required reason and both let the author come back
+# (``rejected → in_review``). What differs is what the author is told: "I want this, fix
+# X" versus "this is not a fit, here is why". Making the second one *terminal* was the
+# alternative and it is a much bigger hammer — it needs an appeal path, an admin escape
+# hatch, and a policy about who may grant one. None of that is worth building before
+# someone needs it, and an honest "no" that the author can answer is worth having now.
+#
+# It is not a door into the store and cannot become one: the only way back is
+# ``in_review``, so approval is still the single edge that publishes. ``rejected → private``
+# is the author shelving it, which is what makes it deletable — the same exit
+# ``taken_down`` has, for the same reason.
+#
+# ⚠️ It must also be in ``is_on_shelf``'s never-listed set. A rejected listing has no
+# ``published_version`` to clear (it was never published), so a stale pointer is not the
+# risk; the risk is the *other* direction — without it, a rejected agent that somehow
+# carried a pointer would read as on-the-shelf and route a withdrawal into an admin queue
+# for something no user can see.
+#
 # ⚠️ ``changes_requested`` covers two different listings — one that was never published, and
 # one that *was* and is still serving while the author revises it (``review_listing``
 # deliberately does not unpublish). Only the first may walk ``→ private`` alone; the second
@@ -154,11 +184,12 @@ LISTING_STATES: Tuple[str, ...] = (
 ALLOWED_TRANSITIONS: Dict[Optional[str], Set[str]] = {
     None: {"in_review"},
     "private": {"in_review"},
-    "in_review": {"published", "changes_requested", "private"},
+    "in_review": {"published", "changes_requested", "private", "rejected"},
     "changes_requested": {"in_review", "private", "withdrawal_requested"},
     "published": {"in_review", "taken_down", "changes_requested", "withdrawal_requested"},
     "taken_down": {"in_review", "changes_requested", "private"},
     "withdrawal_requested": {"private", "published", "changes_requested", "taken_down"},
+    "rejected": {"in_review", "private"},
 }
 
 # States a submission can be made *from* while the listing is already on the shelf — and
@@ -360,7 +391,7 @@ def is_on_shelf(state: Optional[str], published_version: Optional[int]) -> bool:
     ``state`` is still consulted so a cleared-but-stale pointer cannot resurrect something:
     ``private`` and ``taken_down`` are never on the shelf whatever the pointer says.
     """
-    if state in ("private", "taken_down", None):
+    if state in ("private", "taken_down", "rejected", None):
         return False
     return published_version is not None
 

--- a/backend/src/apis/shared/assistants/models.py
+++ b/backend/src/apis/shared/assistants/models.py
@@ -21,6 +21,7 @@ ListingState = Literal[
     "changes_requested",
     "taken_down",
     "withdrawal_requested",
+    "rejected",
 ]
 PublisherKind = Literal["institution", "department", "individual"]
 
@@ -801,13 +802,25 @@ class ListingPreflightResponse(BaseModel):
 
 
 class ReviewListingRequest(BaseModel):
-    """Admin approves a submission or returns it with a reason (D2)."""
+    """Admin approves a submission, returns it with a reason, or declines it (D2).
+
+    ⚠️ ``reject`` is a third decision, not a harsher ``request_changes``. Both return the
+    submission with a required reason; they differ in what the author is told and in what
+    the admin is committing to. See ``assistants.listing``'s note on the ``rejected`` state.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
-    decision: Literal["approve", "request_changes"] = Field(..., description="Reviewer's decision")
+    decision: Literal["approve", "request_changes", "reject"] = Field(
+        ..., description="Reviewer's decision"
+    )
     note: Optional[str] = Field(
-        None, max_length=2000, description="Reason; required for request_changes, renders on the author's card"
+        None,
+        max_length=2000,
+        description=(
+            "Reason; required for request_changes and reject, renders on the author's card. "
+            "A decline with no reason is the one outcome an author cannot act on at all."
+        ),
     )
     category: Optional[str] = Field(None, description="Optionally recategorize at approval (D12/D13)")
     publisher_id: Optional[str] = Field(
@@ -1070,6 +1083,105 @@ class AdminListingRow(BaseModel):
         ),
     )
     admin_edits: List[AdminEdit] = Field(default_factory=list, alias="adminEdits", description="Admin edit log (D13)")
+
+
+class AdminSubmissionReview(BaseModel):
+    """Everything a reviewer needs to decide, read from the **frozen snapshot** (D2).
+
+    The gap this closes: before it, a reviewer had a name, an author, a category and a
+    collapsible diff. ``instructions`` is gated to owner/editor on the user-facing detail
+    read, and ``get_assistant_with_access_check`` refuses a non-owner outright on a PRIVATE
+    Agent — so the person deciding whether to publish something could not read its system
+    prompt, could not see what it binds, and on a **first** submission saw no content at
+    all, because a diff against nothing is empty by construction.
+
+    ⚠️ **The snapshot, never the live record, and that is the whole design.** Widening the
+    user-facing ``GET /agents/{id}`` for admins would have been fewer lines and wrong: it
+    serves the author's *draft*, which the author can edit between the reviewer reading it
+    and the reviewer approving it. ``AgentVersion`` exists precisely to close that window
+    (it is cut at submission, not at approval), and ``review_listing`` promotes
+    ``submitted_version`` — so reading anything else would show an admin one configuration
+    and publish another. Reading the snapshot also sidesteps the PRIVATE 403 without
+    loosening anyone's access gate: this is an admin projection of a frozen artifact, not a
+    hole in ``get_assistant_with_access_check``.
+
+    Disclosure note: ``instructions`` reaches a marketplace admin here, deliberately. You
+    cannot review what you cannot read, and the review diff already discloses them on every
+    *update*; what this changes is that a first submission is no longer the one case where
+    the reviewer is asked to approve prose nobody showed them.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(..., alias="agentId", description="Agent identifier")
+    name: str = Field(..., description="Display name as of the reviewed snapshot")
+    description: str = Field(..., description="Summary as of the reviewed snapshot")
+    tagline: Optional[str] = Field(None, description="Shelf subtitle as of the reviewed snapshot")
+    instructions: str = Field(..., description="System prompt as of the reviewed snapshot — the thing being reviewed")
+    starters: List[str] = Field(default_factory=list, description="Conversation starters as of the reviewed snapshot")
+    emoji: Optional[str] = Field(None, description="Emoji, for the generated icon fallback (D5)")
+    icon_url: Optional[str] = Field(
+        None, alias="iconUrl", description="Where to render the icon from; absent → generated gradient"
+    )
+    owner_name: str = Field(..., alias="ownerName", description="Author display name — who to talk to about behavior")
+    publisher: Optional[PublisherProfile] = Field(None, description="Resolved attribution (D12), display only")
+    category: str = Field(..., description="Category id")
+    category_label: Optional[str] = Field(
+        None,
+        alias="categoryLabel",
+        description="Human label for ``category``; ids are not display content (see ``resolve_listing_display``)",
+    )
+    state: ListingState = Field(..., description="Publication state")
+    capabilities: List[AgentCapability] = Field(
+        default_factory=list,
+        description=(
+            "What the snapshot binds, by name. Resolved against the snapshot's own "
+            "``bindings`` rather than the live record's, so a tool the author added after "
+            "submitting is not attributed to the version under review."
+        ),
+    )
+    model_label: Optional[str] = Field(
+        None, alias="modelLabel", description="Display name of the pinned model; absent = resolve as today"
+    )
+    review_version: Optional[int] = Field(
+        None,
+        alias="reviewVersion",
+        description=(
+            "The snapshot this read is of. ``submittedVersion`` while a submission is "
+            "pending, ``publishedVersion`` otherwise — never 'the latest', which an admin "
+            "presentation edit (§6.2) could have moved underneath the reviewer."
+        ),
+    )
+    published_version: Optional[int] = Field(
+        None, alias="publishedVersion", description="Which snapshot the store is currently serving"
+    )
+    snapshot_unavailable: bool = Field(
+        False,
+        alias="snapshotUnavailable",
+        description=(
+            "No snapshot backs this read, so the fields above come from the Agent's **live "
+            "record** — which its author can still change. True for submissions that predate "
+            "version snapshots.\n\n"
+            "Reported rather than refused. ``diff_pending_version`` 400s in this case because "
+            "a diff of one thing is meaningless, but a reviewer looking at a row in their own "
+            "queue needs *something* to read; answering 'no' would leave them exactly where "
+            "the empty diff left them. The flag is what lets the page say the content is not "
+            "frozen instead of implying it is."
+        ),
+    )
+    submitted_at: Optional[str] = Field(None, alias="submittedAt", description="ISO 8601 submission timestamp")
+    withdrawal_requested_at: Optional[str] = Field(
+        None, alias="withdrawalRequestedAt", description="ISO 8601 timestamp of a pending withdrawal request"
+    )
+    reviewed_at: Optional[str] = Field(None, alias="reviewedAt", description="ISO 8601 timestamp of the last review")
+    review_note: Optional[str] = Field(None, alias="reviewNote", description="Most recent reviewer note")
+    reachability: ListingReachability = Field(
+        ...,
+        description=(
+            "Who can open this Agent if it is shelved. Carried here as well as on the queue "
+            "row because this page is where the decision is actually made."
+        ),
+    )
 
 
 class AdminListingsResponse(BaseModel):

--- a/backend/src/apis/shared/assistants/version_resolution.py
+++ b/backend/src/apis/shared/assistants/version_resolution.py
@@ -11,9 +11,11 @@ should run:
 | Anyone, when nothing is published              | The live record          |
 
 ``resolve_display_agent`` answers the same question for the marketplace **detail read**,
-and differs on exactly one row: editors see the draft too. The two are kept side by side
-here rather than merged, because the reason they differ is easy to lose and expensive to
-get wrong in either direction — see that function's docstring.
+and differs on exactly one row: editors see the draft too. ``resolve_review_agent`` answers
+it for a marketplace **reviewer**, and differs on every row — the artifact a decision is
+about is the *submitted* snapshot, which neither of the others ever serves. The three are
+kept side by side here rather than merged, because the reasons they differ are easy to lose
+and expensive to get wrong in any direction — see each function's docstring.
 
 This is deliberately *not* in ``versions.py`` (pure, no I/O) or in
 ``version_repository.py`` (persistence). Deciding which version a person runs is policy,
@@ -113,6 +115,63 @@ async def resolve_invocation_agent(
 
     logger.info(f"📌 Agent {assistant.assistant_id} running published version {published}")
     return apply_version(assistant, version), published
+
+
+async def resolve_review_agent(assistant: Assistant) -> Tuple[Assistant, Optional[int]]:
+    """Return ``(assistant_under_review, version_number)`` for a **marketplace reviewer**.
+
+    The third caller of the same question, and the one whose answer differs most: a
+    reviewer reads and test-drives the artifact a decision is *about*, which is neither the
+    published snapshot nor the author's draft.
+
+    | Listing state        | Reviews            |
+    |----------------------|--------------------|
+    | ``in_review``        | ``submittedVersion`` |
+    | anything else        | ``publishedVersion`` |
+
+    ⚠️ **``in_review`` reads ``submittedVersion`` because that is what approval promotes**
+    (``listing_service.review_listing``). The live record is the author's draft and they can
+    keep editing it while the row sits in the queue — the window ``AgentVersion`` exists to
+    close, since a version is cut at submission rather than at approval. Reading anything
+    else would show a reviewer one configuration and publish another.
+
+    ⚠️ **Every other state reads ``publishedVersion``, and that is not a fallback.**
+    ``submittedVersion`` is a high-water mark that deliberately survives a decision, so on a
+    ``withdrawal_requested`` listing — where nothing is pending, and the question is whether
+    to pull what is *live* — it names a snapshot the store never served.
+
+    Returns ``(assistant, None)`` when neither pointer resolves: a submission that predates
+    version snapshots, or a pointer to a version that is gone. Unlike ``resolve_invocation_agent``
+    this **does not raise** on a missing snapshot, because there is nothing unsafe about a
+    reviewer reading the live record as long as they are told that is what they are reading —
+    the ``None`` is that signal, and both callers surface it (``snapshotUnavailable`` on the
+    review read; the preview banner on the test drive). Raising would leave a reviewer with a
+    row in their queue and no way to look at it.
+
+    Like the other two, **this is not an access check.** Whether the caller may review at all
+    is the ``admin.marketplace`` scope, decided by the caller.
+    """
+    listing = assistant.listing
+    if listing is None:
+        return assistant, None
+
+    number = (
+        listing.submitted_version if listing.state == "in_review" else listing.published_version
+    )
+    if number is None:
+        return assistant, None
+
+    # Read the version back rather than trusting the pointer: a snapshot that is gone must
+    # read as "not frozen", not as a version number whose content nobody has.
+    version = await get_version(assistant.assistant_id, number)
+    if version is None:
+        logger.warning(
+            f"Agent {assistant.assistant_id} names version {number} for review, "
+            "but it could not be loaded; falling back to the live record."
+        )
+        return assistant, None
+
+    return apply_version(assistant, version), version.version
 
 
 async def resolve_display_agent(

--- a/backend/src/apis/shared/auth/__init__.py
+++ b/backend/src/apis/shared/auth/__init__.py
@@ -3,7 +3,7 @@
 from .dependencies import get_current_user_from_session, security
 from .models import User
 from .state_store import StateStore, InMemoryStateStore, DynamoDBStateStore, create_state_store
-from .rbac import require_app_roles, require_admin, require_admin_scope
+from .rbac import has_admin_scope, require_app_roles, require_admin, require_admin_scope
 
 __all__ = [
     "get_current_user_from_session",
@@ -16,4 +16,5 @@ __all__ = [
     "require_app_roles",
     "require_admin",
     "require_admin_scope",
+    "has_admin_scope",
 ]

--- a/backend/src/apis/shared/auth/rbac.py
+++ b/backend/src/apis/shared/auth/rbac.py
@@ -67,6 +67,31 @@ def require_app_roles(*required_app_roles: str) -> Callable:
     return checker
 
 
+async def has_admin_scope(user: User, scope: str) -> bool:
+    """Whether ``user`` holds ``scope`` — the predicate behind ``require_admin_scope``.
+
+    Exists because one caller needs the *answer* rather than a route guard: the invocation
+    path's reviewer preview (``inference_api.chat.routes``) is a field on an existing
+    request, not a route, so it cannot take a FastAPI dependency. Sharing the predicate is
+    what keeps "who is a marketplace admin" from being answered twice, differently.
+
+    Fails closed, exactly as the dependency does: a permission lookup that raises is a
+    denial, never a default-allow.
+    """
+    from apis.shared.rbac.service import get_app_role_service
+
+    try:
+        permissions = await get_app_role_service().resolve_user_permissions(user)
+    except Exception:
+        logger.exception(
+            f"Failed to resolve admin scope {scope} for {user.name}, denying access"
+        )
+        return False
+    # ``system_admin`` satisfies every scope implicitly — the superuser rule the dependency
+    # applies, restated here rather than reimplemented differently.
+    return "system_admin" in permissions.app_roles or scope in permissions.admin_scopes
+
+
 def require_admin_scope(scope: str) -> Callable:
     """
     Create a dependency guarding one delegated admin surface.
@@ -92,24 +117,9 @@ def require_admin_scope(scope: str) -> Callable:
         HTTPException: 403 if the user holds neither system_admin nor the scope.
     """
     async def checker(user: User = Depends(get_current_user_from_session)) -> User:
-        from apis.shared.rbac.service import get_app_role_service
-
-        try:
-            service = get_app_role_service()
-            permissions = await service.resolve_user_permissions(user)
-
-            if "system_admin" in permissions.app_roles:
-                return user
-
-            if scope in permissions.admin_scopes:
-                logger.debug(
-                    f"User {user.name} authorized for admin scope {scope}"
-                )
-                return user
-        except Exception:
-            logger.exception(
-                f"Failed to resolve admin scope {scope} for {user.name}, denying access"
-            )
+        if await has_admin_scope(user, scope):
+            logger.debug(f"User {user.name} authorized for admin scope {scope}")
+            return user
 
         logger.warning(
             f"User {user.name} (jwt_roles: {user.roles}) denied access — "

--- a/backend/tests/architecture/test_admin_scope_coverage.py
+++ b/backend/tests/architecture/test_admin_scope_coverage.py
@@ -203,8 +203,17 @@ def test_every_mounted_admin_route_has_a_scope_dependency() -> None:
         blob = "\n".join(sources)
         # `checker` is the closure returned by require_app_roles /
         # require_admin_scope; require_marketplace_admin wraps one of them.
+        #
+        # Two markers, because the two checkers now resolve permissions differently:
+        # `require_app_roles` calls `resolve_user_permissions` inline, while
+        # `require_admin_scope` delegates to the shared `has_admin_scope` predicate (which
+        # the invocation path's reviewer preview also needs, and which cannot be a FastAPI
+        # dependency there). This is a source grep one level deep, so a checker that moves
+        # its resolution behind another name must add that name here — the guarantee is
+        # unchanged, the string that evidences it is not.
         governed = (
             "resolve_user_permissions" in blob
+            or "has_admin_scope" in blob
             or "require_marketplace_admin" in blob
             or "agent_marketplace_enabled" in blob
         )

--- a/backend/tests/routes/test_admin_agent_listings.py
+++ b/backend/tests/routes/test_admin_agent_listings.py
@@ -321,6 +321,66 @@ class TestReview:
         assert resp.json()["state"] == "changes_requested"
         assert resp.json()["reviewNote"] == "Please add a tagline."
 
+    def test_reject_declines_the_submission(self, app, _no_writes):
+        """The third decision. Before it, an admin who judged a submission not a fit had to
+        publish it or say "fix this" — promising a review they did not intend to give."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "reject", "note": "Duplicates the Registrar agent."},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "rejected"
+        assert resp.json()["reviewNote"] == "Duplicates the Registrar agent."
+        assert resp.json()["reviewedBy"] == "admin-001"
+
+    def test_reject_requires_a_reason(self, app, _no_writes):
+        """A decline with no reason is the one outcome an author cannot act on at all."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "reject"}
+            )
+
+        assert resp.status_code == 400
+        assert "reason" in resp.json()["detail"]
+        _no_writes.assert_not_called()
+
+    def test_reject_publishes_nothing(self, app, _no_writes):
+        """The load-bearing half: declining must not write a version or a store key."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "reject", "note": "Not a fit."},
+            )
+
+        listing = _no_writes.call_args.args[1]
+        assert listing.published_version is None
+        _no_writes.set_version_index.assert_not_called()
+
+    def test_reject_refuses_a_live_listing(self, app, _no_writes):
+        """A published Agent comes down via ``takedown``, which is a different act with a
+        different record. ``reject`` answers a *submission*."""
+        with _loaded(_make_assistant(listing=_listing("published", publishedVersion=4))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review",
+                json={"decision": "reject", "note": "Not a fit."},
+            )
+
+        assert resp.status_code == 400
+        _no_writes.assert_not_called()
+
+    def test_an_unknown_decision_is_refused_rather_than_defaulted(self, app, _no_writes):
+        """Pydantic rejects it at the boundary; the service maps rather than branches so a
+        decision it does not know can never fall through to ``changes_requested``."""
+        with _loaded(_make_assistant(listing=_listing("in_review"))):
+            resp = TestClient(app).post(
+                "/admin/agents/ast-001/review", json={"decision": "delist", "note": "x"}
+            )
+
+        assert resp.status_code == 422
+        _no_writes.assert_not_called()
+
     def test_reviewer_may_recategorize_at_approval(self, app, _no_writes):
         with _loaded(_make_assistant(listing=_listing("in_review"))):
             resp = TestClient(app).post(
@@ -925,6 +985,217 @@ class TestReviewDiff:
     def test_diffing_an_unsubmitted_agent_is_404(self, app):
         with _loaded(_make_assistant(listing=None)):
             resp = TestClient(app).get("/admin/agents/ast-001/diff")
+        assert resp.status_code == 404
+
+
+class TestSubmissionReview:
+    """The reviewer's read of a submission — instructions, capabilities, model.
+
+    The gap: ``instructions`` is gated to owner/editor on ``GET /agents/{id}``, and that
+    read refuses a non-owner outright on a PRIVATE Agent. So the person deciding whether to
+    publish could not read the system prompt, and on a first submission the review diff —
+    their only other window onto it — is empty by construction.
+
+    The rule these tests hold in place is *which version* is read. Approval promotes
+    ``submittedVersion``; anything else shows an admin one configuration and publishes
+    another.
+    """
+
+    def _version(self, **overrides):
+        from apis.shared.assistants.models import AgentVersion
+
+        data = {
+            "agentId": "ast-001",
+            "version": 4,
+            "name": "Policy Lookup",
+            "description": "Find and cite university policy",
+            "instructions": "SNAPSHOT: answer only from the policy manual.",
+            "tagline": "Policy, cited",
+            "starters": ["What is the drop deadline?"],
+            "category": "Administration",
+            "publisherId": "pub-registrar",
+        }
+        data.update(overrides)
+        return AgentVersion.model_validate(data)
+
+    def _versions(self, **by_number):
+        # Patched on ``version_resolution``, not on the listing service: the which-version
+        # rule lives there so the reviewer's *test drive* on inference-api can share it
+        # (that service cannot import from app_api). Patching the old site would stub a
+        # call this path no longer makes.
+        lookup = {int(k.lstrip("v")): v for k, v in by_number.items()}
+        return patch(
+            "apis.shared.assistants.version_resolution.get_version",
+            new_callable=AsyncMock,
+            side_effect=lambda _agent_id, number: lookup.get(number),
+        )
+
+    def _capabilities(self, capabilities=None, model_label="Claude Opus"):
+        from apis.shared.assistants.models import AgentCapability
+
+        return patch(
+            "apis.app_api.agent_designer.services.agent_detail.resolve_capabilities",
+            new_callable=AsyncMock,
+            return_value=(
+                capabilities if capabilities is not None else [AgentCapability(label="Web search", kind="tool")],
+                model_label,
+            ),
+        )
+
+    def _display(self, category_label="Administration"):
+        return patch(
+            "apis.app_api.agent_designer.services.agent_detail.resolve_listing_display",
+            new_callable=AsyncMock,
+            return_value=(None, category_label),
+        )
+
+    def test_a_pending_submission_reads_the_submitted_snapshot(self, app):
+        """Not the live record. The author can edit their draft while the row sits in the
+        queue, and approval promotes ``submittedVersion`` — so reading anything else shows
+        the admin one configuration and publishes another."""
+        assistant = _make_assistant(
+            instructions="DRAFT: the author kept editing after submitting.",
+            listing=_listing("in_review", submittedVersion=4, publishedVersion=2),
+        )
+        with _loaded(assistant), self._versions(
+            v4=self._version(), v2=self._version(version=2, instructions="OLD")
+        ), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["instructions"] == "SNAPSHOT: answer only from the policy manual."
+        assert body["reviewVersion"] == 4
+        assert body["publishedVersion"] == 2
+        assert body["snapshotUnavailable"] is False
+
+    def test_a_first_submission_still_has_content_to_read(self, app):
+        """The case the review diff cannot serve: nothing is published, so the diff is
+        empty by construction and this read is the only thing the reviewer has."""
+        with _loaded(
+            _make_assistant(listing=_listing("in_review", submittedVersion=4))
+        ), self._versions(v4=self._version()), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        body = resp.json()
+        assert body["instructions"]
+        assert body["publishedVersion"] is None
+        assert body["reviewVersion"] == 4
+
+    def test_a_withdrawal_request_reads_what_the_store_is_serving(self, app):
+        """``submittedVersion`` is a high-water mark that survives a decision, so on a
+        withdrawal request it names a stale snapshot the store never served. The question
+        there is whether to pull what is *live*."""
+        with _loaded(
+            _make_assistant(
+                listing=_listing(
+                    "withdrawal_requested", submittedVersion=4, publishedVersion=2
+                )
+            )
+        ), self._versions(
+            v4=self._version(instructions="NEVER APPROVED"),
+            v2=self._version(version=2, instructions="LIVE: the approved answer."),
+        ), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        body = resp.json()
+        assert body["instructions"] == "LIVE: the approved answer."
+        assert body["reviewVersion"] == 2
+
+    def test_capabilities_resolve_against_the_snapshot(self, app):
+        """A tool the author bound after submitting must not be attributed to the version
+        under review."""
+        captured = {}
+
+        async def _capture(assistant, _user, **_kw):
+            captured["instructions"] = assistant.instructions
+            return [], None
+
+        with _loaded(
+            _make_assistant(
+                instructions="DRAFT",
+                listing=_listing("in_review", submittedVersion=4),
+            )
+        ), self._versions(v4=self._version()), _publisher(), patch(
+            "apis.app_api.agent_designer.services.agent_detail.resolve_capabilities",
+            side_effect=_capture,
+        ), self._display():
+            TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert captured["instructions"] == "SNAPSHOT: answer only from the policy manual."
+
+    def test_a_pre_snapshot_submission_is_flagged_not_refused(self, app):
+        """``diff_pending_version`` 400s here because a diff of one thing is meaningless.
+        This read answers anyway and says the content is not frozen — refusing would leave
+        the reviewer exactly where the empty diff left them."""
+        with _loaded(
+            _make_assistant(
+                instructions="LIVE RECORD: still editable by the author.",
+                listing=_listing("in_review", submittedVersion=None),
+            )
+        ), self._versions(), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert body["snapshotUnavailable"] is True
+        assert body["reviewVersion"] is None
+        assert body["instructions"] == "LIVE RECORD: still editable by the author."
+
+    def test_a_pointer_to_a_missing_snapshot_reads_as_not_frozen(self, app):
+        """Read the version back rather than trusting the number: a pointer to a snapshot
+        that is gone must not render as a version the page cannot show."""
+        with _loaded(
+            _make_assistant(listing=_listing("in_review", submittedVersion=4))
+        ), self._versions(), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert resp.json()["snapshotUnavailable"] is True
+        assert resp.json()["reviewVersion"] is None
+
+    def test_reachability_comes_from_the_live_record(self, app):
+        """``visibility`` is deliberately absent from ``AgentVersion``, and the question is
+        "can people reach this right now?" — which a frozen artifact cannot answer."""
+        with _loaded(
+            _make_assistant(
+                visibility="PRIVATE", listing=_listing("in_review", submittedVersion=4)
+            )
+        ), self._versions(v4=self._version()), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert resp.json()["reachability"] == "owner_only"
+
+    def test_a_private_agent_is_still_readable_by_the_reviewer(self, app):
+        """The 403 this endpoint exists to route around: ``get_assistant_with_access_check``
+        refuses a non-owner outright on a PRIVATE Agent, and a PRIVATE Agent absolutely can
+        be sitting in the review queue."""
+        with _loaded(
+            _make_assistant(
+                visibility="PRIVATE", listing=_listing("in_review", submittedVersion=4)
+            )
+        ), self._versions(v4=self._version()), _publisher(), self._capabilities(), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert resp.status_code == 200
+        assert resp.json()["instructions"]
+
+    def test_a_catalog_hiccup_does_not_strand_the_queue(self, app):
+        """Capabilities are presentation, exactly as on the user-facing detail read."""
+        with _loaded(
+            _make_assistant(listing=_listing("in_review", submittedVersion=4))
+        ), self._versions(v4=self._version()), _publisher(), patch(
+            "apis.app_api.agent_designer.services.agent_detail.resolve_capabilities",
+            side_effect=RuntimeError("catalog down"),
+        ), self._display():
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
+
+        assert resp.status_code == 200
+        assert resp.json()["capabilities"] == []
+        assert resp.json()["instructions"]
+
+    def test_reading_an_unsubmitted_agent_is_404(self, app):
+        with _loaded(_make_assistant(listing=None)):
+            resp = TestClient(app).get("/admin/agents/ast-001/submission")
         assert resp.status_code == 404
 
 

--- a/backend/tests/shared/test_agent_listing_state_machine.py
+++ b/backend/tests/shared/test_agent_listing_state_machine.py
@@ -338,3 +338,60 @@ def test_sort_key_is_created_at_so_browse_is_newest_first():
 def test_default_categories_are_non_empty_and_unique():
     assert DEFAULT_CATEGORIES
     assert len(set(DEFAULT_CATEGORIES)) == len(DEFAULT_CATEGORIES)
+
+
+# ── rejected: the third review decision ──────────────────────────────────────────────
+def test_an_admin_may_decline_a_submission_outright():
+    """The gap ``rejected`` closes: approve and request_changes were the only exits.
+
+    An admin who judged a submission not a fit had to publish it or say "fix this", and
+    the second one promises a review they do not intend to give.
+    """
+    assert_transition("in_review", "rejected")
+
+
+def test_only_a_pending_submission_can_be_rejected():
+    """Not a general-purpose "no". A live listing comes down via ``taken_down``, which is a
+    different act with a different record and a different message to the author."""
+    for state in [s for s in LISTING_STATES if s != "in_review"] + [None]:
+        with pytest.raises(ListingTransitionError):
+            assert_transition(state, "rejected")
+
+
+def test_a_rejected_author_can_revise_and_come_back():
+    """The difference from ``changes_requested`` is intent, not a locked door.
+
+    Making rejection terminal needs an appeal path and an admin escape hatch; an honest
+    "no" the author can answer needs neither.
+    """
+    assert_transition("rejected", "in_review")
+
+
+def test_a_rejected_author_can_shelve_it_so_it_can_be_deleted():
+    """``delete_assistant`` refuses every state but ``private``, so without this exit a
+    declined agent would be undeletable — the same reason ``taken_down → private`` exists."""
+    assert_transition("rejected", "private")
+
+
+def test_rejected_cannot_reach_the_store_without_a_second_review():
+    """``rejected`` must not become a side door. The only way back is another submission."""
+    assert "published" not in ALLOWED_TRANSITIONS["rejected"]
+    publishable = {s for s in ALLOWED_TRANSITIONS if "published" in ALLOWED_TRANSITIONS[s]}
+    assert publishable == {"in_review", "withdrawal_requested"}
+
+
+def test_a_rejected_listing_is_never_on_the_shelf():
+    """State beats a stale pointer, exactly as for ``private`` and ``taken_down``.
+
+    Without this, a rejected listing carrying a leftover ``published_version`` would read
+    as live and route an author's withdrawal into an admin queue for something no user can
+    see.
+    """
+    assert not is_on_shelf("rejected", 3)
+    assert not is_on_shelf("rejected", None)
+    assert not is_listed("rejected")
+
+
+def test_rejected_clears_the_review_queue():
+    """It is a decision, not a deferral — the badge must not keep counting it."""
+    assert "rejected" not in PENDING_DECISION_STATES

--- a/backend/tests/shared/test_agent_version_resolution.py
+++ b/backend/tests/shared/test_agent_version_resolution.py
@@ -22,6 +22,7 @@ from apis.shared.assistants.version_repository import create_version
 from apis.shared.assistants.version_resolution import (
     AgentVersionUnavailableError,
     resolve_invocation_agent,
+    resolve_review_agent,
     runs_own_draft,
 )
 from apis.shared.assistants.versions import snapshot_of
@@ -275,3 +276,133 @@ def test_the_owner_is_unaffected_by_a_missing_snapshot(table):
     resolved, version = asyncio.run(resolve_invocation_agent(live, OWNER))
     assert resolved.instructions == DRAFT_INSTRUCTIONS
     assert version is None
+
+
+# ── the reviewer's configuration (D2) ────────────────────────────────────────────────
+#
+# A third caller of the same question, and the one whose answer differs most: a reviewer
+# reads and test-drives the artifact their decision is *about*, which is neither the
+# published snapshot nor the author's draft. Getting this wrong is quiet in the same way
+# the rest of this file is — nothing raises, an admin just approves something they never
+# saw.
+SUBMITTED_INSTRUCTIONS = "Answer from the policy manual, and refuse anything else."
+
+
+def test_a_reviewer_runs_the_submitted_snapshot_not_the_draft(table):
+    """The whole point. Approval promotes ``submittedVersion``, so that is what a reviewer
+    must be reading and test-driving — the author can keep editing the draft underneath
+    them while the row sits in the queue."""
+    pending = publish(SUBMITTED_INSTRUCTIONS)
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS,
+        listing=listing(state="in_review", submittedVersion=pending),
+    )
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert resolved.instructions == SUBMITTED_INSTRUCTIONS
+    assert version == pending
+
+
+def test_a_reviewer_reads_the_submitted_snapshot_not_the_published_one(table):
+    """An update to a live listing: the store keeps serving the approved version, but the
+    decision is about the new one."""
+    approved = publish(APPROVED_INSTRUCTIONS)
+    pending = publish(SUBMITTED_INSTRUCTIONS)
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS,
+        listing=listing(
+            state="in_review", publishedVersion=approved, submittedVersion=pending
+        ),
+    )
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert resolved.instructions == SUBMITTED_INSTRUCTIONS
+    assert version == pending
+
+
+def test_a_withdrawal_request_reads_what_the_store_serves(table):
+    """``submittedVersion`` is a high-water mark that deliberately survives a decision, so
+    on a withdrawal request it names a snapshot the store never served. The question there
+    is whether to pull what is *live*."""
+    approved = publish(APPROVED_INSTRUCTIONS)
+    never_approved = publish(SUBMITTED_INSTRUCTIONS)
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS,
+        listing=listing(
+            state="withdrawal_requested",
+            publishedVersion=approved,
+            submittedVersion=never_approved,
+        ),
+    )
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert resolved.instructions == APPROVED_INSTRUCTIONS
+    assert version == approved
+
+
+def test_review_resolution_reads_bindings_and_model_from_the_snapshot(table):
+    """A tool the author bound after submitting must not be attributed to the version
+    under review — the capability list on the review page is built from these."""
+    pending = publish(
+        SUBMITTED_INSTRUCTIONS,
+        bindings=[AgentBinding(kind="tool", ref="tool-approved")],
+    )
+    live = make_agent(
+        bindings=[AgentBinding(kind="tool", ref="tool-added-after-submitting")],
+        listing=listing(state="in_review", submittedVersion=pending),
+    )
+
+    resolved, _ = asyncio.run(resolve_review_agent(live))
+
+    assert [b.ref for b in resolved.bindings] == ["tool-approved"]
+
+
+def test_a_pre_snapshot_submission_falls_back_to_the_live_record(table):
+    """Unlike invocation, this does not raise: there is nothing unsafe about a reviewer
+    reading the live record as long as they are told that is what they are reading, and
+    refusing would leave them with a queue row they cannot open."""
+    live = make_agent(
+        instructions=DRAFT_INSTRUCTIONS, listing=listing(state="in_review")
+    )
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert resolved.instructions == DRAFT_INSTRUCTIONS
+    assert version is None
+
+
+def test_a_pointer_to_a_missing_snapshot_falls_back_rather_than_raising(table):
+    """Read the version back rather than trusting the pointer, and report "not frozen"
+    rather than a version number whose content nobody has."""
+    live = make_agent(listing=listing(state="in_review", submittedVersion=99))
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert version is None
+    assert resolved.instructions == APPROVED_INSTRUCTIONS
+
+
+def test_an_agent_that_was_never_submitted_reads_its_live_record(table):
+    live = make_agent(listing=None)
+
+    resolved, version = asyncio.run(resolve_review_agent(live))
+
+    assert resolved is live
+    assert version is None
+
+
+def test_review_resolution_never_touches_visibility_or_ownership(table):
+    """The same rule the other two follow: this chooses a configuration, never an access
+    level. Whether the caller may review at all is the ``admin.marketplace`` scope."""
+    pending = publish(SUBMITTED_INSTRUCTIONS)
+    live = make_agent(
+        visibility="PRIVATE", listing=listing(state="in_review", submittedVersion=pending)
+    )
+
+    resolved, _ = asyncio.run(resolve_review_agent(live))
+
+    assert resolved.visibility == "PRIVATE"
+    assert resolved.owner_id == OWNER

--- a/docs/specs/agent-marketplace.md
+++ b/docs/specs/agent-marketplace.md
@@ -79,9 +79,11 @@ The lifecycle is a state machine on the listing:
 
 ```
 draft ──▶ private ──▶ in_review ──▶ published ──▶ taken_down
-                          │              │             │
-                          └─▶ changes_requested ◀──────┘
-                                     └──▶ in_review (resubmit)
+                        │ │             │              │
+                        │ └─▶ changes_requested ◀──────┘
+                        │            └──▶ in_review (resubmit)
+                        └───▶ rejected ──▶ in_review (revise and resubmit)
+                                       └─▶ private (shelve, so it can be deleted)
 ```
 
 - **Submit** (author) captures a category, an optional note to the reviewer, and runs the D7
@@ -89,9 +91,79 @@ draft ──▶ private ──▶ in_review ──▶ published ──▶ taken_
 - **Approve** (admin) writes the sparse index key and the Agent appears in the store immediately.
 - **Request changes** (admin) returns it with a reason that renders on the author's own card, so the
   author never has to ask what happened.
+- **Decline** (admin) answers a submission that should not be in the store *at all*, also with a
+  required reason. See D2.2 — it is a third decision, not a harsher request-changes.
 - **Take down** (admin) clears the index key and notifies the author with a reason. It is a
   **delisting, not a revocation** — existing pins keep working, conversations underway keep running,
   and the Agent stays reachable by direct link because `visibility` is a separate axis (D3).
+
+### D2.1 — The reviewer reads and test-drives the submission
+
+The queue could name a submission but not show one, and the three access rules that produced
+that were each individually correct:
+
+- `instructions` is gated to owner/editor on `GET /agents/{id}` — an admin is a `viewer` at best.
+- `get_assistant_with_access_check` refuses a non-owner outright on a PRIVATE Agent, and a
+  PRIVATE Agent absolutely can sit in the queue (approval refuses one; submission does not).
+- The review diff (§6.1) is the only other window onto the content, and on a **first** submission
+  it is empty by construction — there is nothing published to diff against.
+
+Net effect: on the most consequential review in the system, the reviewer saw a name, an author,
+a category and nothing else. So:
+
+**`GET /admin/agents/{id}/submission`** returns the full reviewer read — instructions, bound
+capabilities by name, model, starters, publisher, reachability — and **`review_preview` on the
+invocation path** lets them test-drive it.
+
+Three rules hold this together and are each load-bearing:
+
+1. **It reads the frozen snapshot, never the live record.** The live record is the author's draft
+   and they can keep editing it while the row sits in the queue; approval promotes
+   `submittedVersion`. Reading anything else shows an admin one configuration and publishes
+   another — the exact window `AgentVersion` was introduced to close, one level up. The rule lives
+   in `version_resolution.resolve_review_agent` so the page and the test drive cannot disagree
+   about what is under review; `in_review` reads `submittedVersion`, everything else reads
+   `publishedVersion` (on a withdrawal request nothing is pending, and `submittedVersion` is a
+   high-water mark that would name a snapshot the store never served).
+2. **It is a separate endpoint, not a widened `GET /agents/{id}`.** That route is the store's detail
+   read *and* the Agent Designer's form loader — teaching it an admin bypass would put an access
+   exception on the busiest read in the feature, to serve the wrong version anyway. Reading a
+   snapshot through an admin surface also sidesteps the PRIVATE 403 without loosening anyone's
+   access gate.
+3. **Instructions reach a marketplace admin, deliberately.** You cannot review what you cannot
+   read, and the diff already discloses them on every update. What changes is that a first
+   submission is no longer the one case where the reviewer approves prose nobody showed them.
+
+The test drive streams the real invocation path with a `preview-` session id, so nothing lands in
+the author's history, and the path skips its bookkeeping writes (`lastUsedAt`, share interaction) —
+a reviewer poking a submission is not use. It runs under the **reviewer's own identity**, so binding
+resolution is RBAC-filtered for them and not for the eventual users; the panel says so rather than
+letting a clean test drive read as proof it will run for everyone. The `admin.marketplace` scope is
+re-resolved against the caller's roles inside the invocation path, and a caller without it is
+**refused rather than quietly downgraded** — a silent downgrade would run the published snapshot and
+report it as the version under review.
+
+### D2.2 — Declining is a third decision, not a harsher request-changes
+
+Approve and request-changes were the only exits, so an admin who judged a submission not a fit had
+to publish it or say "fix this". The second promises a review they do not intend to give, leaves the
+author revising toward an approval that is not coming, and puts the same submission back in the
+queue every round.
+
+`rejected` is admin-only, entered from `in_review`, and carries a **required reason** for the same
+reason request-changes does: a decline the author cannot read is one they cannot act on.
+
+**The difference from `changes_requested` is intent, not mechanics.** Both let the author come back.
+Making rejection terminal was the alternative and is a much bigger hammer — it needs an appeal path,
+an admin escape hatch, and a policy about who may grant one. None of that is worth building before
+someone needs it, and an honest "no" the author can answer is worth having now.
+
+Two properties keep it safe. It is **not a door into the store**: the only way back is `in_review`,
+so approval remains the single edge that publishes. And it is **never on the shelf** — `is_on_shelf`
+hardcodes it False alongside `private` and `taken_down`, so a rejected listing cannot route a
+withdrawal into an admin queue for something no user can see. `rejected → private` exists for the
+same reason `taken_down → private` does: delete accepts only `private`, so without it a declined
+author holds an agent they can neither shelve nor delete.
 
 **Who owns the queue:** `system_admin`, via the existing `require_admin` dependency. A more granular
 admin permission set (a "marketplace curator" who can review without holding full system admin) is a
@@ -676,7 +748,8 @@ auth rule; admin routes `Depends(require_admin)` (= `require_app_roles("system_a
 | `GET /agents/pins` · `POST`/`DELETE /agents/{id}/pin` | The user's effective pin list; pin / dismiss (D9). Pinning is gated on the caller being able to *reach* the Agent, not on it being published. |
 | `POST /agents/{id}/report` | Feedback on a published Agent (D15) — from the foot of a conversation or the detail page. One open report per reporter. Optional `sessionId` attaches the conversation; verified against the caller and dropped if it does not check out. |
 | `GET /admin/agents/reports` · `POST /admin/agents/{id}/reports/{reportId}/resolve` | Report queue; resolve or dismiss, reporter visible (D15). Also `GET /admin/agents/{id}/reports` for one Agent's history and `GET /admin/agents/queues` for the two nav counts. |
-| `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes (D2). |
+| `GET /admin/agents/submissions` · `POST /admin/agents/{id}/review` | Review queue; approve / request changes / decline (D2, D2.2). |
+| `GET /admin/agents/{id}/submission` | The reviewer's full read of one submission, from the frozen snapshot (D2.1). |
 | `GET /admin/agents/listings` · `POST /admin/agents/{id}/takedown` | Listings table; delist with a reason. |
 | `PATCH /admin/agents/{id}/listing` | Edit presentation only — `name`, `tagline`, `iconKey`, `category`, `publisherId` (D13). Rejects any behavior field. |
 | `GET`/`POST`/`PATCH`/`DELETE /admin/agents/publishers` · `PUT .../{id}/eligibility` | Publisher profiles, `verified`, and who may propose each (D12). |

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -150,6 +150,15 @@ export const adminRoutes: Routes = [
     loadComponent: () => import('./marketplace/pages/review-queue.page').then(m => m.ReviewQueuePage),
   },
   {
+    // One submission in full — instructions, capabilities, model, and a test drive.
+    // Declared after the literal `marketplace/review` path so it is not captured by it.
+    path: 'marketplace/review/:agentId',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,
+    loadComponent: () =>
+      import('./marketplace/pages/submission-review.page').then(m => m.SubmissionReviewPage),
+  },
+  {
     path: 'marketplace/reports',
     canActivate: [adminScopeGuard],
     data: { scope: 'admin.marketplace' } satisfies AdminScopeRouteData,

--- a/frontend/ai.client/src/app/admin/marketplace/components/decline-submission-dialog.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/decline-submission-dialog.component.ts
@@ -1,36 +1,40 @@
 import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroNoSymbol } from '@ng-icons/heroicons/outline';
 import { DialogDismissDirective } from '../../../components/dialog/dialog-dismiss.directive';
 
-export interface RequestChangesDialogData {
-  /**
-   * Just the two fields the copy names.
-   *
-   * Narrowed from the full `AdminListingRow` when the submission review page arrived: that
-   * page holds an `AdminSubmissionReview`, not a queue row, and both surfaces send the same
-   * decision. Widening the type to a union would have been the other option and is worse —
-   * the dialog would then know about two shapes to render one sentence.
-   */
-  listing: { name: string; ownerName: string };
+export interface DeclineSubmissionDialogData {
+  /** Just enough to word the copy — the queue row and the review page both supply it. */
+  name: string;
+  ownerName: string;
 }
 
 /** The reason, or undefined if cancelled. */
-export type RequestChangesDialogResult = string | undefined;
+export type DeclineSubmissionDialogResult = string | undefined;
 
 /**
- * Returns a submission to its author with a reason.
+ * Declines a submission for the store, with a reason.
  *
- * The reason is required, not optional: it renders on the author's own card, which is the
- * whole point — the author never has to ask what happened. (The design mockup decided
- * without one; the spec requires it, so this dialog exists.)
+ * **The third decision, and the one the queue was missing.** Approve and request-changes
+ * were the only exits, so an admin who judged a submission not a fit had to publish it or
+ * say "fix this" — which promises a review they do not intend to give, leaves the author
+ * revising toward an approval that is not coming, and puts the same submission back in the
+ * queue every round.
+ *
+ * ⚠️ Deliberately **not** worded as a permanent block, because it is not one: the author
+ * may revise and submit again (`rejected → in_review`). Making it terminal would need an
+ * appeal path and an admin escape hatch, and none of that is worth building before someone
+ * needs it. What this buys now is an honest "no" the author can read and answer.
+ *
+ * The reason is required for the same reason it is on request-changes: it renders on the
+ * author's own card, and a decline with no reason is the one outcome they cannot act on.
  */
 @Component({
-  selector: 'app-request-changes-dialog',
+  selector: 'app-decline-submission-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [DialogDismissDirective, NgIcon],
-  providers: [provideIcons({ heroXMark })],
+  providers: [provideIcons({ heroXMark, heroNoSymbol })],
   host: {
     class: 'block',
     '(keydown.escape)': 'onCancel()',
@@ -48,18 +52,18 @@ export type RequestChangesDialogResult = string | undefined;
         class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="request-changes-title"
-        aria-describedby="request-changes-description"
+        aria-labelledby="decline-submission-title"
+        aria-describedby="decline-submission-description"
       >
         <div class="flex items-start justify-between gap-3 px-6 pt-5">
           <div class="min-w-0">
-            <h2 id="request-changes-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
-              Request changes
+            <h2 id="decline-submission-title" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+              Decline this submission
             </h2>
-            <p id="request-changes-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-              Returns <span class="font-medium">{{ data.listing.name }}</span> to
-              {{ data.listing.ownerName }}. Your note appears on their card, so they can
-              act on it without asking.
+            <p id="decline-submission-description" class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              <span class="font-medium">{{ data.name }}</span> will not go into the store, and
+              {{ data.ownerName }} sees your reason on their card. Nothing is deleted —
+              they can revise and submit again.
             </p>
           </div>
           <button
@@ -73,11 +77,17 @@ export type RequestChangesDialogResult = string | undefined;
         </div>
 
         <div class="px-6 py-4">
-          <label for="change-reason" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
-            What needs to change?
+          <label for="decline-reason" class="block text-sm/6 font-medium text-gray-900 dark:text-white">
+            Why is this not a fit?
           </label>
+          <!-- The copy steers away from "fix X" on purpose. An admin who writes a to-do
+               list here has picked the wrong control, and the author will read it as one. -->
+          <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+            If the answer is "it needs work", use Request changes instead — that says you
+            want it once it is fixed.
+          </p>
           <textarea
-            id="change-reason"
+            id="decline-reason"
             rows="4"
             [value]="reason()"
             (input)="onReasonInput($event)"
@@ -98,18 +108,19 @@ export type RequestChangesDialogResult = string | undefined;
             type="button"
             [disabled]="!reason().trim()"
             (click)="onSubmit()"
-            class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            class="inline-flex items-center gap-1.5 rounded-2xl bg-rose-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-rose-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            Send to author
+            <ng-icon name="heroNoSymbol" class="size-4" aria-hidden="true" />
+            Decline
           </button>
         </div>
       </div>
     </div>
   `,
 })
-export class RequestChangesDialogComponent {
-  private dialogRef = inject<DialogRef<RequestChangesDialogResult>>(DialogRef);
-  readonly data = inject<RequestChangesDialogData>(DIALOG_DATA);
+export class DeclineSubmissionDialogComponent {
+  private dialogRef = inject<DialogRef<DeclineSubmissionDialogResult>>(DialogRef);
+  readonly data = inject<DeclineSubmissionDialogData>(DIALOG_DATA);
 
   readonly reason = signal('');
 

--- a/frontend/ai.client/src/app/admin/marketplace/components/review-test-drive.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-test-drive.component.ts
@@ -1,0 +1,200 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroBeaker, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { ChatContainerComponent, ChatContainerConfig } from '../../../session/components/chat-container/chat-container.component';
+import { ChatInputComponent } from '../../../session/components/chat-input/chat-input.component';
+import { PreviewChatService } from '../../../assistants/assistant-form/services/preview-chat.service';
+
+/**
+ * Test-drive the submission under review, before deciding on it.
+ *
+ * **The gap this closes.** A reviewer could read a name and a category and, once the
+ * submission review page arrived, a system prompt — but had no way to find out what the
+ * agent actually *does*. `/assistants/{id}/test-chat` is not that harness: it is
+ * owner/editor-only, needs processed documents, and passes `enabled_tools=None`, so it
+ * exercises none of the agent's bindings. Chatting with the agent normally is not it
+ * either, for a subtler reason — `resolve_invocation_agent` hands a non-owner the
+ * *published* snapshot or the live draft, so a reviewer would be test-driving anything
+ * except the version they are about to approve.
+ *
+ * So this streams through the same real invocation path the main chat uses, with
+ * `reviewPreview` set. Server-side that resolves the agent to the snapshot under review
+ * (`resolve_review_agent`) and bypasses the PRIVATE visibility check — a PRIVATE agent can
+ * be sitting in the queue, and an ordinary read 403s on one. The scope is re-checked
+ * against the caller's own roles there, so this flag cannot widen anything on its own.
+ *
+ * ⚠️ **It runs under the reviewer's identity, and that is worth saying out loud on the
+ * page.** Binding resolution is RBAC-filtered per invoker, so a tool the reviewer lacks
+ * behaves differently for them than for the users who will pin this. The banner says so
+ * rather than letting a clean test drive read as proof it will run for everyone.
+ *
+ * The `preview-` session id keeps the whole exchange out of the author's conversation
+ * history, and the invocation path skips its bookkeeping writes (`lastUsedAt`, share
+ * interaction) for a review preview — a reviewer poking a submission is not use.
+ */
+@Component({
+  selector: 'app-review-test-drive',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, ChatContainerComponent, ChatInputComponent],
+  providers: [PreviewChatService, provideIcons({ heroBeaker, heroExclamationTriangle })],
+  template: `
+    <div class="flex h-full min-h-96 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div class="shrink-0 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <div class="flex items-start justify-between gap-2">
+          <div class="min-w-0">
+            <h3 class="flex items-center gap-1.5 text-sm/6 font-semibold text-gray-900 dark:text-white">
+              <ng-icon name="heroBeaker" class="size-4 shrink-0 text-gray-400" aria-hidden="true" />
+              Test drive
+            </h3>
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              @if (reviewVersion(); as version) {
+                Runs version {{ version }} — the snapshot you are deciding on.
+              } @else {
+                Runs this agent's current configuration.
+              }
+            </p>
+          </div>
+          @if (chat.hasMessages()) {
+            <button
+              type="button"
+              (click)="clear()"
+              class="shrink-0 rounded-md px-2 py-1 text-xs/5 font-medium text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            >
+              Clear
+            </button>
+          }
+        </div>
+
+        <!-- Never collapsed away. A reviewer who reads a clean test drive as "this works
+             for everyone" has drawn the one wrong conclusion this panel can produce. -->
+        <p
+          class="mt-2 flex items-start gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-xs/5 text-amber-800 dark:border-amber-800/50 dark:bg-amber-900/20 dark:text-amber-300"
+        >
+          <ng-icon
+            name="heroExclamationTriangle"
+            class="mt-0.5 size-4 shrink-0"
+            aria-hidden="true"
+          />
+          <span>
+            Runs with <span class="font-medium">your</span> permissions. A bound tool you
+            can reach may still be blocked for the people who pin this. Nothing here is
+            saved to the author's conversations.
+          </span>
+        </p>
+      </div>
+
+      <div class="relative flex min-h-0 flex-1 flex-col">
+        @if (!chat.hasMessages()) {
+          <div class="flex flex-1 flex-col items-center justify-center gap-1 overflow-y-auto p-6 text-center">
+            <p class="text-sm/6 font-medium text-gray-900 dark:text-white">
+              Ask {{ name() }} something
+            </p>
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              The questions its users will ask are the ones worth trying.
+            </p>
+          </div>
+          <div class="shrink-0 border-t border-gray-200 p-4 dark:border-gray-700">
+            <!-- No @-mention: this panel exists to exercise one specific submission, and
+                 handing its turn to another agent would make it lie. -->
+            <app-chat-input
+              [sessionId]="chat.sessionId()"
+              [isChatLoading]="chat.isLoading()"
+              [showFileControls]="false"
+              [showVoiceControl]="false"
+              [showSettingsControl]="false"
+              [autoFocus]="false"
+              [showAgentMentions]="false"
+              (messageSubmitted)="onMessageSubmitted($event)"
+              (messageCancelled)="onMessageCancelled()"
+            />
+          </div>
+        } @else {
+          <app-chat-container
+            class="h-full"
+            [messages]="chat.messages()"
+            [sessionId]="chat.sessionId()"
+            [assistant]="null"
+            [isChatLoading]="chat.isLoading()"
+            [streamingMessageId]="chat.streamingMessageId()"
+            [greetingMessage]="greeting()"
+            [config]="chatConfig"
+            (messageSubmitted)="onMessageSubmitted($event)"
+            (messageCancelled)="onMessageCancelled()"
+          />
+        }
+      </div>
+
+      @if (chat.error(); as message) {
+        <p
+          role="alert"
+          class="shrink-0 border-t border-gray-200 px-4 py-2 text-xs/5 text-rose-700 dark:border-gray-700 dark:text-rose-400"
+        >
+          {{ message }}
+        </p>
+      }
+    </div>
+  `,
+  styles: [':host { display: block; }'],
+})
+export class ReviewTestDriveComponent {
+  protected readonly chat = inject(PreviewChatService);
+
+  readonly agentId = input.required<string>();
+  readonly name = input<string>('this agent');
+  /** Which snapshot the server will run; absent when none backs the submission. */
+  readonly reviewVersion = input<number | undefined>(undefined);
+
+  /**
+   * `includeSystemPrompt` / `includeEnabledTools` are off for the same reason the agent
+   * designer's preview turns them off: an agent resolves instructions, model, tools,
+   * skills and memory server-side from its own record. Sending the reviewer's tool set
+   * would fight the bindings and test something nobody will ever run.
+   */
+  private readonly opts = {
+    includeSystemPrompt: false,
+    includeEnabledTools: false,
+    reviewPreview: true,
+  };
+
+  protected readonly chatConfig: Partial<ChatContainerConfig> = {
+    embeddedMode: true,
+    fullPageMode: false,
+    showTopnav: false,
+    showEmptyState: false,
+    allowCloseAssistant: false,
+    showFileControls: false,
+    showVoiceControl: false,
+    showSettingsControl: false,
+  };
+
+  constructor() {
+    // A fresh session per agent, so moving between two queue rows never carries one
+    // submission's exchange into the other's transcript.
+    effect(() => {
+      if (this.agentId()) this.chat.reset();
+    });
+  }
+
+  protected greeting(): string {
+    return `Test drive ${this.name()}`;
+  }
+
+  protected onMessageSubmitted(event: { content: string; timestamp: Date }): void {
+    if (!event.content.trim()) return;
+    void this.chat.sendMessage(event.content, this.agentId(), undefined, undefined, this.opts);
+  }
+
+  protected onMessageCancelled(): void {
+    this.chat.cancelRequest();
+  }
+
+  protected clear(): void {
+    this.chat.clearMessages();
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/models/marketplace.model.ts
@@ -138,10 +138,77 @@ export interface AdminListingsResponse {
 }
 
 export interface ReviewListingRequest {
-  decision: 'approve' | 'request_changes';
+  /**
+   * `reject` is a third decision, not a harsher `request_changes`.
+   *
+   * Both return the submission with a required reason; they differ in what the author is
+   * told and what the admin is committing to. Before it existed, an admin who judged a
+   * submission not a fit had to publish it or say "fix this" — promising a review they did
+   * not intend to give, and re-reading the same submission every time it came back.
+   */
+  decision: 'approve' | 'request_changes' | 'reject';
   note?: string;
   category?: string;
   publisherId?: string;
+}
+
+/**
+ * One capability the reviewed snapshot binds, by name.
+ *
+ * Names, never refs — the same rule the store's detail page follows.
+ */
+export interface AgentCapability {
+  label: string;
+  kind: string;
+}
+
+/**
+ * The reviewer's full read of a submission — instructions, capabilities, model.
+ *
+ * ⚠️ **Every field here comes from the frozen snapshot, not the live record**, and that is
+ * the design rather than an implementation detail. The live record is the author's draft
+ * and they can keep editing it while the row sits in the queue; approval promotes
+ * `submittedVersion`. A page that read the draft would show the reviewer one configuration
+ * and publish another.
+ *
+ * The one deliberate exception is `reachability`, which is a fact about *now* — `visibility`
+ * is not snapshotted, and cannot be, because fusing it with listing state is exactly the
+ * trap the version model exists to avoid.
+ */
+export interface AdminSubmissionReview {
+  agentId: string;
+  name: string;
+  description: string;
+  tagline?: string;
+  /** The system prompt as submitted — the thing being reviewed. */
+  instructions: string;
+  starters: string[];
+  emoji?: string;
+  iconUrl?: string;
+  ownerName: string;
+  publisher?: PublisherProfile | null;
+  category: string;
+  categoryLabel?: string;
+  state: ListingState;
+  capabilities: AgentCapability[];
+  modelLabel?: string;
+  /** Which snapshot this read is of; absent when none backs it — see `snapshotUnavailable`. */
+  reviewVersion?: number;
+  publishedVersion?: number;
+  /**
+   * The content above came from the **live record**, which the author can still change.
+   * True for submissions that predate version snapshots.
+   *
+   * Reported rather than refused: a reviewer looking at a row in their own queue needs
+   * something to read, and the flag is what lets the page say the content is not frozen
+   * instead of implying it is.
+   */
+  snapshotUnavailable: boolean;
+  submittedAt?: string;
+  withdrawalRequestedAt?: string;
+  reviewedAt?: string;
+  reviewNote?: string;
+  reachability: ListingReachability;
 }
 
 export interface TakedownRequest {

--- a/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/listings.page.ts
@@ -271,10 +271,14 @@ export class MarketplaceListingsPage implements OnInit {
   readonly busyId = signal<string | null>(null);
   readonly stateFilter = signal<'' | ListingState>('');
 
+  // The filter chips. `withdrawal_requested` is deliberately absent — those live in the
+  // review queue, not here. `rejected` is present: a declined submission is a listing with
+  // a history, and the Listings table is the only place to find one again.
   readonly states: ListingState[] = [
     'in_review',
     'published',
     'changes_requested',
+    'rejected',
     'taken_down',
     'private',
   ];

--- a/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/reports.page.ts
@@ -318,6 +318,8 @@ export class ReportsPage implements OnInit {
         return 'Changes requested';
       case 'private':
         return 'Unpublished';
+      case 'rejected':
+        return 'Declined';
       default:
         return state;
     }

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.spec.ts
@@ -6,6 +6,7 @@ import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { ReviewQueuePage } from './review-queue.page';
 import { AdminListingRow } from '../models/marketplace.model';
 import { of } from 'rxjs';
+import { provideRouter } from '@angular/router';
 import { ListingReachability } from '../../../agents/models/reachability';
 
 /**
@@ -46,6 +47,9 @@ describe('ReviewQueuePage — reachability warning', () => {
       providers: [
         { provide: AdminMarketplaceService, useValue: mockService },
         { provide: Dialog, useValue: { open: vi.fn() } },
+        // The agent name is a RouterLink into the submission review page, so the row
+        // cannot render without an ActivatedRoute.
+        provideRouter([]),
       ],
     });
   });
@@ -140,6 +144,7 @@ describe('ReviewQueuePage — withdrawal requests', () => {
       providers: [
         { provide: AdminMarketplaceService, useValue: mockService },
         { provide: Dialog, useValue: mockDialog },
+        provideRouter([]),
       ],
     });
   });
@@ -216,5 +221,105 @@ describe('ReviewQueuePage — withdrawal requests', () => {
     // declining restores nothing and granting is what actually takes it down.
     const fixture = await render();
     expect((fixture.nativeElement as HTMLElement).textContent).toMatch(/still live in the store/i);
+  });
+});
+
+/**
+ * Declining from the queue (the third review decision).
+ *
+ * Before it, an admin who judged a submission not a fit had to approve it or say "fix
+ * this" — promising a review they did not intend to give, and seeing the same submission
+ * again every round. These assert it reaches `review` (not the withdrawal endpoint, which
+ * answers the opposite question) and that it never appears on a withdrawal row.
+ */
+describe('ReviewQueuePage — declining a submission', () => {
+  let mockService: any;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  function submissionRow(overrides: Partial<AdminListingRow> = {}): AdminListingRow {
+    return {
+      agentId: 'ast-003',
+      name: 'Policy Lookup',
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      state: 'in_review',
+      usageCount: 0,
+      submittedAt: '2026-07-22T00:00:00Z',
+      updatedAt: '2026-07-22T00:00:00Z',
+      reachability: 'everyone',
+      adminEdits: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockService = {
+      error: signal<string | null>(null),
+      loadSubmissions: vi.fn().mockResolvedValue([submissionRow()]),
+      review: vi.fn().mockResolvedValue(undefined),
+      decideWithdrawal: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDialog = { open: vi.fn().mockReturnValue({ closed: of('Duplicates the Registrar agent.') }) };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: mockDialog },
+        provideRouter([]),
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function render(): Promise<ComponentFixture<ReviewQueuePage>> {
+    const fixture = TestBed.createComponent(ReviewQueuePage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function button(fixture: ComponentFixture<unknown>, label: string): HTMLButtonElement {
+    return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button')).find(
+      (b) => b.textContent?.includes(label),
+    ) as HTMLButtonElement;
+  }
+
+  it('offers Decline alongside the other two decisions', async () => {
+    const fixture = await render();
+    expect(button(fixture, 'Decline')).toBeTruthy();
+    expect(button(fixture, 'Request changes')).toBeTruthy();
+    expect(button(fixture, 'Approve')).toBeTruthy();
+  });
+
+  it('declines through review with the reason attached', async () => {
+    const fixture = await render();
+    button(fixture, 'Decline').click();
+    await fixture.whenStable();
+
+    expect(mockService.review).toHaveBeenCalledWith('ast-003', {
+      decision: 'reject',
+      note: 'Duplicates the Registrar agent.',
+    });
+    // Never the withdrawal endpoint: that one answers "may this come out?", and routing a
+    // decline through it would take down a listing that was never up.
+    expect(mockService.decideWithdrawal).not.toHaveBeenCalled();
+  });
+
+  it('records nothing when the reason dialog is dismissed', async () => {
+    mockDialog.open.mockReturnValue({ closed: of(undefined) });
+    const fixture = await render();
+    button(fixture, 'Decline').click();
+    await fixture.whenStable();
+
+    expect(mockService.review).not.toHaveBeenCalled();
+  });
+
+  it('links the agent name to its full review', async () => {
+    const fixture = await render();
+    const link = (fixture.nativeElement as HTMLElement).querySelector('a[href*="ast-003"]');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toContain('/admin/marketplace/review/ast-003');
   });
 });

--- a/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/review-queue.page.ts
@@ -6,9 +6,16 @@ import {
   OnInit,
 } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
+import { RouterLink } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash } from '@ng-icons/heroicons/outline';
+import {
+  heroInbox,
+  heroCheck,
+  heroArrowUturnLeft,
+  heroEyeSlash,
+  heroNoSymbol,
+} from '@ng-icons/heroicons/outline';
 import { AdminMarketplaceService } from '../services/admin-marketplace.service';
 import { AdminListingRow } from '../models/marketplace.model';
 import { AgentTileComponent } from '../components/agent-tile.component';
@@ -24,6 +31,11 @@ import {
   WithdrawalDecisionDialogData,
   WithdrawalDecisionDialogResult,
 } from '../components/withdrawal-decision-dialog.component';
+import {
+  DeclineSubmissionDialogComponent,
+  DeclineSubmissionDialogData,
+  DeclineSubmissionDialogResult,
+} from '../components/decline-submission-dialog.component';
 import { parseIso } from '../../../utils/date';
 
 /**
@@ -33,14 +45,21 @@ import { parseIso } from '../../../utils/date';
  * and the subtitle carries the three things a reviewer needs before making it (who wrote
  * it, what shelf it wants, how long it has waited).
  *
- * The mockup's "Preview" action is deliberately absent: it opens the agent detail page,
- * which is Phase 3. Rendering a dead button would be worse than not having one.
+ * The mockup's "Preview" action is now the agent name itself, and it opens the submission
+ * review page rather than the store detail page. That distinction is the point: the detail
+ * page gates `instructions` to owner/editor, 403s on a PRIVATE agent, and describes the
+ * *published* version — none of which is what a reviewer needs to read.
+ *
+ * The queue stays a list of decisions. Everything a fast approval needs is on the row (who,
+ * what shelf, how long, what changed); everything a careful one needs is one click away.
  */
 @Component({
   selector: 'app-review-queue',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, AgentTileComponent, ReviewDiffComponent],
-  providers: [provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash })],
+  imports: [NgIcon, RouterLink, AgentTileComponent, ReviewDiffComponent],
+  providers: [
+    provideIcons({ heroInbox, heroCheck, heroArrowUturnLeft, heroEyeSlash, heroNoSymbol }),
+  ],
   template: `
     <div class="min-h-dvh">
       <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
@@ -48,7 +67,9 @@ import { parseIso } from '../../../utils/date';
           <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Review queue</h1>
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Every submission lands here. Approving publishes it to the store immediately;
-            requesting changes returns it to the author with your note attached to their card.
+            requesting changes returns it to the author with your note attached to their card;
+            declining tells them it is not a fit. Open one to read its instructions, see what
+            it binds, and test drive it before deciding.
           </p>
           <p class="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Authors asking to pull a live listing land here too. Those stay published until
@@ -101,7 +122,14 @@ import { parseIso } from '../../../utils/date';
 
                 <div class="min-w-0 flex-1">
                   <h2 class="flex items-center gap-2 text-sm/6 font-semibold text-gray-900 dark:text-white">
-                    <span class="truncate">{{ row.name }}</span>
+                    <!-- The way in to the full read. On the name rather than a separate
+                         button: it is where a reviewer already looks to identify the row,
+                         and the decision buttons stay the row's only competing targets. -->
+                    <a
+                      [routerLink]="['/admin/marketplace/review', row.agentId]"
+                      class="truncate rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                      >{{ row.name }}</a
+                    >
                     <!-- The two things in this queue want opposite answers, and without a
                          label they render identically. A withdrawal request said "take this
                          down"; answering it with the submission verbs re-publishes over the
@@ -167,6 +195,15 @@ import { parseIso } from '../../../utils/date';
                       Take it down
                     </button>
                   } @else {
+                    <button
+                      type="button"
+                      [disabled]="busyId() === row.agentId"
+                      (click)="decline(row)"
+                      class="inline-flex items-center gap-1.5 rounded-2xl border border-rose-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-rose-700 hover:bg-rose-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-800 dark:bg-gray-800 dark:text-rose-300 dark:hover:bg-rose-900/20"
+                    >
+                      <ng-icon name="heroNoSymbol" class="size-4" aria-hidden="true" />
+                      Decline
+                    </button>
                     <button
                       type="button"
                       [disabled]="busyId() === row.agentId"
@@ -295,9 +332,30 @@ export class ReviewQueuePage implements OnInit {
     }
   }
 
+  /**
+   * Decline a submission for the store.
+   *
+   * The third decision, and the one the queue was missing: an admin who judged a
+   * submission not a fit had to approve it or say "fix this", which promises a review they
+   * do not intend to give and puts the same submission back in the queue every round.
+   *
+   * Routed through the same `review` endpoint as the other two — unlike a withdrawal
+   * decision, which has its own — because all three answer "may this go into the store?".
+   */
+  async decline(row: AdminListingRow): Promise<void> {
+    const ref = this.dialog.open<DeclineSubmissionDialogResult, DeclineSubmissionDialogData>(
+      DeclineSubmissionDialogComponent,
+      { data: { name: row.name, ownerName: row.ownerName } },
+    );
+    const note = await firstValueFrom(ref.closed);
+    if (note) {
+      await this.decide(row, { decision: 'reject', note });
+    }
+  }
+
   private async decide(
     row: AdminListingRow,
-    request: { decision: 'approve' | 'request_changes'; note?: string },
+    request: { decision: 'approve' | 'request_changes' | 'reject'; note?: string },
   ): Promise<void> {
     this.busyId.set(row.agentId);
     this.error.set(null);

--- a/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Dialog } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { ActivatedRoute, Router, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { SubmissionReviewPage } from './submission-review.page';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminSubmissionReview } from '../models/marketplace.model';
+
+/**
+ * The page that exists because a reviewer could not read what they were approving.
+ *
+ * The two things asserted here are the two the backend cannot: that the content actually
+ * *renders* (instructions especially — the whole point of the endpoint), and that the
+ * decision bar offers all three answers on a pending submission and none of them on a
+ * listing whose decision is not this page's to make.
+ *
+ * DI tokens rather than vi.mock, per project convention — a shared worker pool makes
+ * module mocks leak across specs.
+ */
+describe('SubmissionReviewPage', () => {
+  let mockService: {
+    error: ReturnType<typeof signal<string | null>>;
+    loadSubmission: ReturnType<typeof vi.fn>;
+    loadDiff: ReturnType<typeof vi.fn>;
+    review: ReturnType<typeof vi.fn>;
+  };
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let navigate: ReturnType<typeof vi.fn>;
+
+  function submission(overrides: Partial<AdminSubmissionReview> = {}): AdminSubmissionReview {
+    return {
+      agentId: 'ast-001',
+      name: 'Policy Lookup',
+      description: 'Find and cite university policy',
+      tagline: 'Policy, cited',
+      instructions: 'Answer only from the policy manual, and always cite the section.',
+      starters: ['What is the drop deadline?'],
+      ownerName: 'Ada Author',
+      category: 'Administration',
+      categoryLabel: 'Administration',
+      state: 'in_review',
+      capabilities: [{ label: 'Web search', kind: 'tool' }],
+      modelLabel: 'Claude Opus',
+      reviewVersion: 4,
+      snapshotUnavailable: false,
+      reachability: 'everyone',
+      ...overrides,
+    } as AdminSubmissionReview;
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    navigate = vi.fn().mockResolvedValue(true);
+    mockService = {
+      error: signal<string | null>(null),
+      loadSubmission: vi.fn().mockResolvedValue(submission()),
+      loadDiff: vi.fn().mockResolvedValue({
+        agentId: 'ast-001',
+        firstSubmission: true,
+        behaviorChanged: false,
+        changes: [],
+        instructionsDiff: [],
+      }),
+      review: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDialog = { open: vi.fn().mockReturnValue({ closed: of('Because.') }) };
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AdminMarketplaceService, useValue: mockService },
+        { provide: Dialog, useValue: mockDialog },
+        { provide: Router, useValue: { navigate } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => 'ast-001' } } },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function render(): Promise<ComponentFixture<SubmissionReviewPage>> {
+    const fixture = TestBed.createComponent(SubmissionReviewPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function text(fixture: ComponentFixture<unknown>): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  function button(fixture: ComponentFixture<unknown>, label: string): HTMLButtonElement {
+    return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button')).find(
+      (b) => b.textContent?.includes(label),
+    ) as HTMLButtonElement;
+  }
+
+  it('shows the instructions — the thing the reviewer could not see before', async () => {
+    const fixture = await render();
+    expect(text(fixture)).toContain('Answer only from the policy manual');
+  });
+
+  it('names what the agent binds, and its model', async () => {
+    const fixture = await render();
+    const rendered = text(fixture);
+    expect(rendered).toContain('Web search');
+    expect(rendered).toContain('Claude Opus');
+  });
+
+  it('says so when the agent binds nothing, rather than rendering an empty list', async () => {
+    mockService.loadSubmission.mockResolvedValue(submission({ capabilities: [] }));
+    const fixture = await render();
+    expect(text(fixture)).toMatch(/instructions alone/i);
+  });
+
+  it('offers all three decisions on a pending submission', async () => {
+    const fixture = await render();
+    expect(button(fixture, 'Approve')).toBeTruthy();
+    expect(button(fixture, 'Request changes')).toBeTruthy();
+    expect(button(fixture, 'Decline')).toBeTruthy();
+  });
+
+  it('offers no decision on a withdrawal request — that is the queue’s question', async () => {
+    // Answering a withdrawal with the submission verbs re-publishes over the author's
+    // request without ever saying so. The page reads it; the queue decides it.
+    mockService.loadSubmission.mockResolvedValue(
+      submission({ state: 'withdrawal_requested', publishedVersion: 4 }),
+    );
+    const fixture = await render();
+    expect(button(fixture, 'Approve')).toBeFalsy();
+    expect(button(fixture, 'Decline')).toBeFalsy();
+  });
+
+  it('offers no decision on a listing already decided', async () => {
+    mockService.loadSubmission.mockResolvedValue(submission({ state: 'published' }));
+    const fixture = await render();
+    expect(button(fixture, 'Approve')).toBeFalsy();
+    expect(text(fixture)).toMatch(/no decision waiting/i);
+  });
+
+  it('declines through review with the reason and returns to the queue', async () => {
+    const fixture = await render();
+    button(fixture, 'Decline').click();
+    await fixture.whenStable();
+
+    expect(mockService.review).toHaveBeenCalledWith('ast-001', {
+      decision: 'reject',
+      note: 'Because.',
+    });
+    expect(navigate).toHaveBeenCalledWith(['/admin/marketplace/review']);
+  });
+
+  it('records nothing when the decline dialog is dismissed', async () => {
+    mockDialog.open.mockReturnValue({ closed: of(undefined) });
+    const fixture = await render();
+    button(fixture, 'Decline').click();
+    await fixture.whenStable();
+
+    expect(mockService.review).not.toHaveBeenCalled();
+  });
+
+  it('approves without a dialog', async () => {
+    const fixture = await render();
+    button(fixture, 'Approve').click();
+    await fixture.whenStable();
+
+    expect(mockService.review).toHaveBeenCalledWith('ast-001', { decision: 'approve' });
+  });
+
+  it('warns when the content is not frozen', async () => {
+    // A submission predating version snapshots: the reviewer may still read it, but the
+    // author can change it under them, and the page must not imply otherwise.
+    mockService.loadSubmission.mockResolvedValue(
+      submission({ snapshotUnavailable: true, reviewVersion: undefined }),
+    );
+    const fixture = await render();
+    expect(text(fixture)).toMatch(/predates version snapshots/i);
+  });
+
+  it('warns that a private agent will 404 for everyone but its author', async () => {
+    mockService.loadSubmission.mockResolvedValue(submission({ reachability: 'owner_only' }));
+    const fixture = await render();
+    expect(text(fixture)).toMatch(/only the author can open this/i);
+  });
+
+  it('surfaces the backend message when the read fails', async () => {
+    mockService.loadSubmission.mockRejectedValue({
+      error: { detail: 'This agent has no marketplace listing to review.' },
+    });
+    const fixture = await render();
+    expect(text(fixture)).toContain('no marketplace listing to review');
+  });
+
+  it('keeps the reviewer on the page when a decision fails', async () => {
+    mockService.review.mockRejectedValue({ error: { detail: 'Visibility is now Private.' } });
+    const fixture = await render();
+    button(fixture, 'Approve').click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(text(fixture)).toContain('Visibility is now Private.');
+    // Re-enabled, or the reviewer is stranded with a dead action bar.
+    expect(button(fixture, 'Approve').hasAttribute('disabled')).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.ts
@@ -1,0 +1,415 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroArrowUturnLeft,
+  heroCheck,
+  heroExclamationTriangle,
+  heroEyeSlash,
+  heroNoSymbol,
+} from '@ng-icons/heroicons/outline';
+import { AdminMarketplaceService } from '../services/admin-marketplace.service';
+import { AdminSubmissionReview, AgentCapability } from '../models/marketplace.model';
+import { AgentTileComponent } from '../components/agent-tile.component';
+import { ReviewDiffComponent } from '../components/review-diff.component';
+import { ReviewTestDriveComponent } from '../components/review-test-drive.component';
+import { reachabilityReviewerMessage } from '../../../agents/models/reachability';
+import {
+  RequestChangesDialogComponent,
+  RequestChangesDialogData,
+  RequestChangesDialogResult,
+} from '../components/request-changes-dialog.component';
+import {
+  DeclineSubmissionDialogComponent,
+  DeclineSubmissionDialogData,
+  DeclineSubmissionDialogResult,
+} from '../components/decline-submission-dialog.component';
+
+/**
+ * One submission, in full, with the decision at the bottom of it (D2).
+ *
+ * **What this page is for.** The review queue could name a submission but not show one.
+ * `instructions` is gated to owner/editor on `GET /agents/{id}`, and that read 403s a
+ * non-owner outright when the agent is PRIVATE — so the person deciding whether to publish
+ * something could not read its system prompt, could not see what it binds, and on a *first*
+ * submission had nothing at all to read, because the review diff is empty by construction
+ * when nothing is published to diff against.
+ *
+ * ⚠️ **Everything here is the frozen snapshot.** The live record is the author's draft and
+ * they can keep editing it while the row sits in the queue; approval promotes
+ * `submittedVersion`. A page that read the draft would show one configuration and publish
+ * another — which is the window `AgentVersion` was introduced to close. The one exception is
+ * reachability, which is a fact about *now* and cannot come from a snapshot.
+ *
+ * Layout is deliberate: identity and warnings first, then instructions (the thing being
+ * reviewed), then what it reaches, then the diff for a resubmission, with the test drive
+ * beside it and the decision bar pinned at the foot. A reviewer should not have to scroll
+ * back up to act on what they just read.
+ */
+@Component({
+  selector: 'app-submission-review',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    RouterLink,
+    NgIcon,
+    AgentTileComponent,
+    ReviewDiffComponent,
+    ReviewTestDriveComponent,
+  ],
+  providers: [
+    provideIcons({
+      heroArrowLeft,
+      heroArrowUturnLeft,
+      heroCheck,
+      heroExclamationTriangle,
+      heroEyeSlash,
+      heroNoSymbol,
+    }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <a
+          routerLink="/admin/marketplace/review"
+          class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-blue-700 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-blue-400"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Review queue
+        </a>
+
+        @if (error(); as message) {
+          <div
+            role="alert"
+            class="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm/6 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-300"
+          >
+            {{ message }}
+          </div>
+        }
+
+        @if (loading()) {
+          <div class="flex items-center justify-center py-24">
+            <div
+              class="size-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600 dark:border-gray-600 dark:border-t-blue-400"
+            ></div>
+            <span class="sr-only">Loading submission</span>
+          </div>
+        } @else if (submission(); as s) {
+          <!-- Identity -->
+          <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start">
+            <app-agent-tile [agentId]="s.agentId" [iconUrl]="s.iconUrl" [emoji]="s.emoji" />
+            <div class="min-w-0 flex-1">
+              <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">{{ s.name }}</h1>
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                {{ s.ownerName }} · {{ s.categoryLabel || s.category }}
+                @if (s.publisher) {
+                  · published as {{ s.publisher.label }}
+                }
+              </p>
+              @if (s.tagline) {
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-300">{{ s.tagline }}</p>
+              }
+            </div>
+          </div>
+
+          <!-- Warnings, before anything a reviewer might act on. -->
+          @if (reachabilityWarning(); as warning) {
+            <p
+              class="mt-4 flex items-start gap-1.5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-300"
+            >
+              <ng-icon name="heroEyeSlash" class="mt-1 size-4 shrink-0" aria-hidden="true" />
+              <span>{{ warning }}</span>
+            </p>
+          }
+          @if (s.snapshotUnavailable) {
+            <!-- Not an error and not a blocker: the reviewer can still read and decide.
+                 What they must not do is assume the text below is pinned, because the
+                 author can change it under them. -->
+            <p
+              class="mt-3 flex items-start gap-1.5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm/6 text-amber-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-300"
+            >
+              <ng-icon
+                name="heroExclamationTriangle"
+                class="mt-1 size-4 shrink-0"
+                aria-hidden="true"
+              />
+              <span>
+                This submission predates version snapshots, so what you see below is the
+                agent's live record — its author can still change it. Approving it is
+                refused; ask them to resubmit and a snapshot is captured on the way in.
+              </span>
+            </p>
+          }
+
+          <div class="mt-6 grid gap-6 lg:grid-cols-2">
+            <!-- Left: what it is -->
+            <div class="flex flex-col gap-6">
+              <section>
+                <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Summary</h2>
+                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-300">{{ s.description }}</p>
+              </section>
+
+              <section>
+                <div class="flex items-baseline justify-between gap-2">
+                  <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                    Instructions
+                  </h2>
+                  @if (s.reviewVersion; as version) {
+                    <span class="text-xs/5 text-gray-500 dark:text-gray-400">
+                      version {{ version }}
+                    </span>
+                  }
+                </div>
+                <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                  The system prompt this agent runs with.
+                </p>
+                <!-- Monospace, pre-wrapped, scrollable: an author's prose has intentional
+                     line breaks, and reflowing it would misrepresent what they wrote. -->
+                <pre
+                  class="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-2xl bg-gray-50 p-3 text-xs/5 text-gray-800 dark:bg-gray-900 dark:text-gray-200"
+                >{{ s.instructions }}</pre>
+              </section>
+
+              <section>
+                <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                  What it reaches
+                </h2>
+                <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                  Tools, skills and memory spaces bound by this version.
+                </p>
+                @if (s.capabilities.length) {
+                  <ul class="mt-2 flex flex-wrap gap-1.5">
+                    @for (capability of s.capabilities; track capabilityKey(capability)) {
+                      <li
+                        class="rounded-2xl bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+                      >
+                        {{ capability.label }}
+                        <span class="font-normal text-gray-500 dark:text-gray-400">
+                          · {{ kindLabel(capability.kind) }}
+                        </span>
+                      </li>
+                    }
+                  </ul>
+                } @else {
+                  <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-300">
+                    Nothing — this agent answers from its instructions alone.
+                  </p>
+                }
+                <dl class="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm/6">
+                  <dt class="text-gray-500 dark:text-gray-400">Model</dt>
+                  <dd class="text-gray-900 dark:text-white">{{ s.modelLabel || '—' }}</dd>
+                  <dt class="text-gray-500 dark:text-gray-400">Starters</dt>
+                  <dd class="text-gray-900 dark:text-white">
+                    @if (s.starters.length) {
+                      <ul>
+                        @for (starter of s.starters; track $index) {
+                          <li>{{ starter }}</li>
+                        }
+                      </ul>
+                    } @else {
+                      —
+                    }
+                  </dd>
+                </dl>
+              </section>
+
+              @if (!isWithdrawal()) {
+                <section>
+                  <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                    Against what is published
+                  </h2>
+                  <app-review-diff [agentId]="s.agentId" />
+                </section>
+              }
+            </div>
+
+            <!-- Right: what it does -->
+            <app-review-test-drive
+              class="h-full"
+              [agentId]="s.agentId"
+              [name]="s.name"
+              [reviewVersion]="s.reviewVersion"
+            />
+          </div>
+
+          <!-- Decision. Pinned at the foot so the reviewer acts where they finished
+               reading, rather than scrolling back to the header. -->
+          <div
+            class="sticky bottom-0 mt-8 flex flex-col gap-3 border-t border-gray-200 bg-white/95 py-4 backdrop-blur sm:flex-row sm:items-center sm:justify-between dark:border-gray-700 dark:bg-gray-900/95"
+          >
+            <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+              @if (isWithdrawal()) {
+                The author asked to pull this listing. Decide it from the queue.
+              } @else if (isDecidable()) {
+                Approving publishes it to the store immediately.
+              } @else {
+                This listing has no decision waiting — you are reading it as a record.
+              }
+            </p>
+            @if (isDecidable()) {
+              <div class="flex shrink-0 flex-wrap gap-2">
+                <button
+                  type="button"
+                  [disabled]="busy()"
+                  (click)="decline()"
+                  class="inline-flex items-center gap-1.5 rounded-2xl border border-rose-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-rose-700 hover:bg-rose-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-800 dark:bg-gray-800 dark:text-rose-300 dark:hover:bg-rose-900/20"
+                >
+                  <ng-icon name="heroNoSymbol" class="size-4" aria-hidden="true" />
+                  Decline
+                </button>
+                <button
+                  type="button"
+                  [disabled]="busy()"
+                  (click)="requestChanges()"
+                  class="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <ng-icon name="heroArrowUturnLeft" class="size-4" aria-hidden="true" />
+                  Request changes
+                </button>
+                <button
+                  type="button"
+                  [disabled]="busy()"
+                  (click)="approve()"
+                  class="inline-flex items-center gap-1.5 rounded-2xl bg-blue-600 px-3 py-1.5 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  <ng-icon name="heroCheck" class="size-4" aria-hidden="true" />
+                  Approve
+                </button>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class SubmissionReviewPage implements OnInit {
+  private readonly service = inject(AdminMarketplaceService);
+  private readonly dialog = inject(Dialog);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  readonly submission = signal<AdminSubmissionReview | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly busy = signal(false);
+
+  private readonly agentId = signal('');
+
+  /**
+   * Only a pending *submission* gets the three decisions.
+   *
+   * A withdrawal request is a different question with opposite answers, and it is decided
+   * in the queue — answering it with the submission verbs would re-publish over the
+   * author's request without ever saying so, which is the failure the queue's own
+   * `isWithdrawal` split exists to prevent.
+   */
+  readonly isDecidable = computed(() => this.submission()?.state === 'in_review');
+  readonly isWithdrawal = computed(() => this.submission()?.state === 'withdrawal_requested');
+
+  private readonly kindLabels: Record<string, string> = {
+    tool: 'tool',
+    skill: 'skill',
+    memory_space: 'memory space',
+    knowledge_base: 'knowledge base',
+  };
+
+  ngOnInit(): void {
+    this.agentId.set(this.route.snapshot.paramMap.get('agentId') ?? '');
+    void this.reload();
+  }
+
+  async reload(): Promise<void> {
+    const id = this.agentId();
+    if (!id) {
+      this.loading.set(false);
+      this.error.set('No agent was named in this link.');
+      return;
+    }
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.submission.set(await this.service.loadSubmission(id));
+    } catch (err) {
+      this.error.set(this.detail(err) ?? 'Could not load this submission.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  reachabilityWarning(): string | null {
+    const s = this.submission();
+    return s ? reachabilityReviewerMessage(s.reachability) : null;
+  }
+
+  capabilityKey(capability: AgentCapability): string {
+    return `${capability.kind}:${capability.label}`;
+  }
+
+  kindLabel(kind: string): string {
+    return this.kindLabels[kind] ?? kind;
+  }
+
+  async approve(): Promise<void> {
+    await this.decide({ decision: 'approve' });
+  }
+
+  async requestChanges(): Promise<void> {
+    const s = this.submission();
+    if (!s) return;
+    const ref = this.dialog.open<RequestChangesDialogResult, RequestChangesDialogData>(
+      RequestChangesDialogComponent,
+      { data: { listing: { name: s.name, ownerName: s.ownerName } } },
+    );
+    const note = await firstValueFrom(ref.closed);
+    if (note) await this.decide({ decision: 'request_changes', note });
+  }
+
+  async decline(): Promise<void> {
+    const s = this.submission();
+    if (!s) return;
+    const ref = this.dialog.open<DeclineSubmissionDialogResult, DeclineSubmissionDialogData>(
+      DeclineSubmissionDialogComponent,
+      { data: { name: s.name, ownerName: s.ownerName } },
+    );
+    const note = await firstValueFrom(ref.closed);
+    if (note) await this.decide({ decision: 'reject', note });
+  }
+
+  /**
+   * Record the decision and return to the queue.
+   *
+   * Navigating away rather than reloading in place: every decision moves the listing out
+   * of `in_review`, so staying here would leave the reviewer on a page whose whole action
+   * bar has just gone, looking at a submission that is no longer theirs to decide.
+   */
+  private async decide(request: {
+    decision: 'approve' | 'request_changes' | 'reject';
+    note?: string;
+  }): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      await this.service.review(this.agentId(), request);
+      await this.router.navigate(['/admin/marketplace/review']);
+    } catch (err) {
+      this.error.set(this.detail(err) ?? 'Failed to record the decision.');
+      this.busy.set(false);
+    }
+  }
+
+  private detail(err: unknown): string | null {
+    const detail = (err as { error?: { detail?: unknown } })?.error?.detail;
+    return typeof detail === 'string' && detail.trim() ? detail : null;
+  }
+}

--- a/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/services/admin-marketplace.service.ts
@@ -16,6 +16,7 @@ import {
   AdminStoreFrontResponse,
   AgentCategory,
   AdminListingsResponse,
+  AdminSubmissionReview,
   ListingPatchRequest,
   ListingState,
   PublisherProfile,
@@ -79,6 +80,21 @@ export class AdminMarketplaceService {
     );
   }
 
+  /**
+   * The reviewer's full read of one submission — instructions, capabilities, model.
+   *
+   * Its own endpoint rather than `GET /agents/{id}`: that route gates `instructions` to
+   * owner/editor and 403s a non-owner outright on a PRIVATE agent, and it would serve the
+   * author's *draft* rather than the snapshot approval promotes.
+   */
+  async loadSubmission(agentId: string): Promise<AdminSubmissionReview> {
+    return firstValueFrom(
+      this.http.get<AdminSubmissionReview>(
+        `${this.baseUrl()}/${encodeURIComponent(agentId)}/submission`,
+      ),
+    );
+  }
+
   /** The Listings table: every agent that has ever been submitted. */
   async loadListings(state?: ListingState): Promise<AdminListingRow[]> {
     const url = state ? `${this.baseUrl()}/listings?state=${state}` : `${this.baseUrl()}/listings`;
@@ -100,7 +116,7 @@ export class AdminMarketplaceService {
     }
   }
 
-  /** Approve a submission, or return it to the author with a reason. */
+  /** Approve a submission, return it with a reason, or decline it for the store. */
   async review(agentId: string, request: ReviewListingRequest): Promise<void> {
     await firstValueFrom(this.http.post(`${this.baseUrl()}/${agentId}/review`, request));
   }

--- a/frontend/ai.client/src/app/agents/components/listing-status.component.ts
+++ b/frontend/ai.client/src/app/agents/components/listing-status.component.ts
@@ -129,6 +129,10 @@ export class ListingStatusComponent {
         return 'The reviewer asked for changes';
       case 'taken_down':
         return 'Why this was taken down';
+      // Its own heading, not "changes requested": the reviewer is not asking for a fix,
+      // and a note headed as a change request would be read as a to-do list.
+      case 'rejected':
+        return 'Why this was declined';
       case 'published':
         return 'Note from the reviewer';
       default:
@@ -138,7 +142,7 @@ export class ListingStatusComponent {
 
   readonly noteClass = computed(() => {
     const state = this.listing()?.state;
-    return state === 'changes_requested' || state === 'taken_down'
+    return state === 'changes_requested' || state === 'taken_down' || state === 'rejected'
       ? 'border-rose-200 bg-rose-50 text-rose-800 dark:border-rose-900 dark:bg-rose-900/20 dark:text-rose-200'
       : 'border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300';
   });

--- a/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
+++ b/frontend/ai.client/src/app/agents/components/share-agent-dialog.component.ts
@@ -687,6 +687,11 @@ export class ShareAgentDialogComponent {
    * shelve it — and therefore no way to delete it, since delete accepts only `private`. The
    * refusal even told them to "take it back to private first", naming a button this component
    * did not render.
+   *
+   * ⚠️ `rejected` is here for exactly that reason and must stay. A declined listing has the
+   * same `→ private` edge and the same consequence if this forgets it: the author is left
+   * holding an agent they cannot shelve and therefore cannot delete, over a listing an admin
+   * already said no to.
    */
   protected readonly canWithdraw = computed(() => {
     const state = this.listingState();
@@ -694,11 +699,24 @@ export class ShareAgentDialogComponent {
       state === 'in_review' ||
       state === 'changes_requested' ||
       state === 'published' ||
-      state === 'taken_down'
+      state === 'taken_down' ||
+      state === 'rejected'
     );
   });
 
   protected readonly isTakenDown = computed(() => this.listingState() === 'taken_down');
+
+  protected readonly isDeclined = computed(() => this.listingState() === 'rejected');
+
+  /**
+   * States where withdrawing *clears a listing* rather than pulling something down.
+   *
+   * `taken_down` and `rejected` differ in how they got here — an admin pulled a live
+   * listing, versus declined one that never went live — but the author's act is identical:
+   * nothing users can see changes, and clearing the listing is what unblocks deleting the
+   * agent. They differ only in the copy, which is why `withdrawCopy` still tells them apart.
+   */
+  protected readonly clearsListing = computed(() => this.isTakenDown() || this.isDeclined());
 
   protected readonly isPublished = computed(() => this.listingState() === 'published');
 
@@ -727,9 +745,10 @@ export class ShareAgentDialogComponent {
         return 'Request withdrawal';
       case 'in_review':
         return 'Withdraw submission';
-      // Not "Withdraw" — an admin already took it down, so there is nothing to withdraw
-      // from. This shelves the listing, which is also what makes the agent deletable.
+      // Not "Withdraw" — an admin already decided, so there is nothing to withdraw from.
+      // This shelves the listing, which is also what makes the agent deletable.
       case 'taken_down':
+      case 'rejected':
         return 'Remove listing';
       default:
         return 'Withdraw';
@@ -914,35 +933,8 @@ export class ShareAgentDialogComponent {
     }
 
     const published = this.isPublished();
-    const takenDown = this.isTakenDown();
     const confirmRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
-      data: {
-        title: published
-          ? 'Request withdrawal?'
-          : takenDown
-            ? 'Remove this listing?'
-            : 'Withdraw this submission?',
-        // Two things this has to get right. (1) §5.1 — this is a *request*: the listing
-        // stays in the store until an admin grants it. (2) D7.3 — say plainly that it
-        // recalls nothing, because an author who thinks withdrawal revokes access decides
-        // worse than one who knows it does not.
-        message: published
-          ? `An admin reviews this before "${name}" comes down from Discover, so it stays ` +
-            'published until they decide. Even once it does come down, nothing is ' +
-            'recalled: anyone who already added it keeps it, conversations underway keep ' +
-            'running, and it stays reachable by direct link.'
-          : takenDown
-            ? // Already off the shelf, so this changes nothing users can see. Name the two
-              // things the author is actually deciding: they keep the agent either way, and
-              // this is what unblocks deleting it if that is where they were heading.
-              `"${name}" is already down from Discover, so this only clears its listing. ` +
-              'The agent itself is unaffected and stays yours — and once its listing is ' +
-              'cleared you can delete it, which a taken-down listing blocks.'
-            : `"${name}" is pulled from the review queue. You can submit it again at any time.`,
-        confirmText: published ? 'Request withdrawal' : takenDown ? 'Remove listing' : 'Withdraw',
-        cancelText: 'Cancel',
-        destructive: published,
-      } as ConfirmationDialogData,
+      data: this.withdrawCopy(name),
     });
 
     if (!(await firstValueFrom(confirmRef.closed))) return;
@@ -950,6 +942,70 @@ export class ShareAgentDialogComponent {
     await this.runWithdraw(
       published ? `Could not request withdrawal of "${name}".` : `Could not withdraw "${name}".`,
     );
+  }
+
+  /**
+   * The confirmation copy for withdrawing, by what withdrawing actually *does* here.
+   *
+   * Built as one object rather than four parallel ternaries. It was three cases and read
+   * badly at three; `rejected` made it four, and a declined listing needs its own sentence
+   * — "already down from Discover" is false for something that was never up there, and
+   * telling an author their agent came down when it never went live is the kind of small
+   * lie that makes them distrust the rest of the card.
+   *
+   * Two things every branch has to get right. (1) §5.1 — withdrawing a live listing is a
+   * *request*: it stays in the store until an admin grants it. (2) D7.3 — say plainly that
+   * it recalls nothing, because an author who thinks withdrawal revokes access decides
+   * worse than one who knows it does not.
+   */
+  private withdrawCopy(name: string): ConfirmationDialogData {
+    if (this.isPublished()) {
+      return {
+        title: 'Request withdrawal?',
+        message:
+          `An admin reviews this before "${name}" comes down from Discover, so it stays ` +
+          'published until they decide. Even once it does come down, nothing is ' +
+          'recalled: anyone who already added it keeps it, conversations underway keep ' +
+          'running, and it stays reachable by direct link.',
+        confirmText: 'Request withdrawal',
+        cancelText: 'Cancel',
+        destructive: true,
+      } as ConfirmationDialogData;
+    }
+
+    if (this.isDeclined()) {
+      // Never on the shelf, so there is nothing to take down and nothing for users to
+      // notice. The two things the author is actually deciding: they keep the agent either
+      // way, and clearing the listing is what unblocks deleting it.
+      return {
+        title: 'Remove this listing?',
+        message:
+          `"${name}" was not published, so this only clears its listing — nothing changes ` +
+          'for anyone else. The agent itself stays yours, and you can submit it again ' +
+          'later or delete it once the listing is cleared.',
+        confirmText: 'Remove listing',
+        cancelText: 'Cancel',
+      } as ConfirmationDialogData;
+    }
+
+    if (this.isTakenDown()) {
+      return {
+        title: 'Remove this listing?',
+        message:
+          `"${name}" is already down from Discover, so this only clears its listing. ` +
+          'The agent itself is unaffected and stays yours — and once its listing is ' +
+          'cleared you can delete it, which a taken-down listing blocks.',
+        confirmText: 'Remove listing',
+        cancelText: 'Cancel',
+      } as ConfirmationDialogData;
+    }
+
+    return {
+      title: 'Withdraw this submission?',
+      message: `"${name}" is pulled from the review queue. You can submit it again at any time.`,
+      confirmText: 'Withdraw',
+      cancelText: 'Cancel',
+    } as ConfirmationDialogData;
   }
 
   /**

--- a/frontend/ai.client/src/app/agents/models/store.model.ts
+++ b/frontend/ai.client/src/app/agents/models/store.model.ts
@@ -29,6 +29,15 @@ export type ListingState =
   | 'changes_requested'
   | 'taken_down'
   /**
+   * An admin declined the submission for the store, with a reason (D2).
+   *
+   * ⚠️ Not a harsher `changes_requested`, and not a permanent block. The difference is what
+   * the author is told — "this isn't a fit, here's why" rather than "fix X and I'll approve"
+   * — and what the admin is committing to. The author may still revise and submit again;
+   * approval remains the only edge that publishes.
+   */
+  | 'rejected'
+  /**
    * The author has asked to pull a live listing and an admin has not yet decided (§5.1).
    *
    * ⚠️ Still **live in the store**. Dropping it off the shelf the moment the author asked
@@ -53,6 +62,7 @@ export const LISTING_STATE_LABELS: Record<ListingState, string> = {
   changes_requested: 'Changes requested',
   taken_down: 'Taken down',
   withdrawal_requested: 'Withdrawal requested',
+  rejected: 'Declined',
 };
 
 /**
@@ -68,6 +78,9 @@ export const LISTING_STATE_CLASSES: Record<ListingState, string> = {
   // Amber like in_review, not rose: this is work waiting on an admin, not a problem with
   // the listing — and it is still published while it waits.
   withdrawal_requested: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  // Rose like changes_requested: from the author's side both are "an admin said no for
+  // now, and left a reason". The reason text is what distinguishes them, not the colour.
+  rejected: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
 };
 
 /**

--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
@@ -171,7 +171,23 @@ export class PreviewChatService {
     assistantId: string,
     liveInstructions?: string,
     fileUploadIds?: string[],
-    opts?: { includeSystemPrompt?: boolean; includeEnabledTools?: boolean },
+    opts?: {
+      includeSystemPrompt?: boolean;
+      includeEnabledTools?: boolean;
+      /**
+       * This preview is a marketplace **reviewer** test-driving a submission.
+       *
+       * Sends `review_preview`, which the invocation path honours only after re-checking
+       * `admin.marketplace` against the caller's own roles. It changes two things
+       * server-side: the Agent resolves to the snapshot *under review* rather than to the
+       * published-or-draft rule, and the PRIVATE visibility check is bypassed — a PRIVATE
+       * agent can be sitting in the review queue, and an ordinary read 403s on one.
+       *
+       * ⚠️ Never set from an author-facing surface. A caller without the scope is refused
+       * outright rather than downgraded, so a stray `true` is a 403, not a wrong answer.
+       */
+      reviewPreview?: boolean;
+    },
   ): Promise<void> {
     if (!userMessage.trim() || this.loadingSignal()) {
       return;
@@ -244,6 +260,11 @@ export class PreviewChatService {
       }
       if (fileUploadIds && fileUploadIds.length > 0) {
         requestBody['file_upload_ids'] = fileUploadIds;
+      }
+      // Omitted rather than sent as `false`, so an ordinary preview's request carries no
+      // claim about a scope it never had.
+      if (opts?.reviewPreview) {
+        requestBody['review_preview'] = true;
       }
 
       // `fetchEventSource` bypasses the HttpClient pipeline, so the


### PR DESCRIPTION
## The gap

A reviewer could name a submission but not see one. Three individually correct access rules produced that:

- `instructions` is gated to owner/editor on `GET /agents/{id}` — an admin is a `viewer` at best.
- `get_assistant_with_access_check` refuses a non-owner outright on a PRIVATE agent, and a PRIVATE agent absolutely can sit in the queue (approval refuses one; submission does not).
- The review diff is the only other window onto the content, and on a **first** submission it is empty by construction — there is nothing published to diff against.

Net effect: on the most consequential review in the system, the admin saw a name, an author and a category. And the only two decisions were approve and request-changes, so an admin who judged a submission not a fit had to publish it or say "fix this".

## Three additions

### 1. Read it — `GET /admin/agents/{id}/submission`

Returns instructions, bound capabilities by name, model, starters, publisher and reachability. Rendered by a new page at `/admin/marketplace/review/:agentId`; the agent name in the queue links to it.

**It serves the frozen snapshot, never the live record, and that is the design rather than an implementation detail.** The live record is the author's draft and they can keep editing it while the row sits in the queue, while approval promotes `submittedVersion`. Reading anything else shows an admin one configuration and publishes another — the window `AgentVersion` exists to close.

Deliberately a separate endpoint rather than a widened `GET /agents/{id}`: that route is the store's detail read *and* the Designer's form loader, so teaching it an admin bypass would put an access exception on the busiest read in the feature, to serve the wrong version anyway. Reading a snapshot through an admin surface also sidesteps the PRIVATE 403 without loosening anyone's access gate.

A submission predating version snapshots is **flagged, not refused** (`snapshotUnavailable`). The diff endpoint 400s in that case, which would otherwise leave the reviewer exactly where the empty diff left them.

### 2. Test-drive it — `review_preview` on the invocation payload

Resolves the reviewed snapshot and bypasses the PRIVATE check, after re-resolving `admin.marketplace` against the caller's own roles. A caller without the scope is **refused rather than quietly downgraded** — a silent downgrade would run the published snapshot and report it to the reviewer as the version under review.

A field on the existing `/invocations` path, not a new inference-api route (that surface only proxies `/invocations` and `/ping`).

The which-version rule lives in `version_resolution.resolve_review_agent` so the page and the test drive cannot disagree — inference-api cannot import from app_api, and two copies of that rule is the same class of bug one level up. `in_review` reads `submittedVersion`; everything else reads `publishedVersion`, because on a withdrawal request nothing is pending and `submittedVersion` is a high-water mark that would name a snapshot the store never served.

Runs on a `preview-` session so nothing lands in the author's history, and the path skips its bookkeeping writes (`lastUsedAt`, share interaction) — a reviewer poking a submission is not use, and `lastUsedAt` feeds the KB-sync inactivity pause. An uncollapsible banner says it runs with the reviewer's own permissions, because a clean test drive read as "this works for everyone" is the one wrong conclusion the panel can produce.

### 3. Decline it — the `rejected` state

A third decision, not a harsher request-changes. Admin-only from `in_review`, required reason, and the author may still revise and resubmit — the difference is intent and framing, not a locked door. Making it terminal needs an appeal path and an admin escape hatch, and none of that is worth building before someone needs it.

Two properties keep it safe: it has no edge to `published`, so approval remains the only door into the store; and it is hardcoded never-on-shelf alongside `private` and `taken_down`. `rejected → private` exists so a declined author can still shelve and therefore delete their own agent — the same reason `taken_down → private` does.

## Please look closely at

**I changed an architecture test.** `test_admin_scope_coverage` greps each route dependency's source for `resolve_user_permissions`. Extracting `has_admin_scope` (so the route guard and the invocation path cannot answer "who is a marketplace admin" differently) moved that call one frame down, so I added the new marker to the predicate. The guarantee is unchanged — but it is a security backstop, so it deserves a real look rather than a nod.

## Tests

6125 backend, 1892 frontend, `tsc --noEmit` clean. New coverage: the reviewer resolution rule against a real (moto) table, the `rejected` transitions, the submission endpoint including the PRIVATE and pre-snapshot cases, and the review page's decision bar.

## Not verified in a browser

No `SKIP_AUTH` here and `localhost:4200` talks to the dev backend, so reaching these pages needs a real SSO login and a pending submission. Types and tests pass; pixels are unverified.

## Spec

`docs/specs/agent-marketplace.md` gains D2.1 (the reviewer read and test drive) and D2.2 (declining), and the D2 state diagram gains `rejected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)