### PR TITLE
fix(kb): grant the tag permissions provisioning and reconciliation need

### DIFF
--- a/infrastructure/lib/constructs/managed-kb/managed-kb-role-construct.ts
+++ b/infrastructure/lib/constructs/managed-kb/managed-kb-role-construct.ts
@@ -127,6 +127,25 @@ export function grantManagedKbProvisioning(
       'bedrock:DeleteKnowledgeBase',
       'bedrock:CreateDataSource',
       'bedrock:DeleteDataSource',
+      // `CreateKnowledgeBase` is called WITH tags (provisioning.py passes
+      // `tags=build_tags(...)`), and AWS authorises the tagging as a separate
+      // `bedrock:TagResource` action against `knowledge-base/*` — the resource
+      // does not exist yet, so the wildcard is the only thing it can match.
+      // Without this the create fails outright:
+      //
+      //   AccessDeniedException: not authorized to perform bedrock:TagResource
+      //
+      // and it fails *after* passing every review, because the create action
+      // itself is granted. Those tags are not decoration: they are what the
+      // reconciler and teardown match knowledge bases on, so creating untagged
+      // would be worse than failing.
+      'bedrock:TagResource',
+      // The reconciler reads tags to decide what belongs to this project
+      // (`tombstones.iter_project_knowledge_bases` → `list_tags_for_resource`).
+      // It fails closed on a read error, so without this permission every
+      // knowledge base looks untagged, matches nothing, and the orphan sweep
+      // silently reports a clean account forever.
+      'bedrock:ListTagsForResource',
     ],
     resources: [knowledgeBaseArnWildcard(config)],
   }));

--- a/infrastructure/test/managed-kb.test.ts
+++ b/infrastructure/test/managed-kb.test.ts
@@ -321,8 +321,34 @@ describe('ManagedKbRoleConstruct — caller grants', () => {
       'bedrock:DeleteKnowledgeBase',
       'bedrock:CreateDataSource',
       'bedrock:DeleteDataSource',
+      'bedrock:TagResource',
+      'bedrock:ListTagsForResource',
     ]);
     expect(s.Resource).toBe(KB_ARN_WILDCARD);
+  });
+
+  it('can tag a knowledge base at create time', () => {
+    // `CreateKnowledgeBase` is called WITH tags, and AWS authorises the tagging
+    // as a separate action. Missing it, provisioning failed in dev with
+    //
+    //   AccessDeniedException: not authorized to perform bedrock:TagResource
+    //
+    // *after* passing review, because the create action itself was granted. The
+    // tags are what the reconciler and teardown match on, so an untagged
+    // knowledge base would be worse than a failed create.
+    const s = statementBySid(t, 'ManagedKbProvisionCrud');
+    expect(s.Action).toContain('bedrock:TagResource');
+    // Must be the wildcard: at create time the knowledge base has no ARN, so a
+    // resource-specific grant could never match.
+    expect(s.Resource).toBe(KB_ARN_WILDCARD);
+  });
+
+  it('can read tags, which is how the reconciler recognises its own resources', () => {
+    // `iter_project_knowledge_bases` fails closed on a tag read error, so
+    // without this the orphan sweep sees every knowledge base as untagged,
+    // matches nothing, and reports a clean account forever.
+    const s = statementBySid(t, 'ManagedKbProvisionCrud');
+    expect(s.Action).toContain('bedrock:ListTagsForResource');
   });
 
   it('keeps the non-resource-scopable create/list actions in their own statement', () => {


### PR DESCRIPTION
## The first migration to reach the worker failed

```
AccessDeniedException: not authorized to perform bedrock:TagResource
on resource arn:aws:bedrock:us-west-2:...:knowledge-base/*
```

`CreateKnowledgeBase` is called **with tags**, and AWS authorises the tagging as a separate action from the create. The grant had `bedrock:CreateKnowledgeBase`, so it reviewed as complete. The gap only surfaces the moment a real knowledge base is created — which nobody had done yet.

Those tags are not decoration. They are what the reconciler and `scripts/teardown/managed-kb.sh` match knowledge bases on, so creating them **untagged** would be worse than failing to create them: an orphan nothing can find. Failing closed was correct behaviour; it just needed the permission.

## Also missing: `bedrock:ListTagsForResource`

Same cause, quieter failure. `tombstones.iter_project_knowledge_bases` reads tags to decide what belongs to this project, and fails closed on a read error. Without this permission every knowledge base looks untagged, matches nothing, and the daily orphan sweep reports a clean account forever.

## Scope

Both on `knowledge-base/*`. At create time there is no ARN to scope to — the wildcard is what the failing request was actually evaluated against.

## Tests

The existing assertion used `toEqual` on the exact action list, so it caught the addition and forced this to be deliberate. That whitelist is the reason a stray Bedrock permission cannot creep in unnoticed (spec defect 8, where an over-grant hid in a separate statement).

Two further tests pin **why** each action is needed rather than just that it is present, and both mutations are verified caught — removing either action fails its own named test.

626 infra tests pass.

## State of the migration

The record for `ast-1a90784a7f18` is now `failed` with the AccessDenied reason stored, work keys removed. That is the intended terminal state: the knowledge base is untouched and still served from the legacy backend, and the upgrade card shows a plain-language failure with a retry control.

After this deploys, retrying re-enters `shadow` on a fresh generation and provisioning should complete.
