### PR TITLE
fix(models): treat an omitted supported_param as unsupported, not pass-through

### DIFF
--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -291,13 +291,32 @@ def _merge_inference_params(
       * supported with admin default -> use the default unless the request
         provides a value within bounds; out-of-bounds values are clamped.
 
-    Request keys for params the managed model says nothing about pass through
-    untouched — the per-provider translation table will drop unknowns.
+    **Omission means unsupported, for any model that declares a spec at all.**
+    A param the spec doesn't mention is dropped rather than passed through.
+    This inverts the original default, which forwarded any request key that
+    appeared in ``KNOWN_CANONICAL_PARAMS``. That was a latent turn-killer:
+    Anthropic deprecated ``temperature``/``top_p``/``top_k`` on Claude Opus 4.7
+    and later, where a non-default value returns a hard 400. Our curated
+    templates for those models correctly *omit* the params — but omitting is
+    not the same as declaring ``supported: false``, so a request that carried a
+    temperature reached Bedrock and killed the turn mid-stream. Inverting the
+    default closes the whole class instead of requiring every future template
+    to enumerate each newly-deprecated param and never miss one.
+
+    Models with **no** spec keep the permissive behavior: an admin who
+    hand-created a record without a ``supportedParams`` block hasn't declared
+    anything, so there is nothing to read an omission against. Every drop is
+    logged, which is what makes the inversion observable if it takes away a
+    param someone was relying on.
     """
     merged: dict = {}
     spec_map = {}
     if managed_model and managed_model.supported_params:
         spec_map = managed_model.supported_params.params or {}
+
+    # A non-empty spec is the signal that the admin described this model's
+    # params deliberately. An empty/absent one is silence, not a claim.
+    spec_is_authoritative = bool(spec_map)
 
     seen_keys: set[str] = set()
     for name, spec in spec_map.items():
@@ -347,14 +366,26 @@ def _merge_inference_params(
         elif spec.default is not None:
             merged[name] = spec.default
 
-    # Pass through request keys the admin spec doesn't mention, but only when
-    # they're in the canonical allow-list. Without this gate, a user could
-    # submit a future canonical key (or one a future provider mapping starts
-    # forwarding) and bypass the admin's per-model bounds entirely. Unknown
-    # keys are dropped here; the provider translation table is the second
-    # line of defense for ones it doesn't understand.
+    # Request keys the spec doesn't mention. For a model that declared a spec,
+    # silence means unsupported and the key is dropped. For one that declared
+    # nothing, fall back to the canonical allow-list: without that gate a user
+    # could submit a future canonical key (or one a future provider mapping
+    # starts forwarding) and bypass the admin's per-model bounds entirely.
+    # The provider translation table remains the second line of defense.
     for name, value in request_params.items():
         if name in seen_keys or value is None:
+            continue
+        if spec_is_authoritative:
+            # Logged at INFO on purpose: this is the inversion taking something
+            # away. If a param a caller depended on starts disappearing, this
+            # line is how it gets found — grep `omitted from its supportedParams`.
+            logger.info(
+                "Dropping inference param '%s' for model %s — omitted from its "
+                "supportedParams spec, which declares %d param(s)",
+                _sanitize_log(name),
+                _sanitize_log(getattr(managed_model, "model_id", "?")),
+                len(spec_map),
+            )
             continue
         if name not in KNOWN_CANONICAL_PARAMS:
             logger.info(

--- a/backend/tests/apis/inference_api/test_inference_param_merge.py
+++ b/backend/tests/apis/inference_api/test_inference_param_merge.py
@@ -121,3 +121,96 @@ class TestEffortAllowedGating:
         model = _model(effort=spec)
         merged = _merge_inference_params(model, {"effort": "max"})
         assert "effort" not in merged
+
+
+class TestOmissionMeansUnsupported:
+    """A spec that declares *any* param is authoritative: silence about a param
+    means unsupported, not "pass it through".
+
+    The original default forwarded any request key in ``KNOWN_CANONICAL_PARAMS``
+    that the spec didn't mention. Anthropic deprecated ``temperature`` /
+    ``top_p`` / ``top_k`` on Claude Opus 4.7 and later — a non-default value
+    returns a hard 400 — and our curated templates for those models *omit*
+    those params rather than declaring ``supported: false``. So the permissive
+    default let a temperature reach Bedrock and kill the turn mid-stream.
+
+    Note the SPA already behaved this way: `model-settings.ts` renders a row
+    only for a param the spec declares AND marks supported, so omission was
+    already "unsupported" in the UI. The backend was the surface that disagreed.
+    """
+
+    # Opus 4.7 / Sonnet 5 shape: max_tokens + effort declared, sampling params
+    # deliberately absent because the model 400s on them.
+    def _opus_47_spec(self) -> SimpleNamespace:
+        return _model(
+            max_tokens=ModelParamSpec(supported=True, min=1, max=64000, default=32000),
+            effort=ModelParamSpec(
+                supported=True, allowed=["low", "medium", "high"], default="medium"
+            ),
+        )
+
+    def test_omitted_param_is_dropped_when_a_spec_is_declared(self):
+        merged = _merge_inference_params(self._opus_47_spec(), {"temperature": 0.9})
+        assert "temperature" not in merged
+
+    def test_every_deprecated_sampling_param_is_dropped(self):
+        merged = _merge_inference_params(
+            self._opus_47_spec(),
+            {"temperature": 0.9, "top_p": 0.5, "top_k": 40},
+        )
+        assert merged.keys() == {"max_tokens", "effort"}
+
+    def test_declared_params_still_merge_normally(self):
+        """The inversion must not disturb the params the spec does declare."""
+        merged = _merge_inference_params(
+            self._opus_47_spec(), {"max_tokens": 4096, "effort": "high"}
+        )
+        assert merged["max_tokens"] == 4096
+        assert merged["effort"] == "high"
+
+    def test_drop_is_logged_with_the_model_id(self, caplog):
+        """The drop-log is the mitigation for taking a param away — without it
+        the inversion is silent and unfalsifiable in production."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            _merge_inference_params(self._opus_47_spec(), {"temperature": 0.9})
+        assert any(
+            "omitted from its supportedParams" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_model_with_no_spec_stays_permissive(self):
+        """A hand-created record that declares nothing hasn't made a claim, so
+        there is no omission to read. Keep the canonical allow-list behavior."""
+        no_spec = SimpleNamespace(model_id="hand-made", supported_params=None)
+        merged = _merge_inference_params(no_spec, {"temperature": 0.7})
+        assert merged["temperature"] == 0.7
+
+    def test_model_with_empty_spec_stays_permissive(self):
+        empty = _model()  # SupportedParams(params={})
+        merged = _merge_inference_params(empty, {"temperature": 0.7})
+        assert merged["temperature"] == 0.7
+
+    def test_unrecognized_key_is_still_dropped_without_a_spec(self):
+        no_spec = SimpleNamespace(model_id="hand-made", supported_params=None)
+        merged = _merge_inference_params(no_spec, {"not_a_real_param": 1})
+        assert merged == {}
+
+    def test_explicit_unsupported_still_wins(self):
+        """Declaring `supported: false` keeps working — the inversion only
+        changes what *silence* means."""
+        model = _model(temperature=ModelParamSpec(supported=False))
+        merged = _merge_inference_params(model, {"temperature": 0.9})
+        assert "temperature" not in merged
+
+    def test_stale_persisted_override_can_no_longer_reach_the_provider(self):
+        """The SPA persists overrides per model id in localStorage and sends
+        them verbatim, unfiltered by the current spec. So an override set while
+        a param was declared outlives the spec that justified it. Before the
+        inversion that stale value reached Bedrock; now it is dropped."""
+        merged = _merge_inference_params(
+            self._opus_47_spec(), {"temperature": 1.0, "max_tokens": 8192}
+        )
+        assert merged == {"max_tokens": 8192, "effort": "medium"}
+

--- a/docs/one-pagers/model-lifecycle-audit.md
+++ b/docs/one-pagers/model-lifecycle-audit.md
@@ -1,0 +1,45 @@
+# Model lifecycle audit — Bedrock, not Anthropic
+
+**Run:** 2026-09-02 · us-west-2 · `aws bedrock list-foundation-models`
+**Why:** kaizen review 2026-08-28, proposal #2 (part 2). Anthropic deprecated
+`temperature` / `top_p` / `top_k` on Claude Opus 4.7 and later, which prompted
+the question of what *else* about our model ids is on a clock we aren't reading.
+
+## The correction this audit exists to make
+
+**Read Bedrock's schedule, not Anthropic's.** Partner platforms set their own
+dates; an Anthropic deprecation notice is evidence about the API, not about the
+Bedrock model id we actually invoke. The two have diverged before and will again.
+
+## What Bedrock actually publishes
+
+A **status, not a date**: `modelLifecycle.status` is `ACTIVE` or `LEGACY`. There
+is no retirement date in the API, so the registry cannot surface a countdown —
+only "still current" vs "on the way out". `LEGACY` is the signal to migrate;
+treat its appearance as the notice period, because that is all there is.
+
+```bash
+aws bedrock list-foundation-models --region us-west-2 --by-provider anthropic \
+  --query 'modelSummaries[].{id:modelId,status:modelLifecycle.status}' --output table
+```
+
+## Result — all four curated models are current
+
+| Curated key | Bedrock model id | Status |
+|---|---|---|
+| `claude-opus-4-7` | `anthropic.claude-opus-4-7` | ACTIVE |
+| `claude-sonnet-5` | `anthropic.claude-sonnet-5` | ACTIVE |
+| `claude-sonnet-4-6` | `anthropic.claude-sonnet-4-6` | ACTIVE |
+| `claude-haiku-4-5` | `anthropic.claude-haiku-4-5-20251001-v1:0` | ACTIVE |
+
+`LEGACY` in us-west-2 as of this run: Sonnet 4 (`20250514`), Opus 4.1, and the
+Claude 3 Haiku family. **We curate none of them**, so there is no migration
+pending and no action falls out of this audit.
+
+## Standing note
+
+Newer ids (Opus 4.7/4.8/5, Sonnet 5, Fable 5.x) carry **no dated suffix** —
+`anthropic.claude-opus-4-7`, not `...-20251101-v1:0`. Version pinning by date is
+no longer available on those, so "which snapshot am I on" stops being answerable
+from the id. Re-run this query when adding a model, and again if a turn starts
+failing in a way that looks like a model changed underneath us.


### PR DESCRIPTION
Kaizen review 2026-08-28, **proposal #2** (Ship-recommended — the only proposal backed by a fault traced end-to-end through our own code).

## The bug

`_merge_inference_params` dropped a param only when the spec declared `supported: false`. A param the spec merely **omitted** passed through if it appeared in `KNOWN_CANONICAL_PARAMS` — the docstring said so in as many words: *"Request keys for params the managed model says nothing about pass through untouched."*

Anthropic deprecated `temperature`, `top_p` and `top_k` on Claude Opus 4.7 and later, where a non-default value returns a **hard 400**. Our curated templates for Opus 4.7 and Sonnet 5 correctly *omit* those params — but omission was not `supported: false`, so a request carrying a temperature reached Bedrock and killed the turn mid-stream. There is no temperature-suppression guard anywhere else in the codebase (0 grep hits across `backend/src` and `frontend/ai.client/src`).

## The frontend already disagreed with the backend

`model-settings.ts` renders a param row only when the spec declares it **and** marks it supported:

```ts
const paramSpec = spec[meta.key];
if (!paramSpec || !paramSpec.supported) continue;
```

So omission already meant unsupported in the UI. The backend was the surface out of step with its own contract — this PR makes them agree.

The concrete path that could still reach the old behavior: overrides are persisted per model id in `localStorage` and sent **verbatim**, unfiltered by the current spec. An override set while a param was declared outlives the spec that justified it. A test covers that case specifically.

## The change

One inverted default. A spec that declares **any** param is authoritative, and silence about a param means unsupported. This closes the entire class instead of requiring every future template to enumerate each newly-deprecated param and never miss one — the exposure grows with each model, and Opus 5 inherits the same restriction.

Records with **no** spec keep the permissive behavior: an admin who declared nothing has made no claim to read an omission against.

**Mitigation for taking a param away:** every drop logs the param, the model id and the spec size. If something a caller depended on starts disappearing, `grep 'omitted from its supportedParams'` finds it. That was the review's stated condition for shipping the inversion.

## Lifecycle audit (part 2 of the proposal)

`docs/one-pagers/model-lifecycle-audit.md`. The correction worth recording: **read Bedrock's schedule, not Anthropic's** — partner platforms set their own dates. Bedrock publishes a *status*, not a date (`modelLifecycle.status`), so the registry cannot surface a countdown, only ACTIVE vs LEGACY.

All four curated models are **ACTIVE** in us-west-2; nothing we curate is LEGACY, so no migration falls out of this. Standing note: newer ids carry no dated suffix (`anthropic.claude-opus-4-7`, not `...-20251101-v1:0`), so "which snapshot am I on" is no longer answerable from the id.

## Verification
- `pytest tests/apis/inference_api/` — 156 passed (9 new).
- Full backend suite — passing.

## Noted, not fixed here
The curated Sonnet 4.6 template declares `thinking` but omits `effort`, even though `models.py` documents Sonnet 4.6 as an adaptive-thinking model where `effort` governs depth. Users can turn thinking on but not control depth. That is a pre-existing data gap, not caused by this change (the SPA never offered the row), and fixing it means verifying Bedrock accepts `output_config.effort` on that id — out of scope for an inversion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)