### PR TITLE
fix(infra): grant MCP Lambda function URL invoke to app-api and widen runtime scope

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -628,6 +628,26 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // Admin "Discover from server" invoke (POST /admin/tools/discover): the
+  // discovery request is signed with *this* task role, not the gateway role
+  // the form's credential picker names — the gateway only signs at runtime,
+  // once the target is registered. Without this, discovery against any
+  // IAM-protected Lambda Function URL comes back 403 and the admin has to
+  // type every tool name by hand. Same resource scope as McpTargetLambdaGrant
+  // above; InvokeFunctionUrl only, since discovery reaches the server over its
+  // function URL and never through the Lambda API.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'McpDiscoveryLambdaInvoke',
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:InvokeFunctionUrl'],
+      resources: [
+        `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:mcp-*`,
+        `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:${config.projectPrefix}-mcp-*`,
+      ],
+    }),
+  );
+
   // ── S3 Vectors (RAG query + document cleanup) ──
   // DeleteVectors is required by documents/services/cleanup_service.py, which
   // removes a document's (or an assistant's) chunks from the index when the

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -120,11 +120,19 @@ export function createRuntimeExecutionRole(
   }));
 
   // ── External MCP Lambda Function URL invocation ──
+  // Both naming conventions: MCP servers deployed from their own repos are
+  // named `mcp-<server>-<env>` (no project prefix), so a prefix-only scope
+  // silently 403s every one of them the moment a tool is configured as a
+  // direct external MCP server rather than a Gateway target. Mirrors the
+  // resource scope app-api uses for the same fleet.
   role.addToPolicy(new iam.PolicyStatement({
     sid: 'ExternalMCPLambdaAccess',
     effect: iam.Effect.ALLOW,
     actions: ['lambda:InvokeFunctionUrl', 'lambda:InvokeFunction'],
-    resources: [`arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:${config.projectPrefix}-mcp-*`],
+    resources: [
+      `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:mcp-*`,
+      `arn:aws:lambda:${config.awsRegion}:${config.awsAccount}:function:${config.projectPrefix}-mcp-*`,
+    ],
   }));
 
   // ── AgentCore Gateway ──

--- a/infrastructure/test/mcp-lambda-invoke-grants.test.ts
+++ b/infrastructure/test/mcp-lambda-invoke-grants.test.ts
@@ -1,0 +1,89 @@
+/**
+ * MCP Lambda Function URL invoke grants.
+ *
+ * Two roles need to reach an IAM-protected MCP server's Lambda Function URL,
+ * and both were scoped wrongly at some point:
+ *
+ *   1. app-api signs the admin "Discover from server" request
+ *      (POST /admin/tools/discover) with its OWN task role — the gateway role
+ *      named in the form's credential picker only signs at runtime. With no
+ *      InvokeFunctionUrl on the task role, discovery 403s for every
+ *      AuthType=AWS_IAM server and the admin has to type each tool name.
+ *
+ *   2. inference-api invokes a direct external MCP server at runtime. Its
+ *      grant was scoped to `<prefix>-mcp-*` only, which never matches an MCP
+ *      server deployed from its own repo as `mcp-<server>-<env>`.
+ *
+ * Both must cover BOTH naming conventions.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+import { createMockConfig, mockSsmContext, MOCK_ACCOUNT, MOCK_REGION, MOCK_PREFIX } from './helpers/mock-config';
+
+interface PolicyStatement {
+  Effect?: string;
+  Action?: string | string[];
+  Resource?: string | string[];
+  Sid?: string;
+}
+
+const UNPREFIXED_MCP_ARN = `arn:aws:lambda:${MOCK_REGION}:${MOCK_ACCOUNT}:function:mcp-*`;
+const PREFIXED_MCP_ARN = `arn:aws:lambda:${MOCK_REGION}:${MOCK_ACCOUNT}:function:${MOCK_PREFIX}-mcp-*`;
+
+function asArray(v: string | string[] | undefined): string[] {
+  if (v === undefined) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+describe('MCP Lambda Function URL invoke grants', () => {
+  let statementsBySid: Map<string, PolicyStatement[]>;
+
+  beforeAll(() => {
+    const config = createMockConfig();
+    const app = new cdk.App();
+    mockSsmContext(app, config);
+    const stack = new PlatformStack(app, 'TestPlatformStack', {
+      config,
+      env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+    });
+    stack.wireCompute();
+    const template = Template.fromStack(stack);
+
+    // CDK splits an oversized inline policy into managed overflow policies
+    // attached to the same role, so both resource types must be scanned.
+    statementsBySid = new Map();
+    for (const type of ['AWS::IAM::Policy', 'AWS::IAM::ManagedPolicy']) {
+      for (const [, r] of Object.entries(template.findResources(type))) {
+        const stmts = ((r.Properties as { PolicyDocument?: { Statement?: PolicyStatement[] } })?.PolicyDocument?.Statement) ?? [];
+        for (const s of stmts) {
+          if (!s.Sid) continue;
+          statementsBySid.set(s.Sid, [...(statementsBySid.get(s.Sid) ?? []), s]);
+        }
+      }
+    }
+  });
+
+  it('app-api can invoke an MCP function URL for admin discovery', () => {
+    const matches = statementsBySid.get('McpDiscoveryLambdaInvoke') ?? [];
+    expect(matches).toHaveLength(1);
+
+    const [statement] = matches;
+    expect(statement.Effect).toBe('Allow');
+    expect(asArray(statement.Action)).toContain('lambda:InvokeFunctionUrl');
+    expect(asArray(statement.Resource)).toEqual(
+      expect.arrayContaining([UNPREFIXED_MCP_ARN, PREFIXED_MCP_ARN]),
+    );
+  });
+
+  it('inference-api external-MCP invoke covers both MCP function naming conventions', () => {
+    const matches = statementsBySid.get('ExternalMCPLambdaAccess') ?? [];
+    expect(matches).toHaveLength(1);
+
+    const [statement] = matches;
+    expect(asArray(statement.Action)).toContain('lambda:InvokeFunctionUrl');
+    expect(asArray(statement.Resource)).toEqual(
+      expect.arrayContaining([UNPREFIXED_MCP_ARN, PREFIXED_MCP_ARN]),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Admin **"Discover from server"** (`POST /admin/tools/discover`) returns **403** for every `AuthType=AWS_IAM` MCP server — in every environment. Surfaced while adding `mcp-brave-search-prod` to prod.

The form's credential picker labels the option *"Gateway IAM Role (SigV4)"*, but the discovery request is signed with the **app-api ECS task role** — boto3's default credentials in the container ([`create_external_mcp_client`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/backend/src/agents/main_agent/integrations/external_mcp_client.py) → `get_sigv4_auth`). The gateway role only signs at runtime, after the target is registered.

That task role carried `lambda:AddPermission` / `RemovePermission` / `GetFunctionUrlConfig` (`McpTargetLambdaGrant`) but never `lambda:InvokeFunctionUrl`. Confirmed against the live prod role (all four policies — inline plus three managed overflows) and the dev role; `git log -S InvokeFunctionUrl` shows it was never granted to app-api. So the button has never worked for IAM-protected servers, and admins have been typing tool names by hand.

The function side was already fine: `mcp-brave-search-prod`'s resource policy allows `<account>:root` for `lambda:InvokeFunctionUrl` (stamped by the MCP server template), plus the per-target `agentcore-gw-brave-search` statement app-api adds at registration. Only the identity policy was missing.

**Second, separate defect:** the runtime role's `ExternalMCPLambdaAccess` was scoped to `<prefix>-mcp-*` only, which never matches an MCP server deployed from its own repo as `mcp-<server>-<env>`. Harmless while such a server is a Gateway target (the gateway role gets its own per-target grant), but a 403 the moment one is configured as a direct external MCP tool. app-api's `McpTargetLambdaGrant` already covered both conventions; the runtime role didn't.

## Changes

- **`app-api-iam-grants.ts`** — new `McpDiscoveryLambdaInvoke` statement: `lambda:InvokeFunctionUrl` on `mcp-*` and `<prefix>-mcp-*`, matching `McpTargetLambdaGrant`'s resource scope. `InvokeFunctionUrl` only — discovery reaches the server over its function URL, never through the Lambda API.
- **`inference-api-iam-roles.ts`** — `ExternalMCPLambdaAccess` now covers `mcp-*` alongside `<prefix>-mcp-*`.
- **`test/mcp-lambda-invoke-grants.test.ts`** — guard test asserting both statements carry `InvokeFunctionUrl` on both patterns. Scans `AWS::IAM::Policy` *and* `AWS::IAM::ManagedPolicy`, since app-api's inline policy overflows into managed ones (three in prod).

## Verification

- `npx tsc --noEmit` clean.
- `npx jest` — 783 passed / 41 suites.
- Stashed the `lib/` changes and re-ran the new test: **both cases fail** against the pre-fix scopes, so it guards rather than tautologically passes.

## Deploy note

Needs a `platform.yml` run to take effect. No runtime behavior changes for existing tools — `mcp-brave-search-prod`'s gateway target and its resource-policy grant are already in place, and the tool list on the gateway form is optional (the gateway runs its own `tools/list` at target sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)