### PR TITLE
fix(chat): don't tell the model a completed answer was cut short

### DIFF
--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -1183,6 +1183,40 @@ class StreamCoordinator:
             except Exception as e:
                 logger.error(f"Failed to clear pending attachments: {e}", exc_info=True)
 
+            # Same reasoning, applied to the interrupted-turn marker: a turn
+            # that reached here produced a COMPLETE answer, so it was not
+            # interrupted — whatever the client signalled.
+            #
+            # WHY THE MARKER CAN BE HERE AT ALL. The client's Stop writes
+            # `lastTurnInterrupted` immediately (app-api, `source=client_signal`),
+            # but the server only observes the armed cancel on the lease
+            # heartbeat, which sleeps LEASE_HEARTBEAT_SECONDS (10s) BEFORE its
+            # first check. A turn that finishes inside that window races the
+            # first tick and wins: the stream completes normally and the
+            # cooperative-stop arm never runs, leaving a marker that describes
+            # a turn which was never actually cut short.
+            #
+            # Left in place, the NEXT turn pops it and prepends
+            # `_build_interruption_note("user_stopped")`, telling the model
+            # that its own complete reply "was the partial that was delivered"
+            # and to treat it as rejected feedback. Every clause of that is
+            # false, and it measurably steers the next answer. Observed in dev
+            # on 2026-09-02: Stop at 2.6s on a 10.4s turn, full answer
+            # persisted, and the follow-up turn logged
+            # "Cleared interrupted_turn ... (reason=user_stopped)".
+            #
+            # Narrowing the heartbeat interval does NOT fix this — any turn
+            # shorter than one tick is unstoppable no matter how the ticks are
+            # spaced, so the marker has to be reconciled against what actually
+            # happened. That is what this does. The real interruption arms
+            # below re-set it after persisting their partial, so a genuine
+            # interruption is unaffected.
+            try:
+                from apis.shared.sessions.metadata import clear_interrupted_turn
+                await clear_interrupted_turn(session_id, user_id)
+            except Exception as e:
+                logger.error(f"Failed to clear stale interrupted_turn: {e}", exc_info=True)
+
         except _CooperativeStopSignal:
             # Deliberate user Stop observed mid-stream (see the in-loop check).
             # Unlike the CancelledError/GeneratorExit backstop below — which

--- a/backend/tests/agents/main_agent/streaming/test_completed_turn_clears_interrupt.py
+++ b/backend/tests/agents/main_agent/streaming/test_completed_turn_clears_interrupt.py
@@ -1,0 +1,138 @@
+"""A turn that completes must not leave an interrupted-turn marker behind.
+
+The client's Stop writes `lastTurnInterrupted` immediately (app-api,
+source=client_signal), but the server only observes the armed cancel on the
+lease heartbeat, which sleeps LEASE_HEARTBEAT_SECONDS (10s) BEFORE its first
+check. A turn that finishes inside that window races the first tick and wins:
+the stream completes normally, the cooperative-stop arm never runs, and a
+marker is left describing a turn that was never cut short.
+
+Left in place, the NEXT turn pops it and prepends
+`_build_interruption_note("user_stopped")` — telling the model its own
+COMPLETE reply "was the partial that was delivered" and to treat it as
+rejected feedback. Observed in dev 2026-09-02: Stop at 2.6s on a 10.4s turn,
+full answer persisted, follow-up turn logged
+"Cleared interrupted_turn ... (reason=user_stopped)".
+
+Narrowing the heartbeat interval cannot fix this — a turn shorter than one
+tick is unstoppable however the ticks are spaced — so the marker has to be
+reconciled against what actually happened.
+"""
+
+import asyncio
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from agents.main_agent.streaming.stream_coordinator import StreamCoordinator
+
+
+class _CompletingAgent:
+    """Agent whose stream yields a full message and then ends cleanly."""
+
+    def __init__(self, events: List[Dict[str, Any]] = None) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+        self._events = events if events is not None else [
+            {"event": {"messageStart": {"role": "assistant"}}},
+            {"event": {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "All done."}}}},
+            {"event": {"messageStop": {"stopReason": "end_turn"}}},
+        ]
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            for event in self._events:
+                yield event
+
+        return _gen()
+
+
+class _InterruptedAgent:
+    """Agent torn down mid-stream, as a client disconnect does."""
+
+    def __init__(self) -> None:
+        self.messages = [{"role": "user", "content": [{"text": "hi"}]}]
+
+    def stream_async(self, prompt: Any) -> AsyncIterator[Dict[str, Any]]:
+        async def _gen() -> AsyncIterator[Dict[str, Any]]:
+            yield {"event": {"messageStart": {"role": "assistant"}}}
+            yield {"event": {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "half"}}}}
+            raise asyncio.CancelledError()
+
+        return _gen()
+
+
+class _NoopSessionManager:
+    cancelled = False
+
+    async def update_after_turn(self, input_tokens: int, current_messages=None):
+        return None
+
+
+async def _drive(agent: Any, expected_exc: type = None) -> None:
+    coordinator = StreamCoordinator()
+
+    async def _run():
+        async for _sse in coordinator.stream_response(
+            agent=agent,
+            prompt="hello",
+            session_manager=_NoopSessionManager(),
+            session_id="sess-complete",
+            user_id="user-1",
+            main_agent_wrapper=None,
+        ):
+            pass
+
+    if expected_exc is not None:
+        with pytest.raises(expected_exc):
+            await _run()
+    else:
+        await _run()
+
+
+@pytest.mark.asyncio
+async def test_completed_turn_clears_a_stale_interrupt_marker():
+    cleared: List[Any] = []
+
+    async def _fake_clear(session_id, user_id):
+        cleared.append((session_id, user_id))
+        return None
+
+    with patch("apis.shared.sessions.metadata.clear_interrupted_turn", _fake_clear):
+        await _drive(_CompletingAgent())
+
+    assert cleared == [("sess-complete", "user-1")], (
+        "a turn that produced a complete answer must reconcile away the "
+        "client-signalled interrupted marker"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interrupted_turn_does_not_clear_the_marker():
+    """The failure arms own the marker — clearing there would erase the real
+    interruption `_persist_interruption` is about to record."""
+    cleared: List[Any] = []
+
+    async def _fake_clear(session_id, user_id):
+        cleared.append((session_id, user_id))
+        return None
+
+    async def _fake_persist(self, **kwargs):
+        return None
+
+    with patch("apis.shared.sessions.metadata.clear_interrupted_turn", _fake_clear), \
+            patch.object(StreamCoordinator, "_persist_interruption", _fake_persist):
+        await _drive(_InterruptedAgent(), asyncio.CancelledError)
+
+    assert cleared == [], "an interrupted turn must keep its marker"
+
+
+@pytest.mark.asyncio
+async def test_clear_failure_never_breaks_the_stream():
+    """Best-effort, like every sibling marker write."""
+
+    async def _boom(session_id, user_id):
+        raise RuntimeError("dynamo down")
+
+    with patch("apis.shared.sessions.metadata.clear_interrupted_turn", _boom):
+        await _drive(_CompletingAgent())


### PR DESCRIPTION
Pre-existing bug, unrelated to the `5f34d2b0` outage work. Found while validating those fixes against dev.

## Stop has a ~10-second dead zone

The client's Stop writes `lastTurnInterrupted` immediately (app-api, `source=client_signal`). The server only observes the armed cancel on the lease heartbeat — and that loop **sleeps before it checks**:

```python
while True:
    await asyncio.sleep(LEASE_HEARTBEAT_SECONDS)   # 10s, first
    cancel_requested = await renew_session_lease(lease)
```

So the earliest a Stop can be seen is 10s into a turn. Anything shorter races the first tick and wins: the stream completes normally, `session_manager.cancelled` is never flipped, the cooperative-stop arm never runs, and the marker survives describing a turn that was never cut short.

The in-loop check in `stream_coordinator` is fine — it runs on every event. The flag just never gets set in time.

## Why the leftover marker matters

The next turn pops it and prepends `_build_interruption_note("user_stopped")`:

> "The user deliberately stopped your previous response before it finished (the last assistant message above is the partial that was delivered). Treat that as meaningful feedback — do not resume or repeat it."

Every clause is false when the answer was complete, and the note measurably steers the following answer. A reload also shows the "response interrupted" affordance against a complete message.

**Verified in dev, 2026-09-02:** Stop at 2.6s on a 10.4s turn → full answer persisted → the follow-up turn logged `Cleared interrupted_turn … (reason=user_stopped)`, i.e. the note fired against a complete reply.

## The fix

Same reconciliation already used for pending attachments: a turn that reaches the end of the success path produced a complete answer, so it was not interrupted — whatever the client signalled. The genuine interruption arms live in `except` blocks and re-set the marker after persisting their partial, so a real interruption is untouched.

**Deliberately not fixed by retuning the heartbeat.** A turn shorter than one tick is unstoppable however the ticks are spaced, and check-then-sleep just moves the first check to t=0, before any Stop could have been pressed. The marker has to be reconciled against what actually happened.

## Scope note — what this does NOT fix

Stop still does not stop a sub-10s turn; the model runs to completion and is billed in full. The cost impact is small (turns too short to stop are short because they're cheap), so I've left the cadence alone rather than adding a DynamoDB write every couple of seconds to every turn. Worth a separate decision if you want Stop to be genuinely immediate.

## Testing

3 new tests: a completed turn clears the marker, an interrupted turn keeps it, and a clear failure never breaks the stream. Confirmed the first fails without the fix.

Full backend suite: **7014 passed**, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)