### PR TITLE
fix(sessions): stop a session id being forked across two users

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -44,7 +44,10 @@ from apis.inference_api.chat.agent_binding_resolver import (
     AgentBindingBlockedError,
     resolve_agent_invocation,
 )
-from apis.shared.sessions.metadata import ensure_session_metadata_exists
+from apis.shared.sessions.metadata import (
+    ensure_session_metadata_exists,
+    session_owned_by_other_user,
+)
 from apis.shared.tools.injected import (
     ARTIFACT_TOOL_IDS,
     EXCEL_SPREADSHEET_TOOL_IDS,
@@ -1132,6 +1135,27 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
     input_data = request
     user_id = current_user.user_id
     auth_token = current_user.raw_token
+
+    # Refuse a turn against a session id another user already owns.
+    #
+    # Session ids travel in shareable URLs (`/s/{sessionId}`). Opening someone
+    # else's link 404s on the metadata read, but the SPA then treats the
+    # session as new and lets the user send — which used to fork the id: a
+    # SECOND metadata row under the requester, on the same session, invisible
+    # to both parties. In prod on 2026-08-31 that also left the original
+    # owner's session resolving non-deterministically between the two rows.
+    #
+    # Not a confidentiality fix — conversation content is keyed by actor id in
+    # AgentCore Memory, so the second user only ever saw an empty thread. This
+    # stops the id from being forked at all. 404 rather than 403 so the
+    # response says nothing about whether the session exists, matching what
+    # `GET /sessions/{id}/metadata` already returns for the same case.
+    if await session_owned_by_other_user(input_data.session_id, user_id):
+        logger.warning(
+            "Rejected invocation for session %s — owned by a different user",
+            input_data.session_id,
+        )
+        raise HTTPException(status_code=404, detail="Session not found")
     # Resume requests reuse the cached agent and its paused interrupt state;
     # they bypass quota, file resolution, and RAG augmentation because those
     # already ran on the original turn that got paused.

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -1122,6 +1122,18 @@ async def ensure_session_metadata_exists(session_id: str, user_id: str) -> bool:
         if existing is not None:
             return False
 
+        # A row exists but belongs to someone else — do NOT create a second one.
+        # The put below would succeed (different PK, so attribute_not_exists
+        # can't see the other row) and fork the session id across two users.
+        # The invocations route rejects these turns outright; this is the
+        # backstop for every other path that pre-creates metadata.
+        if await session_owned_by_other_user(session_id, user_id):
+            logger.warning(
+                "Refusing to create metadata for session %s — already owned by another user",
+                session_id,
+            )
+            return False
+
         now = datetime.now(timezone.utc).isoformat()
         item = {
             "PK": f"USER#{user_id}",
@@ -1492,6 +1504,60 @@ async def set_selected_prompt_id(
         return False
 
 
+async def session_owned_by_other_user(session_id: str, user_id: str) -> bool:
+    """Whether this session id already has a metadata row owned by someone else.
+
+    WHY THIS EXISTS:
+    `_get_session_by_gsi` returns None both for "no such session" and for
+    "exists, but belongs to another user". Callers could not tell those apart,
+    so `ensure_session_metadata_exists` read the second case as the first and
+    created a SECOND metadata row on the same session id under the requester.
+    Its `attribute_not_exists(PK)` guard cannot catch this: the new row has a
+    different PK (`USER#{requester}`), so the conditional put succeeds.
+
+    That is exactly what happened in prod on 2026-08-31 — someone opened the
+    CIO's `/s/{sessionId}` link, the platform silently forked the session, and
+    the resulting duplicate META row made the original owner's session resolve
+    non-deterministically afterwards (see the item-scan in `_get_session_by_gsi`).
+
+    NOT a data-disclosure fix: conversation content lives in AgentCore Memory
+    keyed by actor id, so the second user always saw an empty conversation,
+    never the owner's messages. What leaked was the id, and what broke was the
+    owner's session record.
+
+    Returns True only when at least one META row exists AND none of them belong
+    to `user_id` — so a session the caller legitimately owns is never blocked,
+    including one that already has a fork attached to it.
+
+    Best-effort: any failure returns False (fail open), because this guards a
+    rare misuse and must never take the chat path down.
+    """
+    sessions_metadata_table = os.environ.get("DYNAMODB_SESSIONS_METADATA_TABLE_NAME")
+    if not sessions_metadata_table or is_preview_session(session_id):
+        return False
+
+    try:
+        import boto3
+        from boto3.dynamodb.conditions import Key
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(sessions_metadata_table)
+
+        response = table.query(
+            IndexName="SessionLookupIndex",
+            KeyConditionExpression=Key("GSI_PK").eq(f"SESSION#{session_id}")
+            & Key("GSI_SK").eq("META"),
+        )
+        items = response.get("Items", [])
+        if not items:
+            return False
+
+        return all(item.get("userId") != user_id for item in items)
+    except Exception as e:
+        logger.debug(f"Session ownership probe failed, allowing: {e}")
+        return False
+
+
 async def _get_session_by_gsi(session_id: str, user_id: str, table) -> Optional[dict]:
     """
     Get session record using GSI (SessionLookupIndex)
@@ -1518,14 +1584,23 @@ async def _get_session_by_gsi(session_id: str, user_id: str, table) -> Optional[
         if not items:
             return None
 
-        item = items[0]
+        # Scan ALL matching rows for this user's, rather than trusting items[0].
+        #
+        # A session id is supposed to have exactly one META row, but a
+        # cross-user fork could create a second one (see
+        # `session_owned_by_other_user`, and prod session 5f34d2b0 where it
+        # actually happened). Both rows share GSI_PK/GSI_SK, so DynamoDB
+        # returns them in an unspecified order — reading items[0] meant the
+        # rightful owner's own session could resolve to the other row, fail
+        # the ownership check, and look "not found" to every marker helper
+        # that routes through here. Matching by userId makes the lookup
+        # deterministic even where a fork already exists in the table.
+        for item in items:
+            if item.get('userId') == user_id:
+                return _convert_decimal_to_float(item)
 
-        # Verify user ownership
-        if item.get('userId') != user_id:
-            logger.warning(f"Session {session_id} belongs to different user")
-            return None
-
-        return _convert_decimal_to_float(item)
+        logger.warning(f"Session {session_id} belongs to different user")
+        return None
 
     except Exception as e:
         # JUSTIFICATION: GSI lookup is a fallback mechanism for finding sessions.
@@ -2017,10 +2092,12 @@ async def _get_session_metadata_cloud(
             logger.info(f"Session metadata not found in DynamoDB: {session_id}")
             return None
 
-        item = items[0]
-
-        # Verify user ownership
-        if item.get('userId') != user_id:
+        # Match on userId across every row rather than trusting items[0] — see
+        # the same scan in `_get_session_by_gsi` for why a session id can have
+        # more than one META row, and why picking the wrong one costs the
+        # rightful owner their own session.
+        item = next((i for i in items if i.get('userId') == user_id), None)
+        if item is None:
             logger.warning(f"Session {session_id} belongs to different user")
             return None
 

--- a/backend/tests/shared/test_session_cross_user_fork.py
+++ b/backend/tests/shared/test_session_cross_user_fork.py
@@ -1,0 +1,139 @@
+"""A session id must never be forked across two users.
+
+Prod, 2026-08-31: someone opened the CIO's `/s/{sessionId}` link. The metadata
+read 404'd, the SPA treated the session as new, and the turn that followed
+created a SECOND metadata row on the same session id under the second user —
+`ensure_session_metadata_exists`'s `attribute_not_exists(PK)` guard cannot see
+it, because the new row has a different PK.
+
+Not a confidentiality bug: conversation content is keyed by actor id in
+AgentCore Memory, so the second user only ever saw an empty thread. The damage
+was the duplicate row, the billing attached to it, and the original owner's
+session resolving non-deterministically between the two rows afterwards.
+"""
+
+import pytest
+
+from apis.shared.sessions.models import SessionMetadata
+
+
+def _meta(session_id="s1", user_id="owner", **kw):
+    defaults = dict(
+        sessionId=session_id, userId=user_id, title="Test Session",
+        status="active", createdAt="2026-01-01T00:00:00Z",
+        lastMessageAt="2026-01-01T00:00:00Z", messageCount=1,
+    )
+    defaults.update(kw)
+    return SessionMetadata(**defaults)
+
+
+def _put_forked_row(table, session_id: str, user_id: str, title: str) -> None:
+    """Write a second META row for a session id, bypassing the write path.
+
+    Reproduces the rows the platform created before `session_owned_by_other_user`
+    existed. Both rows carry identical GSI_PK/GSI_SK, so DynamoDB returns them
+    in an unspecified order — which is exactly the condition the item-scan in
+    `_get_session_by_gsi` has to survive.
+    """
+    table.put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"S#{session_id}",
+            "GSI_PK": f"SESSION#{session_id}",
+            "GSI_SK": "META",
+            "sessionId": session_id,
+            "userId": user_id,
+            "title": title,
+            "status": "active",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "lastMessageAt": "2026-01-01T00:00:00Z",
+            "messageCount": 0,
+            "starred": False,
+            "tags": [],
+        }
+    )
+
+
+class TestSessionOwnedByOtherUser:
+    @pytest.mark.asyncio
+    async def test_false_when_no_session_exists(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import session_owned_by_other_user
+        assert await session_owned_by_other_user("nope", "someone") is False
+
+    @pytest.mark.asyncio
+    async def test_false_for_the_owner(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            session_owned_by_other_user,
+        )
+        await store_session_metadata(session_id="s1", user_id="owner", session_metadata=_meta())
+        assert await session_owned_by_other_user("s1", "owner") is False
+
+    @pytest.mark.asyncio
+    async def test_true_for_a_stranger(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            session_owned_by_other_user,
+        )
+        await store_session_metadata(session_id="s1", user_id="owner", session_metadata=_meta())
+        assert await session_owned_by_other_user("s1", "stranger") is True
+
+
+class TestEnsureRefusesToFork:
+    @pytest.mark.asyncio
+    async def test_stranger_does_not_get_a_second_metadata_row(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import (
+            store_session_metadata,
+            ensure_session_metadata_exists,
+        )
+        await store_session_metadata(session_id="s1", user_id="owner", session_metadata=_meta())
+
+        created = await ensure_session_metadata_exists("s1", "stranger")
+
+        assert created is False
+        metas = [
+            i for i in sessions_metadata_table.scan()["Items"]
+            if i.get("GSI_SK") == "META" and i.get("sessionId") == "s1"
+        ]
+        assert len(metas) == 1
+        assert metas[0]["userId"] == "owner"
+
+    @pytest.mark.asyncio
+    async def test_owner_is_unaffected(self, sessions_metadata_table):
+        """The guard must not block the legitimate first-turn create."""
+        from apis.shared.sessions.metadata import ensure_session_metadata_exists
+        assert await ensure_session_metadata_exists("fresh", "owner") is True
+
+
+class TestLookupIsDeterministicAcrossAnExistingFork:
+    """Forked rows already exist in prod, so the read path has to cope."""
+
+    @pytest.mark.asyncio
+    async def test_each_user_resolves_to_their_own_row(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import store_session_metadata, get_session_metadata
+
+        await store_session_metadata(
+            session_id="s1", user_id="owner",
+            session_metadata=_meta(title="Owner's conversation"),
+        )
+        # The stranger's row is written RAW. The write path now refuses to
+        # create it, so this is the only way to reproduce what is already
+        # sitting in prod from before the guard existed.
+        _put_forked_row(sessions_metadata_table, "s1", "stranger", "New Conversation")
+
+        owner_view = await get_session_metadata("s1", "owner")
+        stranger_view = await get_session_metadata("s1", "stranger")
+
+        # Before the item-scan fix this depended on which row items[0] returned,
+        # and the owner could lose their own session.
+        assert owner_view is not None
+        assert owner_view.title == "Owner's conversation"
+        assert stranger_view is not None
+        assert stranger_view.title == "New Conversation"
+
+    @pytest.mark.asyncio
+    async def test_third_party_still_sees_nothing(self, sessions_metadata_table):
+        from apis.shared.sessions.metadata import store_session_metadata, get_session_metadata
+        await store_session_metadata(session_id="s1", user_id="owner", session_metadata=_meta())
+        _put_forked_row(sessions_metadata_table, "s1", "stranger", "New Conversation")
+        assert await get_session_metadata("s1", "outsider") is None


### PR DESCRIPTION
Found while investigating prod session `5f34d2b0`. Unrelated to the outage itself.

## The bug

`_get_session_by_gsi` returns `None` both for "no such session" and for "exists, but owned by someone else". Callers can't tell those apart, so `ensure_session_metadata_exists` reads the second case as the first and creates a **second metadata row on the same session id** under the requester. Its `attribute_not_exists(PK)` guard can't catch this — the new row has a different PK (`USER#{requester}`), so the conditional put succeeds.

Session ids travel in shareable `/s/{sessionId}` URLs. Opening someone else's link 404s on the metadata read, but the SPA then treats the session as new and lets the user send. That send is what forked it.

## What it is not

**Not a confidentiality bug.** Conversation content lives in AgentCore Memory keyed by actor id (`get_messages_from_cloud` passes `actor_id=user_id`), so the second user only ever saw an empty thread — never the owner's messages. Verified in the prod logs: `Retrieved 0 memories from namespace: /strategies/.../actors/{second-user}/sessions/5f34d2b0...`.

## What it actually broke

Beyond the duplicate row and the spend attached to it: both rows carry identical `GSI_PK`/`GSI_SK`, and DynamoDB returns them in an **unspecified order**. Every lookup read `items[0]`, so after a fork the *original owner's* session could resolve to the other user's row, fail the ownership check, and look "not found" to every marker helper. That is why the prod logs show `update_session_activity: session ... missing and could not be created` against a session that plainly existed.

## Changes

- `session_owned_by_other_user` makes the distinction explicit. Fail-open — it guards a rare misuse and must never take the chat path down. Returns True only when rows exist *and none* belong to the caller, so a legitimate owner is never blocked even where a fork is already attached.
- `ensure_session_metadata_exists` refuses to create over another owner (backstop for every pre-create path), and the invocations route rejects the turn with **404** — not 403, so the response says nothing about whether the session exists, matching what `GET /sessions/{id}/metadata` already returns.
- **Both** GSI lookups now scan every returned row for the caller's own instead of reading `items[0]`. Forked rows already exist in prod, so the read path has to stay deterministic over them. There were two copies of this ownership check; they're both fixed.

## Testing

7 new tests (moto). Note the fork can no longer be created through the write path at all, so the determinism tests write the second row raw — that's what's already sitting in prod.

Full backend suite: 6908 passed, 6 skipped.

## Not included

No backfill for the rows already forked in prod. Worth a separate pass once this is deployed — happy to write it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)