### PR TITLE
fix(auth): bind BFF OAuth state to the requesting browser

### DIFF
--- a/backend/src/apis/app_api/auth/bff/cookies.py
+++ b/backend/src/apis/app_api/auth/bff/cookies.py
@@ -8,6 +8,8 @@ those here so individual route handlers can't drift.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from starlette.responses import Response
 
 from apis.shared.sessions_bff.config import CSRF_COOKIE_NAME, SESSION_COOKIE_NAME
@@ -16,7 +18,27 @@ from apis.shared.sessions_bff.config import CSRF_COOKIE_NAME, SESSION_COOKIE_NAM
 # /auth/callback as a GET, which is in-scope for `lax`) while blocking the
 # CSRF-relevant cross-site POSTs. `strict` would break the callback redirect
 # coming from cognito's domain.
-_SAMESITE = "lax"
+#
+# Annotated as a `Literal` rather than a bare `str` so it satisfies Starlette's
+# `samesite` parameter type — a plain `str` is rejected there.
+_SAMESITE: Literal["lax"] = "lax"
+
+# Carries the browser-binding secret for one in-flight OAuth authorization
+# request. Its whole job is to make a `state` value worthless to any browser
+# other than the one that asked for it: the callback hashes this cookie and
+# compares against the digest stored alongside the state.
+#
+# Attribute notes:
+#   - `__Host-` so the browser refuses it from any other host and pins
+#     Path=/ + Secure with no Domain — an attacker on a sibling subdomain
+#     can't plant one.
+#   - `HttpOnly` — the SPA never needs to read it, and script access would
+#     hand an XSS the ability to forge a binding.
+#   - `SameSite=lax` is *required*, not a compromise: the IdP redirects the
+#     user back with a top-level cross-site GET, which is exactly the case
+#     `lax` still sends cookies for. `strict` would withhold the cookie and
+#     break every login.
+OAUTH_STATE_COOKIE_NAME = "__Host-bff_oauth_state"
 
 
 def set_session_cookies(
@@ -69,5 +91,42 @@ def clear_session_cookies(response: Response) -> None:
         path="/",
         secure=True,
         httponly=False,
+        samesite=_SAMESITE,
+    )
+
+
+def set_oauth_state_cookie(
+    response: Response,
+    *,
+    binding_secret: str,
+    max_age_seconds: int,
+) -> None:
+    """Hand the browser the binding secret for one in-flight authorize request.
+
+    `binding_secret` must be a fresh high-entropy value from
+    `secrets.token_urlsafe(...)`; only its SHA-256 digest is persisted with
+    the OAuth state, so this cookie is the sole copy of the plaintext and
+    lives only in the browser that initiated the flow.
+    """
+    response.set_cookie(
+        key=OAUTH_STATE_COOKIE_NAME,
+        value=binding_secret,
+        max_age=max_age_seconds,
+        path="/",
+        secure=True,
+        httponly=True,
+        samesite=_SAMESITE,
+    )
+
+
+def clear_oauth_state_cookie(response: Response) -> None:
+    """Drop the OAuth binding cookie once the flow terminates, successfully or
+    otherwise. Cleared on *every* callback exit so a stale binding can't be
+    paired with a freshly minted state on a later attempt."""
+    response.delete_cookie(
+        OAUTH_STATE_COOKIE_NAME,
+        path="/",
+        secure=True,
+        httponly=True,
         samesite=_SAMESITE,
     )

--- a/backend/src/apis/app_api/auth/bff/routes.py
+++ b/backend/src/apis/app_api/auth/bff/routes.py
@@ -1,22 +1,33 @@
 """BFF Token Handler auth routes (Phase 3).
 
 `GET  /auth/login`     — initiates the OAuth code flow against the Cognito
-                         Hosted UI.
-`GET  /auth/callback`  — completes the flow, persists a session row,
-                         writes sealed cookies, redirects to the SPA.
+                         Hosted UI. Mints the browser-binding cookie, the
+                         PKCE verifier, and the OIDC nonce.
+`GET  /auth/callback`  — completes the flow: verifies the state is bound to
+                         *this* browser, redeems the code with the PKCE
+                         verifier, checks the ID-token nonce, persists a
+                         session row, writes sealed cookies, redirects to
+                         the SPA.
 `GET  /auth/session`   — returns the current user + CSRF token. Read by
                          the SPA on bootstrap to confirm "am I logged in?"
 `POST /auth/logout`    — drops the session row, clears both cookies, and
                          returns the Cognito Hosted UI logout URL so the
                          SPA can finish the round-trip.
 
-These routes are dormant until Phase 5 wires the SPA — a /auth/login hit
-today will work end-to-end as long as Phase 1 env vars are set, but no
-production code path consumes the cookies yet.
+Security invariant for the login round-trip: `state` is a public value —
+it rides in a redirect URL and anyone can mint one anonymously — so it is
+never sufficient on its own. A callback is only honoured when it also
+presents the `__Host-bff_oauth_state` cookie whose digest was recorded with
+that state. Without that pairing, an attacker can complete their own
+authorization request in a victim's browser and the victim silently
+transacts inside the attacker's account (OAuth login CSRF / session
+fixation). See `bff_login` and `_binding_matches`.
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 import re
 import secrets
@@ -47,7 +58,13 @@ from apis.shared.sessions_bff.refresh import resolve_bff_client_secret
 from apis.shared.sessions_bff.repository import SessionRepository
 
 from .config import BFFAuthConfig
-from .cookies import clear_session_cookies, set_session_cookies
+from .cookies import (
+    OAUTH_STATE_COOKIE_NAME,
+    clear_oauth_state_cookie,
+    clear_session_cookies,
+    set_oauth_state_cookie,
+    set_session_cookies,
+)
 from .token_exchange import (
     IdTokenClaims,
     TokenExchangeError,
@@ -70,6 +87,34 @@ router = APIRouter(prefix="/auth", tags=["auth-bff"])
 # matches the OIDC state-store default and gives slow IdPs ample headroom.
 _STATE_TTL_SECONDS = 600
 _AUTHORIZE_SCOPES = "openid email profile"
+
+# Entropy budgets for the three per-login secrets. `token_urlsafe(n)` yields
+# ceil(n * 4/3) characters, so 64 bytes lands at 86 chars — comfortably inside
+# the 43..128 character window RFC 7636 §4.1 mandates for a PKCE verifier.
+_CODE_VERIFIER_BYTES = 64
+_NONCE_BYTES = 32
+_BROWSER_BINDING_BYTES = 32
+
+
+def _pkce_code_challenge(code_verifier: str) -> str:
+    """S256 challenge for `code_verifier` — base64url(SHA-256(v)), unpadded.
+
+    Padding is stripped because RFC 7636 §4.2 specifies base64url *without*
+    padding; Cognito rejects the `=`-suffixed form.
+    """
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _browser_binding_digest(binding_secret: str) -> str:
+    """SHA-256 hex of the state cookie's value.
+
+    Only the digest goes into the state store, so the stored row is not
+    itself a usable credential. Plain SHA-256 (no salt/KDF) is right here:
+    the input is 32 bytes of CSPRNG output, so there is no guessable
+    preimage for a rainbow table to cover.
+    """
+    return hashlib.sha256(binding_secret.encode("utf-8")).hexdigest()
 
 
 # ─── Lazy-initialized collaborators ────────────────────────────────────
@@ -240,6 +285,25 @@ async def bff_login(
 ) -> RedirectResponse:
     """302 to the Cognito Hosted UI authorize endpoint with a fresh state.
 
+    Three per-login secrets are minted here, and all three are what make the
+    round-trip safe:
+
+    1. **Browser binding.** A random secret goes back to the caller in the
+       HttpOnly `__Host-bff_oauth_state` cookie while only its SHA-256 digest
+       is committed to the state row. `state` on its own is a *public* value —
+       it travels in a redirect URL — so without this cookie any party who can
+       read a `state` (including one they minted anonymously themselves) can
+       have a *different* browser complete the flow, and that browser is
+       issued a session for whoever the exchanged code names. That's OAuth
+       login CSRF / session fixation; the cookie is the control that stops it.
+    2. **PKCE (S256).** `code_verifier` stays server-side in the state row;
+       only its challenge goes on the wire. An authorization code lifted from
+       the redirect (proxy log, Referer leak, shoulder-surfed URL) is then
+       unredeemable without the verifier.
+    3. **Nonce.** Echoed by the IdP into the ID token and checked at the
+       callback, so an ID token minted for some other authorize request can't
+       be substituted into this one.
+
     Uses the existing `state_store` (in-memory locally, DynamoDB in cloud)
     to bind one-time-use state tokens to a TTL — the callback validates and
     deletes the state in one atomic step.
@@ -255,17 +319,32 @@ async def bff_login(
     post-login URL — so a deep link the user followed before logging in
     survives the round-trip. Values are filtered through
     `_sanitized_return_to` to keep the redirect same-origin only.
+
+    Note on concurrent logins: the binding cookie holds exactly one in-flight
+    authorization request, so starting a second login in the same browser
+    supersedes the first. Whichever flow the user finishes last is the one
+    that completes; the abandoned one fails closed with `state_not_bound` and
+    the user simply re-runs login. Tracking a set of live bindings per browser
+    would avoid that, at the cost of turning a single cookie compare into
+    list-management for a case a user hits by accident, if ever.
     """
     config = BFFAuthConfig.from_env()
     _require_ready(config)
 
     state = secrets.token_urlsafe(32)
+    code_verifier = secrets.token_urlsafe(_CODE_VERIFIER_BYTES)
+    nonce = secrets.token_urlsafe(_NONCE_BYTES)
+    binding_secret = secrets.token_urlsafe(_BROWSER_BINDING_BYTES)
+
     _get_state_store().store_state(
         state,
         OIDCStateData(
             redirect_uri=config.callback_url,
             provider_id="cognito-bff",
             return_to=_sanitized_return_to(return_to),
+            code_verifier=code_verifier,
+            nonce=nonce,
+            browser_binding_hash=_browser_binding_digest(binding_secret),
         ),
         ttl_seconds=_STATE_TTL_SECONDS,
     )
@@ -276,6 +355,9 @@ async def bff_login(
         "scope": _AUTHORIZE_SCOPES,
         "redirect_uri": config.callback_url,
         "state": state,
+        "code_challenge": _pkce_code_challenge(code_verifier),
+        "code_challenge_method": "S256",
+        "nonce": nonce,
     }
     sanitized_provider = _sanitized_provider_id(provider)
     if sanitized_provider:
@@ -283,10 +365,59 @@ async def bff_login(
 
     params = urllib.parse.urlencode(authorize_params)
     authorize_url = f"{config.cognito_domain_url}/oauth2/authorize?{params}"
-    return RedirectResponse(url=authorize_url, status_code=status.HTTP_302_FOUND)
+    response = RedirectResponse(
+        url=authorize_url, status_code=status.HTTP_302_FOUND
+    )
+    # Cookie lifetime matches the state TTL: once the state row is gone the
+    # binding is useless, so there's no reason for it to outlive the flow.
+    set_oauth_state_cookie(
+        response,
+        binding_secret=binding_secret,
+        max_age_seconds=_STATE_TTL_SECONDS,
+    )
+    return response
 
 
 # ─── /auth/callback ────────────────────────────────────────────────────
+
+
+def _binding_matches(
+    state_data: Optional[OIDCStateData], binding_secret: str
+) -> bool:
+    """True iff the callback's cookie is the one minted with this state.
+
+    Fails closed on a state row that carries no binding digest. Such a row can
+    only come from a revision of this service that predates browser binding,
+    so during a rolling deploy a login started on an old task and finished on
+    a new one is rejected and the user re-runs login. That is the correct
+    trade: accepting unbound rows would keep the login-CSRF hole open for the
+    whole rollout window, which is exactly what an attacker holding a
+    pre-minted state would wait for.
+    """
+    if state_data is None or not state_data.browser_binding_hash:
+        return False
+    return secrets.compare_digest(
+        _browser_binding_digest(binding_secret),
+        state_data.browser_binding_hash,
+    )
+
+
+def _nonce_matches(
+    state_data: Optional[OIDCStateData], claims: IdTokenClaims
+) -> bool:
+    """True iff the ID token echoes the nonce issued with this request.
+
+    A state row with no stored nonce passes: it predates this check, and
+    `_binding_matches` has already rejected those rows on the binding digest,
+    so this is not a bypass — it just keeps the failure attributed to the
+    binding.
+    """
+    if state_data is None or not state_data.nonce:
+        return True
+    if not claims.nonce:
+        return False
+    return secrets.compare_digest(claims.nonce, state_data.nonce)
+
 
 
 @router.get("/callback", summary="Complete the BFF OAuth code flow")
@@ -299,9 +430,21 @@ async def bff_callback(
 ) -> Response:
     """Validate state, exchange code, persist session, set cookies, redirect.
 
+    Order of checks matters. The browser-binding cookie is required *before*
+    the code is exchanged, so a request that isn't the continuation of a login
+    this browser started never reaches Cognito's token endpoint and never
+    mints a session row.
+
     Failure modes all converge on "clear cookies + redirect to a generic
     auth-failed URL". We deliberately don't echo Cognito's error_description
     into the response — that string is attacker-controlled in some flows.
+
+    On why there's no `Origin`/`Sec-Fetch-Site` check here: the legitimate
+    arrival at this endpoint *is* a top-level cross-site GET (the IdP redirects
+    the browser back), so it carries `Sec-Fetch-Site: cross-site` and no
+    `Origin`. Rejecting on those headers would reject every real login while
+    an attacker-crafted link looks identical. Browser binding is the control
+    that actually distinguishes the two.
     """
     config = BFFAuthConfig.from_env()
     _require_ready(config)
@@ -313,11 +456,35 @@ async def bff_callback(
     if not code or not state:
         return _redirect_with_cookies_cleared(config, reason="missing_params")
 
+    # Read the binding before touching the state store: no cookie means this
+    # browser never started a login, so there's nothing to consume.
+    binding_secret = request.cookies.get(OAUTH_STATE_COOKIE_NAME)
+    if not binding_secret:
+        logger.warning(
+            "BFF callback rejected: no %s cookie on the request. Either the "
+            "browser dropped it (check that the response to /auth/login is "
+            "served over HTTPS so the __Host- prefix is accepted) or this "
+            "callback was not initiated by this browser.",
+            OAUTH_STATE_COOKIE_NAME,
+        )
+        return _redirect_with_cookies_cleared(config, reason="missing_state_cookie")
+
     state_ok, state_data = _get_state_store().get_and_delete_state(state)
     if not state_ok:
         # Either the state was forged, replayed, or expired. All three are
         # terminal — the user re-initiates from /auth/login.
         return _redirect_with_cookies_cleared(config, reason="bad_state")
+
+    if not _binding_matches(state_data, binding_secret):
+        # The state is real but was minted for a different browser. This is
+        # the login-CSRF / session-fixation attempt: someone is trying to get
+        # *this* browser to finish *their* authorization request. Log loudly —
+        # unlike the checks above, there is no benign path to here.
+        logger.warning(
+            "BFF callback rejected: OAuth state is not bound to this browser "
+            "(possible login-CSRF attempt)."
+        )
+        return _redirect_with_cookies_cleared(config, reason="state_not_bound")
 
     try:
         client_secret = resolve_bff_client_secret(
@@ -334,6 +501,7 @@ async def bff_callback(
             client_secret=client_secret,
             code=code,
             redirect_uri=config.callback_url,
+            code_verifier=state_data.code_verifier if state_data else None,
         )
     except TokenExchangeError:
         return _redirect_with_cookies_cleared(config, reason="exchange_failed")
@@ -345,6 +513,13 @@ async def bff_callback(
         claims = decode_id_token_claims(tokens.id_token)
     except TokenExchangeError:
         return _redirect_with_cookies_cleared(config, reason="bad_id_token")
+
+    if not _nonce_matches(state_data, claims):
+        logger.warning(
+            "BFF callback rejected: ID token nonce does not match the nonce "
+            "issued with this authorization request."
+        )
+        return _redirect_with_cookies_cleared(config, reason="bad_nonce")
 
     now = int(time.time())
     session_id = secrets.token_urlsafe(24)
@@ -408,6 +583,9 @@ async def bff_callback(
         csrf_token=csrf_token,
         max_age_seconds=config.bff_config.session_ttl_seconds,
     )
+    # The binding cookie has done its job — the state row it guarded is
+    # consumed. Drop it so it can't be paired with a later state.
+    clear_oauth_state_cookie(response)
     return response
 
 
@@ -441,10 +619,16 @@ def _redirect_with_cookies_cleared(
     config: BFFAuthConfig, *, reason: str
 ) -> RedirectResponse:
     """Clear any stale BFF cookies and bounce to the post-login URL with a
-    `?auth_error=<reason>` query string the SPA can surface."""
+    `?auth_error=<reason>` query string the SPA can surface.
+
+    Also drops the OAuth binding cookie: every path through here ends the
+    in-flight authorization request, so keeping the binding around would only
+    let it be replayed against a subsequent state.
+    """
     target = _append_query(config.post_login_redirect_url, {"auth_error": reason})
     response = RedirectResponse(url=target, status_code=status.HTTP_302_FOUND)
     clear_session_cookies(response)
+    clear_oauth_state_cookie(response)
     return response
 
 

--- a/backend/src/apis/app_api/auth/bff/token_exchange.py
+++ b/backend/src/apis/app_api/auth/bff/token_exchange.py
@@ -12,6 +12,13 @@ minted it on the same redirect chain, and only its `sub` /
 to seed the session row. The access token is what drives downstream
 auth — its signature is checked by `_get_bff_cognito_validator()` on
 every request through the dependency.
+
+The `nonce` claim is also read unverified, and that's sound: this token
+arrives as the body of *our own* TLS request to the token endpoint, in
+response to a code we chose. A third party can't substitute a token into
+that response, so the nonce comparison the callback performs still tells
+us what we need — that the IdP issued this token for the authorization
+request we started, not for some other one.
 """
 
 from __future__ import annotations
@@ -62,6 +69,11 @@ class IdTokenClaims:
     # decode at /auth/callback — so we extract them here once instead of
     # threading another decode through the call site.
     roles: List[str] = field(default_factory=list)
+    # `nonce` echoed back by the IdP from the authorize request. The callback
+    # compares it against the value it stashed with the OAuth state so an ID
+    # token minted for a *different* authorization request can't be
+    # substituted into this one.
+    nonce: Optional[str] = None
 
 
 def _extract_roles_from_id_token(claims: dict) -> List[str]:
@@ -98,9 +110,17 @@ async def exchange_code_for_tokens(
     client_secret: str,
     code: str,
     redirect_uri: str,
+    code_verifier: Optional[str] = None,
     http_client: Optional[httpx.AsyncClient] = None,
 ) -> ExchangeResult:
     """Exchange an authorization code for Cognito tokens.
+
+    `code_verifier` is the PKCE secret generated at /auth/login and carried
+    in the OAuth state row. When present it's sent as `code_verifier` so the
+    IdP can check it against the `code_challenge` it recorded on the
+    authorize request; a code intercepted without the verifier is then
+    unredeemable. Optional so a state row minted by an older revision
+    (mid-deploy) still completes rather than dead-ending the user's login.
 
     `http_client` is injected so tests can swap in a mock transport without
     needing real network egress.
@@ -111,6 +131,8 @@ async def exchange_code_for_tokens(
         "code": code,
         "redirect_uri": redirect_uri,
     }
+    if code_verifier:
+        data["code_verifier"] = code_verifier
     auth = (client_id, client_secret)
 
     try:
@@ -179,4 +201,5 @@ def decode_id_token_claims(id_token: str) -> IdTokenClaims:
         ),
         picture=claims.get("picture"),
         roles=_extract_roles_from_id_token(claims),
+        nonce=claims.get("nonce"),
     )

--- a/backend/src/apis/shared/auth/state_store.py
+++ b/backend/src/apis/shared/auth/state_store.py
@@ -23,6 +23,17 @@ class OIDCStateData:
     # before storage — a path that fails the allowlist is dropped, never
     # round-tripped to the browser.
     return_to: Optional[str] = None
+    # SHA-256 (hex) of the browser-binding secret handed to the client in a
+    # short-lived, HttpOnly cookie when this state was minted. The callback
+    # recomputes the digest from the cookie it receives and refuses the
+    # exchange unless it matches. This is what makes `state` useless to a
+    # browser other than the one that started the flow — without it, anyone
+    # who can read a `state` value out of a 302 Location can have a victim's
+    # browser complete *their* login (OAuth login CSRF / session fixation).
+    #
+    # Only the digest is persisted: a read-only compromise of the state table
+    # then yields nothing that can be replayed as the cookie.
+    browser_binding_hash: Optional[str] = None
 
 
 class StateStore(ABC):
@@ -171,6 +182,8 @@ class DynamoDBStateStore(StateStore):
                     item['provider_id'] = data.provider_id
                 if data.return_to:
                     item['return_to'] = data.return_to
+                if data.browser_binding_hash:
+                    item['browser_binding_hash'] = data.browser_binding_hash
 
             # Use expiresAt as TTL attribute (DynamoDB will auto-delete)
             self.table.put_item(Item=item)
@@ -242,6 +255,7 @@ class DynamoDBStateStore(StateStore):
                 nonce=item.get('nonce'),
                 provider_id=item.get('provider_id'),
                 return_to=item.get('return_to'),
+                browser_binding_hash=item.get('browser_binding_hash'),
             )
             return True, data
             

--- a/backend/tests/apis/app_api/auth/bff/conftest.py
+++ b/backend/tests/apis/app_api/auth/bff/conftest.py
@@ -35,6 +35,13 @@ BFF_CLIENT_ID = "test-bff-client-id"
 BFF_CLIENT_SECRET_ARN = "arn:aws:secretsmanager:us-east-1:0:secret:bff-test"
 COOKIE_KMS_ARN = "arn:aws:kms:us-east-1:0:key/test"
 
+# Fixed per-login secrets used by the callback tests. Production mints these
+# per request; pinning them here lets a test seed a state row and hand the
+# matching binding cookie to a TestClient in one step.
+SEEDED_BINDING_SECRET = "test-browser-binding-secret"
+SEEDED_CODE_VERIFIER = "test-pkce-code-verifier"
+SEEDED_NONCE = "test-oidc-nonce"
+
 
 def _make_codec() -> CookieCodec:
     """Real CookieCodec with a deterministic in-memory AES key — no KMS."""
@@ -150,8 +157,15 @@ def make_id_token(
     picture: Optional[str] = None,
     custom_roles: Optional[str] = None,
     cognito_groups: Optional[list] = None,
+    nonce: Optional[str] = SEEDED_NONCE,
 ) -> str:
-    """Unsigned JWT good enough for `decode_id_token_claims`."""
+    """Unsigned JWT good enough for `decode_id_token_claims`.
+
+    `nonce` defaults to `SEEDED_NONCE` so tokens minted here satisfy the
+    callback's nonce check against a state row seeded by `_seed_state`.
+    Pass `nonce=None` to simulate an IdP that dropped the claim, or a
+    different string to simulate token substitution.
+    """
     import json
     import base64
 
@@ -171,5 +185,7 @@ def make_id_token(
         claims["custom:roles"] = custom_roles
     if cognito_groups is not None:
         claims["cognito:groups"] = cognito_groups
+    if nonce is not None:
+        claims["nonce"] = nonce
     body = _b64(claims)
     return f"{header}.{body}."

--- a/backend/tests/apis/app_api/auth/bff/test_callback.py
+++ b/backend/tests/apis/app_api/auth/bff/test_callback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import time
 import urllib.parse
 from unittest.mock import AsyncMock, MagicMock
@@ -10,13 +11,20 @@ import pytest
 from fastapi.testclient import TestClient
 
 from apis.app_api.auth.bff import routes as bff_routes
+from apis.app_api.auth.bff.cookies import OAUTH_STATE_COOKIE_NAME
 from apis.app_api.auth.bff.token_exchange import ExchangeResult, TokenExchangeError
 from apis.shared.sessions_bff.config import (
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
 )
 
-from .conftest import POST_LOGIN_URL, make_id_token
+from .conftest import (
+    POST_LOGIN_URL,
+    SEEDED_BINDING_SECRET,
+    SEEDED_CODE_VERIFIER,
+    SEEDED_NONCE,
+    make_id_token,
+)
 
 
 def _seed_state(
@@ -24,8 +32,17 @@ def _seed_state(
     *,
     redirect_uri: str | None = None,
     return_to: str | None = None,
+    binding_secret: str | None = SEEDED_BINDING_SECRET,
+    code_verifier: str | None = SEEDED_CODE_VERIFIER,
+    nonce: str | None = SEEDED_NONCE,
 ) -> str:
-    """Push a state token through the same store the route reads from."""
+    """Push a state token through the same store the route reads from.
+
+    Mirrors what `/auth/login` writes, including the digest of the
+    browser-binding secret. Pass `binding_secret=None` to seed a row with no
+    binding — that's what a pre-fix revision produced, and the callback must
+    reject it.
+    """
     from .conftest import CALLBACK_URL
 
     store = bff_routes._get_state_store()
@@ -37,10 +54,34 @@ def _seed_state(
             redirect_uri=redirect_uri or CALLBACK_URL,
             provider_id="cognito-bff",
             return_to=return_to,
+            code_verifier=code_verifier,
+            nonce=nonce,
+            browser_binding_hash=(
+                hashlib.sha256(binding_secret.encode()).hexdigest()
+                if binding_secret
+                else None
+            ),
         ),
         ttl_seconds=600,
     )
     return state
+
+
+def _bound_client(app, *, binding_secret: str | None = SEEDED_BINDING_SECRET):
+    """TestClient carrying the binding cookie for a `_seed_state()` row.
+
+    Stands in for the browser that started the login. `binding_secret=None`
+    yields a cookie-less client — the "victim" in the login-CSRF scenario.
+    """
+    client = TestClient(app, follow_redirects=False)
+    if binding_secret is not None:
+        client.cookies.set(OAUTH_STATE_COOKIE_NAME, binding_secret)
+    return client
+
+
+def _auth_error(response) -> str | None:
+    qs = urllib.parse.urlparse(response.headers["location"]).query
+    return dict(urllib.parse.parse_qsl(qs)).get("auth_error")
 
 
 def _patch_token_exchange(monkeypatch, result: ExchangeResult | Exception) -> MagicMock:
@@ -66,7 +107,7 @@ def test_callback_happy_path_writes_row_and_cookies(app, monkeypatch, repository
         ),
     )
 
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=auth-code-xyz&state={state}")
 
     assert response.status_code == 302
@@ -98,7 +139,7 @@ def test_callback_consumes_state_one_time(app, monkeypatch):
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
 
     first = client.get(f"/auth/callback?code=c&state={state}")
     assert first.status_code == 302
@@ -119,7 +160,7 @@ def test_callback_missing_code_redirects_with_error(app, monkeypatch):
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get("/auth/callback?state=whatever")
     assert response.status_code == 302
     qs = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(response.headers["location"]).query))
@@ -127,7 +168,7 @@ def test_callback_missing_code_redirects_with_error(app, monkeypatch):
 
 
 def test_callback_oauth_error_param_redirects_with_error(app):
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(
         "/auth/callback?error=access_denied&error_description=user+cancelled"
     )
@@ -144,7 +185,7 @@ def test_callback_token_exchange_failure_redirects_with_error(app, monkeypatch):
     state = _seed_state("ex-fail")
     _patch_token_exchange(monkeypatch, TokenExchangeError("boom"))
 
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
@@ -163,7 +204,7 @@ def test_callback_missing_id_token_redirects_with_error(app, monkeypatch):
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
     assert response.status_code == 302
     qs = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(response.headers["location"]).query))
@@ -179,7 +220,7 @@ def test_callback_session_id_is_unique_across_logins(app, monkeypatch, repositor
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
 
     s1 = _seed_state("first")
     s2 = _seed_state("second")
@@ -206,7 +247,7 @@ def test_callback_redirects_to_return_to_path_when_set(app, monkeypatch):
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
@@ -226,7 +267,7 @@ def test_callback_falls_back_to_post_login_when_no_return_to(app, monkeypatch):
             access_token_exp=int(time.time()) + 3600,
         ),
     )
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
@@ -274,7 +315,7 @@ def test_callback_upserts_user_with_id_token_claims(app, monkeypatch):
     )
     sync_call = _patch_user_sync(monkeypatch)
 
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
@@ -310,7 +351,7 @@ def test_callback_falls_back_to_cognito_groups_when_custom_roles_absent(
     )
     sync_call = _patch_user_sync(monkeypatch)
 
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
@@ -333,8 +374,268 @@ def test_callback_user_sync_failure_does_not_break_login(app, monkeypatch):
     failing_sync.sync_from_user = AsyncMock(side_effect=RuntimeError("ddb down"))
     monkeypatch.setattr(bff_routes, "_get_user_sync_service", lambda: failing_sync)
 
-    client = TestClient(app, follow_redirects=False)
+    client = _bound_client(app)
     response = client.get(f"/auth/callback?code=c&state={state}")
 
     assert response.status_code == 302
     assert response.headers["location"] == POST_LOGIN_URL
+
+
+# ─── Browser binding: OIDC login CSRF / session fixation (f-8c4f312a) ──
+#
+# `state` is a public value — it rides in a 302 Location and anyone can mint
+# one anonymously. These tests pin the property that makes it insufficient on
+# its own: a callback is honoured only when it also presents the binding
+# cookie whose digest was recorded with that state.
+
+
+def test_callback_rejects_valid_state_from_a_different_browser(
+    app, monkeypatch, repository
+):
+    """The core of the finding: a state minted for browser A must not be
+    redeemable by browser B.
+
+    Browser B here is cookie-less, exactly like the reported victim client —
+    it never visited /auth/login. Before the fix this returned a live session
+    for whatever identity the code named."""
+    state = _seed_state("minted-for-browser-a")
+    exchange = _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    victim = _bound_client(app, binding_secret=None)
+    response = victim.get(f"/auth/callback?code=attacker-code&state={state}")
+
+    assert response.status_code == 302
+    assert _auth_error(response) == "missing_state_cookie"
+    # No session cookie was issued...
+    set_cookie_blob = " ".join(response.headers.get_list("set-cookie"))
+    assert f"{SESSION_COOKIE_NAME}=;" in set_cookie_blob.replace('""', "")
+    # ...no session row was persisted...
+    assert repository._table.scan().get("Items", []) == []
+    # ...and the code never reached the token endpoint, so it stays unspent.
+    exchange.assert_not_awaited()
+
+
+def test_callback_rejects_state_when_binding_cookie_belongs_to_another_flow(
+    app, monkeypatch, repository
+):
+    """A browser that has *a* binding cookie, just not the one this state was
+    minted with, is still refused. Covers the attacker who lures a victim that
+    has their own login in flight."""
+    state = _seed_state("bound-to-someone-else")
+    exchange = _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app, binding_secret="some-other-browsers-secret")
+    response = client.get(f"/auth/callback?code=attacker-code&state={state}")
+
+    assert response.status_code == 302
+    assert _auth_error(response) == "state_not_bound"
+    assert repository._table.scan().get("Items", []) == []
+    exchange.assert_not_awaited()
+
+
+def test_callback_rejects_state_row_with_no_binding_digest(
+    app, monkeypatch, repository
+):
+    """Fail closed on a state row minted before browser binding existed.
+
+    Such rows only appear mid-deploy. Honouring them would keep the hole open
+    for the whole rollout window — precisely when an attacker holding a
+    pre-minted state would strike."""
+    state = _seed_state("legacy-unbound-row", binding_secret=None)
+    exchange = _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert response.status_code == 302
+    assert _auth_error(response) == "state_not_bound"
+    assert repository._table.scan().get("Items", []) == []
+    exchange.assert_not_awaited()
+
+
+def test_callback_binding_is_checked_before_the_state_is_consumed(app, monkeypatch):
+    """A cookie-less request must not burn the state row.
+
+    Otherwise anyone could DoS a user's in-flight login by replaying the state
+    from a crafted link before the user finishes at the IdP."""
+    state = _seed_state("must-survive-probe")
+    _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    attacker = _bound_client(app, binding_secret=None)
+    assert (
+        _auth_error(attacker.get(f"/auth/callback?code=c&state={state}"))
+        == "missing_state_cookie"
+    )
+
+    # The legitimate browser can still complete the same flow.
+    victim = _bound_client(app)
+    response = victim.get(f"/auth/callback?code=c&state={state}")
+    assert _auth_error(response) is None
+    assert response.headers["location"] == POST_LOGIN_URL
+
+
+def test_callback_clears_binding_cookie_on_success(app, monkeypatch):
+    """Binding is single-use: once its state row is consumed the cookie is
+    dropped so it can't be paired with a later state."""
+    state = _seed_state("clears-on-success")
+    _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert _auth_error(response) is None
+    expiry = [
+        h
+        for h in response.headers.get_list("set-cookie")
+        if h.startswith(OAUTH_STATE_COOKIE_NAME)
+    ]
+    assert expiry, f"{OAUTH_STATE_COOKIE_NAME} was not cleared"
+    assert "Max-Age=0" in expiry[0] or 'expires=Thu, 01 Jan 1970' in expiry[0].lower()
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_error"),
+    [
+        ("?code=c&state=never-minted", "bad_state"),
+        ("?error=access_denied", "oauth_error"),
+        ("?state=only-state", "missing_params"),
+    ],
+)
+def test_callback_clears_binding_cookie_on_failure_paths(
+    app, query, expected_error
+):
+    """Every terminal path drops the binding so a failed attempt can't leave a
+    reusable one behind."""
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback{query}")
+
+    assert _auth_error(response) == expected_error
+    assert any(
+        h.startswith(OAUTH_STATE_COOKIE_NAME)
+        for h in response.headers.get_list("set-cookie")
+    )
+
+
+# ─── PKCE ──────────────────────────────────────────────────────────────
+
+
+def test_callback_sends_stored_code_verifier_to_token_endpoint(app, monkeypatch):
+    """The verifier never touches the browser — it comes off the state row, so
+    a code lifted from the redirect can't be redeemed without it."""
+    state = _seed_state("pkce-state")
+    exchange = _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a", refresh_token="r", id_token=make_id_token(),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert _auth_error(response) is None
+    assert exchange.await_args.kwargs["code_verifier"] == SEEDED_CODE_VERIFIER
+
+
+# ─── OIDC nonce ────────────────────────────────────────────────────────
+
+
+def test_callback_rejects_id_token_with_mismatched_nonce(
+    app, monkeypatch, repository
+):
+    """An ID token minted for a different authorization request can't be
+    substituted into this one."""
+    state = _seed_state("nonce-state")
+    _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a",
+            refresh_token="r",
+            id_token=make_id_token(nonce="nonce-from-another-flow"),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert response.status_code == 302
+    assert _auth_error(response) == "bad_nonce"
+    assert repository._table.scan().get("Items", []) == []
+
+
+def test_callback_rejects_id_token_with_no_nonce_when_one_was_requested(
+    app, monkeypatch, repository
+):
+    """A missing claim is a mismatch — otherwise stripping the claim would be
+    a trivial bypass."""
+    state = _seed_state("nonce-absent")
+    _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a",
+            refresh_token="r",
+            id_token=make_id_token(nonce=None),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert _auth_error(response) == "bad_nonce"
+    assert repository._table.scan().get("Items", []) == []
+
+
+def test_callback_accepts_missing_nonce_when_state_predates_the_check(
+    app, monkeypatch
+):
+    """A state row with no stored nonce doesn't fail the nonce check — binding
+    already gates those rows, and attributing the failure twice just muddies
+    the diagnostics."""
+    state = _seed_state("no-stored-nonce", nonce=None)
+    _patch_token_exchange(
+        monkeypatch,
+        ExchangeResult(
+            access_token="a",
+            refresh_token="r",
+            id_token=make_id_token(nonce=None),
+            access_token_exp=int(time.time()) + 3600,
+        ),
+    )
+
+    client = _bound_client(app)
+    response = client.get(f"/auth/callback?code=c&state={state}")
+
+    assert _auth_error(response) is None

--- a/backend/tests/apis/app_api/auth/bff/test_login.py
+++ b/backend/tests/apis/app_api/auth/bff/test_login.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import urllib.parse
 
 import pytest
 from fastapi.testclient import TestClient
+
+from apis.app_api.auth.bff import routes as bff_routes
+from apis.app_api.auth.bff.cookies import OAUTH_STATE_COOKIE_NAME
 
 from .conftest import (
     BFF_CLIENT_ID,
@@ -209,3 +214,125 @@ def test_login_rejects_unsafe_return_to(app_for_login, bad_return_to):
     assert ok is True
     assert data is not None
     assert data.return_to is None
+
+
+# ─── Browser binding, PKCE, nonce (f-8c4f312a) ─────────────────────────
+
+
+def _set_cookie_header(response, name: str) -> str:
+    matches = [
+        h for h in response.headers.get_list("set-cookie") if h.startswith(name)
+    ]
+    assert matches, f"{name} was not set. Set-Cookie: {response.headers.get_list('set-cookie')}"
+    return matches[0]
+
+
+def _binding_secret_from(response) -> str:
+    header = _set_cookie_header(response, OAUTH_STATE_COOKIE_NAME)
+    return header.split(";", 1)[0].split("=", 1)[1]
+
+
+def test_login_sets_browser_binding_cookie(app_for_login):
+    """The 302 must carry the binding cookie. The reported finding was that
+    /auth/login emitted no Set-Cookie at all, leaving `state` — a value that
+    travels in a redirect URL — as the only thing the callback checked."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+
+    header = _set_cookie_header(response, OAUTH_STATE_COOKIE_NAME)
+    assert "HttpOnly" in header  # script must not be able to forge a binding
+    assert "Secure" in header  # required by the __Host- prefix
+    assert "Path=/" in header
+    assert "Domain=" not in header  # __Host- forbids it; sibling hosts can't plant one
+    # `lax`, not `strict`: the IdP returns the user via a top-level cross-site
+    # GET, and `strict` would withhold the cookie and break every login.
+    assert "SameSite=lax" in header
+    assert f"Max-Age={bff_routes._STATE_TTL_SECONDS}" in header
+
+
+def test_login_stores_only_the_digest_of_the_binding_secret(app_for_login):
+    """A read-only leak of the state table must not yield a replayable
+    binding, so the row holds SHA-256(secret) and never the secret."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+
+    secret = _binding_secret_from(response)
+    state = _authorize_params(response)["state"]
+    ok, data = bff_routes._get_state_store().get_and_delete_state(state)
+
+    assert ok is True
+    assert data.browser_binding_hash == hashlib.sha256(secret.encode()).hexdigest()
+    assert secret not in (data.browser_binding_hash or "")
+
+
+def test_login_binding_secret_is_unique_per_request(app_for_login):
+    """Two logins must not share a binding, or one user's state would be
+    redeemable using another's cookie."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    first = _binding_secret_from(client.get("/auth/login"))
+    second = _binding_secret_from(client.get("/auth/login"))
+    assert first != second
+
+
+def test_login_binding_secret_is_not_leaked_in_the_redirect_url(app_for_login):
+    """The secret's whole value is that it lives only in the cookie jar. If it
+    also appeared in the authorize URL, anyone who could read the URL (Referer,
+    proxy log, browser history) could rebuild the binding."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+
+    assert _binding_secret_from(response) not in response.headers["location"]
+
+
+def test_login_sends_pkce_s256_challenge_derived_from_stored_verifier(app_for_login):
+    """Cognito supports S256 only. The verifier stays in the state row; only
+    its challenge goes on the wire."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+    params = _authorize_params(response)
+
+    assert params["code_challenge_method"] == "S256"
+
+    ok, data = bff_routes._get_state_store().get_and_delete_state(params["state"])
+    assert ok is True
+    assert data.code_verifier
+    # RFC 7636 §4.1: 43..128 chars.
+    assert 43 <= len(data.code_verifier) <= 128
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(data.code_verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert params["code_challenge"] == expected
+    # Unpadded base64url — Cognito rejects the `=`-suffixed form.
+    assert "=" not in params["code_challenge"]
+    # The verifier itself must never reach the browser.
+    assert data.code_verifier not in response.headers["location"]
+
+
+def test_login_sends_nonce_matching_the_stored_state(app_for_login):
+    """Cognito echoes `nonce` into the ID token; the callback compares it, so
+    the two must agree."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+    params = _authorize_params(response)
+
+    ok, data = bff_routes._get_state_store().get_and_delete_state(params["state"])
+    assert ok is True
+    assert data.nonce
+    assert params["nonce"] == data.nonce
+
+
+def test_login_secrets_are_independent_of_each_other(app_for_login):
+    """state, verifier, nonce and binding must be four separate draws —
+    deriving any from another would let a leak of the public `state` or
+    `nonce` reconstruct a server-side secret."""
+    client = TestClient(app_for_login, follow_redirects=False)
+    response = client.get("/auth/login")
+    params = _authorize_params(response)
+    secret = _binding_secret_from(response)
+
+    ok, data = bff_routes._get_state_store().get_and_delete_state(params["state"])
+    assert ok is True
+    values = {params["state"], data.code_verifier, data.nonce, secret}
+    assert len(values) == 4

--- a/backend/tests/apis/app_api/auth/bff/test_login_csrf_regression.py
+++ b/backend/tests/apis/app_api/auth/bff/test_login_csrf_regression.py
@@ -1,0 +1,263 @@
+"""End-to-end regression for the BFF OIDC login CSRF / session fixation
+finding (f-8c4f312a, High, Authentication Bypass).
+
+Unlike `test_callback.py`, nothing here seeds the state store by hand — the
+attacker mints state through the real `GET /auth/login`, exactly as reported.
+That's what makes these tests a faithful guard: they exercise the same code
+path an attacker would, so they'd fail if a future change reintroduced an
+unbound state anywhere in the login round-trip.
+
+The reported chain was:
+
+  1. Attacker anonymously hits /auth/login and captures `state` from the 302
+     Location. The response carried no Set-Cookie, so nothing tied that state
+     to the attacker's browser.
+  2. Attacker authenticates at the IdP themselves to obtain a real
+     authorization code, without completing the callback.
+  3. Victim is lured to /auth/callback?code=<attacker code>&state=<captured
+     state>. The BFF exchanged the code and issued the victim a sealed session
+     for the *attacker's* identity — including, in the reported case, a
+     `system_admin` account.
+
+Everything the victim then did (conversations, uploads, memory entries, and
+any third-party OAuth connector consent) happened inside an account the
+attacker still holds the credentials to.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.parse
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apis.app_api.auth.bff import routes as bff_routes
+from apis.app_api.auth.bff.cookies import OAUTH_STATE_COOKIE_NAME
+from apis.app_api.auth.bff.token_exchange import ExchangeResult
+from apis.shared.sessions_bff.config import SESSION_COOKIE_NAME
+
+from .conftest import make_id_token
+
+# Stands in for the attacker's own IdP account — the identity the victim's
+# browser was being handed in the report.
+ATTACKER_SUB = "attacker-sub-999"
+ATTACKER_CODE = "attacker-authorization-code"
+
+
+def _authorize_query(response) -> dict[str, str]:
+    location = response.headers["location"]
+    return dict(urllib.parse.parse_qsl(urllib.parse.urlparse(location).query))
+
+
+def _issued_binding_cookie(response) -> str | None:
+    for header in response.headers.get_list("set-cookie"):
+        if header.startswith(OAUTH_STATE_COOKIE_NAME):
+            value = header.split(";", 1)[0].split("=", 1)[1]
+            return value or None
+    return None
+
+
+def _patch_exchange_to_return_attacker_identity(monkeypatch) -> AsyncMock:
+    """Simulate a token endpoint that would happily redeem the attacker's code.
+
+    The point is that the exchange *would* succeed — the fix must stop the
+    request before it ever gets here, not rely on the exchange failing.
+    """
+    mock = AsyncMock(
+        return_value=ExchangeResult(
+            access_token="attacker.access.token",
+            refresh_token="attacker.refresh.token",
+            id_token=make_id_token(
+                sub=ATTACKER_SUB,
+                username="attacker",
+                email="attacker@example.com",
+                name="Attacker",
+                custom_roles='["system_admin"]',
+                # The IdP echoes the nonce from the authorize request the
+                # attacker drove, so the nonce check alone would not catch
+                # this — browser binding is what does.
+                nonce=None,
+            ),
+            access_token_exp=int(time.time()) + 3600,
+        )
+    )
+    monkeypatch.setattr(bff_routes, "exchange_code_for_tokens", mock)
+    return mock
+
+
+def _assert_no_session_issued(response, repository) -> None:
+    assert response.status_code == 302
+    # No sealed session cookie with a value — only the clearing directive.
+    for header in response.headers.get_list("set-cookie"):
+        if header.startswith(SESSION_COOKIE_NAME):
+            value = header.split(";", 1)[0].split("=", 1)[1].strip('"')
+            assert value == "", f"a session cookie was issued: {header}"
+    # And no server-side session record was persisted.
+    assert repository._table.scan().get("Items", []) == []
+
+
+def test_full_login_csrf_chain_is_refused(app, monkeypatch, repository):
+    """Step 1-3 of the reported chain, end to end."""
+    exchange = _patch_exchange_to_return_attacker_identity(monkeypatch)
+
+    # (1) Attacker mints state anonymously. They receive a binding cookie now,
+    #     but it lands in *their* cookie jar — which is the whole point.
+    attacker = TestClient(app, follow_redirects=False)
+    login = attacker.get("/auth/login")
+    assert login.status_code == 302
+    captured_state = _authorize_query(login)["state"]
+    assert captured_state
+
+    # (2) Attacker authenticates at the IdP off-band and holds a real code.
+    #     Nothing to simulate on our side.
+
+    # (3) Victim follows the crafted link. Cookie-less, as in the report:
+    #     a browser that never visited /auth/login.
+    victim = TestClient(app, follow_redirects=False)
+    response = victim.get(
+        f"/auth/callback?code={ATTACKER_CODE}&state={captured_state}"
+    )
+
+    qs = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(response.headers["location"]).query))
+    assert qs["auth_error"] == "missing_state_cookie"
+    _assert_no_session_issued(response, repository)
+    # The attacker's code was never redeemed, so no third party learns whether
+    # it was valid.
+    exchange.assert_not_awaited()
+
+
+def test_login_csrf_chain_refused_even_with_cross_site_navigation_headers(
+    app, monkeypatch, repository
+):
+    """The report noted the callback accepted `Sec-Fetch-Site: cross-site` and
+    a foreign `Referer`. It still must — a legitimate IdP redirect looks
+    identical — so binding, not fetch metadata, has to carry the rejection."""
+    _patch_exchange_to_return_attacker_identity(monkeypatch)
+
+    attacker = TestClient(app, follow_redirects=False)
+    captured_state = _authorize_query(attacker.get("/auth/login"))["state"]
+
+    victim = TestClient(app, follow_redirects=False)
+    response = victim.get(
+        f"/auth/callback?code={ATTACKER_CODE}&state={captured_state}",
+        headers={
+            "Sec-Fetch-Site": "cross-site",
+            "Sec-Fetch-Mode": "navigate",
+            "Referer": "https://evil.example.com/",
+            "User-Agent": "victim-browser/1.0",
+        },
+    )
+
+    _assert_no_session_issued(response, repository)
+
+
+def test_captured_state_is_useless_without_the_cookie_across_many_retries(
+    app, monkeypatch, repository
+):
+    """The report established that failed attempts don't consume the code, so
+    retries are free and the attack is repeatable. Repetition must not help:
+    every attempt fails the same way and the state row survives for its
+    rightful owner."""
+    _patch_exchange_to_return_attacker_identity(monkeypatch)
+
+    attacker = TestClient(app, follow_redirects=False)
+    captured_state = _authorize_query(attacker.get("/auth/login"))["state"]
+
+    for attempt in range(8):
+        victim = TestClient(app, follow_redirects=False)
+        response = victim.get(
+            f"/auth/callback?code={ATTACKER_CODE}&state={captured_state}"
+        )
+        qs = dict(
+            urllib.parse.parse_qsl(
+                urllib.parse.urlparse(response.headers["location"]).query
+            )
+        )
+        assert qs["auth_error"] == "missing_state_cookie", f"attempt {attempt}"
+        _assert_no_session_issued(response, repository)
+
+
+@pytest.mark.parametrize(
+    "forged_cookie",
+    [
+        "",  # empty
+        "guessed-binding-secret",
+        "0" * 43,  # right shape, wrong value
+    ],
+)
+def test_guessing_the_binding_cookie_does_not_work(
+    app, monkeypatch, repository, forged_cookie
+):
+    """The binding is 32 bytes of CSPRNG output and only its digest is stored,
+    so there is nothing to guess and nothing to steal from the state row."""
+    _patch_exchange_to_return_attacker_identity(monkeypatch)
+
+    attacker = TestClient(app, follow_redirects=False)
+    captured_state = _authorize_query(attacker.get("/auth/login"))["state"]
+
+    victim = TestClient(app, follow_redirects=False)
+    if forged_cookie:
+        victim.cookies.set(OAUTH_STATE_COOKIE_NAME, forged_cookie)
+    response = victim.get(
+        f"/auth/callback?code={ATTACKER_CODE}&state={captured_state}"
+    )
+
+    _assert_no_session_issued(response, repository)
+
+
+def test_the_browser_that_started_the_login_still_completes_it(
+    app, monkeypatch, repository
+):
+    """The other half of the contract: binding must not break real logins.
+
+    Replays the whole round-trip in one client, carrying the cookie forward
+    from the /auth/login response the way a browser would, and asserts the
+    session is issued to the identity the IdP named.
+    """
+    exchange = _patch_exchange_to_return_attacker_identity(monkeypatch)
+
+    client = TestClient(app, follow_redirects=False)
+    login = client.get("/auth/login")
+    params = _authorize_query(login)
+
+    # PKCE and nonce went out on the authorize request...
+    assert params["code_challenge_method"] == "S256"
+    assert params["code_challenge"]
+    assert params["nonce"]
+
+    # ...and the browser holds the binding. TestClient's jar won't replay a
+    # `Secure` cookie over the http test transport, so re-seat it explicitly —
+    # a real browser sends it because /auth/login is served over HTTPS.
+    binding = _issued_binding_cookie(login)
+    assert binding
+    client.cookies.set(OAUTH_STATE_COOKIE_NAME, binding)
+
+    # The ID token has to echo the nonce Cognito was given, per
+    # docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html.
+    exchange.return_value = ExchangeResult(
+        access_token="real.access.token",
+        refresh_token="real.refresh.token",
+        id_token=make_id_token(sub="legit-user", nonce=params["nonce"]),
+        access_token_exp=int(time.time()) + 3600,
+    )
+
+    response = client.get(
+        f"/auth/callback?code=legitimate-code&state={params['state']}"
+    )
+
+    assert response.status_code == 302
+    assert "auth_error" not in response.headers["location"]
+    session_headers = [
+        h
+        for h in response.headers.get_list("set-cookie")
+        if h.startswith(SESSION_COOKIE_NAME)
+    ]
+    assert session_headers and "=;" not in session_headers[0]
+
+    items = repository._table.scan().get("Items", [])
+    assert len(items) == 1
+    assert items[0]["user_id"] == "legit-user"
+    # The verifier that was withheld from the browser is what redeemed the code.
+    assert exchange.await_args.kwargs["code_verifier"]


### PR DESCRIPTION
Fixes a High-severity OIDC login CSRF / session fixation hole in the BFF auth flow (finding f-8c4f312a).

`GET /auth/login` minted a `state`, stored it server-side, and redirected to the Cognito Hosted UI without issuing any browser-side material — no state cookie, no PKCE, no nonce. `state` is a public value: it travels in a 302 Location and anyone can mint one anonymously. `GET /auth/callback` nonetheless treated "this state exists in the store" as proof the request continued a login *this* browser started, so it accepted any (code, state) pair from any browser.

Exploit: an attacker mints a state anonymously, authenticates at the IdP themselves to get a real authorization code, then lures a victim to /auth/callback?code=<theirs>&state=<captured>. The victim's browser is silently issued a live session for the attacker's account — reported against a `system_admin` identity — and everything the victim then does (conversations, uploads, memory entries, third-party connector consent) lands inside an account the attacker still holds credentials to.

Browser binding is the fix:

  - /auth/login mints a 32-byte secret, returns it in a new `__Host-bff_oauth_state` cookie (HttpOnly, Secure, Path=/, no Domain, SameSite=lax), and commits only its SHA-256 digest to the state row.
  - /auth/callback recomputes the digest from the cookie and refuses the exchange unless it matches, via `secrets.compare_digest`. The attacker's cookie is in the attacker's jar, so the victim fails closed before the code ever reaches the token endpoint.

Three deliberate choices:

  - The cookie is checked *before* the state-store lookup, so a probe from a crafted link can't burn a user's in-flight state.
  - `SameSite=lax` is required, not a compromise: the IdP returns the user via a top-level cross-site GET, which `strict` would withhold.
  - A state row carrying no digest fails closed. Those exist only mid-deploy; honouring them would keep the hole open for the whole rollout window, which is exactly when an attacker holding a pre-minted state would strike. Cost is one retry for logins spanning the deploy.

Also adds PKCE (S256) and OIDC nonce verification end-to-end: the verifier and nonce live in the state row and never reach the browser; the verifier is sent to /oauth2/token and the nonce is compared against the ID-token claim. Both are defense in depth (code interception, token substitution) — PKCE alone would NOT have closed this finding, since the attacker drives the BFF-minted authorize URL and the stored verifier matches their code.

No Origin / Sec-Fetch-Site check was added, despite the report suggesting one: a legitimate arrival at /auth/callback *is* a top-level cross-site GET carrying `Sec-Fetch-Site: cross-site` and no `Origin`, so it is indistinguishable from the attacker's link. Rejecting on those headers would break every login and stop nothing. A test pins that those headers are still accepted and that binding carries the rejection.

Verification: the new tests were confirmed to catch the vulnerability, not just the implementation — neutering the three enforcement conditions fails 12 of them, including the full-chain test. Full backend suite is 6840 passed / 35 failed, with the 35 byte-identical to a baseline captured with this work stashed (pre-existing, in web_sources and artifact_render).

Tests:
  - test_login_csrf_regression.py (new): replays the reported chain against the real /auth/login with no hand-seeded state, covers the free-retry observation and forged cookies, plus a positive control that the originating browser still completes login.
  - test_callback.py: browser-binding, PKCE and nonce enforcement; seeded state rows now carry the binding digest.
  - test_login.py: cookie attributes, digest-only storage, per-request uniqueness, secret absent from the redirect URL, S256 challenge derivation, nonce/state agreement.

Incidental: annotate `_SAMESITE` as `Literal["lax"]`, clearing five pre-existing mypy arg-type errors on Starlette's `samesite` parameter.