### PR TITLE
feat(artifacts): artifact sharing PR-1 — data model, owner CRUD, share-scoped mint

### DIFF
--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -1,10 +1,19 @@
-"""Request/response models for the render-token endpoint."""
+"""Request/response models for the artifacts API.
+
+Covers the render-token, session-list and content endpoints, plus the
+artifact-sharing surface (`artifacts/shares.py`).
+
+JSON casing is split by design and matches what already shipped: the
+render-token / list / content models are snake_case (this domain's
+original REST shape), while the sharing models are camelCase aliases to
+mirror the conversation-sharing API the SPA share modal is adapted from.
+"""
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class RenderTokenRequest(BaseModel):
@@ -64,3 +73,134 @@ class ArtifactContentResponse(BaseModel):
     content: str
     content_type: str
     version: int
+
+
+# ---------------------------------------------------------------------
+# Artifact sharing
+# ---------------------------------------------------------------------
+
+
+class CreateArtifactShareRequest(BaseModel):
+    """Request body for sharing one artifact version.
+
+    `version` is required and never defaults to the artifact's HEAD: a
+    share pins one immutable version, and a pointer that moves under the
+    recipient is a different feature with different consent semantics.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: int = Field(
+        ..., ge=1, description="Artifact version to share (never #HEAD)"
+    )
+    access_level: Literal["public", "specific"] = Field(
+        ...,
+        alias="accessLevel",
+        description="'public' = any authenticated tenant user; "
+        "'specific' = email allowlist",
+    )
+    allowed_emails: Optional[List[str]] = Field(
+        default=None,
+        alias="allowedEmails",
+        description="Email addresses allowed to view "
+        "(required when accessLevel is 'specific')",
+    )
+
+    @model_validator(mode="after")
+    def validate_allowed_emails(self) -> "CreateArtifactShareRequest":
+        if self.access_level == "specific" and not self.allowed_emails:
+            raise ValueError(
+                "allowed_emails is required when access_level is 'specific'"
+            )
+        return self
+
+
+class UpdateArtifactShareRequest(BaseModel):
+    """Request body for changing an existing share's access controls.
+
+    The share target — `(artifact_id, version)` — is immutable; only who
+    may view it can change.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    access_level: Optional[Literal["public", "specific"]] = Field(
+        default=None, alias="accessLevel", description="New access level"
+    )
+    allowed_emails: Optional[List[str]] = Field(
+        default=None,
+        alias="allowedEmails",
+        description="Updated email allowlist",
+    )
+
+    @model_validator(mode="after")
+    def validate_allowed_emails(self) -> "UpdateArtifactShareRequest":
+        if self.access_level == "specific" and not self.allowed_emails:
+            raise ValueError(
+                "allowed_emails is required when access_level is 'specific'"
+            )
+        return self
+
+
+class ArtifactShareResponse(BaseModel):
+    """An artifact share, as its owner sees it.
+
+    Owner-only: `allowedEmails` is other people's addresses, so this
+    shape must never be returned on a recipient-facing route.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    share_id: str = Field(..., alias="shareId")
+    artifact_id: str = Field(..., alias="artifactId")
+    version: int = Field(..., description="Pinned artifact version")
+    owner_id: str = Field(..., alias="ownerId")
+    access_level: Literal["public", "specific"] = Field(
+        ..., alias="accessLevel"
+    )
+    allowed_emails: Optional[List[str]] = Field(
+        default=None, alias="allowedEmails"
+    )
+    title: str = Field(default="", description="Denormalized artifact title")
+    content_type: str = Field(default="", alias="contentType")
+    created_at: str = Field(..., alias="createdAt")
+    updated_at: Optional[str] = Field(default=None, alias="updatedAt")
+    share_url: str = Field(
+        ...,
+        alias="shareUrl",
+        description="SPA-relative recipient route for this share",
+    )
+
+
+class ArtifactShareListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    shares: List[ArtifactShareResponse] = Field(default_factory=list)
+
+
+class SharedArtifactResponse(BaseModel):
+    """Recipient-facing share metadata. Never carries artifact content.
+
+    Deliberately omits `ownerId`, `artifactId` and `allowedEmails`: a
+    recipient needs enough to render a header and decide what chrome to
+    show, not the owner's internal ids or the rest of the allowlist.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    share_id: str = Field(..., alias="shareId")
+    title: str = Field(default="")
+    content_type: str = Field(default="", alias="contentType")
+    version: int
+    created_at: str = Field(..., alias="createdAt")
+    owner_email: str = Field(
+        ..., alias="ownerEmail", description="Who shared this"
+    )
+    can_download: bool = Field(
+        default=True,
+        alias="canDownload",
+        description="Whether the recipient may save a local copy. The "
+        "download path is the same render URL with ?download=1, so a "
+        "recipient who can view can also download — surfaced as a field "
+        "so a future policy can withhold it without a shape change.",
+    )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -17,6 +17,8 @@ import os
 import re
 import threading
 import time
+import uuid
+from datetime import datetime, timezone
 from typing import Optional
 
 import boto3
@@ -24,6 +26,7 @@ import jwt
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
+from apis.shared.auth import User
 from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
@@ -225,6 +228,84 @@ class RenderTokenService:
         logger.info(
             "minted render token user=%s artifact=%s v=%s",
             user_id,
+            scrub_log(artifact_id),
+            scrub_log(version),
+        )
+        return f"{origin}/?t={token}", exp
+
+    def mint_for_share(
+        self, *, share_id: str, viewer: User
+    ) -> tuple[str, int]:
+        """Mint a render token for a *shared* artifact version.
+
+        Returns (render_url, exp_unix). Raises ShareNotFoundError,
+        ShareAccessDeniedError, ArtifactNotFoundError, or
+        RenderTokenConfigError. Origin resolves first so a misconfigured
+        deploy fails closed before any DDB call.
+
+        ############################################################
+        # SECURITY — READ BEFORE CHANGING `sub` BELOW.
+        #
+        # `sub` is the OWNER's user id, not the viewer's. That is
+        # deliberate and load-bearing: the render Lambda uses `sub`
+        # purely as the DynamoDB partition key it builds the lookup
+        # from (PK = USER#{sub}), and performs no ownership comparison
+        # of its own — it never sees the viewer. `sub` here is an
+        # ADDRESS, not an identity assertion.
+        #
+        # Setting `sub` to the viewer would not "fix" anything; it
+        # would point the Lambda at the viewer's own partition and the
+        # shared artifact would simply 404.
+        #
+        # The consequence is that `_check_share_access` immediately
+        # below is the ONLY thing standing between "sharing" and "read
+        # any artifact by id". Do not reorder it, do not make it
+        # conditional, and do not move minting ahead of it.
+        #
+        # The real viewer identity travels in `vwr`, and the grant it
+        # was issued under in `shr`, so the render log can attribute
+        # the view correctly rather than crediting it to the owner.
+        # The deployed verifier validates a fixed claim list and has no
+        # extras rejection, so these are forward-compatible additions
+        # requiring no Lambda change or deploy sequencing.
+        ############################################################
+        """
+        origin = _origin()
+        share = _get_share_lookup(share_id)
+        if not share:
+            raise ShareNotFoundError("share not found")
+        _check_share_access(share, viewer)
+
+        owner_id = str(share.get("owner_id", ""))
+        artifact_id = str(share.get("artifact_id", ""))
+        version = int(share.get("version", 0))
+        # The share row is denormalized metadata; the version row is the
+        # truth. Re-assert it so a share whose artifact version has gone
+        # away 404s here rather than minting a token that renders the
+        # Lambda's error page inside the recipient's iframe.
+        _assert_version_exists(owner_id, artifact_id, version)
+
+        now = int(time.time())
+        exp = now + _TTL_SECONDS
+        claims = {
+            "iss": _ISS,
+            "aud": _AUD,
+            "sub": owner_id,  # DynamoDB partition — NOT an identity claim.
+            "aid": artifact_id,
+            "ver": version,
+            "sid": "",
+            "vwr": viewer.user_id,  # who actually looked (audit)
+            "shr": share_id,  # under which grant (audit)
+            "iat": now,
+            "exp": exp,
+        }
+        token = jwt.encode(claims, _signing_key(), algorithm="HS256")
+        logger.info(
+            "minted shared render token share=%s owner=%s viewer=%s "
+            "artifact=%s v=%s",
+            scrub_log(share_id),
+            scrub_log(owner_id),
+            scrub_log(viewer.user_id),
             scrub_log(artifact_id),
             scrub_log(version),
         )
@@ -477,3 +558,350 @@ class ArtifactContentService:
 
 def get_artifact_content_service() -> ArtifactContentService:
     return ArtifactContentService()
+
+
+# ---------------------------------------------------------------------
+# Artifact sharing
+#
+# Two rows per share, on this same table, written in one transaction:
+#
+#   owner row   PK = USER#{owner_id}
+#               SK = SHARE#{artifact_id}#V#{version:05d}#{share_id}
+#   lookup row  PK = SHARE#{share_id}
+#               SK = META
+#
+# The owner row makes "list my shares for this artifact" a begins_with
+# query on the owner's existing partition; the lookup row makes the
+# recipient path — which knows only a share id — a single GetItem. Two
+# items in a transaction is deliberately chosen over a GSI: an index
+# would mean an infra deploy that has to land before the code that
+# queries it, one UpdateTable at a time.
+#
+# Both rows carry the identical attribute set. The duplication is
+# bounded (access_level / allowed_emails are the only mutable fields)
+# and every write below rewrites both rows together, so they cannot
+# drift.
+# ---------------------------------------------------------------------
+
+_SHARE_LOOKUP_SK = "META"
+
+
+class ArtifactShareError(Exception):
+    """Base class for artifact-share failures."""
+
+
+class ShareNotFoundError(ArtifactShareError):
+    """No share row for the requested share id (never created, or revoked)."""
+
+
+class ShareAccessDeniedError(ArtifactShareError):
+    """The viewer is not permitted to open this share."""
+
+
+class NotShareOwnerError(ArtifactShareError):
+    """A non-owner attempted to mutate or revoke a share."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _owner_share_sk(artifact_id: str, version: int, share_id: str) -> str:
+    """Owner-row sort key. The `V#{version:05d}` zero-pad matches the
+    artifact version rows so the two key spaces read consistently."""
+    return f"SHARE#{artifact_id}#V#{version:05d}#{share_id}"
+
+
+def _owner_share_prefix(artifact_id: str) -> str:
+    return f"SHARE#{artifact_id}#V#"
+
+
+def _share_lookup_key(share_id: str) -> dict:
+    return {"PK": f"SHARE#{share_id}", "SK": _SHARE_LOOKUP_SK}
+
+
+def _get_share_lookup(share_id: str) -> Optional[dict]:
+    """Resolve a share id to its record without knowing the owner.
+
+    Returns None when the share does not exist — a revoked share is a
+    deleted row, which is what makes revocation effective within one
+    token TTL."""
+    try:
+        result = _table().get_item(Key=_share_lookup_key(share_id))
+    except ClientError as exc:
+        raise ArtifactQueryError("share lookup failed") from exc
+    return result.get("Item")
+
+
+def _check_share_access(share: dict, viewer: User) -> None:
+    """Decide whether `viewer` may open `share`.
+
+    Direct port of ShareService._check_access (conversation sharing).
+    `public` means "any authenticated tenant user", never anonymous —
+    every route reaching here is already behind the session dependency.
+
+    This is the security boundary for the whole feature: the share-scoped
+    mint hands the viewer a credential addressed to the *owner's*
+    DynamoDB partition, so this check is the only thing between
+    "sharing" and "read any artifact by id". Fail closed — an unknown or
+    missing access level is treated as `specific` with no allowlist.
+    """
+    if viewer.user_id and viewer.user_id == share.get("owner_id"):
+        return
+
+    access_level = share.get("access_level", "specific")
+    if access_level == "public":
+        return
+
+    if access_level == "specific":
+        allowed = [
+            str(e).lower() for e in (share.get("allowed_emails") or [])
+        ]
+        viewer_email = (viewer.email or "").lower()
+        if viewer_email and viewer_email in allowed:
+            return
+
+    raise ShareAccessDeniedError("access denied")
+
+
+def _resolve_allowed_emails(
+    access_level: str,
+    allowed_emails: Optional[list[str]],
+    owner_email: str,
+) -> Optional[list[str]]:
+    """Normalize the allowlist, keeping the owner on it.
+
+    Port of ShareService._resolve_allowed_emails: `public` carries no
+    list at all, and the owner is always implicitly allowed (they also
+    pass the owner branch of _check_share_access, but keeping them on
+    the list makes the row self-describing in the share UI)."""
+    if access_level != "specific":
+        return None
+    emails = list(allowed_emails or [])
+    if owner_email and owner_email.lower() not in [
+        e.lower() for e in emails
+    ]:
+        emails.insert(0, owner_email)
+    return emails
+
+
+class ArtifactShareService:
+    """Owner-side CRUD for artifact shares.
+
+    A share pins one immutable `(artifact_id, version)` pair — never
+    `#HEAD`. Version rows are append-only, so the recipient's view can
+    never change under them and no snapshot copy is needed.
+    """
+
+    def create(
+        self,
+        *,
+        owner: User,
+        artifact_id: str,
+        version: int,
+        access_level: str,
+        allowed_emails: Optional[list[str]],
+    ) -> dict:
+        """Create a share for one artifact version.
+
+        The version row is fetched with a PK built from the *owner's*
+        session id, so a caller can only ever share their own artifact —
+        an unknown or someone else's version is an indistinguishable
+        404. Title and content type are denormalized off that row so the
+        recipient header needs no second read.
+        """
+        item = _get_version_item(owner.user_id, artifact_id, version)
+
+        share_id = str(uuid.uuid4())
+        now = _now_iso()
+        attrs = {
+            "share_id": share_id,
+            "artifact_id": artifact_id,
+            "version": version,
+            "owner_id": owner.user_id,
+            "owner_email": owner.email,
+            "access_level": access_level,
+            "title": item.get("title", ""),
+            "content_type": item.get(
+                "content_type", "text/html; charset=utf-8"
+            ),
+            "session_id": item.get("session_id", ""),
+            "created_at": now,
+            "updated_at": now,
+        }
+        resolved = _resolve_allowed_emails(
+            access_level, allowed_emails, owner.email
+        )
+        if resolved is not None:
+            attrs["allowed_emails"] = resolved
+
+        self._write_share_rows(attrs)
+        logger.info(
+            "created artifact share share=%s artifact=%s v=%s access=%s",
+            scrub_log(share_id),
+            scrub_log(artifact_id),
+            scrub_log(version),
+            scrub_log(access_level),
+        )
+        return attrs
+
+    def list_for_artifact(
+        self, *, owner_id: str, artifact_id: str
+    ) -> list[dict]:
+        """Every share the caller owns for one artifact.
+
+        Partition-scoped by construction: PK is the authenticated user,
+        so this can never surface another owner's shares."""
+        table = _table()
+        items: list[dict] = []
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"USER#{owner_id}")
+            & Key("SK").begins_with(_owner_share_prefix(artifact_id)),
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError("share list query failed") from exc
+        return [self._strip_keys(item) for item in items]
+
+    def get_for_viewer(self, *, share_id: str, viewer: User) -> dict:
+        """Access-checked read of a share record. Never returns content."""
+        share = _get_share_lookup(share_id)
+        if not share:
+            raise ShareNotFoundError("share not found")
+        _check_share_access(share, viewer)
+        return self._strip_keys(share)
+
+    def update(
+        self,
+        *,
+        share_id: str,
+        owner: User,
+        access_level: Optional[str],
+        allowed_emails: Optional[list[str]],
+    ) -> dict:
+        """Change access level / allowlist on an existing share.
+
+        Rewrites both rows so the owner row and the lookup row the
+        recipient path reads can never disagree about who may view."""
+        share = _get_share_lookup(share_id)
+        if not share:
+            raise ShareNotFoundError("share not found")
+        if share.get("owner_id") != owner.user_id:
+            raise NotShareOwnerError("not the share owner")
+
+        updated = self._strip_keys(share)
+        new_access = access_level or updated.get("access_level", "specific")
+        updated["access_level"] = new_access
+
+        if new_access == "specific":
+            emails = allowed_emails or updated.get("allowed_emails") or []
+            updated["allowed_emails"] = _resolve_allowed_emails(
+                new_access, emails, str(updated.get("owner_email", ""))
+            )
+        else:
+            # Switching to public — drop the stale allowlist rather than
+            # leaving a list that no longer gates anything.
+            updated.pop("allowed_emails", None)
+
+        updated["version"] = int(updated.get("version", 0))
+        updated["updated_at"] = _now_iso()
+
+        self._write_share_rows(updated)
+        logger.info(
+            "updated artifact share share=%s access=%s",
+            scrub_log(share_id),
+            scrub_log(new_access),
+        )
+        return updated
+
+    def revoke(self, *, share_id: str, owner: User) -> None:
+        """Delete both rows. Effective within one render-token TTL."""
+        share = _get_share_lookup(share_id)
+        if not share:
+            raise ShareNotFoundError("share not found")
+        if share.get("owner_id") != owner.user_id:
+            raise NotShareOwnerError("not the share owner")
+
+        table = _table()
+        owner_sk = _owner_share_sk(
+            str(share.get("artifact_id", "")),
+            int(share.get("version", 0)),
+            share_id,
+        )
+        try:
+            table.meta.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Delete": {
+                            "TableName": table.name,
+                            "Key": {
+                                "PK": f"USER#{share.get('owner_id', '')}",
+                                "SK": owner_sk,
+                            },
+                        }
+                    },
+                    {
+                        "Delete": {
+                            "TableName": table.name,
+                            "Key": _share_lookup_key(share_id),
+                        }
+                    },
+                ]
+            )
+        except ClientError as exc:
+            raise ArtifactQueryError("share revoke failed") from exc
+        logger.info("revoked artifact share share=%s", scrub_log(share_id))
+
+    @staticmethod
+    def _write_share_rows(attrs: dict) -> None:
+        """Put the owner row and the lookup row in one transaction.
+
+        Both carry the same attributes; only the keys differ. A partial
+        write would either strand an unreachable share (owner row with
+        no lookup) or an unlistable one, so this is atomic. Plain Puts
+        only — a ConditionCheck item would need `dynamodb:ConditionCheckItem`
+        added to the task role, which plain writes do not.
+        """
+        table = _table()
+        owner_sk = _owner_share_sk(
+            str(attrs["artifact_id"]),
+            int(attrs["version"]),
+            str(attrs["share_id"]),
+        )
+        owner_row = {
+            **attrs,
+            "PK": f"USER#{attrs['owner_id']}",
+            "SK": owner_sk,
+        }
+        lookup_row = {**attrs, **_share_lookup_key(str(attrs["share_id"]))}
+        try:
+            table.meta.client.transact_write_items(
+                TransactItems=[
+                    {"Put": {"TableName": table.name, "Item": owner_row}},
+                    {"Put": {"TableName": table.name, "Item": lookup_row}},
+                ]
+            )
+        except ClientError as exc:
+            raise ArtifactQueryError("share write failed") from exc
+
+    @staticmethod
+    def _strip_keys(item: dict) -> dict:
+        """Drop the DynamoDB key attributes and normalize `version`.
+
+        `version` comes back off DynamoDB as a Decimal; the SK builder
+        and the response models both want a real int."""
+        stripped = {k: v for k, v in item.items() if k not in ("PK", "SK")}
+        if "version" in stripped:
+            stripped["version"] = int(stripped["version"])
+        return stripped
+
+
+def get_artifact_share_service() -> ArtifactShareService:
+    return ArtifactShareService()

--- a/backend/src/apis/app_api/artifacts/shares.py
+++ b/backend/src/apis/app_api/artifacts/shares.py
@@ -1,0 +1,354 @@
+"""Artifact sharing API routes.
+
+Two routers, mounted together under the same enablement signal that
+gates `artifacts/routes.py` (presence of
+`ARTIFACTS_RENDER_TOKEN_SECRET_ARN`):
+
+  - ``artifact_shares_router`` — owner CRUD, under ``/artifacts``.
+  - ``shared_artifacts_router`` — the recipient surface, under
+    ``/shared-artifacts``.
+
+Every route depends on ``get_current_user_from_session``. "Public" here
+means *any authenticated tenant user*, exactly as it does for
+conversation shares — never anonymous. Governance is Entra JWT identity,
+so there is no unauthenticated path to an artifact at all.
+
+The recipient render-token route is the security-critical one: it hands
+a viewer a short-lived credential addressed to the *owner's* DynamoDB
+partition. See the block comment on ``RenderTokenService.mint_for_share``
+before touching it.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.security.log_sanitize import scrub_log
+
+from .models import (
+    ArtifactShareListResponse,
+    ArtifactShareResponse,
+    CreateArtifactShareRequest,
+    RenderTokenResponse,
+    SharedArtifactResponse,
+    UpdateArtifactShareRequest,
+)
+from .service import (
+    ArtifactNotFoundError,
+    ArtifactQueryError,
+    ArtifactShareService,
+    NotShareOwnerError,
+    RenderTokenConfigError,
+    RenderTokenService,
+    ShareAccessDeniedError,
+    ShareNotFoundError,
+    get_artifact_share_service,
+    get_render_token_service,
+)
+
+logger = logging.getLogger(__name__)
+
+artifact_shares_router = APIRouter(prefix="/artifacts", tags=["artifact-shares"])
+shared_artifacts_router = APIRouter(
+    prefix="/shared-artifacts", tags=["artifact-shares"]
+)
+
+
+def _share_response(share: dict) -> ArtifactShareResponse:
+    return ArtifactShareResponse(
+        share_id=share["share_id"],
+        artifact_id=share.get("artifact_id", ""),
+        version=int(share.get("version", 0)),
+        owner_id=share.get("owner_id", ""),
+        access_level=share.get("access_level", "specific"),
+        allowed_emails=share.get("allowed_emails"),
+        title=share.get("title", ""),
+        content_type=share.get("content_type", ""),
+        created_at=share.get("created_at", ""),
+        updated_at=share.get("updated_at"),
+        share_url=f"/shared-artifact/{share['share_id']}",
+    )
+
+
+# ------------------------------------------------------------------
+# Owner endpoints
+# ------------------------------------------------------------------
+
+
+@artifact_shares_router.post(
+    "/{artifact_id}/shares",
+    response_model=ArtifactShareResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_artifact_share(
+    artifact_id: str,
+    request: CreateArtifactShareRequest,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> ArtifactShareResponse:
+    """Share one immutable artifact version.
+
+    The version row is looked up with a partition key built from the
+    authenticated session, so a caller can only share their own
+    artifact — someone else's version is an indistinguishable 404.
+    """
+    try:
+        share = service.create(
+            owner=user,
+            artifact_id=artifact_id,
+            version=request.version,
+            access_level=request.access_level,
+            allowed_emails=request.allowed_emails,
+        )
+    except ArtifactNotFoundError:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Artifact version not found"
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact share service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact share write failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return _share_response(share)
+
+
+@artifact_shares_router.get(
+    "/{artifact_id}/shares",
+    response_model=ArtifactShareListResponse,
+    response_model_by_alias=True,
+)
+async def list_artifact_shares(
+    artifact_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> ArtifactShareListResponse:
+    """List the caller's shares for one artifact.
+
+    Partition-scoped to the authenticated user, so an unknown or
+    unowned artifact id is a normal empty list rather than a 404 — it
+    reveals nothing about whether that artifact exists.
+    """
+    try:
+        shares = service.list_for_artifact(
+            owner_id=user.user_id, artifact_id=artifact_id
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact share service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact share list query failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return ArtifactShareListResponse(
+        shares=[_share_response(share) for share in shares]
+    )
+
+
+@artifact_shares_router.patch(
+    "/shares/{share_id}",
+    response_model=ArtifactShareResponse,
+    response_model_by_alias=True,
+)
+async def update_artifact_share(
+    share_id: str,
+    request: UpdateArtifactShareRequest,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> ArtifactShareResponse:
+    """Change who may view an existing share. Owner only."""
+    try:
+        share = service.update(
+            share_id=share_id,
+            owner=user,
+            access_level=request.access_level,
+            allowed_emails=request.allowed_emails,
+        )
+    except ShareNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
+    except NotShareOwnerError:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "You do not have permission to update this share",
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact share service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact share update failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return _share_response(share)
+
+
+@artifact_shares_router.delete(
+    "/shares/{share_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def revoke_artifact_share(
+    share_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> Response:
+    """Revoke a share. Owner only.
+
+    Deletes both rows, so the next recipient open finds nothing to mint
+    against. Already-issued tokens stay valid until they expire, which
+    bounds the revocation window at the ~120s token TTL rather than at
+    the length of the recipient's session.
+    """
+    try:
+        service.revoke(share_id=share_id, owner=user)
+    except ShareNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
+    except NotShareOwnerError:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "You do not have permission to revoke this share",
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact share service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact share revoke failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ------------------------------------------------------------------
+# Recipient endpoints
+# ------------------------------------------------------------------
+
+
+@shared_artifacts_router.get(
+    "/{share_id}",
+    response_model=SharedArtifactResponse,
+    response_model_by_alias=True,
+)
+async def get_shared_artifact(
+    share_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> SharedArtifactResponse:
+    """Metadata for a shared artifact. Never returns content.
+
+    Access-controlled: a revoked share is a 404 and a viewer outside the
+    allowlist is a 403, so a recipient learns nothing about a share they
+    cannot open beyond whether the link is dead or simply not theirs.
+    """
+    try:
+        share = service.get_for_viewer(share_id=share_id, viewer=user)
+    except ShareNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
+    except ShareAccessDeniedError:
+        logger.info(
+            "artifact share access denied share=%s viewer=%s",
+            scrub_log(share_id),
+            scrub_log(user.user_id),
+        )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Access denied")
+    except RenderTokenConfigError:
+        logger.exception("artifact share service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("shared artifact lookup failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return SharedArtifactResponse(
+        share_id=share["share_id"],
+        title=share.get("title", ""),
+        content_type=share.get("content_type", ""),
+        version=int(share.get("version", 0)),
+        created_at=share.get("created_at", ""),
+        owner_email=share.get("owner_email", ""),
+        can_download=True,
+    )
+
+
+@shared_artifacts_router.post(
+    "/{share_id}/render-token", response_model=RenderTokenResponse
+)
+async def mint_shared_render_token(
+    share_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: RenderTokenService = Depends(get_render_token_service),
+) -> RenderTokenResponse:
+    """Mint a render token for a shared artifact version.
+
+    Returns the same ``{url, expires_at}`` shape as the owner endpoint,
+    so the SPA's iframe and ``?download=1`` paths work unchanged.
+
+    The minted token's ``sub`` is the OWNER, because it is the DynamoDB
+    partition key the render Lambda builds — the ACL check inside
+    ``mint_for_share`` is what makes that safe. Read the block comment
+    there before changing anything on this path.
+    """
+    try:
+        url, exp = service.mint_for_share(share_id=share_id, viewer=user)
+    except ShareNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
+    except ShareAccessDeniedError:
+        logger.info(
+            "artifact share mint denied share=%s viewer=%s",
+            scrub_log(share_id),
+            scrub_log(user.user_id),
+        )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Access denied")
+    except ArtifactNotFoundError:
+        # The share row outlived the artifact version it points at. A
+        # 404 beats minting a token that renders the Lambda's error page
+        # inside the recipient's iframe.
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Artifact version not found"
+        )
+    except RenderTokenConfigError:
+        logger.exception("render token service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact rendering is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("shared render token lookup failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact rendering is temporarily unavailable",
+        )
+
+    return RenderTokenResponse(
+        url=url,
+        expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
+    )

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -264,8 +264,17 @@ if skills_enabled():
 # environment, so its presence is the enablement signal.
 if os.environ.get("ARTIFACTS_RENDER_TOKEN_SECRET_ARN"):
     from apis.app_api.artifacts.routes import router as artifacts_router
+    from apis.app_api.artifacts.shares import (
+        artifact_shares_router,
+        shared_artifacts_router,
+    )
     app.include_router(artifacts_router)
-    logger.info("Artifact render-token routes enabled")
+    # Artifact sharing rides the same enablement signal: a share is only
+    # ever consumed by minting a render token, so it cannot be useful
+    # without the artifacts feature being on.
+    app.include_router(artifact_shares_router)
+    app.include_router(shared_artifacts_router)
+    logger.info("Artifact render-token and sharing routes enabled")
 
 # Mount static file directories for serving generated content
 # These are created by tools (visualization, code interpreter, etc.)

--- a/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
@@ -1,0 +1,460 @@
+"""Tests for artifact-share CRUD (owner side).
+
+Covers the two-row transactional write, partition-scoped listing, owner
+enforcement on mutation, and revocation. The security-critical mint path
+lives in `test_shared_render_token.py`.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as token_service
+from apis.app_api.artifacts.shares import (
+    artifact_shares_router,
+    shared_artifacts_router,
+)
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+REGION = "us-east-1"
+OWNER_ID = "owner-1"
+OWNER_EMAIL = "owner@x.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    token_service._reset_caches_for_tests()
+
+
+def _owner() -> User:
+    return User(
+        email=OWNER_EMAIL, user_id=OWNER_ID, name="Owner", roles=[]
+    )
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch):
+    """A mocked artifacts table plus an app mounting both share routers.
+
+    Yields (make_client, ddb) so a test can re-bind the authenticated
+    user without rebuilding the table.
+    """
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("ARTIFACTS_ORIGIN", "https://a.test.example.com")
+
+        def make_client(user: User | None = None) -> TestClient:
+            app = FastAPI()
+            app.include_router(artifact_shares_router)
+            app.include_router(shared_artifacts_router)
+            app.dependency_overrides[get_current_user_from_session] = (
+                lambda: user or _owner()
+            )
+            return TestClient(app)
+
+        yield make_client, boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_version(
+    ddb,
+    *,
+    user_id: str = OWNER_ID,
+    artifact: str = "art-1",
+    version: int = 1,
+    title: str = "My Chart",
+    session_id: str = "sess-1",
+) -> None:
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "artifact_id": artifact,
+            "user_id": user_id,
+            "version": version,
+            "storage": "s3",
+            "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "title": title,
+            "session_id": session_id,
+        }
+    )
+
+
+def _create_share(tc: TestClient, *, artifact="art-1", **body) -> dict:
+    payload = {"version": 1, "accessLevel": "public"}
+    payload.update(body)
+    resp = tc.post(f"/artifacts/{artifact}/shares", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ------------------------------------------------------------------
+# Create
+# ------------------------------------------------------------------
+
+
+def test_create_writes_both_rows_transactionally(env) -> None:
+    """Both the owner row and the share-lookup row must exist after a
+    single create — the owner row is what makes listing possible, the
+    lookup row is what makes the recipient path possible."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _create_share(make_client())
+
+    share_id = share["shareId"]
+    table = ddb.Table(TABLE)
+
+    owner_row = table.get_item(
+        Key={
+            "PK": f"USER#{OWNER_ID}",
+            "SK": f"SHARE#art-1#V#00001#{share_id}",
+        }
+    ).get("Item")
+    lookup_row = table.get_item(
+        Key={"PK": f"SHARE#{share_id}", "SK": "META"}
+    ).get("Item")
+
+    assert owner_row is not None
+    assert lookup_row is not None
+    # Identical attribute sets — only the keys differ. If these drift,
+    # the owner's view of who can see a share stops matching what the
+    # recipient path actually enforces.
+    assert {k: v for k, v in owner_row.items() if k not in ("PK", "SK")} == {
+        k: v for k, v in lookup_row.items() if k not in ("PK", "SK")
+    }
+    assert lookup_row["owner_id"] == OWNER_ID
+    assert lookup_row["artifact_id"] == "art-1"
+    assert int(lookup_row["version"]) == 1
+
+
+def test_create_denormalizes_title_and_content_type(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, title="Quarterly Deck")
+    share = _create_share(make_client())
+    assert share["title"] == "Quarterly Deck"
+    assert share["contentType"] == "text/html; charset=utf-8"
+    assert share["shareUrl"] == f"/shared-artifact/{share['shareId']}"
+
+
+def test_create_for_unknown_version_is_404(env) -> None:
+    make_client, _ = env
+    resp = make_client().post(
+        "/artifacts/art-1/shares", json={"version": 1, "accessLevel": "public"}
+    )
+    assert resp.status_code == 404
+
+
+def test_cannot_share_another_users_artifact(env) -> None:
+    """Ownership scoping: the version lookup builds its PK from the
+    session user, so someone else's artifact is an indistinguishable
+    404 rather than a shareable target."""
+    make_client, ddb = env
+    _put_version(ddb, user_id="someone-else")
+    resp = make_client().post(
+        "/artifacts/art-1/shares", json={"version": 1, "accessLevel": "public"}
+    )
+    assert resp.status_code == 404
+
+
+def test_specific_requires_allowed_emails(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    resp = make_client().post(
+        "/artifacts/art-1/shares",
+        json={"version": 1, "accessLevel": "specific"},
+    )
+    assert resp.status_code == 422
+
+
+def test_owner_email_is_kept_on_the_allowlist(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _create_share(
+        make_client(),
+        accessLevel="specific",
+        allowedEmails=["friend@x.com"],
+    )
+    assert OWNER_EMAIL in share["allowedEmails"]
+    assert "friend@x.com" in share["allowedEmails"]
+
+
+def test_public_share_carries_no_allowlist(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _create_share(make_client())
+    assert share["allowedEmails"] is None
+
+
+def test_version_must_be_positive(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    resp = make_client().post(
+        "/artifacts/art-1/shares", json={"version": 0, "accessLevel": "public"}
+    )
+    assert resp.status_code == 422
+
+
+# ------------------------------------------------------------------
+# List
+# ------------------------------------------------------------------
+
+
+def test_list_is_scoped_to_the_artifact_and_the_owner(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, artifact="art-1")
+    _put_version(ddb, artifact="art-2")
+    tc = make_client()
+    a1 = _create_share(tc, artifact="art-1")
+    _create_share(tc, artifact="art-2")
+
+    listed = tc.get("/artifacts/art-1/shares").json()["shares"]
+    assert [s["shareId"] for s in listed] == [a1["shareId"]]
+
+
+def test_list_does_not_leak_another_owners_shares(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, artifact="art-1")
+    _create_share(make_client(), artifact="art-1")
+
+    other = User(email="other@x.com", user_id="other-1", name="O", roles=[])
+    listed = make_client(other).get("/artifacts/art-1/shares").json()
+    assert listed["shares"] == []
+
+
+def test_list_for_unshared_artifact_is_empty_not_404(env) -> None:
+    """An empty list reveals nothing about whether the artifact exists."""
+    make_client, _ = env
+    resp = make_client().get("/artifacts/does-not-exist/shares")
+    assert resp.status_code == 200
+    assert resp.json()["shares"] == []
+
+
+def test_multiple_versions_of_one_artifact_list_together(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, version=1)
+    _put_version(ddb, version=2)
+    tc = make_client()
+    _create_share(tc, version=1)
+    _create_share(tc, version=2)
+
+    listed = tc.get("/artifacts/art-1/shares").json()["shares"]
+    assert sorted(s["version"] for s in listed) == [1, 2]
+
+
+# ------------------------------------------------------------------
+# Update
+# ------------------------------------------------------------------
+
+
+def test_update_changes_access_level_on_both_rows(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    tc = make_client()
+    share = _create_share(
+        tc, accessLevel="specific", allowedEmails=["friend@x.com"]
+    )
+    share_id = share["shareId"]
+
+    resp = tc.patch(
+        f"/artifacts/shares/{share_id}", json={"accessLevel": "public"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["accessLevel"] == "public"
+    # Switching to public clears the stale allowlist rather than leaving
+    # a list that no longer gates anything.
+    assert resp.json()["allowedEmails"] is None
+
+    table = ddb.Table(TABLE)
+    for key in (
+        {"PK": f"USER#{OWNER_ID}", "SK": f"SHARE#art-1#V#00001#{share_id}"},
+        {"PK": f"SHARE#{share_id}", "SK": "META"},
+    ):
+        row = table.get_item(Key=key)["Item"]
+        assert row["access_level"] == "public"
+        assert "allowed_emails" not in row
+
+
+def test_update_replaces_the_allowlist(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    tc = make_client()
+    share = _create_share(
+        tc, accessLevel="specific", allowedEmails=["a@x.com"]
+    )
+    resp = tc.patch(
+        f"/artifacts/shares/{share['shareId']}",
+        json={"accessLevel": "specific", "allowedEmails": ["b@x.com"]},
+    )
+    assert resp.status_code == 200
+    emails = resp.json()["allowedEmails"]
+    assert "b@x.com" in emails
+    assert "a@x.com" not in emails
+    assert OWNER_EMAIL in emails
+
+
+def test_update_by_non_owner_is_403(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _create_share(make_client())
+
+    other = User(email="other@x.com", user_id="other-1", name="O", roles=[])
+    resp = make_client(other).patch(
+        f"/artifacts/shares/{share['shareId']}", json={"accessLevel": "public"}
+    )
+    assert resp.status_code == 403
+
+
+def test_update_unknown_share_is_404(env) -> None:
+    make_client, _ = env
+    resp = make_client().patch(
+        "/artifacts/shares/nope", json={"accessLevel": "public"}
+    )
+    assert resp.status_code == 404
+
+
+# ------------------------------------------------------------------
+# Revoke
+# ------------------------------------------------------------------
+
+
+def test_revoke_deletes_both_rows(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    tc = make_client()
+    share = _create_share(tc)
+    share_id = share["shareId"]
+
+    assert tc.delete(f"/artifacts/shares/{share_id}").status_code == 204
+
+    table = ddb.Table(TABLE)
+    assert "Item" not in table.get_item(
+        Key={"PK": f"SHARE#{share_id}", "SK": "META"}
+    )
+    assert "Item" not in table.get_item(
+        Key={
+            "PK": f"USER#{OWNER_ID}",
+            "SK": f"SHARE#art-1#V#00001#{share_id}",
+        }
+    )
+
+
+def test_revoked_share_404s_for_the_recipient(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    tc = make_client()
+    share = _create_share(tc)
+    tc.delete(f"/artifacts/shares/{share['shareId']}")
+
+    viewer = User(email="v@x.com", user_id="viewer-1", name="V", roles=[])
+    resp = make_client(viewer).get(f"/shared-artifacts/{share['shareId']}")
+    assert resp.status_code == 404
+
+
+def test_revoke_by_non_owner_is_403_and_leaves_the_share_live(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    tc = make_client()
+    share = _create_share(tc)
+
+    other = User(email="other@x.com", user_id="other-1", name="O", roles=[])
+    assert (
+        make_client(other)
+        .delete(f"/artifacts/shares/{share['shareId']}")
+        .status_code
+        == 403
+    )
+    assert (
+        tc.get(f"/shared-artifacts/{share['shareId']}").status_code == 200
+    )
+
+
+def test_revoke_unknown_share_is_404(env) -> None:
+    make_client, _ = env
+    assert make_client().delete("/artifacts/shares/nope").status_code == 404
+
+
+# ------------------------------------------------------------------
+# Recipient metadata
+# ------------------------------------------------------------------
+
+
+def test_recipient_metadata_shape_never_carries_content(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, title="Shared Chart")
+    share = _create_share(make_client())
+
+    viewer = User(email="v@x.com", user_id="viewer-1", name="V", roles=[])
+    body = make_client(viewer).get(
+        f"/shared-artifacts/{share['shareId']}"
+    ).json()
+
+    assert body["title"] == "Shared Chart"
+    assert body["ownerEmail"] == OWNER_EMAIL
+    assert body["version"] == 1
+    assert body["canDownload"] is True
+    # Content never travels on this route, and neither do the owner's
+    # internal ids or the rest of the allowlist.
+    for leaked in ("content", "ownerId", "artifactId", "allowedEmails"):
+        assert leaked not in body
+
+
+def test_recipient_metadata_denies_a_disallowed_viewer(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _create_share(
+        make_client(), accessLevel="specific", allowedEmails=["friend@x.com"]
+    )
+
+    stranger = User(
+        email="stranger@x.com", user_id="stranger-1", name="S", roles=[]
+    )
+    resp = make_client(stranger).get(f"/shared-artifacts/{share['shareId']}")
+    assert resp.status_code == 403
+
+
+# ------------------------------------------------------------------
+# Auth
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,body",
+    [
+        ("post", "/artifacts/art-1/shares", {"version": 1, "accessLevel": "public"}),
+        ("get", "/artifacts/art-1/shares", None),
+        ("patch", "/artifacts/shares/s1", {"accessLevel": "public"}),
+        ("delete", "/artifacts/shares/s1", None),
+        ("get", "/shared-artifacts/s1", None),
+        ("post", "/shared-artifacts/s1/render-token", None),
+    ],
+)
+def test_every_route_requires_a_session(method, path, body) -> None:
+    """No dependency override and no session cookie → blocked by the
+    session dependency before any share logic runs. There is no
+    anonymous path to a shared artifact; "public" means any
+    *authenticated* tenant user."""
+    app = FastAPI()
+    app.include_router(artifact_shares_router)
+    app.include_router(shared_artifacts_router)
+    tc = TestClient(app)
+    kwargs = {"json": body} if body is not None else {}
+    assert getattr(tc, method)(path, **kwargs).status_code == 401

--- a/backend/tests/apis/app_api/artifacts/test_shared_render_token.py
+++ b/backend/tests/apis/app_api/artifacts/test_shared_render_token.py
@@ -1,0 +1,434 @@
+"""The security core of artifact sharing.
+
+The share-scoped mint hands a viewer a short-lived credential addressed
+to the *owner's* DynamoDB partition. The render Lambda performs no
+ownership comparison of its own — it never sees the viewer — so the ACL
+check in `mint_for_share` is the only thing between "sharing" and "read
+any artifact by id". These tests exist to hold that boundary.
+
+`test_render_lambda_accepts_the_new_claims` is what makes "no Lambda
+change required" a verified fact rather than a reading of the handler:
+it feeds a token carrying the new `vwr`/`shr` claims straight through
+the currently-deployed verifier.
+"""
+
+from __future__ import annotations
+
+import boto3
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as token_service
+from apis.app_api.artifacts.shares import (
+    artifact_shares_router,
+    shared_artifacts_router,
+)
+from apis.shared.auth import User, get_current_user_from_session
+from lambdas.artifact_render import handler as render_lambda
+
+KEY = "test-render-key-44-chars-of-entropy-aaaaaaaa"
+SECRET_NAME = "test-artifact-render-token-key"
+TABLE = "test-user-artifacts"
+ORIGIN = "https://artifacts.test.example.com"
+REGION = "us-east-1"
+
+OWNER_ID = "owner-1"
+OWNER_EMAIL = "owner@x.com"
+VIEWER_ID = "viewer-1"
+VIEWER_EMAIL = "viewer@x.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    token_service._reset_caches_for_tests()
+    # The verifier caches its own signing key separately.
+    monkeypatch.setattr(render_lambda, "_cached_signing_key", None)
+
+
+def _user(user_id: str, email: str) -> User:
+    return User(email=email, user_id=user_id, name=user_id, roles=[])
+
+
+OWNER = _user(OWNER_ID, OWNER_EMAIL)
+VIEWER = _user(VIEWER_ID, VIEWER_EMAIL)
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        sm = boto3.client("secretsmanager", region_name=REGION)
+        arn = sm.create_secret(Name=SECRET_NAME, SecretString=KEY)["ARN"]
+
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        monkeypatch.setenv("ARTIFACTS_RENDER_TOKEN_SECRET_ARN", arn)
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("ARTIFACTS_ORIGIN", ORIGIN)
+
+        def make_client(user: User) -> TestClient:
+            app = FastAPI()
+            app.include_router(artifact_shares_router)
+            app.include_router(shared_artifacts_router)
+            app.dependency_overrides[get_current_user_from_session] = (
+                lambda: user
+            )
+            return TestClient(app)
+
+        yield make_client, boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_version(
+    ddb, *, user_id: str = OWNER_ID, artifact="art-1", version=1
+) -> None:
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "artifact_id": artifact,
+            "user_id": user_id,
+            "version": version,
+            "storage": "s3",
+            "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "title": "Shared Artifact",
+            "session_id": "sess-1",
+        }
+    )
+
+
+def _share(make_client, *, access_level="public", allowed=None, version=1) -> str:
+    body: dict = {"version": version, "accessLevel": access_level}
+    if allowed is not None:
+        body["allowedEmails"] = allowed
+    resp = make_client(OWNER).post("/artifacts/art-1/shares", json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["shareId"]
+
+
+def _token_from_url(url: str) -> str:
+    assert url.startswith(f"{ORIGIN}/?t=")
+    return url.split("?t=", 1)[1]
+
+
+def _decode(url: str) -> dict:
+    return jwt.decode(
+        _token_from_url(url),
+        KEY,
+        algorithms=["HS256"],
+        audience="artifact-render",
+    )
+
+
+def _mint(make_client, user: User, share_id: str):
+    return make_client(user).post(f"/shared-artifacts/{share_id}/render-token")
+
+
+# ------------------------------------------------------------------
+# The claim contract
+# ------------------------------------------------------------------
+
+
+def test_minted_claims_address_the_owner_and_record_the_viewer(env) -> None:
+    """`sub` is the OWNER, not the viewer.
+
+    That is deliberate and load-bearing: `sub` is the DynamoDB partition
+    key the render Lambda builds (PK = USER#{sub}), an ADDRESS rather
+    than an identity assertion. Setting it to the viewer would point the
+    Lambda at the viewer's own partition and the shared artifact would
+    simply 404. The real viewer identity travels in `vwr`, and the grant
+    it was issued under in `shr`, so a render log attributes the view to
+    the person who actually looked instead of crediting it to the owner.
+
+    If this test ever fails because someone "fixed" `sub` to be the
+    viewer, the fix is to revert that change — not to update this test.
+    """
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+
+    resp = _mint(make_client, VIEWER, share_id)
+    assert resp.status_code == 200
+    claims = _decode(resp.json()["url"])
+
+    assert claims["sub"] == OWNER_ID
+    assert claims["vwr"] == VIEWER_ID
+    assert claims["shr"] == share_id
+    assert claims["sub"] != VIEWER_ID
+
+    assert claims["iss"] == "app-api"
+    assert claims["aud"] == "artifact-render"
+    assert claims["aid"] == "art-1"
+    assert claims["ver"] == 1
+    assert claims["exp"] - claims["iat"] == 120
+    assert resp.json()["expires_at"].endswith("+00:00")
+
+
+def test_owner_minting_their_own_share_is_still_attributed_to_them(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+
+    claims = _decode(_mint(make_client, OWNER, share_id).json()["url"])
+    assert claims["sub"] == OWNER_ID
+    assert claims["vwr"] == OWNER_ID
+
+
+def test_render_lambda_accepts_the_new_claims(env, monkeypatch) -> None:
+    """The currently-deployed verifier must accept `vwr`/`shr`.
+
+    This is what turns "PR-1 needs no Lambda change" into a verified
+    fact: `_verify_token` validates a fixed claim list and has no extras
+    rejection, so a token carrying the two new claims verifies against
+    the handler exactly as it ships today. If a future verifier change
+    ever adds strict claim checking, this test fails first — before a
+    deploy silently breaks every shared artifact.
+    """
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+    monkeypatch.setattr(render_lambda, "_cached_signing_key", KEY)
+
+    token = _token_from_url(_mint(make_client, VIEWER, share_id).json()["url"])
+
+    verified = render_lambda._verify_token(token)
+    assert verified["sub"] == OWNER_ID
+    assert verified["aid"] == "art-1"
+    assert verified["ver"] == 1
+    assert verified["vwr"] == VIEWER_ID
+    assert verified["shr"] == share_id
+
+
+def test_shared_token_resolves_to_the_owners_partition(
+    env, monkeypatch
+) -> None:
+    """End-to-end proof that `sub` is an address: the Lambda's own
+    record lookup, driven by the minted claims, must land on the owner's
+    row. A viewer-valued `sub` would miss it entirely."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+    claims = _decode(_mint(make_client, VIEWER, share_id).json()["url"])
+
+    # The Lambda pins its table name at module load from its own env var.
+    monkeypatch.setattr(render_lambda, "_ARTIFACTS_TABLE", TABLE)
+    monkeypatch.setattr(render_lambda, "_ddb_table", None)
+
+    record = render_lambda._get_version_record(
+        claims["sub"], claims["aid"], claims["ver"]
+    )
+    assert record["user_id"] == OWNER_ID
+    assert record["content_key"].startswith(f"{OWNER_ID}/")
+
+
+# ------------------------------------------------------------------
+# The ACL boundary
+# ------------------------------------------------------------------
+
+
+def test_public_admits_an_arbitrary_authenticated_user(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client, access_level="public")
+
+    stranger = _user("stranger-1", "stranger@x.com")
+    resp = _mint(make_client, stranger, share_id)
+    assert resp.status_code == 200
+    assert _decode(resp.json()["url"])["vwr"] == "stranger-1"
+
+
+def test_specific_admits_only_allowlisted_emails(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(
+        make_client, access_level="specific", allowed=[VIEWER_EMAIL]
+    )
+
+    assert _mint(make_client, VIEWER, share_id).status_code == 200
+
+    stranger = _user("stranger-1", "stranger@x.com")
+    assert _mint(make_client, stranger, share_id).status_code == 403
+
+
+@pytest.mark.parametrize(
+    "allowed_email,viewer_email",
+    [
+        ("Viewer@X.com", "viewer@x.com"),
+        ("viewer@x.com", "VIEWER@X.COM"),
+        ("ViEwEr@x.CoM", "vIeWeR@X.com"),
+    ],
+)
+def test_specific_matches_emails_case_insensitively(
+    env, allowed_email, viewer_email
+) -> None:
+    """Entra hands back whatever casing the directory holds, so a
+    case-sensitive compare would lock out legitimately-invited people."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(
+        make_client, access_level="specific", allowed=[allowed_email]
+    )
+
+    viewer = _user("viewer-cased", viewer_email)
+    assert _mint(make_client, viewer, share_id).status_code == 200
+
+
+def test_specific_denies_a_near_miss_email(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(
+        make_client, access_level="specific", allowed=["viewer@x.com"]
+    )
+
+    for near_miss in (
+        "viewer@x.com.evil.com",
+        "notviewer@x.com",
+        "viewer@y.com",
+        " viewer@x.com",
+    ):
+        impostor = _user("impostor", near_miss)
+        assert _mint(make_client, impostor, share_id).status_code == 403
+
+
+def test_owner_always_passes_a_specific_share(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(
+        make_client, access_level="specific", allowed=["someone-else@x.com"]
+    )
+    assert _mint(make_client, OWNER, share_id).status_code == 200
+
+
+def test_revoked_share_mints_nothing(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+    assert _mint(make_client, VIEWER, share_id).status_code == 200
+
+    make_client(OWNER).delete(f"/artifacts/shares/{share_id}")
+
+    resp = _mint(make_client, VIEWER, share_id)
+    assert resp.status_code == 404
+    assert "url" not in resp.json()
+
+
+def test_downgrade_to_specific_locks_out_a_former_public_viewer(env) -> None:
+    """Revocation is not the only control: narrowing a live share must
+    take effect on the very next mint."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client, access_level="public")
+    assert _mint(make_client, VIEWER, share_id).status_code == 200
+
+    make_client(OWNER).patch(
+        f"/artifacts/shares/{share_id}",
+        json={"accessLevel": "specific", "allowedEmails": ["other@x.com"]},
+    )
+    assert _mint(make_client, VIEWER, share_id).status_code == 403
+
+
+def test_unknown_share_id_mints_nothing(env) -> None:
+    """A share id is not a capability on its own — guessing one gets a
+    404, never a token."""
+    make_client, ddb = env
+    _put_version(ddb)
+    resp = _mint(make_client, VIEWER, "not-a-real-share")
+    assert resp.status_code == 404
+
+
+def test_missing_version_row_404s_instead_of_minting(env) -> None:
+    """A share can outlive the version it points at. Better a clean 404
+    than a token that renders the Lambda's error page in the recipient's
+    iframe."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+    ddb.Table(TABLE).delete_item(
+        Key={"PK": f"USER#{OWNER_ID}", "SK": "ARTIFACT#art-1#V#00001"}
+    )
+
+    resp = _mint(make_client, VIEWER, share_id)
+    assert resp.status_code == 404
+    assert "url" not in resp.json()
+
+
+def test_access_check_runs_before_the_version_lookup(env) -> None:
+    """A denied viewer must not be able to probe whether the owner's
+    artifact version exists — both cases have to be indistinguishable
+    from the outside. Here the version row is gone AND the viewer is not
+    allowed; the answer must be 403 (the ACL), not 404 (the probe)."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(
+        make_client, access_level="specific", allowed=["friend@x.com"]
+    )
+    ddb.Table(TABLE).delete_item(
+        Key={"PK": f"USER#{OWNER_ID}", "SK": "ARTIFACT#art-1#V#00001"}
+    )
+
+    stranger = _user("stranger-1", "stranger@x.com")
+    assert _mint(make_client, stranger, share_id).status_code == 403
+
+
+def test_share_pins_the_version_it_was_created_for(env) -> None:
+    """A share is pinned to one immutable version. A newer version of
+    the same artifact must not change what the recipient sees."""
+    make_client, ddb = env
+    _put_version(ddb, version=1)
+    share_id = _share(make_client, version=1)
+    _put_version(ddb, version=2)
+
+    claims = _decode(_mint(make_client, VIEWER, share_id).json()["url"])
+    assert claims["ver"] == 1
+
+
+# ------------------------------------------------------------------
+# Fail-closed config
+# ------------------------------------------------------------------
+
+
+def test_missing_origin_is_500_and_mints_nothing(env, monkeypatch) -> None:
+    """Origin resolves before any DDB call or ACL check, so a broken
+    artifacts deploy fails closed rather than handing back a usable
+    token embedded in a relative, unloadable URL."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+    monkeypatch.delenv("ARTIFACTS_ORIGIN", raising=False)
+
+    resp = _mint(make_client, VIEWER, share_id)
+    assert resp.status_code == 500
+    assert "url" not in resp.json()
+
+
+def test_token_is_never_logged(env, caplog) -> None:
+    """The token is a bearer credential carried in a URL. Log lines on
+    this path must carry identifiers only."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share_id = _share(make_client)
+
+    with caplog.at_level("INFO"):
+        url = _mint(make_client, VIEWER, share_id).json()["url"]
+
+    token = _token_from_url(url)
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert token not in logged
+    assert url not in logged
+    # Identifiers are expected — that is the point of `vwr`/`shr`.
+    assert share_id in logged

--- a/docs/specs/artifact-sharing.md
+++ b/docs/specs/artifact-sharing.md
@@ -1,0 +1,363 @@
+# Artifact sharing
+
+**Status:** proposed
+**Feasibility:** high — no new AWS resources, no new IAM, no CSP change
+**Builds on:** artifacts feature (#306–#311), conversation sharing
+(`backend/src/apis/app_api/shares/`), render-token contract
+(`backend/src/lambdas/artifact_render/handler.py`)
+
+## Summary
+
+Users can create artifacts (`create_artifact` / `update_artifact`) but cannot
+show one to anyone. The only egress today is **download** — mint a token, save
+the file, email the file. That loses the live render, loses versioning, and
+loses revocation.
+
+This spec adds a share record on an **artifact version**, mirroring the
+conversation-share model already in production: an owner-created, revocable,
+access-controlled pointer that any authenticated recipient can open at
+`/shared-artifact/{shareId}`, viewing the exact bytes in the same sandboxed
+iframe the owner sees.
+
+The feasibility conclusion is that this is mostly **plumbing an ACL check in
+front of an existing minting call**. Every hard part — the isolated render
+origin, the strict CSP, the signed short-lived token, immutable versions, the
+sandboxed viewer component, the download path — already exists and is already
+deployed.
+
+## Why it is feasible
+
+### 1. The render token already separates *authorization* from *identity*
+
+`RenderTokenService.mint` (`app_api/artifacts/service.py`) does exactly two
+things: assert the `(user, artifact, version)` row exists, then sign an HS256
+JWT. The render Lambda then uses the token's `sub` claim purely as the
+**DynamoDB partition key** to locate the artifact:
+
+```
+PK = USER#{sub}
+SK = ARTIFACT#{aid}#V#{ver:05d}
+```
+
+The Lambda performs **no ownership comparison of its own** — it never sees the
+viewer. The token *is* the capability. So a share flow only has to answer "may
+this viewer be handed a token for the owner's row?" in app-api, and mint with
+`sub` = the owner's id. **The render Lambda needs no change at all** for the
+core feature.
+
+That is the single most important finding: the expensive half of a sharing
+feature (a viewer-safe, authenticated, sandboxed rendering path for
+attacker-authored HTML) is already built and is identity-agnostic.
+
+### 2. Versions are immutable, so snapshot semantics come for free
+
+`update_artifact_record` appends `V#{n+1}` and re-points `#HEAD`; there is no
+`DeleteObject` grant in inference-api. A share pinned to `(artifactId, version)`
+can therefore **never change under the recipient** — no snapshot copy, no S3
+duplication, no schema-versioned body like `shares/snapshot_store.py` needed for
+conversations. The conversation-share feature had to offload a JSON body to S3
+to get point-in-time semantics; artifact sharing gets them from the storage model.
+
+### 3. The CSP already permits exactly the topology we want
+
+`ArtifactsDistributionConstruct` sets `frame-ancestors https://{domainName}`
+(plus `config.artifacts.extraFrameAncestors`) and `connect-src 'none'`. A
+recipient viewing a shared artifact **inside the SPA** is the SPA origin
+framing the artifact origin — already allowed. Artifact JS still cannot reach
+app-api, cannot phone home, cannot exfiltrate. Nothing in the CSP, the
+distribution, or the response-headers policy changes.
+
+### 4. app-api already holds every permission required
+
+`app-api-iam-grants.ts` grants the task role `GetItem/PutItem/UpdateItem/
+DeleteItem/Query` on the artifacts table (and `index/*`), `GetObject/PutObject/
+PutObjectTagging/ListBucket` on the content bucket, and `GetSecretValue` on the
+render-token secret. Share rows can live on the **existing artifacts table**
+under a new key prefix. **Zero new CDK resources, zero new IAM statements.**
+
+### 5. The whole UX pattern is already in the codebase
+
+| Need | Existing thing to model on |
+|---|---|
+| Share dialog (public / specific-emails, copy link) | `session/components/share-modal/` |
+| Share HTTP client | `session/services/share/share.service.ts` |
+| Recipient page behind `authGuard` | `shared/shared-view.page.ts`, route `shared/:shareId` |
+| Manage/revoke existing shares | `manage-sessions/manage-shares-dialog/` |
+| Sandboxed artifact viewer | `artifact-panel.component.ts` |
+| Download of a shared version | `artifact-download.service.ts` + `?download=1` |
+
+### Feasibility risk register
+
+| Risk | Severity | Handling |
+|---|---|---|
+| Minting a token whose `sub` is another user makes the render log attribute the view to the owner | medium | Add `vwr` (viewer id) + `shr` (share id) claims at mint time. `_verify_token` validates `alg`/`iss`/`aud`/`exp`/`iat`/`sub`/`aid`/`ver` and then returns the claim dict — it has **no extras rejection**, verified by reading the handler — so extra claims are forward-compatible with the currently-deployed Lambda and a later Lambda deploy starts logging them. No deploy sequencing required. |
+| Recipient could re-share by copying the iframe URL | low | Already true of the owner's own render URL, and tokens live ~120s. The share record, not the token, is the revocable control. |
+| Artifacts survive session deletion (no cascade today; the `lifecycle-class=deleted` S3 rule has no writer) | medium | Cascade artifact-share revocation on session delete, mirroring `delete_shares_for_session`. See §7. |
+| Shared artifacts inside a **shared conversation** silently vanish | medium | Pre-existing gap, documented in §8 as explicitly out of scope for PR-1. |
+| A recipient views an artifact whose owner has since revoked | low | Every open re-checks the share row before minting; tokens are ~120s, so the revocation window is bounded by token TTL, not by session length. |
+
+## Non-goals
+
+- **Anonymous/unauthenticated public links.** Conversation sharing's `"public"`
+  already means "any authenticated tenant user" — the `/shared/:shareId` route
+  sits behind `authGuard` and `get_shared_conversation` depends on
+  `get_current_user_from_session`. Artifact sharing matches that exactly.
+  Governance here is Entra JWT identity, not content inspection.
+- **Collaborative editing.** Shares are read-only. A recipient who wants to
+  iterate forks (§6, deferred).
+- **Sharing `#HEAD` (a moving pointer).** A share pins one version. Sharing a
+  pointer that moves under the recipient is a different feature with different
+  consent semantics, and a moving pointer is the exact trap that bit agent
+  version snapshots.
+- **Changing the render Lambda's verification contract.**
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Share target | One **immutable `(artifactId, version)`** pair, never `#HEAD` |
+| Access levels | `public` (any authenticated user) \| `specific` (email allowlist) — same literals as conversation shares |
+| Storage | New key prefix on the **existing** `user-artifacts` table |
+| Snapshot | **None** — version immutability is the snapshot |
+| Render path | app-api ACL check → mint token with `sub`=owner, `vwr`=viewer, `shr`=share |
+| Render Lambda change | **None required** for PR-1 |
+| Recipient surface | SPA route `/shared-artifact/:shareId` behind `authGuard` |
+| Revocation | Delete the share row; effective within one token TTL (~120s) |
+| Feature enablement | Same signal as artifacts: presence of `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` |
+| Audit | Structured logs only (conversation sharing sets this precedent; `AuditAction` is a closed set scoped to admin mutations) |
+
+### Why a new key prefix instead of the shared-conversations table
+
+The share row must be read on **every** render-token mint for a shared
+artifact, and the mint path already touches the artifacts table to validate the
+version. Co-locating keeps that to one table and no second client. The
+conversation-share table is keyed `share_id` with a `SessionShareIndex`; it has
+no artifact concept and adding one would leave two unrelated record shapes
+under one key.
+
+## 1. Data model
+
+Added to the existing `{prefix}-user-artifacts` table. No new GSI **for PR-1**
+(see the lookup note below).
+
+**Share record** — the owner-scoped row, so an owner can list their own shares
+with one `Query` on their existing partition:
+
+```
+PK  = USER#{owner_id}
+SK  = SHARE#{artifact_id}#V#{version:05d}#{share_id}
+attrs:
+  share_id, artifact_id, version, owner_id, owner_email,
+  access_level: "public" | "specific",
+  allowed_emails: [str]        # present only when access_level == "specific"
+  title                        # denormalized for the recipient header
+  content_type                 # denormalized so the viewer can pick its chrome
+  session_id                   # provenance / cascade-revoke
+  created_at, updated_at
+```
+
+**Share lookup record** — the recipient path resolves `share_id` alone, with no
+idea who the owner is:
+
+```
+PK  = SHARE#{share_id}
+SK  = META
+attrs: owner_id, artifact_id, version, access_level, allowed_emails,
+       title, content_type, created_at
+```
+
+Two rows, written in one `transact_write_items`, is deliberately chosen over a
+GSI. Per the GSI deploy-ordering trap, adding an index means a `platform.yml`
+deploy that must land before the backend code that queries it, one
+`UpdateTable` at a time, with CFN green ≠ index `ACTIVE`. Two items in a
+transaction needs no infra deploy at all and makes the recipient read a single
+`GetItem`. The cost is denormalized duplication on update — bounded, because
+the only mutable fields are `access_level` and `allowed_emails`.
+
+No IAM change is needed for the transaction: DynamoDB authorizes
+`TransactWriteItems` against the **underlying** item actions, and the artifacts
+grant already carries `PutItem`/`UpdateItem`/`DeleteItem`. `TransactWriteItems`
+appears in no grant in `app-api-iam-grants.ts`, yet
+`apis/shared/rbac/repository.py` calls `transact_write_items` against the
+app-roles table in production — the pattern is already proven here. (Keep the
+transaction to plain writes; a `ConditionCheck` item *would* need
+`dynamodb:ConditionCheckItem` added.)
+
+## 2. API
+
+New router, `backend/src/apis/app_api/artifacts/shares.py`, mounted under the
+same `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` guard that already gates
+`artifacts_router` in `main.py`.
+
+All owner endpoints use `get_current_user_from_session` (SPA-facing — Bearer-only
+would cause 401 redirect loops).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/artifacts/{artifact_id}/shares` | Create a share for `{version, accessLevel, allowedEmails?}`. 201. |
+| `GET` | `/artifacts/{artifact_id}/shares` | List the caller's shares for this artifact. |
+| `PATCH` | `/artifacts/shares/{share_id}` | Change `accessLevel` / `allowedEmails`. Owner only. |
+| `DELETE` | `/artifacts/shares/{share_id}` | Revoke. 204. Owner only. |
+| `GET` | `/shared-artifacts/{share_id}` | Recipient metadata: `{shareId, title, contentType, version, createdAt, ownerEmail, canDownload}`. Access-controlled. **Never returns content.** |
+| `POST` | `/shared-artifacts/{share_id}/render-token` | Access-checked mint. Returns the same `{url, expires_at}` shape as the owner endpoint. |
+
+Error mapping follows the existing artifacts routes: 404 unknown share/version,
+403 access denied, 413 too large (content view), 500 `RenderTokenConfigError`,
+503 `ArtifactQueryError`.
+
+### The mint, in full
+
+```python
+def mint_for_share(self, *, share_id: str, viewer: User) -> tuple[str, int]:
+    origin = _origin()                       # fail closed before any DDB call
+    share = _get_share_lookup(share_id)      # PK=SHARE#{id}, SK=META
+    if not share:
+        raise ArtifactNotFoundError(...)
+    _check_share_access(share, viewer)       # owner | public | email allowlist
+    _assert_version_exists(                  # unchanged helper
+        share["owner_id"], share["artifact_id"], int(share["version"])
+    )
+    now = int(time.time())
+    claims = {
+        "iss": _ISS, "aud": _AUD,
+        "sub": share["owner_id"],            # DDB partition — NOT the viewer
+        "aid": share["artifact_id"],
+        "ver": int(share["version"]),
+        "sid": "",
+        "vwr": viewer.user_id,               # who actually looked (audit)
+        "shr": share_id,                     # under which grant
+        "iat": now, "exp": now + _TTL_SECONDS,
+    }
+    ...
+```
+
+`_check_share_access` is a direct port of `ShareService._check_access`: owner
+always passes, `public` passes, `specific` compares `viewer.email.lower()`
+against the lowercased allowlist, else `AccessDeniedError`.
+
+**`sub` is the owner and that is load-bearing** — it is the DynamoDB partition
+key the render Lambda builds, not an identity assertion. `vwr`/`shr` carry the
+real viewer. This must be commented at the mint site, or a future reader will
+"fix" it into a privilege bug.
+
+## 3. Frontend
+
+**Owner side.** A `Share` button beside `Download` on both the artifact card
+(`artifact-card.component.ts`, action row near line 102) and the panel header
+(`artifact-panel.component.ts`). Icon-only variants need `[appTooltip]` per the
+frontend accessibility rule; the card's existing pattern keeps a visible label,
+so match it. Opens `artifact-share-modal.component.ts`, adapted from
+`share-modal.component.ts` (same access-level radio, same email chips, same
+clipboard copy, same `@angular/cdk/dialog` shell).
+
+**Recipient side.** Route `shared-artifact/:shareId` behind `authGuard`. New
+`shared-artifact-view.page.ts`, modelled on `shared-view.page.ts`: the same
+sticky "Shared read-only snapshot" banner, the same 403/404/500 branches, and
+the artifact rendered full-width in the same sandboxed iframe
+(`sandbox="allow-scripts"`, **no** `allow-same-origin`) the panel uses. Reuse
+the panel's render/code toggle by extracting its iframe + `ArtifactSourceComponent`
+body into a presentational child both pages import — the panel keeps its
+docking, resize, and version-menu chrome.
+
+**Services.** `ArtifactShareService` alongside `artifact-http.service.ts`
+(owner CRUD), and a `mintSharedRenderToken(shareId)` path. `ArtifactDownloadService`
+takes an optional share id so the hidden-iframe `?download=1` trick works
+unchanged for recipients — the recipient mint is a different endpoint, same
+returned URL shape.
+
+**Content/code view for recipients.** `GET /artifacts/{id}/content` builds its
+key from the authenticated user and must stay that way. Recipients get a
+parallel `GET /shared-artifacts/{share_id}/content` that resolves the owner from
+the share row after the same ACL check, reusing `ArtifactContentService` with an
+explicit `owner_id` argument.
+
+## 4. Delivery plan
+
+| PR | Scope |
+|---|---|
+| **PR-1** | Data model + owner CRUD API + share-scoped mint. Backend only, fully tested. |
+| **PR-2** | Owner UI: Share button on card + panel, share modal, manage/revoke list. |
+| **PR-3** | Recipient UI: route, page, extracted viewer child component, shared content + download. |
+| **PR-4** | Cascade revoke on session delete (§7) + docs-site page update. |
+
+PR-1 through PR-3 are independently mergeable behind the artifacts enablement
+signal; the Share button in PR-2 is the first user-visible change.
+
+## 5. Testing
+
+Backend (`backend/tests/apis/app_api/artifacts/`):
+
+- `test_artifact_shares.py` — create writes both rows transactionally; owner
+  list is partition-scoped; PATCH/DELETE reject a non-owner with 403; revoked
+  share 404s.
+- `test_shared_render_token.py` — **the security core.** Assert the minted
+  claims: `sub` == owner, `vwr` == viewer, `shr` == share id. Assert `public`
+  admits an arbitrary authenticated user; `specific` admits only allowlisted
+  emails (case-insensitively) and 403s everyone else; a revoked share mints
+  nothing; a share whose underlying version row is gone 404s rather than
+  minting a token that renders the Lambda's error page.
+- A test that the currently-deployed verifier accepts a token carrying the new
+  `vwr`/`shr` claims — import `_verify_token` from the Lambda handler directly
+  (it takes no AWS calls before the signature check) and assert it returns the
+  claims rather than raising. This is the assertion that makes "no Lambda
+  change required" a fact rather than a reading.
+
+Frontend (`ng test` — never bare `npx vitest run`): share-modal interaction,
+recipient page 403/404 branches, and the extracted viewer child rendering from
+a stubbed token. Use DI token overrides, not `vi.mock`.
+
+## 6. Deferred
+
+- **Fork-to-own-artifact**, mirroring `POST /shares/{id}/export`: copy the
+  version's S3 object into the recipient's own `{user_id}/{new_aid}/v1/` prefix
+  and write fresh v1 rows, so a recipient can iterate on someone else's
+  artifact in their own chat. This is the artifact analogue of "Continue this
+  conversation" and is the most likely next ask.
+- **Artifacts inside shared conversations** (§8).
+- Share expiry (`ttl` on the share rows — the table already has a TTL attribute
+  configured, so this is a field, not an infra change).
+- View counts / "who opened this".
+
+## 7. Session-delete cascade
+
+`sessions/routes.py` already schedules `share_service.delete_shares_for_session`
+as a background task on conversation delete. Artifacts are **not** cleaned up
+there today, and the S3 `lifecycle-class=deleted` rule has no backend writer at
+all — so artifacts (and their shares) would outlive the conversation that
+produced them.
+
+PR-4 adds `delete_artifact_shares_for_session(session_id)`, called from the same
+background task. It queries `SessionIndex` for the session's artifact ids, then
+deletes matching `SHARE#` rows and their lookup rows. Best-effort and
+never-raising, exactly like the conversation version: the failure mode is an
+orphan row, never a blocked delete.
+
+Deliberately **not** in scope: deleting artifact content on session delete.
+That is a retention decision about the artifacts feature as a whole, not about
+sharing, and it deserves its own spec.
+
+## 8. Known gap: artifacts in shared conversations
+
+`shared-view.page.ts` renders `MessageListComponent` with `embeddedMode` and has
+no artifact wiring. Artifact hydration goes through
+`GET /artifacts?session_id=…`, which filters HEAD rows by
+`item.user_id == requester`. A recipient viewing a shared conversation that
+produced artifacts therefore sees **nothing** where the owner sees artifact
+cards — silently, with no placeholder.
+
+Closing it properly means auto-provisioning artifact shares for every artifact
+in a conversation at conversation-share time (a consent decision: sharing a
+conversation would then also share its artifacts), plus surfacing them in the
+shared view. That is a separate spec, and it depends on this one's share record
+existing first. Recording it here so it is a known gap rather than a discovered
+bug.
+
+## Effort estimate
+
+| Area | Assessment |
+|---|---|
+| Infrastructure | **None.** No new table, bucket, distribution, secret, cert, DNS, IAM, or CSP change. |
+| Render Lambda | **None** for PR-1. Optional later change to log `vwr`/`shr`. |
+| Backend | Moderate — one service + one router, both close ports of existing code. |
+| Frontend | Moderate — one new modal, one new page, one extracted viewer child. |
+| Highest-risk surface | The share-scoped mint. It hands a viewer a credential for another user's DynamoDB partition; the ACL check is the only thing standing between "sharing" and "read any artifact by id". Test it as the security boundary it is. |


### PR DESCRIPTION
PR-1 of the artifact sharing spec (`docs/specs/artifact-sharing.md`, included in this branch as its first commit). **Backend only** — no frontend (PR-2/PR-3), no session-delete cascade (PR-4).

## What this adds

**Data model** — two rows on the **existing** `{prefix}-user-artifacts` table under a new `SHARE#` key prefix, written together in one `transact_write_items`:

```
owner row   PK = USER#{owner_id}
            SK = SHARE#{artifact_id}#V#{version:05d}#{share_id}
lookup row  PK = SHARE#{share_id}, SK = META
```

The owner row makes "list my shares for this artifact" a `begins_with` query on the owner's existing partition; the lookup row makes the recipient path — which knows only a share id — a single `GetItem`. Two items in a transaction instead of a GSI, deliberately: an index would mean a `platform.yml` deploy that has to land before the code querying it, one `UpdateTable` at a time, with CFN green ≠ index `ACTIVE`.

**No infrastructure change of any kind**: no new table, no new GSI, no CDK change, no IAM change. `TransactWriteItems` authorizes against the underlying `Put`/`Delete` actions the artifacts grant already carries (and `apis/shared/rbac/repository.py` already does exactly this in production). Both rows are plain Puts — a `ConditionCheck` item *would* have needed `dynamodb:ConditionCheckItem` added.

**API** — new router `backend/src/apis/app_api/artifacts/shares.py`, mounted under the same `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` guard that already gates `artifacts_router`:

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/artifacts/{artifact_id}/shares` | Create a share for one version. 201. |
| `GET` | `/artifacts/{artifact_id}/shares` | List the caller's shares for this artifact. |
| `PATCH` | `/artifacts/shares/{share_id}` | Change access level / allowlist. Owner only. |
| `DELETE` | `/artifacts/shares/{share_id}` | Revoke. 204. Owner only. |
| `GET` | `/shared-artifacts/{share_id}` | Recipient metadata. Never returns content. |
| `POST` | `/shared-artifacts/{share_id}/render-token` | Access-checked mint. |

Every route depends on `get_current_user_from_session`. `public` means *any authenticated tenant user*, never anonymous — same semantics as conversation sharing.

## The security core

`RenderTokenService.mint_for_share` mints with **`sub` set to the owner's user id, not the viewer's.**

That is deliberate and load-bearing. `sub` is the DynamoDB partition key the render Lambda builds (`PK = USER#{sub}`) — an *address*, not an identity assertion. The Lambda performs no ownership comparison of its own and never sees the viewer. Setting `sub` to the viewer would not "fix" anything; it would point the Lambda at the viewer's own partition and the shared artifact would simply 404.

The consequence is that the ACL check immediately before the mint is the **only** thing between "sharing" and "read any artifact by id". It carries a loud block comment at the mint site, and `test_minted_claims_address_the_owner_and_record_the_viewer` says in as many words that if it fails because someone "fixed" `sub` to be the viewer, the fix is to revert — not to update the test.

The real viewer identity travels in a new `vwr` claim and the grant it was issued under in `shr`, so a render log attributes the view to who actually looked instead of crediting it to the owner.

## No render-Lambda change

`backend/src/lambdas/artifact_render/handler.py` is **untouched** (0 lines of diff), which is what avoids deploy sequencing risk. Its `_verify_token` validates a fixed claim list and has no extras rejection, so `vwr`/`shr` are forward-compatible with what is deployed today.

`test_render_lambda_accepts_the_new_claims` imports that verifier directly and asserts it accepts a token carrying both — turning "no Lambda change required" from a reading of the handler into a verified fact. If a future verifier change ever adds strict claim checking, that test fails first, before a deploy silently breaks every shared artifact.

## Tests

47 new tests across `test_artifact_shares.py` (28) and `test_shared_render_token.py` (19):

- Minted claims asserted explicitly: `sub` == owner, `vwr` == viewer, `shr` == share id — plus an end-to-end check that the Lambda's own record lookup, driven by those claims, lands on the owner's row.
- `public` admits an arbitrary authenticated user; `specific` admits only allowlisted emails **case-insensitively** (parametrized over mixed casing) and 403s everyone else, including near-miss addresses like `viewer@x.com.evil.com`.
- A revoked share mints nothing; narrowing a live share locks out a former viewer on the very next mint; a share whose version row is gone 404s rather than minting a token that renders the Lambda's error page.
- The ACL check is asserted to run *before* the version lookup, so a denied viewer cannot probe whether the owner's artifact exists.
- Both share rows are asserted to carry identical attribute sets after create and after update, so the owner's view of who can see a share cannot drift from what the recipient path enforces.
- Fail-closed config (missing origin → 500, no token), every route requires a session, and the token/URL are asserted absent from log output.

Full backend suite: **7049 passed, 6 skipped**.

## Out of scope (per the spec's delivery plan)

PR-2 owner UI · PR-3 recipient UI · PR-4 session-delete cascade + docs-site page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
