### PR TITLE
fix(skills): close privilege-escalating stored XSS in skill resources

### DIFF
--- a/backend/src/apis/app_api/admin/skills/routes.py
+++ b/backend/src/apis/app_api/admin/skills/routes.py
@@ -32,6 +32,10 @@ from apis.shared.skills.models import (
     SkillRolesResponse,
     SkillUpdateRequest,
 )
+from apis.shared.skills.resource_types import (
+    resource_download_headers,
+    safe_download_content_type,
+)
 from apis.app_api.skills.service import get_skill_catalog_service
 
 logger = logging.getLogger(__name__)
@@ -331,7 +335,16 @@ async def read_skill_resource(
     filename: str,
     admin: User = Depends(require_skills_admin),
 ):
-    """Return the raw bytes of one catalog-skill reference file."""
+    """Return the raw bytes of one catalog-skill reference file.
+
+    SECURITY — the served media type is re-derived from the filename
+    (``safe_download_content_type``) instead of reflecting the stored
+    ``content_type``, and the response is ``attachment`` + ``nosniff`` + an
+    inert CSP. app-api shares an origin with the SPA, so an ``inline`` response
+    carrying a stored ``text/html`` would execute as a document in the reader's
+    authenticated session. Re-deriving at serve time also neutralizes rows
+    written before the upload allowlist existed, with no data migration.
+    """
     logger.info("Admin reading skill reference file")
 
     service = get_skill_catalog_service()
@@ -343,10 +356,8 @@ async def read_skill_resource(
 
     return Response(
         content=content,
-        media_type=ref.content_type or "application/octet-stream",
-        headers={
-            "Content-Disposition": f'inline; filename="{ref.filename}"',
-        },
+        media_type=safe_download_content_type(ref.filename),
+        headers=resource_download_headers(ref.filename),
     )
 
 

--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -49,6 +49,10 @@ from apis.shared.skills.models import (
     SkillStatus,
 )
 from apis.shared.skills.repository import get_skill_catalog_repository
+from apis.shared.skills.resource_types import (
+    resource_download_headers,
+    safe_download_content_type,
+)
 
 from .user_service import (
     UserSkillError,
@@ -402,7 +406,13 @@ async def read_my_skill_resource(
     filename: str,
     user: User = Depends(get_current_user_from_session),
 ):
-    """Return the raw bytes of one of an owned skill's supporting files."""
+    """Return the raw bytes of one of an owned skill's supporting files.
+
+    Hardened identically to the admin read route: the media type is re-derived
+    from the filename and the body is served ``attachment`` + ``nosniff`` +
+    inert CSP, so a resource can never become a script-bearing document on the
+    SPA's origin (see ``apis.shared.skills.resource_types``).
+    """
     try:
         ref, content = await get_user_skill_service().read_resource(
             skill_id, filename, user
@@ -414,8 +424,8 @@ async def read_my_skill_resource(
 
     return Response(
         content=content,
-        media_type=ref.content_type or "application/octet-stream",
-        headers={"Content-Disposition": f'inline; filename="{ref.filename}"'},
+        media_type=safe_download_content_type(ref.filename),
+        headers=resource_download_headers(ref.filename),
     )
 
 

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -30,6 +30,7 @@ from apis.shared.skills.repository import (
     get_skill_catalog_repository,
 )
 from apis.shared.skills.bundle import generate_skill_md
+from apis.shared.skills.resource_types import resolve_upload_content_type
 from apis.shared.skills.resource_store import (
     SkillResourceStore,
     SkillResourceStoreError,
@@ -322,10 +323,21 @@ class SkillCatalogService:
         garbage-collected. ``script`` files are accept-and-inert (stored,
         listed, never executed — D5).
 
+        SECURITY — the caller-supplied ``content_type`` is accepted for
+        signature compatibility and then **ignored**. The stored type is derived
+        from the filename extension against
+        ``apis.shared.skills.resource_types``' allowlist, because both tiers'
+        upload routes are reachable by an unprivileged author while the bytes
+        are downloaded by other users from the SPA's own origin. Letting a
+        caller label their upload ``text/html`` made an uploaded file a
+        same-origin script-execution primitive against whoever opened it.
+
         Returns the skill's updated manifest.
 
         Raises:
             ValueError: If the skill is missing, the kind or filename is invalid,
+                the file type is not allowed
+                (:class:`~apis.shared.skills.resource_types.SkillResourceTypeError`),
                 the file is too large, or the per-skill file cap is exceeded.
         """
         if kind not in VALID_RESOURCE_KINDS:
@@ -339,6 +351,9 @@ class SkillCatalogService:
             raise ValueError(f"Skill '{skill_id}' not found")
 
         self._validate_filename(filename)
+        # Type allowlist before any byte handling: an unacceptable filename is
+        # rejected without ever reaching S3 or the manifest.
+        resolved_type = resolve_upload_content_type(filename)
         if len(content) > MAX_RESOURCE_BYTES:
             raise ValueError(
                 f"Reference file '{filename}' is {len(content)} bytes; "
@@ -357,7 +372,6 @@ class SkillCatalogService:
                 f"{MAX_RESOURCES_PER_SKILL} reference files."
             )
 
-        resolved_type = content_type or "application/octet-stream"
         digest = compute_content_hash(content)
         s3_key = self.resource_store.put(
             skill_id=skill_id,

--- a/backend/src/apis/shared/skills/resource_types.py
+++ b/backend/src/apis/shared/skills/resource_types.py
@@ -1,0 +1,239 @@
+"""MIME policy for skill bundle files — the one place that decides what a
+skill resource may be and how it is allowed to leave the API.
+
+Why this module exists
+----------------------
+A skill resource is **content one user uploads and another user's browser
+downloads**, and app-api is served from the *same origin* as the Angular SPA
+(the CloudFront ``/api/*`` behavior). That makes an uploaded file a potential
+top-level document on the SPA's own origin: if the response says
+``Content-Type: text/html`` and ``Content-Disposition: inline``, the browser
+parses it as a document and any ``<script>`` in it runs with the *viewer's*
+session — the viewer's cookies, the viewer's CSRF token, the viewer's
+privileges. An unprivileged author uploading ``payload.html`` and getting an
+admin to open it is full privilege escalation, not a display bug.
+
+Two controls, applied at both ends, so neither one is load-bearing alone:
+
+**Write side** — :func:`resolve_upload_content_type` derives the stored media
+type from the *filename extension against an allowlist* and **ignores the
+client-supplied multipart ``Content-Type`` entirely**. A caller cannot label
+their bytes, and cannot upload an extension that is not on the list. This is
+the same posture the agent-icon route already takes (sniff the bytes, ignore
+the header) — see ``apis.shared.assistants.icons``.
+
+**Read side** — :func:`safe_download_content_type` and
+:func:`resource_download_headers` re-derive the served type from the filename
+at *serve* time and force ``attachment`` + ``nosniff`` + a no-op CSP. This is
+what protects rows written before the allowlist existed: a stored
+``content_type`` of ``text/html`` is never reflected back to a browser, so
+already-uploaded payloads are neutralized without a data migration.
+
+No entry in the allowlist is a media type a browser will execute as script in
+the page's origin. Notably absent:
+
+* ``.html`` / ``.htm`` / ``.xhtml`` / ``.xml`` / ``.svg`` — parsed as documents
+  and can carry inline script. SVG is on this list for the same reason as HTML:
+  ``image/svg+xml`` navigated to top-level is a scriptable document.
+* ``.js`` / ``.mjs`` / ``.css`` as *active* types — the extensions are allowed
+  (a skill may legitimately ship example code) but map to ``text/plain``, so
+  the bytes are readable and inert. This matches spec D5: ``script`` resources
+  are stored, listed, and never executed.
+
+Both tiers (admin catalog and user-authored "My Skills") funnel their uploads
+through ``SkillCatalogService.add_resource``, so applying the policy there
+covers both. Enforced by tests/apis/app_api/skills/test_skill_resource_mime.py.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Dict, Final
+
+# Extension → the media type we store and serve. Every value is inert: no
+# entry is parsed as a scriptable document by any browser. Source-code
+# extensions deliberately collapse to ``text/plain`` (readable, never
+# executable) rather than their "correct" active type.
+SAFE_EXTENSION_CONTENT_TYPES: Final[Dict[str, str]] = {
+    # Prose / structured text — the bread and butter of a skill bundle.
+    "md": "text/markdown",
+    "markdown": "text/markdown",
+    "txt": "text/plain",
+    "text": "text/plain",
+    "csv": "text/csv",
+    "tsv": "text/tab-separated-values",
+    "json": "application/json",
+    "jsonl": "application/json",
+    "yaml": "application/yaml",
+    "yml": "application/yaml",
+    "toml": "text/plain",
+    "ini": "text/plain",
+    "cfg": "text/plain",
+    "env": "text/plain",
+    "log": "text/plain",
+    "rst": "text/plain",
+    "tex": "text/plain",
+    # Example / helper code. Stored inert (D5): text/plain, not an active type.
+    "py": "text/plain",
+    "sh": "text/plain",
+    "bash": "text/plain",
+    "zsh": "text/plain",
+    "ps1": "text/plain",
+    "rb": "text/plain",
+    "pl": "text/plain",
+    "r": "text/plain",
+    "js": "text/plain",
+    "mjs": "text/plain",
+    "cjs": "text/plain",
+    "ts": "text/plain",
+    "jsx": "text/plain",
+    "tsx": "text/plain",
+    "css": "text/plain",
+    "sql": "text/plain",
+    "graphql": "text/plain",
+    "java": "text/plain",
+    "kt": "text/plain",
+    "go": "text/plain",
+    "rs": "text/plain",
+    "c": "text/plain",
+    "h": "text/plain",
+    "cpp": "text/plain",
+    "hpp": "text/plain",
+    "cs": "text/plain",
+    "swift": "text/plain",
+    "php": "text/plain",
+    "lua": "text/plain",
+    "dockerfile": "text/plain",
+    "diff": "text/plain",
+    "patch": "text/plain",
+    # Documents.
+    "pdf": "application/pdf",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    # Raster images only. SVG is excluded on purpose — see the module docstring.
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+    "ico": "image/vnd.microsoft.icon",
+    # Archives (a bundle may ship sample data).
+    "zip": "application/zip",
+    "gz": "application/gzip",
+    "tar": "application/x-tar",
+}
+
+# What a resource is served as when its extension is not on the allowlist.
+# Only reachable for rows written before the allowlist existed, and only on the
+# read path, which pairs it with ``attachment`` + ``nosniff``.
+FALLBACK_CONTENT_TYPE: Final[str] = "application/octet-stream"
+
+# Response headers that make a skill-resource body undownloadable *as a
+# document*, whatever its bytes or its stored type claim to be:
+#
+#   nosniff  — the browser must honor our Content-Type and must not re-sniff
+#              ``<html>`` bytes into ``text/html``.
+#   CSP      — ``default-src 'none'`` + ``sandbox`` means that even if a
+#              browser did treat the body as a document, it has no script,
+#              no fetch, and an opaque origin, so it cannot touch the SPA's
+#              session. ``frame-ancestors 'none'`` keeps it out of frames.
+#   no-store — these are per-user private files behind a session cookie;
+#              nothing on the path (CloudFront included) should retain them.
+RESOURCE_SECURITY_HEADERS: Final[Dict[str, str]] = {
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": (
+        "default-src 'none'; frame-ancestors 'none'; sandbox"
+    ),
+    "Referrer-Policy": "no-referrer",
+    "Cache-Control": "no-store",
+}
+
+# The upload-side filename guard in ``SkillCatalogService`` already forbids path
+# separators, so a header value built from a validated filename cannot break
+# out. Belt-and-braces for the read path, which also runs against legacy rows:
+# collapse anything outside the safe set before it reaches a header.
+_HEADER_SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+class SkillResourceTypeError(ValueError):
+    """An upload whose filename is not an allowed skill-resource type.
+
+    A ``ValueError`` subclass so the existing route mappers
+    (``_skill_value_error`` / ``_resource_value_error``) turn it into a 400
+    with this message, which names the extension the author actually sent.
+    """
+
+
+def resource_extension(filename: str) -> str:
+    """Return a filename's lowercase extension without the dot ('' if none).
+
+    ``Dockerfile`` (and any other extension-less name whose stem is itself a
+    known type key) resolves through its stem, so a bundle can ship one.
+    """
+    name = os.path.basename(filename or "").strip()
+    stem, _, ext = name.rpartition(".")
+    if not stem:  # no dot at all — try the whole name as a type key
+        return name.lower() if name.lower() in SAFE_EXTENSION_CONTENT_TYPES else ""
+    return ext.lower()
+
+
+def is_allowed_resource_filename(filename: str) -> bool:
+    """True when ``filename``'s extension is on the allowlist."""
+    return resource_extension(filename) in SAFE_EXTENSION_CONTENT_TYPES
+
+
+def resolve_upload_content_type(filename: str) -> str:
+    """The media type to store for an upload, derived from its filename.
+
+    The client-supplied multipart ``Content-Type`` is deliberately **not** a
+    parameter: it is attacker-controlled and was the write half of the stored-XSS
+    chain this module exists to close.
+
+    Raises:
+        SkillResourceTypeError: The extension is missing or not allowed. The
+            message names what was sent so an author can rename or convert.
+    """
+    ext = resource_extension(filename)
+    content_type = SAFE_EXTENSION_CONTENT_TYPES.get(ext)
+    if content_type is None:
+        sent = f"'.{ext}'" if ext else "no recognized extension"
+        raise SkillResourceTypeError(
+            f"File type not allowed for skill resources ({sent}). "
+            "Skill files must be documents, data, images, or plain-text code — "
+            "web documents such as .html, .htm, .xhtml, .xml and .svg are not "
+            "accepted because they can execute script in a reader's browser. "
+            f"Allowed extensions: {', '.join(sorted(SAFE_EXTENSION_CONTENT_TYPES))}."
+        )
+    return content_type
+
+
+def safe_download_content_type(filename: str) -> str:
+    """The media type to *serve*, re-derived from the filename at read time.
+
+    Never returns the stored ``content_type``. Rows written before the upload
+    allowlist existed can carry ``text/html``; reflecting that is exactly the
+    bug. An unrecognized extension serves as ``application/octet-stream``.
+    """
+    return SAFE_EXTENSION_CONTENT_TYPES.get(
+        resource_extension(filename), FALLBACK_CONTENT_TYPE
+    )
+
+
+def resource_download_headers(filename: str) -> Dict[str, str]:
+    """Full response headers for serving one skill resource's bytes.
+
+    ``attachment``, not ``inline``: both callers of the read routes are the SPA
+    fetching the body over XHR (``responseType: 'text'``) to render it in an
+    in-app viewer, so nothing legitimate depends on the browser rendering this
+    URL as a document — and ``attachment`` is what stops a hand-shared link
+    from becoming a top-level document on the SPA's origin.
+    """
+    safe_name = _HEADER_SAFE_FILENAME_RE.sub("_", os.path.basename(filename or ""))
+    safe_name = safe_name.strip(" ._") or "resource"
+    return {
+        "Content-Disposition": f'attachment; filename="{safe_name}"',
+        **RESOURCE_SECURITY_HEADERS,
+    }

--- a/backend/tests/apis/app_api/skills/test_skill_resource_mime.py
+++ b/backend/tests/apis/app_api/skills/test_skill_resource_mime.py
@@ -1,0 +1,400 @@
+"""Regression tests for the skill-resource stored-XSS chain.
+
+The bug: **an unprivileged author could plant a script that executed with a
+system_admin's session on the SPA's own origin.** Two failures chained.
+
+1. *Write side.* ``POST /skills/mine/{id}/resources`` is reachable by any
+   authenticated user and persisted the **client-supplied multipart
+   Content-Type verbatim** with no allowlist, so an ``.html`` file could be
+   stored as ``text/html``.
+2. *Read side.* The read routes reflected that stored type as the HTTP response
+   media type together with ``Content-Disposition: inline``. app-api shares an
+   origin with the Angular SPA (the CloudFront ``/api/*`` behavior), so the
+   uploaded file parsed as a **top-level HTML document on the SPA's origin** and
+   its inline ``<script>`` ran with the viewer's session — reading the
+   non-httpOnly CSRF cookie and driving authenticated admin calls.
+
+Both halves are pinned here, plus the case that matters most operationally: a
+row written *before* the allowlist existed (``content_type == "text/html"``)
+must be neutralized on the read path, because the fix ships without a data
+migration.
+"""
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.admin.skills import routes as admin_skill_routes
+from apis.app_api.skills import routes as my_skill_routes
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.skills.resource_types import (
+    SAFE_EXTENSION_CONTENT_TYPES,
+    SkillResourceTypeError,
+    resolve_upload_content_type,
+    resource_download_headers,
+    safe_download_content_type,
+)
+from tests.conftest import override_admin_auth
+
+from .conftest import AWS_REGION, SKILL_RESOURCES_BUCKET
+
+# The payload from the report, verbatim in shape.
+XSS_PAYLOAD = (
+    b"<html><body><h1>XSS Verify</h1><script>"
+    b"document.title='XSSEXEC|'+document.domain;"
+    b"alert('XSS on '+document.domain+' cookie='+document.cookie);"
+    b"</script></body></html>"
+)
+
+# Every extension that turns a response body into a scriptable document.
+ACTIVE_DOCUMENT_FILENAMES = [
+    "vx.html",
+    "vx.htm",
+    "vx.xhtml",
+    "vx.xml",
+    "vx.svg",
+    "vx.shtml",
+    "vx.mhtml",
+    "vx.xht",
+]
+
+
+# ---------------------------------------------------------------------------
+# Policy module — the allowlist itself
+# ---------------------------------------------------------------------------
+
+
+class TestResourceTypePolicy:
+    @pytest.mark.parametrize("filename", ACTIVE_DOCUMENT_FILENAMES)
+    def test_active_document_extensions_are_refused(self, filename):
+        with pytest.raises(SkillResourceTypeError):
+            resolve_upload_content_type(filename)
+
+    def test_client_supplied_content_type_is_not_a_parameter(self):
+        """The signature itself is the control: there is nothing to spoof.
+
+        The vulnerability was that the multipart header reached storage. If a
+        future refactor reintroduces a caller-supplied type argument, this fails.
+        """
+        import inspect
+
+        params = list(inspect.signature(resolve_upload_content_type).parameters)
+        assert params == ["filename"]
+
+    def test_allowlist_contains_no_scriptable_media_type(self):
+        """No allowlist value may be a type a browser parses as a document."""
+        forbidden = {
+            "text/html",
+            "application/xhtml+xml",
+            "image/svg+xml",
+            "text/xml",
+            "application/xml",
+            "text/javascript",
+            "application/javascript",
+            "application/x-shockwave-flash",
+        }
+        assert forbidden.isdisjoint(set(SAFE_EXTENSION_CONTENT_TYPES.values()))
+
+    def test_code_extensions_store_as_inert_plain_text(self):
+        """D5: script resources are stored, listed, and never executable."""
+        for ext in ("js", "mjs", "ts", "py", "sh", "css"):
+            assert resolve_upload_content_type(f"example.{ext}") == "text/plain"
+
+    def test_ordinary_bundle_types_still_work(self):
+        assert resolve_upload_content_type("forms.md") == "text/markdown"
+        assert resolve_upload_content_type("data.json") == "application/json"
+        assert resolve_upload_content_type("chart.png") == "image/png"
+        assert resolve_upload_content_type("manual.pdf") == "application/pdf"
+
+    def test_extension_match_is_case_insensitive(self):
+        """``.HTML`` must not slip past a lowercase-only comparison."""
+        with pytest.raises(SkillResourceTypeError):
+            resolve_upload_content_type("vx.HTML")
+        assert resolve_upload_content_type("FORMS.MD") == "text/markdown"
+
+    def test_double_extension_resolves_on_the_last_one(self):
+        """``notes.md.html`` is an HTML file, not a markdown file."""
+        with pytest.raises(SkillResourceTypeError):
+            resolve_upload_content_type("notes.md.html")
+
+    def test_extensionless_filename_is_refused(self):
+        with pytest.raises(SkillResourceTypeError):
+            resolve_upload_content_type("payload")
+
+    def test_refusal_message_names_the_extension(self):
+        """An author who is blocked needs to know what to rename or convert."""
+        with pytest.raises(SkillResourceTypeError, match=r"\.html"):
+            resolve_upload_content_type("vx.html")
+
+    def test_download_type_never_reflects_an_active_type(self):
+        for filename in ACTIVE_DOCUMENT_FILENAMES:
+            assert safe_download_content_type(filename) == "application/octet-stream"
+
+    def test_download_headers_are_attachment_nosniff_and_inert_csp(self):
+        headers = resource_download_headers("vx.html")
+        assert headers["Content-Disposition"].startswith("attachment;")
+        assert "inline" not in headers["Content-Disposition"]
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert "default-src 'none'" in headers["Content-Security-Policy"]
+        assert "sandbox" in headers["Content-Security-Policy"]
+
+    def test_download_headers_cannot_be_broken_out_of(self):
+        """A quote or CRLF in a legacy filename must not reach a header value."""
+        headers = resource_download_headers('a".md\r\nX-Evil: 1')
+        value = headers["Content-Disposition"]
+        assert '"' not in value.removeprefix('attachment; filename="').removesuffix('"')
+        assert "\r" not in value and "\n" not in value
+
+
+# ---------------------------------------------------------------------------
+# Write side — the unprivileged upload route
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def author_client(user_skill_service, author_user, monkeypatch):
+    """The attacker in the report: authenticated, zero admin privilege."""
+    monkeypatch.setattr(
+        my_skill_routes, "get_user_skill_service", lambda: user_skill_service
+    )
+    app = FastAPI()
+    app.include_router(my_skill_routes.router)
+    app.dependency_overrides[get_current_user_from_session] = lambda: author_user
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def admin_client(skill_service, admin_user, monkeypatch):
+    """The victim in the report: an ``admin.skills`` holder reading a resource."""
+    monkeypatch.setattr(
+        admin_skill_routes, "get_skill_catalog_service", lambda: skill_service
+    )
+    app = FastAPI()
+    app.include_router(admin_skill_routes.router)
+    override_admin_auth(app, lambda: admin_user)
+    return TestClient(app)
+
+
+def _create_my_skill(client, name="Verify XSS Skill QQ") -> str:
+    resp = client.post(
+        "/skills/mine",
+        json={"displayName": name, "description": "security verification"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["skillId"]
+
+
+def _upload_mine(client, skill_id, filename, body, content_type, kind="reference"):
+    return client.post(
+        f"/skills/mine/{skill_id}/resources",
+        files={"file": (filename, body, content_type)},
+        data={"kind": kind},
+    )
+
+
+class TestUnprivilegedUploadIsAllowlisted:
+    def test_html_upload_is_rejected(self, author_client):
+        """Step 4 of the report: the upload that planted the payload."""
+        skill_id = _create_my_skill(author_client)
+        resp = _upload_mine(
+            author_client, skill_id, "vx.html", XSS_PAYLOAD, "text/html"
+        )
+        assert resp.status_code == 400, resp.text
+        assert "not allowed" in resp.json()["detail"].lower()
+
+        # Nothing was persisted — not in the manifest, not in S3.
+        manifest = author_client.get(f"/skills/mine/{skill_id}/resources").json()
+        assert manifest["resources"] == []
+        s3 = boto3.client("s3", region_name=AWS_REGION)
+        keys = [
+            o["Key"]
+            for o in s3.list_objects_v2(Bucket=SKILL_RESOURCES_BUCKET).get(
+                "Contents", []
+            )
+        ]
+        assert not any(k.endswith("vx.html") for k in keys)
+
+    @pytest.mark.parametrize("filename", ACTIVE_DOCUMENT_FILENAMES)
+    def test_every_active_document_extension_is_rejected(
+        self, author_client, filename
+    ):
+        skill_id = _create_my_skill(author_client)
+        resp = _upload_mine(
+            author_client, skill_id, filename, XSS_PAYLOAD, "text/html"
+        )
+        assert resp.status_code == 400, f"{filename} was accepted"
+
+    def test_html_payload_under_a_markdown_name_is_stored_as_markdown(
+        self, author_client
+    ):
+        """Bytes are not sniffed — the *served type* is what disarms them.
+
+        ``.md`` is allowed and HTML bytes inside a markdown file are legitimate
+        (a documentation snippet), so this upload succeeds. What makes it inert
+        is that it is stored and served as ``text/markdown`` with ``attachment``
+        + ``nosniff``, never as a document.
+        """
+        skill_id = _create_my_skill(author_client)
+        resp = _upload_mine(
+            author_client, skill_id, "vx.md", XSS_PAYLOAD, "text/html"
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["resources"][0]["contentType"] == "text/markdown"
+
+    def test_declared_content_type_is_ignored_entirely(self, author_client):
+        """The multipart header is attacker-controlled and must not be stored."""
+        skill_id = _create_my_skill(author_client)
+        resp = _upload_mine(
+            author_client, skill_id, "notes.md", b"# notes", "text/html"
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["resources"][0]["contentType"] == "text/markdown"
+
+    def test_script_kind_does_not_bypass_the_allowlist(self, author_client):
+        """``kind=script`` is about bundle layout, not about type freedom."""
+        skill_id = _create_my_skill(author_client)
+        resp = _upload_mine(
+            author_client,
+            skill_id,
+            "vx.html",
+            XSS_PAYLOAD,
+            "text/html",
+            kind="script",
+        )
+        assert resp.status_code == 400
+
+
+class TestAdminUploadIsAllowlisted:
+    """The admin catalog tier shares the code path and the same policy."""
+
+    def _create_catalog_skill(self, admin_client, skill_id="pdf_workflows"):
+        resp = admin_client.post(
+            "/skills/",
+            json={
+                "skillId": skill_id,
+                "displayName": "PDF Workflows",
+                "description": "Fill, merge and split PDFs.",
+                "instructions": "# PDF Workflows",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        return skill_id
+
+    def test_html_upload_is_rejected(self, admin_client):
+        skill_id = self._create_catalog_skill(admin_client)
+        resp = admin_client.post(
+            f"/skills/{skill_id}/resources",
+            files={"file": ("vx.html", XSS_PAYLOAD, "text/html")},
+        )
+        assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Read side — a legacy row must be neutralized without a data migration
+# ---------------------------------------------------------------------------
+
+
+def _plant_legacy_html_resource(service, skill_id, filename="vx.html"):
+    """Write a manifest entry the way the *vulnerable* upload path would have.
+
+    Goes straight at the repository and the store, deliberately bypassing
+    ``add_resource``, because the point is to reproduce a row that already
+    exists in a deployed environment: ``content_type == "text/html"``.
+    """
+    from apis.shared.skills.models import SkillResourceRef
+    from apis.shared.skills.resource_store import compute_content_hash
+
+    key = service.resource_store.put(
+        skill_id=skill_id,
+        filename=filename,
+        content=XSS_PAYLOAD,
+        content_type="text/html",
+        kind="reference",
+    )
+    ref = SkillResourceRef(
+        filename=filename,
+        content_hash=compute_content_hash(XSS_PAYLOAD),
+        size=len(XSS_PAYLOAD),
+        content_type="text/html",  # the poisoned value
+        s3_key=key,
+        kind="reference",
+    )
+    return ref
+
+
+def _assert_response_cannot_execute(resp):
+    """The response body may be the payload; it may not be a document."""
+    assert resp.status_code == 200, resp.text
+    assert resp.content == XSS_PAYLOAD  # bytes are still readable by the SPA
+    assert "text/html" not in resp.headers["content-type"]
+    assert resp.headers["content-type"].startswith("application/octet-stream")
+    assert resp.headers["content-disposition"].startswith("attachment;")
+    assert "inline" not in resp.headers["content-disposition"]
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert "default-src 'none'" in resp.headers["content-security-policy"]
+
+
+class TestLegacyRowIsNeutralizedOnRead:
+    @pytest.mark.asyncio
+    async def test_admin_read_of_a_legacy_html_row(
+        self, admin_client, skill_service, admin_user
+    ):
+        """Step 5 of the report: the request that executed the script."""
+        admin_client.post(
+            "/skills/",
+            json={
+                "skillId": "legacy_skill",
+                "displayName": "Legacy",
+                "description": "d",
+                "instructions": "i",
+            },
+        )
+        ref = _plant_legacy_html_resource(skill_service, "legacy_skill")
+        await skill_service.repository.update_skill(
+            "legacy_skill", {"resources": [ref]}, admin_user_id=admin_user.user_id
+        )
+
+        resp = admin_client.get("/skills/legacy_skill/resources/vx.html")
+        _assert_response_cannot_execute(resp)
+
+    @pytest.mark.asyncio
+    async def test_owner_read_of_a_legacy_html_row(
+        self, author_client, user_skill_service, author_user
+    ):
+        """The owner-tier read route is hardened identically."""
+        skill_id = _create_my_skill(author_client, "Legacy Mine")
+        ref = _plant_legacy_html_resource(
+            user_skill_service.catalog_service, skill_id
+        )
+        await user_skill_service.repository.update_skill(
+            skill_id, {"resources": [ref]}, admin_user_id=author_user.user_id
+        )
+
+        resp = author_client.get(f"/skills/mine/{skill_id}/resources/vx.html")
+        _assert_response_cannot_execute(resp)
+
+
+class TestHardenedHeadersOnOrdinaryReads:
+    def test_markdown_read_keeps_its_type_but_gains_the_headers(
+        self, author_client
+    ):
+        """The SPA reads these over XHR as text, so ``attachment`` is safe."""
+        skill_id = _create_my_skill(author_client, "Notes Skill")
+        _upload_mine(author_client, skill_id, "forms.md", b"# Forms", "text/markdown")
+
+        resp = author_client.get(f"/skills/mine/{skill_id}/resources/forms.md")
+        assert resp.status_code == 200
+        assert resp.content == b"# Forms"
+        assert resp.headers["content-type"].startswith("text/markdown")
+        assert resp.headers["content-disposition"].startswith("attachment;")
+        assert resp.headers["x-content-type-options"] == "nosniff"
+
+    def test_no_read_route_serves_inline(self):
+        """Pins the header both tiers regressed on, at the source level."""
+        import inspect
+
+        for module in (my_skill_routes, admin_skill_routes):
+            source = inspect.getsource(module)
+            assert "inline; filename=" not in source, module.__name__

--- a/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
+++ b/frontend/ai.client/src/app/admin/skills/pages/skill-form.page.ts
@@ -30,6 +30,11 @@ import {
   parseSkillMarkdown,
   slugifySkillId,
 } from '../models/skill-import.util';
+import {
+  DISALLOWED_RESOURCE_MESSAGE,
+  RESOURCE_ACCEPT_ATTR,
+  isAllowedResourceFilename,
+} from '../../../shared/skills/skill-resource-types';
 
 @Component({
   selector: 'app-skill-form',
@@ -233,7 +238,7 @@ import {
                   id="refUpload"
                   type="file"
                   multiple
-                  accept=".md,.markdown,.txt,text/markdown,text/plain"
+                  [attr.accept]="acceptedFileTypes"
                   class="sr-only"
                   [disabled]="resourceBusy()"
                   (change)="onRefFilesSelected($event)"
@@ -407,6 +412,8 @@ export class SkillFormPage implements OnInit {
   readonly resources = signal<SkillResourceRef[]>([]);
   readonly pendingFiles = signal<File[]>([]);
   readonly resourceBusy = signal(false);
+  /** `accept` filter for the file picker — mirrors the server allowlist. */
+  readonly acceptedFileTypes = RESOURCE_ACCEPT_ATTR;
   readonly viewing = signal<{ filename: string; content: string } | null>(null);
 
   // Inline new-file authoring.
@@ -530,6 +537,16 @@ export class SkillFormPage implements OnInit {
    * after the skill is created, since uploads need a skill_id).
    */
   private async acceptFiles(files: File[]): Promise<void> {
+    // Mirror of the backend type allowlist (see `resource_types.py`). The
+    // server rejects these with a 400 regardless; refusing here gives the
+    // admin a specific message instead of a failed round-trip.
+    const disallowed = files.filter((f) => !isAllowedResourceFilename(f.name));
+    if (disallowed.length > 0) {
+      this.error.set(
+        `${disallowed.map((f) => f.name).join(', ')} ${DISALLOWED_RESOURCE_MESSAGE}`,
+      );
+      return;
+    }
     if (this.isEditMode()) {
       const id = this.skillId()!;
       this.resourceBusy.set(true);

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.html
@@ -161,6 +161,7 @@
             id="resource-upload"
             type="file"
             multiple
+            [attr.accept]="acceptedFileTypes"
             class="sr-only"
             [disabled]="uploading()"
             (change)="onFilesSelected($event)"

--- a/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
+++ b/frontend/ai.client/src/app/my-skills/my-skill-form.page.ts
@@ -10,6 +10,11 @@ import {
 } from '@ng-icons/heroicons/outline';
 import { parseSkillMarkdown } from '../admin/skills/models/skill-import.util';
 import {
+  DISALLOWED_RESOURCE_MESSAGE,
+  RESOURCE_ACCEPT_ATTR,
+  isAllowedResourceFilename,
+} from '../shared/skills/skill-resource-types';
+import {
   MAX_RESOURCE_BYTES,
   MAX_RESOURCES_PER_SKILL,
   MySkillResourceRef,
@@ -45,6 +50,8 @@ export class MySkillFormPage {
 
   protected readonly resourceKinds = RESOURCE_KINDS;
   protected readonly maxFiles = MAX_RESOURCES_PER_SKILL;
+  /** `accept` filter for the file picker — the allowed extensions. */
+  protected readonly acceptedFileTypes = RESOURCE_ACCEPT_ATTR;
 
   protected readonly skillId = signal<string | null>(null);
   protected readonly isEdit = computed(() => this.skillId() !== null);
@@ -160,6 +167,18 @@ export class MySkillFormPage {
     if (oversized.length > 0) {
       this.error.set(
         `${oversized.map((f) => f.name).join(', ')} exceeds the 1 MB per-file limit.`,
+      );
+      return;
+    }
+    // Mirror of the backend type allowlist. The server is the control (it
+    // rejects these with a 400); this just turns that into an immediate,
+    // specific message instead of a failed round-trip. Web-document types are
+    // refused because a resource is downloaded by other users from this app's
+    // own origin, where a rendered document could run script in their session.
+    const disallowed = files.filter((f) => !isAllowedResourceFilename(f.name));
+    if (disallowed.length > 0) {
+      this.error.set(
+        `${disallowed.map((f) => f.name).join(', ')} ${DISALLOWED_RESOURCE_MESSAGE}`,
       );
       return;
     }

--- a/frontend/ai.client/src/app/shared/skills/skill-resource-types.spec.ts
+++ b/frontend/ai.client/src/app/shared/skills/skill-resource-types.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards the client mirror of the skill-resource type allowlist.
+ *
+ * The server is the real control, but this mirror decides what the file picker
+ * offers and what the forms refuse locally — so it must never drift open on the
+ * dangerous extensions. The stored-XSS chain these tests exist for: a
+ * `.html` skill resource served from the SPA's own origin executed its inline
+ * `<script>` in a reading admin's authenticated session.
+ */
+import {
+  ALLOWED_RESOURCE_EXTENSIONS,
+  RESOURCE_ACCEPT_ATTR,
+  isAllowedResourceFilename,
+} from './skill-resource-types';
+
+describe('skill resource type allowlist (client mirror)', () => {
+  const SCRIPTABLE = [
+    'html',
+    'htm',
+    'xhtml',
+    'xht',
+    'xml',
+    'svg',
+    'shtml',
+    'mhtml',
+    'swf',
+  ];
+
+  it('excludes every scriptable document extension', () => {
+    for (const ext of SCRIPTABLE) {
+      expect(ALLOWED_RESOURCE_EXTENSIONS).not.toContain(ext);
+      expect(isAllowedResourceFilename(`payload.${ext}`)).toBe(false);
+    }
+  });
+
+  it('rejects a scriptable extension regardless of case', () => {
+    expect(isAllowedResourceFilename('payload.HTML')).toBe(false);
+    expect(isAllowedResourceFilename('payload.SvG')).toBe(false);
+  });
+
+  it('resolves on the last extension, not the first', () => {
+    // `notes.md.html` is an HTML file; matching on `.md` would wave it through.
+    expect(isAllowedResourceFilename('notes.md.html')).toBe(false);
+    expect(isAllowedResourceFilename('notes.html.md')).toBe(true);
+  });
+
+  it('accepts the ordinary bundle file types', () => {
+    for (const name of ['forms.md', 'data.json', 'chart.png', 'manual.pdf']) {
+      expect(isAllowedResourceFilename(name)).toBe(true);
+    }
+  });
+
+  it('rejects an empty or extension-less name', () => {
+    expect(isAllowedResourceFilename('')).toBe(false);
+    expect(isAllowedResourceFilename('payload')).toBe(false);
+  });
+
+  it('builds a dotted accept attribute with no scriptable type', () => {
+    expect(RESOURCE_ACCEPT_ATTR).toContain('.md');
+    for (const ext of SCRIPTABLE) {
+      expect(RESOURCE_ACCEPT_ATTR.split(',')).not.toContain(`.${ext}`);
+    }
+  });
+});

--- a/frontend/ai.client/src/app/shared/skills/skill-resource-types.ts
+++ b/frontend/ai.client/src/app/shared/skills/skill-resource-types.ts
@@ -1,0 +1,60 @@
+/**
+ * Client mirror of the skill-resource type allowlist.
+ *
+ * Canonical source: `backend/src/apis/shared/skills/resource_types.py`
+ * (`SAFE_EXTENSION_CONTENT_TYPES`). **The server is the control** — it rejects a
+ * disallowed upload with a 400 whatever the client does. This module exists so
+ * the file picker can filter and a rejected file produces an immediate,
+ * specific message instead of a failed round-trip.
+ *
+ * Web-document extensions (`.html`, `.htm`, `.xhtml`, `.xml`, `.svg`) are
+ * absent deliberately. A skill resource is uploaded by one user and downloaded
+ * by others from **this app's own origin**, so a resource a browser renders as
+ * a document could execute script inside a reader's authenticated session.
+ * Source-code extensions are allowed but are stored and served as plain text.
+ *
+ * Keep this list in sync with the Python allowlist when either changes.
+ */
+
+/** Extensions (without the dot) the backend accepts for a skill resource. */
+export const ALLOWED_RESOURCE_EXTENSIONS: readonly string[] = [
+  // Prose / structured text
+  'md', 'markdown', 'txt', 'text', 'csv', 'tsv', 'json', 'jsonl', 'yaml', 'yml',
+  'toml', 'ini', 'cfg', 'env', 'log', 'rst', 'tex',
+  // Example / helper code — stored and served as inert plain text
+  'py', 'sh', 'bash', 'zsh', 'ps1', 'rb', 'pl', 'r', 'js', 'mjs', 'cjs', 'ts',
+  'jsx', 'tsx', 'css', 'sql', 'graphql', 'java', 'kt', 'go', 'rs', 'c', 'h',
+  'cpp', 'hpp', 'cs', 'swift', 'php', 'lua', 'dockerfile', 'diff', 'patch',
+  // Documents
+  'pdf', 'docx', 'xlsx', 'pptx',
+  // Raster images only — SVG is a scriptable document
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico',
+  // Archives
+  'zip', 'gz', 'tar',
+];
+
+/** Value for the `accept` attribute of a skill-resource file input. */
+export const RESOURCE_ACCEPT_ATTR = ALLOWED_RESOURCE_EXTENSIONS.map(
+  (ext) => `.${ext}`,
+).join(',');
+
+/**
+ * True when a filename's extension is one the backend will accept.
+ *
+ * Resolves on the LAST extension, matching the server, so `notes.md.html` is
+ * correctly treated as HTML rather than markdown. An extension-less name is
+ * accepted only if the whole name is itself a known type key (`Dockerfile`).
+ */
+export function isAllowedResourceFilename(filename: string): boolean {
+  const name = (filename ?? '').trim().toLowerCase();
+  if (!name) return false;
+  const dot = name.lastIndexOf('.');
+  const key = dot === -1 ? name : name.slice(dot + 1);
+  return ALLOWED_RESOURCE_EXTENSIONS.includes(key);
+}
+
+/** The message shown when a file is refused, shared by both skill forms. */
+export const DISALLOWED_RESOURCE_MESSAGE =
+  'is not an accepted file type. Skill files must be documents, data, images, ' +
+  'or plain-text code — web documents such as .html and .svg are not accepted ' +
+  "because they can run script in a reader's browser.";

--- a/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
+++ b/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
@@ -184,6 +184,57 @@ function handler(event) {
       keepaliveTimeout: cdk.Duration.seconds(60),
     });
 
+    // Security headers for the /api/* behavior. Distinct from the SPA policy
+    // above: an API response must never be usable as a *document*, and the SPA
+    // policy's `frame-src` allowances are irrelevant here.
+    //
+    // This matters because /api/* is served from the SAME origin as the SPA, so
+    // any API response a browser can be navigated to is a potential document on
+    // the SPA's origin. app-api serves user-uploaded bytes (skill resources,
+    // agent icons, exports); without `nosniff` a browser may re-sniff those
+    // bytes into text/html, and without a CSP an HTML-typed body would execute
+    // script with the viewer's session cookie and CSRF token. The app-api routes
+    // apply the same controls per-response — this policy is the origin-wide
+    // backstop so a future route cannot regress the whole origin.
+    //
+    // `default-src 'none'` is the load-bearing directive: in a document it
+    // blocks inline `<script>`, external script, and every fetch, so an
+    // HTML-typed API body has no way to reach the SPA's session even if a
+    // browser does render it. `sandbox` is deliberately NOT set here (unlike on
+    // the skill-resource responses themselves, which are only ever read over
+    // XHR): the edge policy covers every /api/* response including
+    // `Content-Disposition: attachment` bodies and OAuth navigations, and an
+    // opaque-origin directive on that whole surface risks breaking a download
+    // for no additional protection over `default-src 'none'`.
+    const apiResponseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      'ApiResponseHeadersPolicy',
+      {
+        responseHeadersPolicyName: getResourceName(config, 'api-headers'),
+        comment: 'Security headers for /api/* (same-origin document defense)',
+        securityHeadersBehavior: {
+          contentTypeOptions: { override: true },
+          frameOptions: {
+            frameOption: cloudfront.HeadersFrameOption.DENY,
+            override: true,
+          },
+          referrerPolicy: {
+            referrerPolicy: cloudfront.HeadersReferrerPolicy.NO_REFERRER,
+            override: true,
+          },
+          strictTransportSecurity: {
+            accessControlMaxAge: cdk.Duration.seconds(31536000),
+            includeSubdomains: true,
+            override: true,
+          },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: "default-src 'none'; frame-ancestors 'none'",
+            override: true,
+          },
+        },
+      },
+    );
+
     const apiBehavior: cloudfront.BehaviorOptions = {
       origin: appApiOrigin,
       viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -192,6 +243,7 @@ function handler(event) {
       cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
       originRequestPolicy:
         cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+      responseHeadersPolicy: apiResponseHeadersPolicy,
       compress: false,
       functionAssociations: [
         {

--- a/infrastructure/test/api-security-headers.test.ts
+++ b/infrastructure/test/api-security-headers.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression cover for the `/api/*` behavior's response-headers policy.
+ *
+ * app-api is served from the SAME CloudFront distribution — and therefore the
+ * same browser origin — as the Angular SPA. The `/api/*` behavior originally
+ * carried no `responseHeadersPolicy` at all, so API responses shipped with
+ * neither `X-Content-Type-Options: nosniff` nor a `Content-Security-Policy`
+ * while `GET /` (the SPA) had both. That gap was the read half of a stored-XSS
+ * privilege escalation: a user-uploaded skill resource served as
+ * `text/html; charset=utf-8` with `Content-Disposition: inline` parsed as a
+ * top-level document on the SPA's origin and executed its inline `<script>`
+ * with the victim admin's session cookie and CSRF token.
+ *
+ * The app-api routes now harden their own responses, but this policy is the
+ * origin-wide backstop: it means no future route can regress the whole origin
+ * by forgetting a header. Both halves are asserted here.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { loadConfig } from '../lib/config';
+import { PlatformStack } from '../lib/platform-stack';
+import { mockSsmContext, MOCK_ACCOUNT, MOCK_REGION } from './helpers/mock-config';
+
+/** Seed every context value loadConfig requires. */
+function seedRequiredContext(app: cdk.App): void {
+  app.node.setContext('projectPrefix', 'test-project');
+  app.node.setContext('awsRegion', MOCK_REGION);
+  app.node.setContext('awsAccount', MOCK_ACCOUNT);
+  app.node.setContext('vpcCidr', '10.0.0.0/16');
+  app.node.setContext('production', false);
+  app.node.setContext('retainDataOnDelete', false);
+  app.node.setContext('frontend', { cloudFrontPriceClass: 'PriceClass_100' });
+  app.node.setContext('appApi', { cpu: 256, memory: 512, desiredCount: 1, maxCapacity: 2 });
+  app.node.setContext('inferenceApi', {});
+  app.node.setContext('fineTuning', {});
+  app.node.setContext('artifacts', { retentionDays: 90, extraFrameAncestors: [] });
+  app.node.setContext('mcpSandbox', { extraFrameAncestors: [] });
+  app.node.setContext('ragIngestion', {
+    additionalCorsOrigins: '',
+    lambdaMemorySize: 10240,
+    lambdaTimeout: 900,
+    embeddingModel: 'amazon.titan-embed-text-v2',
+    vectorDimension: 1024,
+    vectorDistanceMetric: 'cosine',
+  });
+}
+
+function synth(): Template {
+  const app = new cdk.App();
+  seedRequiredContext(app);
+  const config = loadConfig(app);
+  mockSsmContext(app, config);
+  const stack = new PlatformStack(app, 'ApiHeadersPlatformStack', {
+    config,
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  return Template.fromStack(stack);
+}
+
+describe('/api/* security response headers', () => {
+  it('defines a dedicated api-headers policy with nosniff and an inert CSP', () => {
+    synth().hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+      ResponseHeadersPolicyConfig: {
+        Name: 'test-project-api-headers',
+        SecurityHeadersConfig: {
+          // Without nosniff a browser may re-sniff `<html>` bytes served as
+          // octet-stream back into text/html.
+          ContentTypeOptions: { Override: true },
+          // `default-src 'none'` blocks inline and external script, so an
+          // HTML-typed API body cannot reach the SPA's session even if a
+          // browser renders it.
+          ContentSecurityPolicy: {
+            ContentSecurityPolicy: "default-src 'none'; frame-ancestors 'none'",
+            Override: true,
+          },
+          FrameOptions: { FrameOption: 'DENY', Override: true },
+          ReferrerPolicy: { ReferrerPolicy: 'no-referrer', Override: true },
+        },
+      },
+    });
+  });
+
+  it('attaches the policy to the /api/* cache behavior', () => {
+    const template = synth();
+    const distributions = template.findResources('AWS::CloudFront::Distribution');
+
+    // The SPA distribution is the one carrying the /api/* behavior.
+    const spa = Object.values(distributions).find((d) =>
+      (d.Properties?.DistributionConfig?.CacheBehaviors ?? []).some(
+        (b: { PathPattern?: string }) => b.PathPattern === '/api/*',
+      ),
+    );
+    expect(spa).toBeDefined();
+
+    const apiBehavior = spa!.Properties.DistributionConfig.CacheBehaviors.find(
+      (b: { PathPattern?: string }) => b.PathPattern === '/api/*',
+    );
+    expect(apiBehavior.ResponseHeadersPolicyId).toBeDefined();
+
+    // ...and it is the api policy, not the SPA's (whose CSP only sets
+    // frame-src and would leave script-src unconstrained on /api/*).
+    const policies = template.findResources('AWS::CloudFront::ResponseHeadersPolicy');
+    const apiPolicyLogicalId = Object.entries(policies).find(
+      ([, p]) =>
+        p.Properties?.ResponseHeadersPolicyConfig?.Name === 'test-project-api-headers',
+    )?.[0];
+    expect(apiPolicyLogicalId).toBeDefined();
+    expect(apiBehavior.ResponseHeadersPolicyId).toEqual({ Ref: apiPolicyLogicalId });
+  });
+});


### PR DESCRIPTION
An authenticated, zero-privilege user could plant JavaScript that later executed on the SPA's own origin inside a system_admin's authenticated browser session (finding f-317ac252). Two control failures chained:

1. WRITE — the skill-resource upload routes persisted the client-supplied multipart Content-Type verbatim with no allowlist, and permitted an .html filename, so an ordinary user could store bytes labelled text/html.
2. READ — the read routes reflected that stored type as the response media type with `Content-Disposition: inline`, and the CloudFront /api/* behavior carried no response-headers policy, so responses shipped without nosniff and without a CSP (GET / had both). Because app-api is served from the same origin as the Angular SPA, the uploaded file parsed as a top-level HTML document and its inline <script> ran with the viewer's session — reading the non-httpOnly CSRF cookie and making arbitrary state-changing admin calls drivable as system_admin.

Three independent layers, so no single one is load-bearing:

* Upload allowlist. New `apis/shared/skills/resource_types.py` derives the stored media type from the filename extension against an allowlist whose every value is inert, and ignores the client-supplied Content-Type entirely — the same posture the agent-icon route already takes. .html/.htm/.xhtml/.xml/.svg are refused; source-code extensions are allowed but collapse to text/plain, matching the existing spec-D5 rule that script resources are stored inert. Applied in `SkillCatalogService.add_resource`, which both the admin catalog tier and the user-authored "My Skills" tier funnel through.

* Read hardening. Both read routes now re-derive the served type from the filename instead of reflecting the row, and respond with `attachment` + `X-Content-Type-Options: nosniff` + `default-src 'none'; frame-ancestors 'none'; sandbox`. Re-deriving at serve time is what neutralizes rows written before the allowlist existed, so no data migration is needed. `attachment` is safe because both SPA callers fetch these over XHR as text for an in-app viewer; nothing navigates to the URL.

* Edge backstop. The CloudFront /api/* behavior gets its own ResponseHeadersPolicy (nosniff, `default-src 'none'; frame-ancestors 'none'`, X-Frame-Options DENY, HSTS, no-referrer) so a future route cannot regress the whole origin. `sandbox` is deliberately omitted at the edge: `default-src 'none'` already blocks all script in a document, and an opaque-origin directive across every API response would risk breaking attachment downloads and OAuth navigations for no added protection.

Also mirrors the allowlist client-side (`shared/skills/skill-resource-types.ts`) so both skill forms filter the file picker and refuse a bad file with a specific message instead of a 400 mid-upload. UX only — the server is the control.

Note: the cross-owner read half of the finding (the admin route resolving a user-authored skill) was already fixed by the `require_catalog_skill` predicate in 632e1acf; the two failures above were still live, and either alone reproduces the escalation for a catalog skill's resources.

Tests
- backend/tests/apis/app_api/skills/test_skill_resource_mime.py — 36 tests reproducing the report's upload and read steps with the verbatim payload, every scriptable extension, and a planted legacy text/html row. 17 of the 36 fail without the source changes.
- infrastructure/test/api-security-headers.test.ts — asserts the /api/* policy exists and is attached to that behavior. Both tests fail without the construct change.
- frontend .../skill-resource-types.spec.ts — pins the client mirror against drifting open on the dangerous extensions.

Verified: 165 backend tests pass (skills + architecture), 100 CDK tests pass across the 8 CloudFront/SPA suites, frontend tsc clean, production build succeeds, 52 frontend tests pass.