### PR TITLE
feat(chat): tell the user a quiet response is still working

### DIFF
--- a/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect } from 'vitest';
+import { PulsatingLoaderComponent } from './pulsating-loader.component';
+
+@Component({
+  imports: [PulsatingLoaderComponent],
+  template: `<app-pulsating-loader [notice]="notice" />`,
+})
+class HostComponent {
+  notice: string | null = null;
+}
+
+function render(notice: string | null) {
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.componentInstance.notice = notice;
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('PulsatingLoaderComponent', () => {
+  it('cycles its own phrases when no notice is set', () => {
+    const fixture = render(null);
+    const loader = fixture.debugElement.children[0].componentInstance as PulsatingLoaderComponent;
+    // The typewriter starts empty and fills in; what matters is that it is not
+    // showing a caller-supplied string.
+    expect(loader.displayText()).not.toContain('Retrying');
+  });
+
+  it('shows the notice verbatim instead of a loading phrase', () => {
+    const fixture = render('The model is busy. Retrying…');
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('The model is busy. Retrying');
+  });
+
+  it('drops the typing cursor for a notice', () => {
+    // The cursor reads as "still typing" on text that is finished.
+    const withNotice = render('Still working…');
+    expect((withNotice.nativeElement as HTMLElement).querySelector('.typing-cursor')).toBeNull();
+
+    const withoutNotice = render(null);
+    expect(
+      (withoutNotice.nativeElement as HTMLElement).querySelector('.typing-cursor'),
+    ).not.toBeNull();
+  });
+
+  it('marks the indicator dot so the change is visible peripherally', () => {
+    const fixture = render('Still working…');
+    const dot = (fixture.nativeElement as HTMLElement).querySelector('.pulsing-circle');
+    expect(dot?.classList.contains('is-notice')).toBe(true);
+  });
+
+  it('announces a notice to assistive tech', () => {
+    const fixture = render('Still working…');
+    const status = (fixture.nativeElement as HTMLElement).querySelector('[role="status"]');
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    expect(status?.getAttribute('aria-label')).toContain('Still working');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -147,7 +147,7 @@
   <!-- Loading indicator -->
   @if (isChatLoading()) {
     <div class="py-4">
-      <app-pulsating-loader [notice]="retryNotice()" />
+      <app-pulsating-loader [notice]="loaderNotice()" />
     </div>
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, output, inject, PLATFORM_ID } from '@angular/core';
+import { Component, computed, effect, input, output, inject, signal, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import { Message } from '../../services/models/message.model';
 import type { Artifact } from '../../services/artifacts/artifact.model';
@@ -58,6 +58,27 @@ export class MessageListComponent {
   private readonly HEADER_HEIGHT = 64;
   private readonly SCROLL_PADDING = 16;
 
+  /**
+   * Silence thresholds for the "still working" notice.
+   *
+   * A model call that produces nothing looks exactly like a hung one. In prod
+   * session 5f34d2b0 two turns went ~95 seconds with no output and the user
+   * abandoned both — the second one while the request was, as far as the
+   * telemetry shows, still in flight.
+   *
+   * 30s is comfortably past a normal first token (~5-7s) and past most tool
+   * calls, so a healthy turn rarely trips it. 90s is past anything routine and
+   * is where the phrasing stops reassuring and starts admitting something is
+   * wrong. The tick is coarse because the thresholds are: the notice appears
+   * within one tick of crossing them.
+   */
+  private readonly STALL_NOTICE_MS = 30_000;
+  private readonly LONG_STALL_NOTICE_MS = 90_000;
+  private readonly STALL_TICK_MS = 5_000;
+
+  /** Clock for the stall thresholds; only ticks while a response is pending. */
+  private readonly nowMs = signal(Date.now());
+
   messages = input.required<Message[]>();
   isChatLoading = input<boolean>(false);
   streamingMessageId = input<string | null>(null);
@@ -93,6 +114,53 @@ export class MessageListComponent {
    * threaded through every `[isChatLoading]` binding — preview and test-drive
    * hosts have no session id and correctly get nothing.
    */
+  constructor() {
+    // Tick only while a response is pending: an always-on interval would wake
+    // every open conversation forever to answer a question nobody is asking.
+    // The write happens in the callback, not the effect body, so this never
+    // re-triggers itself.
+    if (this.isBrowser) {
+      effect((onCleanup) => {
+        if (!this.isChatLoading()) {
+          return;
+        }
+        const timer = setInterval(() => this.nowMs.set(Date.now()), this.STALL_TICK_MS);
+        onCleanup(() => clearInterval(timer));
+      });
+    }
+  }
+
+  /**
+   * Copy for a response that has gone quiet for long enough to look broken.
+   *
+   * Deliberately client-side. The server cannot say anything during a stalled
+   * model call without racing the agent stream against a timer, and that
+   * machinery — cancellation, lease release, interrupted-turn persistence —
+   * has already been the source of several production bugs. The SPA has the
+   * one fact that matters: when the last byte arrived. If the connection had
+   * dropped, fetch-event-source would have surfaced an error instead of
+   * silence, so silence on an open stream really is "the server has not sent
+   * anything yet".
+   */
+  protected readonly stallNotice = computed<string | null>(() => {
+    const sessionId = this.sessionId();
+    if (!sessionId || !this.isChatLoading()) {
+      return null;
+    }
+    const lastEventAt = this.streamParser.lastEventAtFor(sessionId)();
+    if (!lastEventAt) {
+      return null;
+    }
+    const silentFor = this.nowMs() - lastEventAt;
+    if (silentFor >= this.LONG_STALL_NOTICE_MS) {
+      return 'Still working \u2014 this is taking longer than usual.';
+    }
+    if (silentFor >= this.STALL_NOTICE_MS) {
+      return 'Still working\u2026';
+    }
+    return null;
+  });
+
   protected readonly retryNotice = computed<string | null>(() => {
     const sessionId = this.sessionId();
     if (!sessionId) {
@@ -106,6 +174,15 @@ export class MessageListComponent {
       ? 'The model is busy. Retrying\u2026'
       : `The model is busy. Retrying \u2014 attempt ${retry.attempt}.`;
   });
+
+  /**
+   * What the loading indicator says. A retry is a specific, known fact and
+   * outranks the generic stall notice, which is only ever an inference from
+   * elapsed silence.
+   */
+  protected readonly loaderNotice = computed<string | null>(
+    () => this.retryNotice() ?? this.stallNotice(),
+  );
 
   /** Persisted app-initiated tool cards, hydrated on reload (PR #6). */
   protected mcpAppCards = this.mcpAppCardState.cards;

--- a/frontend/ai.client/src/app/session/services/chat/stream-liveness.spec.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-liveness.spec.ts
@@ -1,0 +1,105 @@
+// stream-liveness.spec.ts
+//
+// A model call that produces nothing looks exactly like a hung one. In prod
+// session 5f34d2b0 two turns went ~95 seconds with no output and the user
+// abandoned both — the second one while the request was, as far as the
+// telemetry shows, still in flight. The SPA holds the one fact that can tell
+// those apart: when the last byte arrived.
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { StreamParserService } from './stream-parser.service';
+import { ChatStateService } from './chat-state.service';
+import { ErrorService } from '../../../services/error/error.service';
+import { QuotaWarningService } from '../../../services/quota/quota-warning.service';
+
+describe('StreamParserService - stream liveness', () => {
+  let service: StreamParserService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [StreamParserService, ChatStateService, ErrorService, QuotaWarningService],
+    });
+    service = TestBed.inject(StreamParserService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('reports 0 before a stream has started', () => {
+    expect(service.lastEventAtFor('never-started')()).toBe(0);
+  });
+
+  it('stamps the clock when a stream is reset', () => {
+    const before = Date.now();
+    service.reset('s1');
+    expect(service.lastEventAtFor('s1')()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('advances on each received event', () => {
+    vi.useFakeTimers();
+    service.reset('s1');
+    const first = service.lastEventAtFor('s1')();
+
+    vi.advanceTimersByTime(10_000);
+    service.parseEventSourceMessage('s1', 'message_start', { role: 'assistant' });
+
+    expect(service.lastEventAtFor('s1')()).toBe(first + 10_000);
+  });
+
+  it('advances on an event the state gate drops', () => {
+    // Liveness is about the connection, not the payload. An event this stream
+    // state ignores is still proof the server is talking.
+    vi.useFakeTimers();
+    service.reset('s1');
+    service.parseEventSourceMessage('s1', 'done', {});
+    const afterDone = service.lastEventAtFor('s1')();
+
+    vi.advanceTimersByTime(5_000);
+    service.parseEventSourceMessage('s1', 'metadata', { usage: {} });
+
+    expect(service.lastEventAtFor('s1')()).toBe(afterDone + 5_000);
+  });
+
+  it('advances on a malformed event', () => {
+    vi.useFakeTimers();
+    service.reset('s1');
+    const first = service.lastEventAtFor('s1')();
+
+    vi.advanceTimersByTime(3_000);
+    service.parseEventSourceMessage('s1', 'content_block_delta', { nonsense: true });
+
+    expect(service.lastEventAtFor('s1')()).toBe(first + 3_000);
+  });
+
+  it('ignores events from a superseded stream', () => {
+    // Otherwise a dead stream's late events would keep its replacement
+    // looking alive, and the replacement's own stall would never surface.
+    vi.useFakeTimers();
+    service.reset('s1');
+    const staleStreamId = service.getCurrentStreamId('s1');
+
+    service.reset('s1'); // new stream for the same session
+    const afterReset = service.lastEventAtFor('s1')();
+
+    vi.advanceTimersByTime(20_000);
+    service.parseEventSourceMessage('s1', 'message_start', { role: 'assistant' }, staleStreamId);
+
+    expect(service.lastEventAtFor('s1')()).toBe(afterReset);
+  });
+
+  it('tracks each session independently', () => {
+    vi.useFakeTimers();
+    service.reset('s1');
+    service.reset('s2');
+    const s1Start = service.lastEventAtFor('s1')();
+
+    vi.advanceTimersByTime(30_000);
+    service.parseEventSourceMessage('s2', 'message_start', { role: 'assistant' });
+
+    expect(service.lastEventAtFor('s1')()).toBe(s1Start);
+    expect(service.lastEventAtFor('s2')()).toBe(s1Start + 30_000);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -98,6 +98,16 @@ interface ParserSessionState {
   toolProgress: WritableSignal<ToolProgress>;
 
   /**
+   * Epoch ms of the last event received on this stream. Stamped on EVERY
+   * event, including ones the state gate then drops — the point is liveness
+   * of the connection, not whether the payload was useful. Lets the UI tell a
+   * long stall apart from a hang, which is otherwise impossible from the
+   * client side (prod 5f34d2b0: two turns went ~95s with no output and the
+   * user abandoned both).
+   */
+  lastEventAt: WritableSignal<number>;
+
+  /**
    * The most recent model-call retry this turn, or null. Set by the
    * `model_retry` SSE event and cleared as soon as content arrives, so the
    * loading indicator can explain the silence instead of leaving the user to
@@ -162,6 +172,7 @@ export class StreamParserService {
   private readonly streamingMessageIdCache = new Map<string, Signal<string | null>>();
   private readonly toolProgressCache = new Map<string, Signal<ToolProgress>>();
   private readonly modelRetryCache = new Map<string, Signal<ModelRetryEvent | null>>();
+  private readonly lastEventAtCache = new Map<string, Signal<number>>();
   private readonly citationsCache = new Map<string, Signal<Citation[]>>();
   private readonly errorCache = new Map<string, Signal<string | null>>();
   private readonly isStreamCompleteCache = new Map<string, Signal<boolean>>();
@@ -200,6 +211,15 @@ export class StreamParserService {
     return this.cachedAccessor(this.modelRetryCache, sessionId, (state) => state.modelRetry(), null);
   }
 
+  /**
+   * Epoch ms of the last event seen on a session's stream, or 0 before one
+   * starts. The UI compares it against the clock to decide when silence has
+   * gone on long enough to be worth explaining.
+   */
+  lastEventAtFor(sessionId: string): Signal<number> {
+    return this.cachedAccessor(this.lastEventAtCache, sessionId, (state) => state.lastEventAt(), 0);
+  }
+
   /** Pending citations for a session's next assistant message. */
   citationsFor(sessionId: string): Signal<Citation[]> {
     return this.cachedAccessor(this.citationsCache, sessionId, (state) => state.pendingCitations(), []);
@@ -221,7 +241,15 @@ export class StreamParserService {
    */
   parseSSELine(sessionId: string, line: string): void {
     const state = this.states().get(sessionId);
-    if (!state || !this.shouldProcessEvent(state)) {
+    if (!state) {
+      return;
+    }
+
+    // Liveness first — see parseEventSourceMessage. A line the state gate
+    // below drops still proves the connection is alive.
+    state.lastEventAt.set(Date.now());
+
+    if (!this.shouldProcessEvent(state)) {
       return;
     }
 
@@ -252,6 +280,12 @@ export class StreamParserService {
     if (expectedStreamId && state.currentStreamId !== expectedStreamId) {
       return; // Stale event from a superseded stream for this session.
     }
+
+    // Stamp liveness before the validation and state gates below: a `ping` or
+    // an event this stream state drops is still proof the server is talking.
+    // Placed after the stale-stream guard so a superseded stream can't keep
+    // its replacement looking alive.
+    state.lastEventAt.set(Date.now());
 
     // Validate inputs
     if (!event || typeof event !== 'string') {
@@ -365,6 +399,7 @@ export class StreamParserService {
       completedMessages,
       toolProgress: signal<ToolProgress>({ visible: false }),
       modelRetry: signal<ModelRetryEvent | null>(null),
+      lastEventAt: signal<number>(Date.now()),
       error: signal<string | null>(null),
       isStreamComplete,
       metadata: signal<MetadataEvent | null>(null),


### PR DESCRIPTION
The fifth and last change from the `5f34d2b0` post-mortem. **It missed the #905 merge window** — pushed to that branch ~18 minutes after it merged, so it never reached develop. Same commit, rebased onto develop, no changes.

## Why

`model_retry` (shipped in #905) covers the pauses *between* retry attempts. It cannot cover the failing model call itself — which is the longest silence and the one that actually loses sessions. Both dead turns in the incident ran ~95 seconds with no output and the user abandoned both; the second while the request was, as far as the telemetry shows, still in flight, with no Bedrock outcome ever recorded for it.

## What it does

The parser stamps the arrival time of every event. The loading indicator says "Still working…" after 30s of silence and "Still working — this is taking longer than usual." after 90s. A known retry outranks the stall notice: one is a fact, the other an inference from elapsed time.

Liveness is stamped on **every** event, including ones the stream-state gate then drops — the question is whether the connection is alive, not whether the payload was useful — but only *after* the stale-stream guard, so a superseded stream can't keep its replacement looking alive.

Thresholds sit past a normal first token (~5–7s in this session) and past most tool calls, so a healthy turn rarely trips them. In the incident, both dead turns would have shown the second message about four seconds before the user gave up.

## Deliberately client-side — the call most worth challenging

A server-sent heartbeat has to race the agent stream against a timer, and there are only two ways:

- **Run `__anext__` as a fresh task per element.** This breaks anyio cancel scopes inside the MCP clients — entering and exiting a scope from different tasks is exactly what anyio forbids, and our MCP sessions stay open across the stream.
- **Pump the stream through a queue in a side task.** Adds a task boundary straight through the cancellation path that owns lease release and interrupted-turn persistence — machinery that #653, #863 and #874 have each already had to repair.

The SPA holds the one fact that matters (when the last byte arrived), and a dropped connection surfaces through fetch-event-source as an *error* rather than as silence, so silence on an open stream really does mean the server hasn't sent anything yet.

**The honest cost:** if a connection dies in a way the browser doesn't notice, "Still working…" is a lie where a server heartbeat would have proven liveness. I judged that less likely and less damaging than destabilising the cancellation path — but say so if you'd rather take the server-side risk and I'll build it.

The ticker runs only while a response is pending; an always-on interval would wake every open conversation to answer a question nobody is asking.

## Testing

12 new SPA tests (stream liveness incl. superseded-stream isolation; loader notice rendering, cursor suppression, a11y announcement). Full SPA suite on top of develop: **1977 passed**, `tsc --noEmit` clean. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)