### PR TITLE
fix(marketplace): make the review test drive big enough to use

### DIFF
--- a/frontend/ai.client/src/app/admin/marketplace/components/review-test-drive.component.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/components/review-test-drive.component.ts
@@ -4,9 +4,15 @@ import {
   effect,
   inject,
   input,
+  output,
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroBeaker, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import {
+  heroArrowsPointingIn,
+  heroArrowsPointingOut,
+  heroBeaker,
+  heroExclamationTriangle,
+} from '@ng-icons/heroicons/outline';
 import { ChatContainerComponent, ChatContainerConfig } from '../../../session/components/chat-container/chat-container.component';
 import { ChatInputComponent } from '../../../session/components/chat-input/chat-input.component';
 import { PreviewChatService } from '../../../assistants/assistant-form/services/preview-chat.service';
@@ -42,9 +48,17 @@ import { PreviewChatService } from '../../../assistants/assistant-form/services/
   selector: 'app-review-test-drive',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, ChatContainerComponent, ChatInputComponent],
-  providers: [PreviewChatService, provideIcons({ heroBeaker, heroExclamationTriangle })],
+  providers: [
+    PreviewChatService,
+    provideIcons({
+      heroArrowsPointingIn,
+      heroArrowsPointingOut,
+      heroBeaker,
+      heroExclamationTriangle,
+    }),
+  ],
   template: `
-    <div class="flex h-full min-h-96 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+    <div class="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
       <div class="shrink-0 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
         <div class="flex items-start justify-between gap-2">
           <div class="min-w-0">
@@ -60,15 +74,35 @@ import { PreviewChatService } from '../../../assistants/assistant-form/services/
               }
             </p>
           </div>
-          @if (chat.hasMessages()) {
+          <div class="flex shrink-0 items-center gap-1">
+            @if (chat.hasMessages()) {
+              <button
+                type="button"
+                (click)="clear()"
+                class="rounded-md px-2 py-1 text-xs/5 font-medium text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              >
+                Clear
+              </button>
+            }
+            <!-- Widens the panel across the page rather than opening an overlay. The
+                 conversation has to survive the toggle, so the element never moves in the
+                 DOM — only its classes change — and a plain layout change needs none of
+                 the focus trapping an overlay would. -->
             <button
               type="button"
-              (click)="clear()"
-              class="shrink-0 rounded-md px-2 py-1 text-xs/5 font-medium text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              (click)="expandedChange.emit(!expanded())"
+              [attr.aria-expanded]="expanded()"
+              [attr.aria-label]="expanded() ? 'Collapse the test drive' : 'Expand the test drive to full width'"
+              [title]="expanded() ? 'Collapse' : 'Expand to full width'"
+              class="rounded-md p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             >
-              Clear
+              <ng-icon
+                [name]="expanded() ? 'heroArrowsPointingIn' : 'heroArrowsPointingOut'"
+                class="size-4"
+                aria-hidden="true"
+              />
             </button>
-          }
+          </div>
         </div>
 
         <!-- Never collapsed away. A reviewer who reads a clean test drive as "this works
@@ -149,6 +183,15 @@ export class ReviewTestDriveComponent {
   readonly name = input<string>('this agent');
   /** Which snapshot the server will run; absent when none backs the submission. */
   readonly reviewVersion = input<number | undefined>(undefined);
+  /**
+   * Whether the panel currently spans the page.
+   *
+   * Owned by the page, not by this component: expanding changes the page's grid, and the
+   * panel is not in a position to know that. This only renders the control and reports the
+   * intent.
+   */
+  readonly expanded = input(false);
+  readonly expandedChange = output<boolean>();
 
   /**
    * `includeSystemPrompt` / `includeEnabledTools` are off for the same reason the agent

--- a/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
@@ -189,6 +189,46 @@ describe('SubmissionReviewPage', () => {
     expect(text(fixture)).toMatch(/only the author can open this/i);
   });
 
+  it('gives the test drive viewport height, not the height of the prose beside it', async () => {
+    // The bug this guards: the panel was sized by its grid cell, so a short left column
+    // left ~120px between the banner and the composer — too small to judge an agent
+    // through. Assert it is sized against the viewport and sticks while the reviewer
+    // scrolls, rather than asserting a pixel count no test can see.
+    const fixture = await render();
+    const panel = (fixture.nativeElement as HTMLElement).querySelector('app-review-test-drive');
+
+    expect(panel?.className).toMatch(/100dvh/);
+    expect(panel?.className).toContain('lg:sticky');
+  });
+
+  it('spans the page when expanded, without remounting the conversation', async () => {
+    const fixture = await render();
+    const before = (fixture.nativeElement as HTMLElement).querySelector('app-review-test-drive');
+
+    fixture.componentInstance.expanded.set(true);
+    fixture.detectChanges();
+
+    const after = (fixture.nativeElement as HTMLElement).querySelector('app-review-test-drive');
+    expect(after?.className).toContain('lg:col-span-2');
+    // Same element: expanding is a class change, never a move in the DOM. Moving it would
+    // destroy the component and take the reviewer's conversation with it.
+    expect(after).toBe(before);
+  });
+
+  it('says an empty system prompt is empty rather than rendering a blank box', async () => {
+    // A blank panel under a heading reads as a page that failed to load — and an agent
+    // that genuinely ships no instructions is itself a reason to decline, so the two must
+    // not look alike.
+    mockService.loadSubmission.mockResolvedValue(
+      submission({ instructions: '   ', description: '' }),
+    );
+    const fixture = await render();
+    const rendered = text(fixture);
+
+    expect(rendered).toMatch(/ships no system prompt/i);
+    expect(rendered).toMatch(/no summary/i);
+  });
+
   it('surfaces the backend message when the read fails', async () => {
     mockService.loadSubmission.mockRejectedValue({
       error: { detail: 'This agent has no marketplace listing to review.' },

--- a/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.ts
@@ -151,12 +151,23 @@ import {
             </p>
           }
 
-          <div class="mt-6 grid gap-6 lg:grid-cols-2">
+          <!-- items-start so the right column can be sticky: a stretched grid cell has
+               no room to stick within. -->
+          <div class="mt-6 grid items-start gap-6 lg:grid-cols-2">
             <!-- Left: what it is -->
-            <div class="flex flex-col gap-6">
+            <!-- A whole-string class binding rather than a per-class one: a class-binding
+                 *name* cannot contain a colon, so Tailwind's breakpoint prefixes have to be
+                 toggled as a string. -->
+            <div [class]="readColumnClasses()">
               <section>
                 <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">Summary</h2>
-                <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-300">{{ s.description }}</p>
+                @if (s.description.trim()) {
+                  <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-300">{{ s.description }}</p>
+                } @else {
+                  <p class="mt-1 text-sm/6 italic text-gray-500 dark:text-gray-400">
+                    None — this agent has no summary.
+                  </p>
+                }
               </section>
 
               <section>
@@ -174,10 +185,23 @@ import {
                   The system prompt this agent runs with.
                 </p>
                 <!-- Monospace, pre-wrapped, scrollable: an author's prose has intentional
-                     line breaks, and reflowing it would misrepresent what they wrote. -->
-                <pre
-                  class="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-2xl bg-gray-50 p-3 text-xs/5 text-gray-800 dark:bg-gray-900 dark:text-gray-200"
-                >{{ s.instructions }}</pre>
+                     line breaks, and reflowing it would misrepresent what they wrote.
+
+                     ⚠️ An empty system prompt gets a sentence, not an empty box. A blank
+                     panel under a heading reads as a page that failed to load, and a
+                     reviewer who thinks the read is broken cannot tell it apart from an
+                     agent that genuinely ships no instructions — which is itself a reason
+                     to decline, and so must be legible rather than ambiguous. -->
+                @if (s.instructions.trim()) {
+                  <pre
+                    class="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-2xl bg-gray-50 p-3 text-xs/5 text-gray-800 dark:bg-gray-900 dark:text-gray-200"
+                  >{{ s.instructions }}</pre>
+                } @else {
+                  <p class="mt-2 text-sm/6 italic text-gray-500 dark:text-gray-400">
+                    None — this agent ships no system prompt and will behave like a plain
+                    chat.
+                  </p>
+                }
               </section>
 
               <section>
@@ -233,12 +257,20 @@ import {
               }
             </div>
 
-            <!-- Right: what it does -->
+            <!-- Right: what it does.
+                 Sized against the viewport rather than against the left column, which is
+                 what made it unusable: a chat surface whose height is "whatever the prose
+                 beside it happens to need" leaves ~120px between the banner and the
+                 composer, and a reviewer cannot judge an agent through a two-line window.
+                 Sticky so it stays put while they scroll the instructions — reading and
+                 asking are the same loop, not two passes. -->
             <app-review-test-drive
-              class="h-full"
+              [class]="testDriveClasses()"
               [agentId]="s.agentId"
               [name]="s.name"
               [reviewVersion]="s.reviewVersion"
+              [expanded]="expanded()"
+              (expandedChange)="expanded.set($event)"
             />
           </div>
 
@@ -305,6 +337,35 @@ export class SubmissionReviewPage implements OnInit {
   readonly busy = signal(false);
 
   private readonly agentId = signal('');
+
+  /**
+   * Whether the test drive has taken the full width of the page.
+   *
+   * Held here rather than inside the panel because it changes the *page's* grid: expanding
+   * spans the panel across both columns and pushes the read above it. Toggled by class
+   * binding only — never by moving the element in the DOM, which would destroy the
+   * component and take the reviewer's conversation with it.
+   */
+  readonly expanded = signal(false);
+
+  /**
+   * Sticky and viewport-tall in the column; full-width and tall when expanded.
+   *
+   * `100dvh` rather than `100vh` so a mobile browser's collapsing toolbar does not leave
+   * the composer under the chrome.
+   */
+  testDriveClasses(): string {
+    return this.expanded()
+      ? 'h-[calc(100dvh-14rem)] min-h-[28rem] lg:col-span-2'
+      : 'h-[32rem] lg:sticky lg:top-6 lg:h-[calc(100dvh-10rem)] lg:min-h-[28rem]';
+  }
+
+  /** The read column takes the full width once the test drive is spanning both. */
+  readColumnClasses(): string {
+    return this.expanded()
+      ? 'flex flex-col gap-6 lg:col-span-2'
+      : 'flex flex-col gap-6';
+  }
 
   /**
    * Only a pending *submission* gets the three decisions.


### PR DESCRIPTION
Follow-up to #882, from testing it on the real page.

## The problem

The test drive was sized by its grid cell, so its height came from whatever the prose in the left column happened to need. On a short submission that leaves roughly **120px** between the warning banner and the composer — around two lines of conversation. That is too small a window to judge an agent through, which is the one thing the panel exists for.

## The fix

- **Sized against the viewport**, not against the column beside it (`lg:h-[calc(100dvh-10rem)]`, `100dvh` so a mobile toolbar does not hide the composer).
- **Sticky**, so it stays put while the reviewer scrolls the instructions — reading and asking are one loop, not two passes. The grid gets `items-start`, since a stretched cell has no room to stick within.
- **An expand control** that spans it across both columns for a longer session. Expanding is a **class change only** — the element never moves in the DOM, because remounting the component would destroy `PreviewChatService` and take the reviewer's conversation with it. That is what the "without remounting" assertion in the spec is guarding.

## Also in here

An empty summary or system prompt now says so instead of rendering a blank box — visible in the screenshot that prompted this. A blank panel under a heading reads as a page that failed to load, and an agent that genuinely ships no instructions is *itself* a reason to decline, so the two must not look alike.

## Note for reviewers

`[class.lg:col-span-2]` does not work — an Angular class-binding *name* cannot contain a colon, so Tailwind breakpoint prefixes have to be toggled as a whole-string `[class]` binding. Worth knowing before someone reaches for the per-class form here again.

## Tests

79 marketplace-admin tests pass (3 new: viewport sizing, expand-without-remount, empty-content fallbacks); `tsc --noEmit` clean.

Layout changes are not something the specs can really prove — they assert the classes are applied, not the resulting pixels. Worth a look on the real page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)