### PR TITLE
feat(chat): queue a mid-stream follow-up instead of interrupting the run

### DIFF
--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.html
@@ -28,6 +28,40 @@
       </div>
     }
 
+    <!--
+      Queued follow-ups. The user typed these while a response was still
+      streaming; they send one at a time as each turn finishes. Shown inside the
+      composer shell rather than in the message list because they have not
+      entered the conversation yet and can still be taken back.
+    -->
+    @if (queuedMessages().length > 0) {
+      <div class="border-b border-gray-200 dark:border-gray-700 px-4 py-2">
+        <ul class="flex flex-col gap-1.5" aria-live="polite">
+          @for (queued of queuedMessages(); track $index) {
+            <li class="flex items-start gap-2 rounded-lg bg-gray-100 px-3 py-2 dark:bg-white/5">
+              <ng-icon
+                name="heroClock"
+                class="mt-0.5 size-4 shrink-0 text-gray-500 dark:text-gray-400"
+                aria-hidden="true"
+              />
+              <span class="min-w-0 flex-1 truncate text-sm text-gray-700 dark:text-gray-300">
+                <span class="sr-only">Queued, sends when the current response finishes: </span>
+                {{ queued.content }}
+              </span>
+              <button
+                type="button"
+                (click)="removeQueuedMessage($index)"
+                class="shrink-0 rounded-sm p-0.5 text-gray-500 transition-colors hover:bg-gray-200 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
+                [attr.aria-label]="'Remove queued message: ' + queued.content"
+              >
+                <ng-icon name="heroXMark" class="size-4" aria-hidden="true" />
+              </button>
+            </li>
+          }
+        </ul>
+      </div>
+    }
+
     <!-- File Attachments Area -->
     @if (showFileAttachments()) {
       <div class="border-b border-gray-200 dark:border-gray-700">
@@ -76,7 +110,7 @@
         (click)="onTextareaCaretMove($event)"
         (focus)="onFocus()"
         (blur)="onBlur()"
-        placeholder="How can I help you today?"
+        [attr.placeholder]="placeholder()"
         role="combobox"
         aria-autocomplete="list"
         [attr.aria-expanded]="isMentionMenuOpen()"
@@ -215,7 +249,7 @@
           <!-- Submit/Stop Button -->
           <button
             type="button"
-            (click)="onSubmit()"
+            (click)="onPrimaryButtonClick()"
             [disabled]="!isLoading() && hasActivePendingUploads()"
             [class]="isLoading()
               ? 'flex size-10 items-center justify-center rounded-full bg-red-500 text-white shadow-sm transition-all hover:bg-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500'

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.spec.ts
@@ -140,3 +140,219 @@ describe('ChatInputComponent — the `@` menu keyboard path (D11)', () => {
     expect(component.userInput()).toBe('@Bravo ');
   });
 });
+
+/**
+ * Queue-instead-of-interrupt (kaizen 2026-08-28 #5).
+ *
+ * Enter used to route to Stop while a response was streaming, so a follow-up
+ * typed out of habit killed the run the user was waiting on. And a send that
+ * raced the single-flight guard cleared the composer before the 409 came back,
+ * losing the text outright. Both are covered here.
+ */
+describe('ChatInputComponent — queueing a follow-up mid-stream', () => {
+  let fixture: ComponentFixture<ChatInputComponent>;
+  let component: ChatInputComponent;
+  let textarea: HTMLTextAreaElement;
+  let submitted: { content: string; timestamp: Date; mentionAgentId?: string }[];
+  let cancelled: number;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatInputComponent],
+      providers: [
+        { provide: AgentMentionService, useClass: MentionServiceStub },
+        {
+          provide: FileUploadService,
+          useValue: {
+            pendingUploadsList: signal([]),
+            hasActivePendingUploads: signal(false),
+            readyUploadIds: signal([]),
+            clearReadyUploads: () => undefined,
+            clearPendingUpload: () => undefined,
+          },
+        },
+        { provide: ToastService, useValue: { error: () => undefined, warning: () => undefined, info: () => undefined } },
+        { provide: ToolService, useValue: {} },
+        {
+          provide: VoiceChatService,
+          useValue: {
+            status: signal('idle'),
+            isVoiceActive: signal(false),
+            agentTranscript: signal(''),
+          },
+        },
+        { provide: SystemPromptsService, useValue: { activePrompt: signal(null) } },
+        { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+      ],
+    })
+      .overrideComponent(ChatInputComponent, {
+        set: { imports: [], schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ChatInputComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('showFileControls', false);
+    fixture.componentRef.setInput('showVoiceControl', false);
+    fixture.componentRef.setInput('showSettingsControl', false);
+    fixture.componentRef.setInput('autoFocus', false);
+
+    submitted = [];
+    cancelled = 0;
+    component.messageSubmitted.subscribe(m => submitted.push(m));
+    component.messageCancelled.subscribe(() => cancelled++);
+
+    fixture.detectChanges();
+    textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+  });
+
+  function type(value: string): void {
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
+
+  function pressEnter(): void {
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true }),
+    );
+    fixture.detectChanges();
+  }
+
+  function setStreaming(streaming: boolean): void {
+    fixture.componentRef.setInput('isChatLoading', streaming);
+    fixture.detectChanges();
+  }
+
+  it('sends immediately when nothing is streaming', () => {
+    type('first question');
+    pressEnter();
+    expect(submitted.map(m => m.content)).toEqual(['first question']);
+  });
+
+  it('queues instead of aborting the run when Enter lands mid-stream', () => {
+    setStreaming(true);
+    type('actually, use TypeScript');
+    pressEnter();
+
+    // The regression this replaces: Enter routed to Stop.
+    expect(cancelled).toBe(0);
+    expect(submitted).toEqual([]);
+    expect(component.queuedMessages().map(q => q.content)).toEqual(['actually, use TypeScript']);
+  });
+
+  it('clears the composer on queue so the next follow-up can be typed', () => {
+    setStreaming(true);
+    type('one');
+    pressEnter();
+    expect(component.userInput()).toBe('');
+
+    type('two');
+    pressEnter();
+    expect(component.queuedMessages().map(q => q.content)).toEqual(['one', 'two']);
+  });
+
+  it('sends exactly one queued message when the turn finishes', () => {
+    setStreaming(true);
+    type('one');
+    pressEnter();
+    type('two');
+    pressEnter();
+
+    setStreaming(false);
+
+    // One per completion — the backend serialises turns per session, so
+    // flushing both at once would just collide with the single-flight guard.
+    expect(submitted.map(m => m.content)).toEqual(['one']);
+    expect(component.queuedMessages().map(q => q.content)).toEqual(['two']);
+  });
+
+  it('drains the rest of the queue across subsequent completions, in order', () => {
+    setStreaming(true);
+    type('one');
+    pressEnter();
+    type('two');
+    pressEnter();
+
+    setStreaming(false);
+    setStreaming(true);
+    setStreaming(false);
+
+    expect(submitted.map(m => m.content)).toEqual(['one', 'two']);
+    expect(component.queuedMessages()).toEqual([]);
+  });
+
+  it('flushes after an aborted or failed turn too, not just a clean finish', () => {
+    // The composer cannot tell done from abort from error — it only sees
+    // loading go false. Reading the flush as an invariant rather than a
+    // transition is what makes all three paths behave the same.
+    setStreaming(true);
+    type('follow-up');
+    pressEnter();
+
+    component.cancelChatRequest();
+    setStreaming(false);
+
+    expect(cancelled).toBe(1);
+    expect(submitted.map(m => m.content)).toEqual(['follow-up']);
+  });
+
+  it('stamps the timestamp at send time, not queue time', () => {
+    setStreaming(true);
+    type('later');
+    pressEnter();
+    const queuedAt = Date.now();
+
+    setStreaming(false);
+
+    // Ordering in the message list is by timestamp; stamping at queue time
+    // would sort this ahead of the reply that was still streaming.
+    expect(submitted[0].timestamp.getTime()).toBeGreaterThanOrEqual(queuedAt);
+  });
+
+  it('keeps the button on Stop while streaming', () => {
+    setStreaming(true);
+    type('typed but not sent');
+
+    component.onPrimaryButtonClick();
+
+    expect(cancelled).toBe(1);
+    expect(submitted).toEqual([]);
+    // The text is untouched — stopping is not sending.
+    expect(component.userInput()).toBe('typed but not sent');
+  });
+
+  it('lets a queued message be taken back before it sends', () => {
+    setStreaming(true);
+    type('one');
+    pressEnter();
+    type('two');
+    pressEnter();
+
+    component.removeQueuedMessage(0);
+    setStreaming(false);
+
+    expect(submitted.map(m => m.content)).toEqual(['two']);
+  });
+
+  it('refuses to queue an empty composer', () => {
+    setStreaming(true);
+    type('   ');
+    pressEnter();
+    expect(component.queuedMessages()).toEqual([]);
+  });
+
+  it('carries the turn-scoped @-mention with the queued message', () => {
+    setStreaming(true);
+    type('@Alpha');
+    fixture.detectChanges();
+    pressEnter(); // commits the mention from the open menu
+    type('@Alpha check this');
+    pressEnter(); // queues
+
+    setStreaming(false);
+
+    expect(submitted[0].mentionAgentId).toBe('a1');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -7,6 +7,7 @@ import {
   computed,
   viewChild,
   effect,
+  untracked,
   afterNextRender,
   ElementRef,
 } from '@angular/core';
@@ -57,6 +58,19 @@ interface Message {
    * Marketplace D11: the Agent `@`-mentioned for **this turn only**. The conversation is
    * not bound to it — the next message with no mention is plain chat again.
    */
+  mentionAgentId?: string;
+}
+
+/**
+ * A follow-up the user sent while a response was still streaming. Carries
+ * everything a real send carries except the timestamp, which is stamped at
+ * flush time: the message enters the conversation when it is actually sent, and
+ * stamping it at queue time would sort it ahead of the assistant reply that was
+ * still streaming when the user typed it.
+ */
+interface QueuedMessage {
+  content: string;
+  fileUploadIds?: string[];
   mentionAgentId?: string;
 }
 
@@ -128,8 +142,26 @@ export class ChatInputComponent {
   isFocused = signal(false);
   isDraggingOver = signal(false);
 
+  /**
+   * Follow-ups typed while a response was streaming, oldest first.
+   *
+   * Enter used to mean Stop mid-stream, so a follow-up typed out of habit
+   * killed the response the user was waiting on — and a send that raced the
+   * single-flight guard cleared the composer before the 409 came back, eating
+   * the text outright. Queueing removes both: the draft is never destroyed, so
+   * there is nothing to recover, and the guard becomes unreachable for
+   * user-typed follow-ups rather than merely survivable.
+   *
+   * A list rather than one slot, because a queue that silently drops the second
+   * entry is the same bug in a smaller box.
+   */
+  readonly queuedMessages = signal<QueuedMessage[]>([]);
+
   // Track drag enter/leave depth to handle nested elements
   private dragCounter = 0;
+
+  /** Whether a turn has been observed in flight since the last queue flush. */
+  private turnInFlight = false;
 
   // Output events
   fileAttached = output<File>();
@@ -144,6 +176,16 @@ export class ChatInputComponent {
 
   // Computed: show file attachments area
   readonly showFileAttachments = computed(() => this.pendingUploads().length > 0);
+
+  /**
+   * The composer stays usable mid-stream, so the placeholder is the only place
+   * the queueing behaviour announces itself before the user tries it.
+   */
+  protected readonly placeholder = computed(() =>
+    this.isLoading()
+      ? 'Send a follow-up — it goes out when this response finishes'
+      : 'How can I help you today?',
+  );
 
   // Computed: can submit (has content or ready files)
   readonly canSubmit = computed(() => {
@@ -258,6 +300,34 @@ export class ChatInputComponent {
       this.sessionId();
       this.focusInput();
     });
+
+    // Send one queued follow-up per completed turn.
+    //
+    // Edge-triggered on loading going true -> false, not level-triggered on
+    // "idle with something waiting". The parent only raises `isChatLoading`
+    // after `messageSubmitted` round-trips through the chat service, so a level
+    // check sees itself as still-idle immediately after emitting and drains the
+    // whole queue in one pass — straight into the single-flight guard that
+    // rejects the second turn. Consuming the edge is what holds it to one.
+    //
+    // The parent cannot tell us *how* the turn ended, and it doesn't need to:
+    // done, aborted and errored all land on the same falling edge, which is
+    // what makes the three paths symmetric without three code paths.
+    effect(() => {
+      if (this.isLoading()) {
+        this.turnInFlight = true;
+        return;
+      }
+      if (!this.turnInFlight) return;
+      const [next, ...rest] = untracked(() => this.queuedMessages());
+      if (!next) return;
+      // Consume the edge before emitting: the next message waits for the next
+      // turn to start and finish. If the parent never starts one, the follow-up
+      // stays visible and removable rather than being fired into a rejection.
+      this.turnInFlight = false;
+      this.queuedMessages.set(rest);
+      this.messageSubmitted.emit({ ...next, timestamp: new Date() });
+    });
   }
 
   private focusInput(): void {
@@ -266,12 +336,75 @@ export class ChatInputComponent {
     }
   }
 
+  /**
+   * Enter (and the send affordance when idle). While a response is streaming
+   * this **queues** rather than stopping: Enter always means "say this".
+   *
+   * Stopping stays on the button, deliberately. Making Enter ambiguous — send
+   * when idle, abort when busy — is what let a reflex keystroke kill a run the
+   * user was waiting on, and stopping is the rarer, more destructive of the two.
+   */
   onSubmit() {
+    if (this.isLoading()) {
+      this.queueChatRequest();
+    } else {
+      this.submitChatRequest();
+    }
+  }
+
+  /**
+   * The round button on the right. Unlike Enter it keeps its old meaning while
+   * streaming — it is the only Stop affordance, and taking that away to make
+   * room for a second Send would leave a user with text typed unable to stop.
+   */
+  onPrimaryButtonClick() {
     if (this.isLoading()) {
       this.cancelChatRequest();
     } else {
       this.submitChatRequest();
     }
+  }
+
+  /**
+   * Capture the composer's contents as a pending follow-up and clear it, so the
+   * user can keep typing. Mirrors `submitChatRequest`'s validation exactly —
+   * anything that would not have been sendable is not queueable either.
+   */
+  private queueChatRequest(): void {
+    const content = this.userInput().trim();
+    const fileUploadIds = this.readyUploadIds();
+
+    if (!content && fileUploadIds.length === 0) {
+      return;
+    }
+
+    if (this.hasActivePendingUploads()) {
+      this.toastService.warning('Upload in Progress', 'Please wait for file uploads to complete.');
+      return;
+    }
+
+    this.queuedMessages.update(queue => [
+      ...queue,
+      {
+        content,
+        fileUploadIds: fileUploadIds.length > 0 ? [...fileUploadIds] : undefined,
+        mentionAgentId: this.mentionedAgent()?.agentId,
+      },
+    ]);
+
+    // Clear exactly what a real send clears — the queued copy already owns the
+    // upload ids, so releasing them here is what lets the next message attach
+    // its own files.
+    this.userInput.set('');
+    this.mentionedAgent.set(null);
+    this.closeMentionMenu();
+    this.resetTextareaHeight();
+    this.fileUploadService.clearReadyUploads();
+  }
+
+  /** Drop a pending follow-up before it is sent. */
+  removeQueuedMessage(index: number): void {
+    this.queuedMessages.update(queue => queue.filter((_, i) => i !== index));
   }
 
   submitChatRequest() {


### PR DESCRIPTION
Kaizen review 2026-08-28, **proposal #5** — *"the change a user would notice first."* Supersedes the draft-recovery proposal queued from 2026-08-14.

## Two ways the composer lost your text

**1. Enter meant Stop.** `onSubmit()` routed to `cancelChatRequest()` whenever `isLoading()` was true, so a follow-up typed out of habit aborted the response you were waiting on. Worse than it looks: a client abort does not propagate through the AgentCore Runtime, so the server kept generating — and billing — for an answer nobody would see.

**2. A raced send ate the draft.** `submitChatRequest()` clears the composer on emit. If the single-flight guard rejected that turn, `chat-http.service.ts` surfaced *"This conversation is still generating a response"* — over an empty box. That is the case the draft-recovery pattern was proposed to patch.

## The change

Enter now always means "say this". The composer stays live during a run and the message is **queued**, sending when that turn finishes.

The draft is never destroyed, so there is nothing to recover — this retires the draft-recovery item outright — and the 409-on-duplicate-turn becomes **unreachable** for user-typed follow-ups rather than merely survivable. The guard stays for what it was built for (second tab, transport retry).

Stopping stays on the button. Making Enter ambiguous — send when idle, abort when busy — is what caused the problem, and the button is the only Stop affordance: taking it away to make room for a second Send would leave a user with text typed unable to stop at all.

## Design notes worth reviewing

**A list, not a slot.** A queue that silently drops the second entry is the same class of bug as eating the first. Queued messages render inside the composer shell with a remove control, since they haven't entered the conversation yet and can still be taken back.

**The flush is edge-triggered, and this is the subtle part.** The obvious formulation — "if idle and something is waiting, send it" — drains the whole queue in one pass, because the parent only raises `isChatLoading` *after* `messageSubmitted` round-trips through the chat service. The effect sees itself as still idle immediately after emitting and fires the rest straight into the single-flight guard it exists to avoid. I wrote it that way first and the test caught it; it now consumes a `true -> false` edge, one message per completed turn. `drains the rest of the queue across subsequent completions, in order` is the regression test.

**Done / abort / error are symmetric for free.** The composer cannot tell how a turn ended and doesn't need to — all three land on the same falling edge. One code path, three behaviors covered.

**Timestamp is stamped at send, not at queue.** The message list orders by timestamp; stamping at queue time would sort the follow-up ahead of the reply that was still streaming when it was typed.

**All three composer surfaces get it** — session chat, agent preview, and marketplace test-drive all pass `isChatLoading` through `chat-container`, so the behavior lands with no plumbing changes.

## Scope

Queues to the **end of the turn**, not to the next tool boundary. True mid-turn steering needs the backend to accept an injection into a running turn, and there is no path for that today — the SSE stream is one turn. Calling this "steering" would oversell it; it is "your text is never lost and never kills the run."

## Verification
- `ng test --include='**/chat-input.component.spec.ts'` — 16 passed (11 new).
- Full SPA suite — 174 files, 1988 tests, all passing.
- **Not manually exercised in a browser**: no `SKIP_AUTH` locally, and driving a real streaming turn needs a dev-backend session. The queue/flush/abort paths are covered by unit tests, but the visual treatment of the queued chips has not been seen rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)