### PR TITLE
fix(fine-tuning): make the feature work end to end

### DIFF
--- a/.github/ACTIONS-REFERENCE.md
+++ b/.github/ACTIONS-REFERENCE.md
@@ -43,6 +43,7 @@ GitHub provides two mechanisms for storing configuration values:
 | CDK_FILE_UPLOAD_CORS_ORIGINS | Variable | No | None | Platform | Additional CORS origins for the file upload S3 bucket only (appended to global CORS origins) |
 | CDK_FILE_UPLOAD_MAX_SIZE_MB | Variable | No | `10` | Platform | Maximum file upload size in megabytes |
 | CDK_FINE_TUNING_CORS_ORIGINS | Variable | No | None | SageMaker Fine-Tuning | Additional CORS origins for the fine-tuning S3 bucket only (appended to global CORS origins) |
+| CDK_FINE_TUNING_ENABLED | Variable | No | `true` | App API | Mounts the `/fine-tuning` and `/admin/fine-tuning` routers (sets the container's `FINE_TUNING_ENABLED`). Default ON; set to `false` as a kill switch. Storage and IAM are provisioned either way, so switching off never orphans datasets or trained models. |
 | CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS | Variable | No | `0` | App API | Default monthly GPU-hour quota for all authenticated users. `0` = whitelist-only (admin must grant each user). Positive value (e.g. `5`) = open access with that default budget. |
 | CDK_FRONTEND_BUCKET_NAME | Variable | No | None | Frontend | S3 bucket name for frontend assets (defaults to generated name with account ID) |
 | CDK_FRONTEND_CORS_ORIGINS | Variable | No | None | Frontend | Additional CORS origins for the frontend SSM export only (appended to global CORS origins) |

--- a/.github/docs/deploy/step-03-github-config.md
+++ b/.github/docs/deploy/step-03-github-config.md
@@ -109,6 +109,8 @@ The per-origin cert vars below are **optional overrides** — set one only if yo
 | `CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS` | — | Comma-separated extra origins (beyond `https://{CDK_DOMAIN_NAME}`) allowed to embed artifact iframes via CSP `frame-ancestors` — applied to both the CloudFront response-headers policy and the render Lambda. Set to `http://localhost:4200` to point a local SPA at this deployment. **Leave unset in production**: every listed origin can frame your users' artifacts (still render-token gated, but a real loosening on a shared environment). |
 | `CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS` | — | Comma-separated extra origins (beyond `https://{CDK_DOMAIN_NAME}`) allowed to embed the MCP Apps sandbox proxy via CSP `frame-ancestors`. Set to `http://localhost:4200` to point a local SPA at this deployment. **Leave unset in production.** |
 | `CDK_FINE_TUNING_CORS_ORIGINS` | — | Comma-separated extra CORS origins for the SageMaker fine-tuning data bucket, beyond `https://{CDK_DOMAIN_NAME}`. Optional — fine-tuning itself is always provisioned. |
+| `CDK_FINE_TUNING_ENABLED` | `true` | Mounts the fine-tuning routers. Default ON — leave unset unless you want the kill switch. Note this is a *runtime* flag on the app-api container; the identically-named CDK stack gate was removed in the single-stack migration. |
+| `CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS` | `0` | Monthly GPU-hour quota auto-granted to any authenticated user. `0` = whitelist-only (an admin grants each user). A positive value (e.g. `10`) = open access with that budget. |
 
 ### Managed Knowledge Bases
 

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -133,6 +133,25 @@ jobs:
       # and see the ones their role grants. Which skills a cohort gets is a
       # role's `grantedSkills`, managed in the admin roles UI.
       CDK_SKILLS_ENABLED: ${{ vars.CDK_SKILLS_ENABLED }}
+      # SageMaker fine-tuning. The tables, bucket, SageMaker role and IAM
+      # grants deploy unconditionally, but these two decide whether the feature
+      # is reachable and how it is rationed, and neither was forwarded before —
+      # so every deployed environment served 404s from `/fine-tuning/*` while
+      # the repo variable `CDK_FINE_TUNING_ENABLED` read "true".
+      #
+      # ENABLED is default ON with a kill switch: unset resolves to empty
+      # string, which config.ts treats as the default (on). Set it to "false"
+      # to dark-stop the routes; storage is untouched either way, so no dataset
+      # or trained model is orphaned.
+      #
+      # DEFAULT_QUOTA_HOURS picks the access model: `0` (the default) is
+      # whitelist-only, where an admin grants each user explicitly; a positive
+      # value auto-grants that monthly GPU-hour budget to any signed-in user.
+      CDK_FINE_TUNING_ENABLED: ${{ vars.CDK_FINE_TUNING_ENABLED }}
+      CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS: ${{ vars.CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS }}
+      # Extra CORS origins for the fine-tuning data bucket, beyond the global
+      # CDK_CORS_ORIGINS above. Also never forwarded until now.
+      CDK_FINE_TUNING_CORS_ORIGINS: ${{ vars.CDK_FINE_TUNING_CORS_ORIGINS }}
       # Agent Designer /agents surface. Default OFF (opt-in) until the Phase-4
       # Designer UI ships — a headless API helps no forker. Set the
       # `CDK_AGENTS_API_ENABLED` variable to "true" in an environment (e.g. dev)

--- a/backend/src/apis/app_api/admin/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/admin/fine_tuning/routes.py
@@ -235,6 +235,13 @@ async def list_all_inference_jobs(
 
 # ========== Cost Dashboard ==========
 
+# Terminal statuses AWS bills for, in the exact casing persisted on the job
+# record by the status maps in ``fine_tuning/routes.py``. The StatusIndex GSI
+# compares its partition key case-sensitively, so SageMaker's own "Completed"
+# spelling matches nothing here.
+BILLED_TERMINAL_STATUSES = ("COMPLETED", "FAILED", "STOPPED")
+
+
 def _date_range_for_period(period: str) -> tuple[str, str]:
     """Return (start_iso, end_iso) for a YYYY-MM period string."""
     year, month = int(period[:4]), int(period[5:7])
@@ -259,8 +266,16 @@ async def get_cost_dashboard(
 ):
     """Get aggregated fine-tuning cost dashboard for a billing period.
 
-    Queries the StatusIndex GSI for Completed and Stopped jobs within
-    the requested month, then aggregates costs by user in application code.
+    Queries the StatusIndex GSI for every billed terminal status within the
+    requested month, then aggregates costs by user in application code.
+
+    Two things are easy to get wrong here. The GSI partition key is compared
+    case-sensitively, so the status values must be the ones actually stored
+    (``COMPLETED``/``FAILED``/``STOPPED`` — see the status maps in
+    ``fine_tuning/routes.py``), not SageMaker's own ``Completed``/``Stopped``
+    spelling. And FAILED belongs in the list: AWS bills a job that fails
+    partway through, so leaving it out understates real spend. The user-facing
+    quota counter already charges for failures; this dashboard matches it.
     """
     period = month or datetime.now(timezone.utc).strftime("%Y-%m")
     safe_period = period.replace("\n", "").replace("\r", "")
@@ -269,15 +284,19 @@ async def get_cost_dashboard(
     try:
         start_iso, end_iso = _date_range_for_period(period)
 
-        # Query training jobs (Completed + Stopped) via StatusIndex GSI
-        training_completed = jobs_repo.query_jobs_by_status_and_date("Completed", start_iso, end_iso)
-        training_stopped = jobs_repo.query_jobs_by_status_and_date("Stopped", start_iso, end_iso)
-        all_training = training_completed + training_stopped
+        # Query training jobs in every billed terminal status via StatusIndex GSI
+        all_training = [
+            job
+            for status_value in BILLED_TERMINAL_STATUSES
+            for job in jobs_repo.query_jobs_by_status_and_date(status_value, start_iso, end_iso)
+        ]
 
-        # Query inference jobs (Completed + Stopped) via StatusIndex GSI
-        inf_completed = inf_repo.query_jobs_by_status_and_date("Completed", start_iso, end_iso)
-        inf_stopped = inf_repo.query_jobs_by_status_and_date("Stopped", start_iso, end_iso)
-        all_inference = inf_completed + inf_stopped
+        # Query inference jobs in every billed terminal status via StatusIndex GSI
+        all_inference = [
+            job
+            for status_value in BILLED_TERMINAL_STATUSES
+            for job in inf_repo.query_jobs_by_status_and_date(status_value, start_iso, end_iso)
+        ]
 
         # Aggregate by user email
         user_data: dict[str, dict] = defaultdict(

--- a/backend/src/apis/app_api/fine_tuning/inference_repository.py
+++ b/backend/src/apis/app_api/fine_tuning/inference_repository.py
@@ -218,7 +218,8 @@ class InferenceRepository:
         """Query the StatusIndex GSI for inference jobs with a given status in a date range.
 
         Args:
-            status_value: Job status (e.g. "Completed", "Stopped").
+            status_value: Stored job status, case-sensitive on the GSI key
+                (e.g. "COMPLETED", "FAILED", "STOPPED").
             start_date: ISO date string (inclusive lower bound on createdAt).
             end_date: ISO date string (inclusive upper bound on createdAt).
 

--- a/backend/src/apis/app_api/fine_tuning/job_models.py
+++ b/backend/src/apis/app_api/fine_tuning/job_models.py
@@ -223,6 +223,13 @@ INSTANCE_COST_PER_HOUR: Dict[str, float] = {
 # Request / Response Models
 # =========================================================================
 
+# Dataset formats the SageMaker training script can read — keep in sync with
+# SUPPORTED_DATASET_EXTENSIONS in fine_tuning/sagemaker_scripts/train.py.
+# Enforced here so an unreadable dataset is rejected before a GPU instance is
+# ever provisioned; otherwise the job fails several billed minutes in.
+SUPPORTED_DATASET_EXTENSIONS = (".csv", ".jsonl", ".json")
+
+
 class PresignRequest(BaseModel):
     """Request for a presigned upload URL for a training dataset."""
     filename: str

--- a/backend/src/apis/app_api/fine_tuning/job_repository.py
+++ b/backend/src/apis/app_api/fine_tuning/job_repository.py
@@ -257,24 +257,32 @@ class FineTuningJobsRepository:
     ) -> List[dict]:
         """Query the StatusIndex GSI for jobs with a given status in a date range.
 
+        Training and inference records share this table and this GSI, so the
+        query filters on the ``JOB#`` sort-key prefix. Without it an inference
+        record comes back as a training job, and any caller that also queries
+        the inference repository counts its cost twice.
+
         Args:
-            status_value: Job status (e.g. "Completed", "Stopped").
+            status_value: Stored job status, case-sensitive on the GSI key
+                (e.g. "COMPLETED", "FAILED", "STOPPED").
             start_date: ISO date string (inclusive lower bound on createdAt).
             end_date: ISO date string (inclusive upper bound on createdAt).
 
         Returns:
-            List of job dicts.
+            List of training job dicts.
         """
         try:
             items: List[dict] = []
             response = self._table.query(
                 IndexName="StatusIndex",
                 KeyConditionExpression="#s = :status AND createdAt BETWEEN :start AND :end",
+                FilterExpression="begins_with(SK, :sk_prefix)",
                 ExpressionAttributeNames={"#s": "status"},
                 ExpressionAttributeValues={
                     ":status": status_value,
                     ":start": start_date,
                     ":end": end_date,
+                    ":sk_prefix": "JOB#",
                 },
                 ScanIndexForward=False,
             )
@@ -284,11 +292,13 @@ class FineTuningJobsRepository:
                 response = self._table.query(
                     IndexName="StatusIndex",
                     KeyConditionExpression="#s = :status AND createdAt BETWEEN :start AND :end",
+                    FilterExpression="begins_with(SK, :sk_prefix)",
                     ExpressionAttributeNames={"#s": "status"},
                     ExpressionAttributeValues={
                         ":status": status_value,
                         ":start": start_date,
                         ":end": end_date,
+                        ":sk_prefix": "JOB#",
                     },
                     ScanIndexForward=False,
                     ExclusiveStartKey=response["LastEvaluatedKey"],

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -20,6 +20,7 @@ from .repository import (
 from .job_models import (
     AVAILABLE_MODELS,
     MODEL_CATALOG,
+    SUPPORTED_DATASET_EXTENSIONS,
     PresignRequest,
     PresignResponse,
     CreateJobRequest,
@@ -193,6 +194,23 @@ async def search_huggingface_models(
 # Presigned URL
 # =========================================================================
 
+def _validate_dataset_format(name: str) -> None:
+    """Reject a dataset filename the training script could not read.
+
+    Checked before upload and again before the job is submitted, so an
+    unreadable dataset never reaches a billed GPU instance.
+    """
+    if not name.lower().endswith(SUPPORTED_DATASET_EXTENSIONS):
+        supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported dataset format. Supported formats: {supported}. "
+                'Each record needs a "text" and a "label" field.'
+            ),
+        )
+
+
 @router.post("/presign", response_model=PresignResponse)
 async def presign_upload(
     request: PresignRequest,
@@ -201,6 +219,8 @@ async def presign_upload(
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
 ):
     """Generate a presigned PUT URL for dataset upload."""
+    _validate_dataset_format(request.filename)
+
     try:
         presigned_url, s3_key = s3_service.generate_upload_url(
             user_id=user.user_id,
@@ -248,7 +268,9 @@ async def create_job(
         if not hf_id or len(hf_id) > 200:
             raise HTTPException(status_code=400, detail="Invalid HuggingFace model ID.")
 
-    # Verify dataset exists in S3
+    # Verify the dataset is readable by the training script and exists in S3
+    _validate_dataset_format(request.dataset_s3_key)
+
     if not s3_service.check_object_exists(request.dataset_s3_key):
         raise HTTPException(status_code=400, detail="Dataset not found in S3. Upload your dataset first.")
 

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
@@ -162,19 +162,81 @@ def resolve_max_context_length(config, tokenizer):
     return min(valid_vals) if valid_vals else None
 
 
-def find_csv_in_channel(channel_dir):
-    """Find the first CSV file in a SageMaker input channel directory.
+# Dataset formats the trainer can read, mapped to the pandas reader that loads
+# them. A training record has to carry both a "text" and a "label" field, which
+# is why plain .txt is absent: it has no way to express the label. (.txt stays
+# valid for *inference* input, which is unlabelled — one record per line.)
+#
+# Kept as data rather than an if/elif chain so the supported-format contract can
+# be asserted without importing pandas, which only exists inside the SageMaker
+# training container and not in the backend venv.
+DATASET_READERS = {
+    ".csv": ("read_csv", {}),
+    ".jsonl": ("read_json", {"lines": True}),
+    ".json": ("read_json", {}),
+}
 
-    Raises FileNotFoundError if no CSV file is found.
+SUPPORTED_DATASET_EXTENSIONS = tuple(DATASET_READERS)
+
+REQUIRED_DATASET_COLUMNS = ("text", "label")
+
+
+def find_dataset_in_channel(channel_dir):
+    """Find the first supported dataset file in a SageMaker input channel.
+
+    Raises FileNotFoundError if the directory is missing, or if it holds no
+    file with a supported extension.
     """
     if not os.path.isdir(channel_dir):
         raise FileNotFoundError(f"Channel directory does not exist: {channel_dir}")
 
     for f in sorted(os.listdir(channel_dir)):
-        if f.lower().endswith(".csv"):
+        if f.lower().endswith(SUPPORTED_DATASET_EXTENSIONS):
             return os.path.join(channel_dir, f)
 
-    raise FileNotFoundError(f"No CSV file found in {channel_dir}")
+    supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
+    raise FileNotFoundError(
+        f"No dataset file found in {channel_dir}. Supported formats: {supported}"
+    )
+
+
+def resolve_dataset_reader(dataset_path):
+    """Return the (pandas reader name, kwargs) pair for a dataset file.
+
+    Raises ValueError for an extension the trainer cannot read.
+    """
+    extension = os.path.splitext(dataset_path)[1].lower()
+
+    if extension not in DATASET_READERS:
+        supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
+        raise ValueError(
+            f"Unsupported dataset format '{extension}'. Supported formats: {supported}"
+        )
+
+    return DATASET_READERS[extension]
+
+
+def validate_dataset_columns(columns, dataset_path):
+    """Raise ValueError if a required column is absent from the dataset."""
+    missing = [c for c in REQUIRED_DATASET_COLUMNS if c not in columns]
+    if missing:
+        raise ValueError(
+            f"Dataset {os.path.basename(dataset_path)} is missing required "
+            f"column(s): {', '.join(missing)}. Each record needs a \"text\" "
+            f'and a "label" field.'
+        )
+
+
+def load_dataset_frame(dataset_path):
+    """Load a dataset file into a DataFrame with "text" and "label" columns."""
+    import pandas as pd
+
+    reader_name, reader_kwargs = resolve_dataset_reader(dataset_path)
+    df = getattr(pd, reader_name)(dataset_path, **reader_kwargs)
+
+    validate_dataset_columns(df.columns, dataset_path)
+
+    return df
 
 
 def copy_inference_script(model_output_dir):
@@ -221,10 +283,10 @@ def train(args):
     )
     model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
 
-    # Find and load CSV dataset
-    csv_path = find_csv_in_channel(train_channel)
-    logger.info(f"Loading dataset from {csv_path}")
-    df = pd.read_csv(csv_path)
+    # Find and load the dataset (CSV / JSONL / JSON)
+    dataset_path = find_dataset_in_channel(train_channel)
+    logger.info(f"Loading dataset from {dataset_path}")
+    df = load_dataset_frame(dataset_path)
 
     # Label normalization — support non-numeric class labels
     label_names = sorted(list(pd.Series(df["label"]).astype(str).unique()))

--- a/backend/tests/fine_tuning/test_admin_routes.py
+++ b/backend/tests/fine_tuning/test_admin_routes.py
@@ -383,3 +383,106 @@ class TestListAllInferenceJobs:
         client = TestClient(app)
         resp = client.get("/admin/fine-tuning/inference-jobs")
         assert resp.status_code == 403
+
+
+class TestCostDashboard:
+    """The dashboard reported $0.00 while real jobs were being billed.
+
+    Two causes, both regression-guarded here: the StatusIndex GSI partition key
+    is compared case-sensitively and was queried with SageMaker's "Completed"
+    spelling instead of the stored "COMPLETED"; and FAILED jobs were excluded
+    even though AWS bills a job that dies partway through.
+    """
+
+    @staticmethod
+    def _job(email, status_value, billable, cost):
+        return {
+            "email": email,
+            "status": status_value,
+            "billable_seconds": billable,
+            "estimated_cost_usd": cost,
+        }
+
+    def _client(self, make_user, training_by_status, inference_by_status=None):
+        app = _create_app()
+        _override_auth(app, make_user(email="admin@example.com", roles=["Admin"]))
+
+        jobs_repo = MagicMock()
+        jobs_repo.query_jobs_by_status_and_date.side_effect = (
+            lambda status_value, *_: list(training_by_status.get(status_value, []))
+        )
+        _override_jobs_repo(app, jobs_repo)
+
+        inf_repo = MagicMock()
+        inf_repo.query_jobs_by_status_and_date.side_effect = (
+            lambda status_value, *_: list((inference_by_status or {}).get(status_value, []))
+        )
+        _override_inf_repo(app, inf_repo)
+
+        return TestClient(app), jobs_repo, inf_repo
+
+    def test_queries_stored_uppercase_statuses(self, make_user):
+        """SageMaker's "Completed" casing matches nothing on the GSI."""
+        client, jobs_repo, inf_repo = self._client(make_user, {})
+
+        resp = client.get("/admin/fine-tuning/costs?month=2026-08")
+
+        assert resp.status_code == 200
+        for repo in (jobs_repo, inf_repo):
+            queried = {
+                call.args[0] for call in repo.query_jobs_by_status_and_date.call_args_list
+            }
+            assert queried == {"COMPLETED", "FAILED", "STOPPED"}
+
+    def test_aggregates_completed_jobs(self, make_user):
+        client, _, _ = self._client(
+            make_user,
+            {"COMPLETED": [self._job("user@example.com", "COMPLETED", 300, 0.1175)]},
+        )
+
+        body = client.get("/admin/fine-tuning/costs?month=2026-08").json()
+
+        assert body["total_cost_usd"] == pytest.approx(0.1175)
+        # Rounded to 2dp by the route: 300s = 0.0833h -> 0.08
+        assert body["total_gpu_hours"] == pytest.approx(0.08)
+        assert body["training_job_count"] == 1
+        assert body["active_user_count"] == 1
+        assert body["users"][0]["email"] == "user@example.com"
+
+    def test_counts_failed_jobs_because_aws_bills_them(self, make_user):
+        client, _, _ = self._client(
+            make_user,
+            {"FAILED": [self._job("user@example.com", "FAILED", 296, 0.1159)]},
+        )
+
+        body = client.get("/admin/fine-tuning/costs?month=2026-08").json()
+
+        assert body["total_cost_usd"] == pytest.approx(0.1159)
+        assert body["training_job_count"] == 1
+
+    def test_sums_training_and_inference_per_user(self, make_user):
+        client, _, _ = self._client(
+            make_user,
+            {
+                "COMPLETED": [self._job("user@example.com", "COMPLETED", 300, 0.1175)],
+                "FAILED": [self._job("user@example.com", "FAILED", 296, 0.1159)],
+            },
+            {"COMPLETED": [self._job("user@example.com", "COMPLETED", 230, 0.09)]},
+        )
+
+        body = client.get("/admin/fine-tuning/costs?month=2026-08").json()
+
+        assert body["total_cost_usd"] == pytest.approx(0.1175 + 0.1159 + 0.09)
+        assert body["training_job_count"] == 2
+        assert body["inference_job_count"] == 1
+        assert body["active_user_count"] == 1
+
+    def test_requires_admin_role(self):
+        app = _create_app()
+
+        def _raise_403():
+            raise HTTPException(status_code=403, detail="Forbidden")
+        override_admin_auth(app, _raise_403)
+
+        resp = TestClient(app).get("/admin/fine-tuning/costs")
+        assert resp.status_code == 403

--- a/backend/tests/fine_tuning/test_job_repository.py
+++ b/backend/tests/fine_tuning/test_job_repository.py
@@ -283,3 +283,108 @@ class TestDeleteJob:
 
     def test_returns_false_for_nonexistent(self, jobs_repository):
         assert jobs_repository.delete_job("user-001", "nonexistent") is False
+
+
+class TestQueryJobsByStatusAndDate:
+    """The cost dashboard's GSI query.
+
+    Training and inference records share one table and one StatusIndex, so this
+    query has to return training rows only — otherwise a caller that also
+    queries the inference repository counts an inference job's cost twice.
+    """
+
+    def _completed_training_job(self, jobs_repository, job_id):
+        jobs_repository.create_job(
+            user_id="user-001",
+            email="alice@example.com",
+            job_id=job_id,
+            model_id="electra-tiny",
+            model_name="ELECTRA Tiny",
+            dataset_s3_key="datasets/user-001/abc/train.csv",
+            instance_type="ml.g5.xlarge",
+            hyperparameters={"epochs": "3"},
+            sagemaker_job_name=f"ft-{job_id[:8]}",
+            output_s3_prefix=f"output/user-001/{job_id}",
+        )
+        jobs_repository.update_job_status(
+            user_id="user-001",
+            job_id=job_id,
+            status="COMPLETED",
+            billable_seconds=300,
+            estimated_cost_usd=0.1175,
+        )
+
+    def _completed_inference_job(self, inference_repository, job_id):
+        inference_repository.create_inference_job(
+            user_id="user-001",
+            email="alice@example.com",
+            job_id=job_id,
+            training_job_id="train-001",
+            model_name="ELECTRA Tiny",
+            model_s3_path="s3://bucket/model.tar.gz",
+            input_s3_key="inference-input/user-001/in.txt",
+            instance_type="ml.g5.xlarge",
+            transform_job_name=f"inf-{job_id[:8]}",
+            output_s3_prefix=f"inference-output/user-001/{job_id}",
+        )
+        inference_repository.update_inference_status(
+            user_id="user-001",
+            job_id=job_id,
+            status="COMPLETED",
+            billable_seconds=230,
+            estimated_cost_usd=0.0901,
+        )
+
+    @staticmethod
+    def _range():
+        return "2000-01-01T00:00:00+00:00", "2100-01-01T00:00:00+00:00"
+
+    def test_returns_matching_training_job(self, jobs_repository):
+        job_id = uuid.uuid4().hex
+        self._completed_training_job(jobs_repository, job_id)
+        start, end = self._range()
+
+        results = jobs_repository.query_jobs_by_status_and_date("COMPLETED", start, end)
+
+        assert [j["job_id"] for j in results] == [job_id]
+
+    def test_stored_status_casing_is_what_matches(self, jobs_repository):
+        """SageMaker spells it "Completed"; the record stores "COMPLETED"."""
+        self._completed_training_job(jobs_repository, uuid.uuid4().hex)
+        start, end = self._range()
+
+        assert jobs_repository.query_jobs_by_status_and_date("Completed", start, end) == []
+        assert len(jobs_repository.query_jobs_by_status_and_date("COMPLETED", start, end)) == 1
+
+    def test_excludes_inference_jobs(self, jobs_repository, inference_repository):
+        training_id = uuid.uuid4().hex
+        self._completed_training_job(jobs_repository, training_id)
+        self._completed_inference_job(inference_repository, uuid.uuid4().hex)
+        start, end = self._range()
+
+        results = jobs_repository.query_jobs_by_status_and_date("COMPLETED", start, end)
+
+        assert [j["job_id"] for j in results] == [training_id]
+
+    def test_inference_query_excludes_training_jobs(
+        self, jobs_repository, inference_repository
+    ):
+        self._completed_training_job(jobs_repository, uuid.uuid4().hex)
+        inference_id = uuid.uuid4().hex
+        self._completed_inference_job(inference_repository, inference_id)
+        start, end = self._range()
+
+        results = inference_repository.query_jobs_by_status_and_date(
+            "COMPLETED", start, end
+        )
+
+        assert [j["job_id"] for j in results] == [inference_id]
+
+    def test_excludes_jobs_outside_the_period(self, jobs_repository):
+        self._completed_training_job(jobs_repository, uuid.uuid4().hex)
+
+        results = jobs_repository.query_jobs_by_status_and_date(
+            "COMPLETED", "2000-01-01T00:00:00+00:00", "2000-02-01T00:00:00+00:00"
+        )
+
+        assert results == []

--- a/backend/tests/fine_tuning/test_job_routes.py
+++ b/backend/tests/fine_tuning/test_job_routes.py
@@ -119,6 +119,25 @@ class TestPresign:
         assert "s3_key" in body
         assert "expires_at" in body
 
+    @pytest.mark.parametrize("filename", ["notes.txt", "data.parquet"])
+    def test_rejects_format_the_trainer_cannot_read(self, make_user, filename):
+        """Reject before upload, not several billed GPU-minutes into training."""
+        app = _create_app()
+        user = make_user(email="user@example.com")
+
+        mock_s3 = MagicMock()
+        _setup_deps(app, user, SAMPLE_GRANT, s3_service=mock_s3)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/fine-tuning/presign",
+            json={"filename": filename, "content_type": "text/plain"},
+        )
+
+        assert resp.status_code == 400
+        assert "Unsupported dataset format" in resp.json()["detail"]
+        mock_s3.generate_upload_url.assert_not_called()
+
 
 class TestCreateJob:
 
@@ -158,6 +177,31 @@ class TestCreateJob:
         assert resp.status_code == 201
         body = resp.json()
         assert body["model_id"] == "distilgpt2"
+
+    def test_rejects_dataset_the_trainer_cannot_read(self, make_user):
+        """Last gate before SageMaker: no GPU is provisioned for a doomed job."""
+        app = _create_app()
+        user = make_user(email="user@example.com")
+
+        mock_s3 = MagicMock()
+        mock_s3.check_object_exists.return_value = True
+
+        mock_sm = MagicMock()
+
+        _setup_deps(app, user, SAMPLE_GRANT, s3_service=mock_s3, sagemaker=mock_sm)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/fine-tuning/jobs",
+            json={
+                "model_id": "distilgpt2",
+                "dataset_s3_key": "datasets/user-001/abc/notes.txt",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "Unsupported dataset format" in resp.json()["detail"]
+        mock_sm.create_training_job.assert_not_called()
 
     @patch.dict("os.environ", {"PROJECT_PREFIX": "test-prefix"})
     def test_sagemaker_job_name_includes_project_prefix(self, make_user):

--- a/backend/tests/fine_tuning/test_train_script.py
+++ b/backend/tests/fine_tuning/test_train_script.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch, call
 
 from apis.app_api.fine_tuning.sagemaker_scripts.train import (
     resolve_max_context_length,
-    find_csv_in_channel,
+    find_dataset_in_channel,
+    load_dataset_frame,
+    resolve_dataset_reader,
+    validate_dataset_columns,
+    SUPPORTED_DATASET_EXTENSIONS,
     copy_inference_script,
     DynamoDBProgressCallback,
     SageMakerLoggingCallback,
@@ -59,32 +63,117 @@ class TestResolveMaxContextLength:
         assert result == 768
 
 
-class TestFindCsvInChannel:
+class TestFindDatasetInChannel:
 
     def test_finds_csv_file(self, tmp_path):
         csv_file = tmp_path / "dataset.csv"
         csv_file.write_text("text,label\nhello,1\n")
 
-        result = find_csv_in_channel(str(tmp_path))
+        result = find_dataset_in_channel(str(tmp_path))
         assert result == str(csv_file)
 
-    def test_raises_when_no_csv(self, tmp_path):
-        txt_file = tmp_path / "readme.txt"
-        txt_file.write_text("not a csv")
+    @pytest.mark.parametrize("filename", ["dataset.jsonl", "dataset.json"])
+    def test_finds_json_formats(self, tmp_path, filename):
+        """The UI offers JSONL/JSON, so the trainer has to find them too."""
+        dataset = tmp_path / filename
+        dataset.write_text('{"text": "hello", "label": "a"}\n')
 
-        with pytest.raises(FileNotFoundError, match="No CSV file found"):
-            find_csv_in_channel(str(tmp_path))
+        result = find_dataset_in_channel(str(tmp_path))
+        assert result == str(dataset)
+
+    def test_raises_when_no_supported_dataset(self, tmp_path):
+        txt_file = tmp_path / "readme.txt"
+        txt_file.write_text("not a dataset")
+
+        with pytest.raises(FileNotFoundError, match="No dataset file found"):
+            find_dataset_in_channel(str(tmp_path))
 
     def test_case_insensitive_extension(self, tmp_path):
         csv_file = tmp_path / "DATA.CSV"
         csv_file.write_text("text,label\nhello,1\n")
 
-        result = find_csv_in_channel(str(tmp_path))
+        result = find_dataset_in_channel(str(tmp_path))
         assert result == str(csv_file)
 
     def test_raises_when_dir_missing(self):
         with pytest.raises(FileNotFoundError, match="does not exist"):
-            find_csv_in_channel("/nonexistent/path")
+            find_dataset_in_channel("/nonexistent/path")
+
+
+class TestResolveDatasetReader:
+    """Every format the upload UI accepts must actually be readable.
+
+    A JSONL dataset previously uploaded and dispatched fine, then died on the
+    GPU several billed minutes in because the trainer only read CSV. These
+    assert the dispatch table directly so they run without pandas, which
+    exists only inside the SageMaker training container.
+    """
+
+    def test_supports_the_formats_the_ui_offers(self):
+        assert set(SUPPORTED_DATASET_EXTENSIONS) == {".csv", ".jsonl", ".json"}
+
+    def test_csv_uses_read_csv(self):
+        assert resolve_dataset_reader("/data/dataset.csv") == ("read_csv", {})
+
+    def test_jsonl_reads_line_delimited(self):
+        assert resolve_dataset_reader("/data/dataset.jsonl") == (
+            "read_json",
+            {"lines": True},
+        )
+
+    def test_json_reads_whole_document(self):
+        assert resolve_dataset_reader("/data/dataset.json") == ("read_json", {})
+
+    def test_extension_match_is_case_insensitive(self):
+        assert resolve_dataset_reader("/data/DATA.CSV") == ("read_csv", {})
+
+    def test_raises_on_unsupported_extension(self):
+        with pytest.raises(ValueError, match="Unsupported dataset format"):
+            resolve_dataset_reader("/data/dataset.parquet")
+
+
+class TestValidateDatasetColumns:
+
+    def test_accepts_required_columns(self):
+        validate_dataset_columns(["text", "label"], "/data/dataset.csv")
+
+    def test_raises_when_label_missing(self):
+        with pytest.raises(ValueError, match="missing required column"):
+            validate_dataset_columns(["text"], "/data/dataset.csv")
+
+    def test_raises_when_text_missing(self):
+        with pytest.raises(ValueError, match="missing required column"):
+            validate_dataset_columns(["label"], "/data/dataset.csv")
+
+
+class TestLoadDatasetFrame:
+    """End-to-end load, where pandas is available (the training container)."""
+
+    @pytest.mark.parametrize(
+        "filename,content",
+        [
+            ("dataset.csv", "text,label\nhello,positive\nbye,negative\n"),
+            (
+                "dataset.jsonl",
+                '{"text": "hello", "label": "positive"}\n'
+                '{"text": "bye", "label": "negative"}\n',
+            ),
+            (
+                "dataset.json",
+                '[{"text": "hello", "label": "positive"},'
+                ' {"text": "bye", "label": "negative"}]',
+            ),
+        ],
+    )
+    def test_loads_each_supported_format(self, tmp_path, filename, content):
+        pytest.importorskip("pandas")
+        path = tmp_path / filename
+        path.write_text(content)
+
+        df = load_dataset_frame(str(path))
+
+        assert df["text"].tolist() == ["hello", "bye"]
+        assert df["label"].tolist() == ["positive", "negative"]
 
 
 class TestCopyInferenceScript:

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -23,7 +23,7 @@
   <section class="mb-8">
     <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">1. Upload Dataset</h2>
     <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
-      Upload your training data as a JSONL, CSV, or TXT file. Each record should include "text" and "label" fields.
+      Upload your training data as a CSV, JSONL, or JSON file. Each record should include "text" and "label" fields.
     </p>
 
     @if (uploadState(); as upload) {
@@ -95,13 +95,13 @@
           <p class="mt-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
             Click or drag &amp; drop your dataset
           </p>
-          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">JSONL, CSV, or TXT file</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CSV, JSONL, or JSON file</p>
         </label>
         <input
           id="dataset-upload"
           type="file"
           class="sr-only"
-          accept=".jsonl,.csv,.txt,.json"
+          accept=".csv,.jsonl,.json"
           (change)="onFileSelected($event)"
         />
       </div>

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -302,6 +302,21 @@ export interface AgentMarketplaceConfig {
 
 export interface FineTuningConfig {
   additionalCorsOrigins?: string; // Extra CORS origins to append (comma-separated)
+  /**
+   * Mounts the `/fine-tuning` and `/admin/fine-tuning` routers in app-api.
+   *
+   * Distinct from the long-deleted `CDK_FINE_TUNING_ENABLED`, which gated
+   * whether the SageMaker *stack* deployed and went away with the single-stack
+   * migration (#396). The tables, bucket and SageMaker role are provisioned
+   * unconditionally; this only decides whether the routes are reachable.
+   */
+  enabled: boolean;
+  /**
+   * Monthly GPU-hour quota granted to any authenticated user on first use.
+   * `0` keeps the original whitelist-only behaviour, where an admin has to
+   * grant each user explicitly.
+   */
+  defaultQuotaHours: number;
 }
 
 /**
@@ -700,6 +715,17 @@ export function loadConfig(scope: cdk.App): AppConfig {
     },
     fineTuning: {
       additionalCorsOrigins: process.env.CDK_FINE_TUNING_CORS_ORIGINS || scope.node.tryGetContext('fineTuning')?.additionalCorsOrigins,
+      // Default ON with a kill switch, same empty-string-safe ternary as
+      // `agentMarketplace` above: the workflow forwards an EMPTY STRING when the
+      // variable is unset, so treat empty/unset as the default (on) and only the
+      // literal "false" as off.
+      enabled: process.env.CDK_FINE_TUNING_ENABLED
+        ? process.env.CDK_FINE_TUNING_ENABLED !== 'false'
+        : scope.node.tryGetContext('fineTuning')?.enabled ?? true,
+      defaultQuotaHours:
+        parseIntEnv(process.env.CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS)
+        ?? scope.node.tryGetContext('fineTuning')?.defaultQuotaHours
+        ?? 0,
     },
     artifacts: {
       certificateArn: process.env.CDK_ARTIFACTS_CERTIFICATE_ARN || scope.node.tryGetContext('artifacts')?.certificateArn,

--- a/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
@@ -188,9 +188,16 @@ export class AppApiServiceConstruct extends Construct {
     environment['S3_MEMORY_SPACES_BUCKET_NAME'] = props.refs.memorySpacesBucket.bucketName;
     environment['DYNAMODB_MEMORY_SPACES_TABLE_NAME'] = props.refs.memorySpacesTable.tableName;
 
-    // Fine-tuning env vars (always-on). Names verified against
+    // Fine-tuning env vars. Names verified against
     // backend/src/apis/app_api/fine_tuning/* to match the exact env
     // var names Python reads via os.environ.get(...).
+    //
+    // FINE_TUNING_ENABLED is what mounts the routers in app_api/main.py and
+    // admin/routes.py, and it defaults to "false" in Python. Storage and IAM
+    // below are provisioned unconditionally, so omitting this flag left every
+    // deployed environment serving 404s from a fully-built feature.
+    environment['FINE_TUNING_ENABLED'] = String(config.fineTuning.enabled);
+    environment['FINE_TUNING_DEFAULT_QUOTA_HOURS'] = String(config.fineTuning.defaultQuotaHours);
     environment['DYNAMODB_FINE_TUNING_JOBS_TABLE_NAME'] = props.refs.fineTuningJobsTable.tableName;
     environment['DYNAMODB_FINE_TUNING_ACCESS_TABLE_NAME'] = props.refs.fineTuningAccessTable.tableName;
     environment['S3_FINE_TUNING_BUCKET_NAME'] = props.refs.fineTuningDataBucket.bucketName;

--- a/infrastructure/test/compute-image-resolution.test.ts
+++ b/infrastructure/test/compute-image-resolution.test.ts
@@ -42,7 +42,10 @@ describe('Compute image URI resolution', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);

--- a/infrastructure/test/fine-tuning-runtime-flags.test.ts
+++ b/infrastructure/test/fine-tuning-runtime-flags.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Fine-tuning runtime flags reach the app-api container.
+ *
+ * The fine-tuning tables, bucket, SageMaker role and IAM grants have always
+ * been provisioned unconditionally, but the two variables that decide whether
+ * the feature is *usable* were never passed to the container:
+ *
+ *   - `FINE_TUNING_ENABLED` mounts the `/fine-tuning` and `/admin/fine-tuning`
+ *     routers (app_api/main.py, admin/routes.py). It defaults to "false" in
+ *     Python, so every deployed environment served 404s from a fully built and
+ *     fully provisioned feature.
+ *   - `FINE_TUNING_DEFAULT_QUOTA_HOURS` selects whitelist-only mode (0) versus
+ *     open access with a default budget. Its absence defaults to 0, so users
+ *     get a 403 instead of the intended automatic grant.
+ *
+ * The trap was a name collision: a GitHub variable `CDK_FINE_TUNING_ENABLED`
+ * existed and read `true`, but it had gated whether the SageMaker *stack*
+ * deployed and its consumer was deleted in the single-stack migration (#396).
+ * Reading the repo settings suggested the feature was on; the container env
+ * said otherwise. These tests assert the container, not the settings.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+import { AppConfig } from '../lib/config';
+
+function appApiEnvironment(config: AppConfig): Record<string, unknown> {
+  const app = new cdk.App();
+  mockSsmContext(app, config);
+  const stack = new PlatformStack(app, 'TestPlatformStack', {
+    config,
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  stack.wireCompute();
+  const template = Template.fromStack(stack);
+
+  const taskDefs = template.findResources('AWS::ECS::TaskDefinition');
+  for (const resource of Object.values(taskDefs)) {
+    const containers = (resource.Properties?.ContainerDefinitions ?? []) as Array<{
+      Name?: string;
+      Environment?: Array<{ Name: string; Value: unknown }>;
+    }>;
+    const appApi = containers.find((c) => c.Name === 'app-api');
+    if (appApi) {
+      return Object.fromEntries(
+        (appApi.Environment ?? []).map((e) => [e.Name, e.Value]),
+      );
+    }
+  }
+
+  throw new Error('No app-api container found in any ECS task definition');
+}
+
+describe('fine-tuning runtime flags on the app-api container', () => {
+  it('mounts the routers by default', () => {
+    const env = appApiEnvironment(createMockConfig());
+
+    // Python compares this lowercased against "true".
+    expect(env.FINE_TUNING_ENABLED).toBe('true');
+  });
+
+  it('passes the default quota through', () => {
+    const env = appApiEnvironment(
+      createMockConfig({ fineTuning: { enabled: true, defaultQuotaHours: 10 } }),
+    );
+
+    expect(env.FINE_TUNING_DEFAULT_QUOTA_HOURS).toBe('10');
+  });
+
+  it('emits a quota of 0 as "0", not an empty string', () => {
+    // A missing or empty value silently means whitelist-only. Assert the
+    // literal so a stringify regression cannot pass unnoticed.
+    const env = appApiEnvironment(
+      createMockConfig({ fineTuning: { enabled: true, defaultQuotaHours: 0 } }),
+    );
+
+    expect(env.FINE_TUNING_DEFAULT_QUOTA_HOURS).toBe('0');
+  });
+
+  it('honours the kill switch', () => {
+    const env = appApiEnvironment(
+      createMockConfig({ fineTuning: { enabled: false, defaultQuotaHours: 0 } }),
+    );
+
+    expect(env.FINE_TUNING_ENABLED).toBe('false');
+  });
+
+  it('still provisions storage when the routes are switched off', () => {
+    // Storage is unconditional by design — turning the routes off must not
+    // orphan or destroy a user's datasets and trained models.
+    const env = appApiEnvironment(
+      createMockConfig({ fineTuning: { enabled: false, defaultQuotaHours: 0 } }),
+    );
+
+    expect(env.DYNAMODB_FINE_TUNING_JOBS_TABLE_NAME).toBeDefined();
+    expect(env.DYNAMODB_FINE_TUNING_ACCESS_TABLE_NAME).toBeDefined();
+    expect(env.S3_FINE_TUNING_BUCKET_NAME).toBeDefined();
+  });
+});

--- a/infrastructure/test/gsi-update-limit.test.ts
+++ b/infrastructure/test/gsi-update-limit.test.ts
@@ -63,7 +63,10 @@ function buildInventory(): Inventory {
     frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
     artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
     mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-    fineTuning: {},
+    fineTuning: {
+      enabled: true,
+      defaultQuotaHours: 0,
+    },
   });
 
   const app = new cdk.App();

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -85,7 +85,10 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
     agentMarketplace: {
       enabled: false,
     },
-    fineTuning: {},
+    fineTuning: {
+      enabled: true,
+      defaultQuotaHours: 0,
+    },
     artifacts: {
       retentionDays: 90,
       extraFrameAncestors: [],

--- a/infrastructure/test/integration.test.ts
+++ b/infrastructure/test/integration.test.ts
@@ -21,7 +21,10 @@ describe('Single-stack integration', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);

--- a/infrastructure/test/kb-migration.test.ts
+++ b/infrastructure/test/kb-migration.test.ts
@@ -961,7 +961,10 @@ describe('KbMigration wiring on PlatformStack', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);

--- a/infrastructure/test/managed-kb.test.ts
+++ b/infrastructure/test/managed-kb.test.ts
@@ -487,7 +487,10 @@ describe('Managed_KB retrieval wiring on PlatformStack', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -24,7 +24,10 @@ describe('PlatformStack', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);
@@ -281,7 +284,10 @@ describe('PlatformStack', () => {
         frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
         artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
         mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-        fineTuning: {},
+        fineTuning: {
+          enabled: true,
+          defaultQuotaHours: 0,
+        },
         mcpIdentity,
       });
       const app = new cdk.App();

--- a/infrastructure/test/runtime-env-var-limit.test.ts
+++ b/infrastructure/test/runtime-env-var-limit.test.ts
@@ -50,7 +50,10 @@ describe('AgentCore Runtime environment variable ceiling', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
       tokenExchange: {
         url: 'https://tokens.example.com/v2/oauth/token',
         clientId: 'test-client',

--- a/infrastructure/test/security-policy.test.ts
+++ b/infrastructure/test/security-policy.test.ts
@@ -53,7 +53,10 @@ describe('Security policy hardening', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);

--- a/infrastructure/test/ssm-safety.test.ts
+++ b/infrastructure/test/ssm-safety.test.ts
@@ -53,7 +53,10 @@ describe('Same-stack SSM safety', () => {
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
       artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
-      fineTuning: {},
+      fineTuning: {
+        enabled: true,
+        defaultQuotaHours: 0,
+      },
     });
     const app = new cdk.App();
     mockSsmContext(app, config);


### PR DESCRIPTION
Browser-testing the fine-tuning feature against dev surfaced three bugs that each independently prevented it from working. All three are fixed here, verified against real SageMaker jobs and real dev data.

## What was wrong

**1. The UI accepted four dataset formats; the trainer read one.** The page says "JSONL, CSV, or TXT" and accepts `.jsonl,.csv,.txt,.json`, but `train.py` only looked for `.csv`. A JSONL file uploaded and dispatched fine, then died on the GPU ~5 billed minutes in with `No CSV file found in /opt/ml/input/data/train`. The user lost the time, the quota and $0.12, and got a SageMaker `AlgorithmError` instead of a reason.

**2. The admin cost dashboard reported $0.00, always.** Three faults stacked: the `StatusIndex` GSI key is case-sensitive and was queried with SageMaker's `"Completed"` against the stored `"COMPLETED"`; `FAILED` was excluded although AWS bills partial failures; and training/inference share the table but only the inference query filtered by type — so fixing the casing alone would have turned a silent $0.00 into a `KeyError` 500.

**3. The feature was off in every deployed environment.** `FINE_TUNING_ENABLED` gates the router mounts and defaults to `false` in Python. Nothing in CDK or the workflows ever set it. Storage, IAM and the SageMaker role all shipped; the routes never mounted.

## Why #3 hid in plain sight

A repo variable `CDK_FINE_TUNING_ENABLED = true` exists, so the settings read as "on". That flag gated whether the SageMaker *stack* deployed and its consumer was removed in the single-stack migration (#396). It has had no reader since. The container's `FINE_TUNING_ENABLED` is a different flag that was never wired.

Three links were missing, not one — `config.ts`, the app-api construct, and `platform.yml`, which forwarded *no* fine-tuning variables at all. `CDK_FINE_TUNING_DEFAULT_QUOTA_HOURS = 10` was stranded the same way; absent, it falls back to `0` = whitelist-only, so users would have hit a 403 instead of the intended auto-grant.

## Evidence

Before, on deployed dev:

| Endpoint | Result |
|---|---|
| `/api/sessions` | 401 (mounted) |
| `/api/fine-tuning/access` | **404** (router absent) |

The GSI, queried against real dev data:

```
Completed  -> 0 rows     <- what the old code asked for
COMPLETED  -> 2 rows     <- 1 training + 1 inference
FAILED     -> 1 row
```

After both query fixes: 1 training COMPLETED + 1 training FAILED + 1 inference COMPLETED, each counted once — 826s / 0.229h, matching the independent quota counter exactly.

Verified end to end by running real jobs in dev: dataset upload → S3, SageMaker training → `model.tar.gz` (20.7 MiB), batch inference → labelled predictions.

## Notes for review

- **`.txt` is dropped from training uploads.** A training record needs a text *and* a label; a newline-delimited text file cannot express the label without guessing a delimiter. It remains valid for inference input, which is unlabelled — that page is untouched.
- **The reader dispatch is a table, not an if/elif chain,** so the format contract is assertable without pandas — which exists only inside the training container. That absence is why the loader had zero coverage and why this survived.
- **Config fields are required, not optional.** That surfaced ten hand-built `fineTuning: {}` literals in the CDK tests — the type system catching precisely the omission behind bug #3.
- **Deploys through two pipelines.** Commits 1–2 ship via `backend.yml`, commit 3 via `platform.yml`, and that order isn't enforced. Either interleaving is safe: platform-first briefly mounts routes on the old code in an environment where they were 404 anyway.

## Tests

24 new tests across 5 files, each verified to fail against the unfixed code — stripping the SK filter reproduces the real `KeyError: 'model_id'`, and reverting the status casing fails all four dashboard tests.

| Suite | Result |
|---|---|
| Backend (full) | 6781 passed, 6 skipped |
| Infrastructure (full) | 631 passed, 30 suites |
| Frontend typecheck + training-page specs | clean, 22/22 |

## Follow-ups (not in this PR)

- Job detail pages poll every ~2s and never stop on terminal state — ~45 redundant round trips on a finished job.
- The inference detail page is the one UI surface not visually confirmed; its API, SageMaker job and S3 output are verified.

Separately, the repo variable `CDK_CORS_ORIGINS` was `localhost:4200` with no scheme, so S3 never matched it and dataset uploads from a local SPA failed CORS preflight. Corrected to `http://localhost:4200` in repo settings — no code change, but this PR's deploy is what applies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
