### PR TITLE
feat(artifacts): artifact sharing PR-2 — owner UI (Share button + share modal)

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
@@ -1,0 +1,130 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Dialog } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { ArtifactCardComponent } from './artifact-card.component';
+import { ArtifactShareModalComponent } from './artifact-share-modal.component';
+import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
+import { UserService } from '../../../../../auth/user.service';
+import type { Artifact } from '../../../../services/artifacts/artifact.model';
+
+const ARTIFACT: Artifact = {
+  artifactId: 'art-1',
+  version: 3,
+  title: 'Quarterly Chart',
+  contentType: 'text/html; charset=utf-8',
+  updatedAt: '2026-09-03T00:00:00+00:00',
+};
+
+describe('ArtifactCardComponent', () => {
+  let fixture: ComponentFixture<ArtifactCardComponent>;
+  let dialog: { open: ReturnType<typeof vi.fn> };
+  let artifactState: { openArtifactPanel: ReturnType<typeof vi.fn> };
+  let download: { download: ReturnType<typeof vi.fn> };
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  const button = (label: RegExp): HTMLButtonElement => {
+    const match = Array.from(el().querySelectorAll('button')).find((b) =>
+      label.test(b.getAttribute('aria-label') ?? ''),
+    );
+    if (!match) throw new Error(`no button matching ${label}`);
+    return match as HTMLButtonElement;
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    dialog = { open: vi.fn() };
+    artifactState = { openArtifactPanel: vi.fn() };
+    download = { download: vi.fn().mockResolvedValue(true) };
+
+    TestBed.configureTestingModule({
+      imports: [ArtifactCardComponent],
+      providers: [
+        { provide: Dialog, useValue: dialog },
+        { provide: ArtifactStateService, useValue: artifactState },
+        { provide: ArtifactDownloadService, useValue: download },
+        {
+          provide: UserService,
+          useValue: { currentUser: signal({ email: 'owner@example.com' }) },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ArtifactCardComponent);
+    fixture.componentRef.setInput('artifact', ARTIFACT);
+    fixture.detectChanges();
+  });
+
+  it('renders Share alongside Download', () => {
+    expect(el().textContent).toContain('Share');
+    expect(el().textContent).toContain('Download');
+  });
+
+  it('gives both actions a visible label inside their accessible name', () => {
+    // WCAG 2.5.3: the visible label must be contained in the accessible
+    // name. Both card actions are labelled, so neither needs a tooltip.
+    expect(button(/^Share /).getAttribute('aria-label')).toContain('Share');
+    expect(button(/^Download /).getAttribute('aria-label')).toContain(
+      'Download',
+    );
+  });
+
+  it('shares the version on the card, not the artifact head', () => {
+    button(/^Share /).click();
+
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+    const [component, config] = dialog.open.mock.calls[0];
+    expect(component).toBe(ArtifactShareModalComponent);
+    // The card renders one row per version, so the version it shares is
+    // the one the user is looking at — a share pins an immutable version
+    // and never follows HEAD.
+    expect(config.data).toEqual({
+      artifactId: 'art-1',
+      version: 3,
+      title: 'Quarterly Chart',
+      ownerEmail: 'owner@example.com',
+    });
+  });
+
+  it('tolerates an unresolved user rather than blocking the dialog', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ArtifactCardComponent],
+      providers: [
+        { provide: Dialog, useValue: dialog },
+        { provide: ArtifactStateService, useValue: artifactState },
+        { provide: ArtifactDownloadService, useValue: download },
+        { provide: UserService, useValue: { currentUser: signal(null) } },
+      ],
+    });
+    fixture = TestBed.createComponent(ArtifactCardComponent);
+    fixture.componentRef.setInput('artifact', ARTIFACT);
+    fixture.detectChanges();
+
+    button(/^Share /).click();
+    expect(dialog.open.mock.calls[0][1].data.ownerEmail).toBe('');
+  });
+
+  it('still opens the panel when the card body is clicked', () => {
+    const hit = el().querySelector<HTMLButtonElement>('.artifact-card__hit');
+    hit!.click();
+
+    expect(artifactState.openArtifactPanel).toHaveBeenCalledWith({
+      artifactId: 'art-1',
+      version: 3,
+      title: 'Quarterly Chart',
+    });
+    // Adding Share must not have stolen the card's primary action.
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('still downloads the version on the card', () => {
+    button(/^Download /).click();
+    expect(download.download).toHaveBeenCalledWith({
+      artifactId: 'art-1',
+      version: 3,
+    });
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -6,16 +6,23 @@ import {
   input,
   signal,
 } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroCodeBracket,
   heroDocumentText,
   heroArrowDownTray,
   heroArrowPath,
+  heroArrowUpOnSquare,
 } from '@ng-icons/heroicons/outline';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
+import {
+  ArtifactShareModalComponent,
+  type ArtifactShareModalData,
+} from './artifact-share-modal.component';
+import { UserService } from '../../../../../auth/user.service';
 import { parseIso } from '../../../../../utils/date';
 
 /** Visual treatment derived from an artifact's content type. */
@@ -58,6 +65,7 @@ interface ArtifactKind {
       heroDocumentText,
       heroArrowDownTray,
       heroArrowPath,
+      heroArrowUpOnSquare,
     }),
   ],
   template: `
@@ -99,21 +107,33 @@ interface ArtifactKind {
           </span>
         </span>
 
-        <button
-          type="button"
-          class="artifact-card__download"
-          [class.is-busy]="downloading()"
-          [attr.aria-label]="downloadAriaLabel()"
-          [attr.aria-busy]="downloading()"
-          [disabled]="downloading()"
-          (click)="download()"
-        >
-          <ng-icon
-            [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
-            aria-hidden="true"
-          />
-          <span class="artifact-card__download-label">Download</span>
-        </button>
+        <span class="artifact-card__actions">
+          <button
+            type="button"
+            class="artifact-card__action"
+            [attr.aria-label]="shareAriaLabel()"
+            (click)="share()"
+          >
+            <ng-icon name="heroArrowUpOnSquare" aria-hidden="true" />
+            <span class="artifact-card__action-label">Share</span>
+          </button>
+
+          <button
+            type="button"
+            class="artifact-card__action"
+            [class.is-busy]="downloading()"
+            [attr.aria-label]="downloadAriaLabel()"
+            [attr.aria-busy]="downloading()"
+            [disabled]="downloading()"
+            (click)="download()"
+          >
+            <ng-icon
+              [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
+              aria-hidden="true"
+            />
+            <span class="artifact-card__action-label">Download</span>
+          </button>
+        </span>
       </span>
     </div>
   `,
@@ -284,13 +304,22 @@ interface ArtifactKind {
       opacity: 0.4;
     }
 
-    /* Secondary action: a bordered, labelled download button in the
-       grid's last column. It lives inside the pointer-events:none
-       surface but re-enables them for itself, so it captures its own
-       clicks while the rest of the card falls through to the open
-       button. Resting colour clears the 3:1 non-text contrast bar. */
-    .artifact-card__download {
+    /* Secondary actions (Share, Download) sit in the grid's last column.
+       The row re-enables pointer events for itself so the buttons
+       capture their own clicks while the rest of the card falls through
+       to the stretched open button beneath. */
+    .artifact-card__actions {
       pointer-events: auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    /* A bordered, labelled action button. Both actions keep a visible
+       text label, so no tooltip is needed for the accessible name
+       (WCAG 2.5.3) — the icon-only variant would. Resting colour clears
+       the 3:1 non-text contrast bar. */
+    .artifact-card__action {
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
@@ -312,47 +341,47 @@ interface ArtifactKind {
         background-color 0.18s ease;
     }
 
-    .artifact-card__download ng-icon {
+    .artifact-card__action ng-icon {
       font-size: 0.95rem;
       line-height: 1;
     }
 
-    .artifact-card:hover .artifact-card__download,
-    .artifact-card__download:hover {
+    .artifact-card:hover .artifact-card__action,
+    .artifact-card__action:hover {
       color: #374151;
     }
 
-    .artifact-card__download:hover {
+    .artifact-card__action:hover {
       background: rgba(0, 0, 0, 0.05);
     }
 
-    .artifact-card__download:focus-visible {
+    .artifact-card__action:focus-visible {
       outline: 2px solid #2563eb;
       outline-offset: 2px;
     }
 
-    .artifact-card__download:disabled {
+    .artifact-card__action:disabled {
       cursor: default;
     }
 
-    .artifact-card__download.is-busy ng-icon {
+    .artifact-card__action.is-busy ng-icon {
       animation: artifact-card-spin 0.8s linear infinite;
     }
 
-    :host-context(html.dark) .artifact-card__download {
+    :host-context(html.dark) .artifact-card__action {
       color: #9aa3b2;
     }
 
-    :host-context(html.dark) .artifact-card:hover .artifact-card__download,
-    :host-context(html.dark) .artifact-card__download:hover {
+    :host-context(html.dark) .artifact-card:hover .artifact-card__action,
+    :host-context(html.dark) .artifact-card__action:hover {
       color: #cbd2dd;
     }
 
-    :host-context(html.dark) .artifact-card__download:hover {
+    :host-context(html.dark) .artifact-card__action:hover {
       background: rgba(255, 255, 255, 0.08);
     }
 
-    :host-context(html.dark) .artifact-card__download:focus-visible {
+    :host-context(html.dark) .artifact-card__action:focus-visible {
       outline-color: #60a5fa;
     }
 
@@ -365,10 +394,10 @@ interface ArtifactKind {
     @media (prefers-reduced-motion: reduce) {
       .artifact-card__surface,
       .artifact-card__rule,
-      .artifact-card__download {
+      .artifact-card__action {
         transition: none;
       }
-      .artifact-card__download.is-busy ng-icon {
+      .artifact-card__action.is-busy ng-icon {
         animation: none;
       }
     }
@@ -379,6 +408,8 @@ export class ArtifactCardComponent {
 
   private artifactState = inject(ArtifactStateService);
   private artifactDownload = inject(ArtifactDownloadService);
+  private dialog = inject(Dialog);
+  private userService = inject(UserService);
 
   protected readonly downloading = signal(false);
 
@@ -404,12 +435,34 @@ export class ArtifactCardComponent {
       `Download ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
   );
 
+  protected readonly shareAriaLabel = computed(
+    () =>
+      `Share ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
+  );
+
   protected open(): void {
     const a = this.artifact();
     this.artifactState.openArtifactPanel({
       artifactId: a.artifactId,
       version: a.version,
       title: a.title,
+    });
+  }
+
+  /** Open the share dialog for *this* version.
+   *
+   *  The card shows one row per version, so the version it shares is the
+   *  one the user is looking at — a share pins an immutable version and
+   *  never follows HEAD. */
+  protected share(): void {
+    const a = this.artifact();
+    this.dialog.open(ArtifactShareModalComponent, {
+      data: {
+        artifactId: a.artifactId,
+        version: a.version,
+        title: a.title,
+        ownerEmail: this.userService.currentUser()?.email ?? '',
+      } as ArtifactShareModalData,
     });
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -11,19 +11,24 @@ import {
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
+import { Dialog } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroXMark,
   heroArrowPath,
   heroExclamationTriangle,
   heroArrowDownTray,
+  heroArrowUpOnSquare,
   heroEye,
   heroCodeBracket,
   heroClipboard,
   heroCheck,
   heroChevronUpDown,
 } from '@ng-icons/heroicons/outline';
-import type { Artifact } from '../../../../services/artifacts/artifact.model';
+import type {
+  Artifact,
+  OpenArtifactRef,
+} from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
 import {
   ArtifactHttpService,
@@ -32,6 +37,12 @@ import {
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { SessionService } from '../../../../services/session/session.service';
 import { ArtifactSourceComponent } from './artifact-source.component';
+import {
+  ArtifactShareModalComponent,
+  type ArtifactShareModalData,
+} from './artifact-share-modal.component';
+import { UserService } from '../../../../../auth/user.service';
+import { TooltipDirective } from '../../../../../components/tooltip/tooltip.directive';
 
 /**
  * Right-docked pane that renders one artifact version in a sandboxed
@@ -53,13 +64,14 @@ import { ArtifactSourceComponent } from './artifact-source.component';
 @Component({
   selector: 'app-artifact-panel',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, NgTemplateOutlet, ArtifactSourceComponent],
+  imports: [NgIcon, NgTemplateOutlet, ArtifactSourceComponent, TooltipDirective],
   providers: [
     provideIcons({
       heroXMark,
       heroArrowPath,
       heroExclamationTriangle,
       heroArrowDownTray,
+      heroArrowUpOnSquare,
       heroEye,
       heroCodeBracket,
       heroClipboard,
@@ -242,6 +254,20 @@ import { ArtifactSourceComponent } from './artifact-source.component';
               />
             </button>
           }
+          <button
+            type="button"
+            class="flex size-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+            [attr.aria-label]="'Share artifact, version ' + ref.version"
+            [appTooltip]="'Share version ' + ref.version"
+            appTooltipPosition="bottom"
+            (click)="share(ref)"
+          >
+            <ng-icon
+              name="heroArrowUpOnSquare"
+              class="text-lg"
+              aria-hidden="true"
+            />
+          </button>
           <button
             type="button"
             class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
@@ -430,6 +456,8 @@ export class ArtifactPanelComponent {
   private sessionService = inject(SessionService);
   private sanitizer = inject(DomSanitizer);
   private artifactDownload = inject(ArtifactDownloadService);
+  private dialog = inject(Dialog);
+  private userService = inject(UserService);
 
   protected readonly open = this.artifactState.openArtifact;
 
@@ -770,6 +798,22 @@ export class ArtifactPanelComponent {
     this.sourceLoading.set(false);
     this.copied.set(false);
     this.loadedSourceKey = null;
+  }
+
+  /** Open the share dialog for the version currently on screen.
+   *
+   *  `ref` is the panel's open-artifact ref, so switching versions in
+   *  the header menu switches what gets shared — a share pins one
+   *  immutable version and never follows HEAD. */
+  protected share(ref: OpenArtifactRef): void {
+    this.dialog.open(ArtifactShareModalComponent, {
+      data: {
+        artifactId: ref.artifactId,
+        version: ref.version,
+        title: ref.title,
+        ownerEmail: this.userService.currentUser()?.email ?? '',
+      } as ArtifactShareModalData,
+    });
   }
 
   protected async download(): Promise<void> {

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.spec.ts
@@ -1,0 +1,363 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import {
+  ArtifactShareModalComponent,
+  type ArtifactShareModalData,
+} from './artifact-share-modal.component';
+import {
+  ArtifactShareService,
+  type ArtifactShare,
+} from '../../../../services/artifacts/artifact-share.service';
+
+const DATA: ArtifactShareModalData = {
+  artifactId: 'art-1',
+  version: 2,
+  title: 'Quarterly Chart',
+  ownerEmail: 'owner@example.com',
+};
+
+const SHARE: ArtifactShare = {
+  shareId: 'share-1',
+  artifactId: 'art-1',
+  version: 2,
+  ownerId: 'owner-1',
+  accessLevel: 'public',
+  title: 'Quarterly Chart',
+  contentType: 'text/html; charset=utf-8',
+  createdAt: '2026-09-03T00:00:00+00:00',
+  shareUrl: '/shared-artifact/share-1',
+};
+
+describe('ArtifactShareModalComponent', () => {
+  let component: ArtifactShareModalComponent;
+  let fixture: ComponentFixture<ArtifactShareModalComponent>;
+  let shareService: {
+    createShare: ReturnType<typeof vi.fn>;
+    listShares: ReturnType<typeof vi.fn>;
+    updateShare: ReturnType<typeof vi.fn>;
+    revokeShare: ReturnType<typeof vi.fn>;
+  };
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+
+  /** Reach past `protected` for interaction tests, matching the
+   *  conversation share-modal spec's approach. */
+  const api = () => component as unknown as Record<string, any>;
+  const text = () => (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    shareService = {
+      createShare: vi.fn(),
+      listShares: vi.fn().mockResolvedValue([]),
+      updateShare: vi.fn(),
+      revokeShare: vi.fn().mockResolvedValue(undefined),
+    };
+    dialogRef = { close: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [ArtifactShareModalComponent],
+      providers: [
+        // DI token overrides, not vi.mock — module mocks leak across specs.
+        { provide: ArtifactShareService, useValue: shareService },
+        { provide: DIALOG_DATA, useValue: DATA },
+        { provide: DialogRef, useValue: dialogRef },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ArtifactShareModalComponent);
+    component = fixture.componentInstance;
+
+    // jsdom has no clipboard; the copy path is exercised explicitly below.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  async function init(): Promise<void> {
+    await component.ngOnInit();
+    fixture.detectChanges();
+  }
+
+  // ----------------------------------------------------------------
+  // Rendering
+  // ----------------------------------------------------------------
+
+  it('creates the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('names the artifact and the version being shared', async () => {
+    await init();
+    expect(text()).toContain('Quarterly Chart');
+    expect(text()).toContain('version 2');
+  });
+
+  it('offers exactly the public and limited access levels', async () => {
+    await init();
+    expect(text()).toContain('Public link');
+    expect(text()).toContain('Limited share');
+    expect(text()).not.toContain('Keep private');
+  });
+
+  it('loads existing links on open', async () => {
+    shareService.listShares.mockResolvedValue([{ ...SHARE, version: 1 }]);
+    await init();
+    expect(shareService.listShares).toHaveBeenCalledWith('art-1');
+    expect(text()).toContain('Existing links');
+    expect(text()).toContain('Version 1');
+  });
+
+  it('still opens when the existing-links call fails', async () => {
+    shareService.listShares.mockRejectedValue(new Error('boom'));
+    await init();
+    // The list is a convenience; failing it must not block sharing.
+    expect(text()).toContain('Create share link');
+    expect(api()['error']()).toBeNull();
+  });
+
+  // ----------------------------------------------------------------
+  // Create
+  // ----------------------------------------------------------------
+
+  it('creates a share pinned to the version it was opened for', async () => {
+    shareService.createShare.mockResolvedValue(SHARE);
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(shareService.createShare).toHaveBeenCalledWith(
+      'art-1',
+      2,
+      'public',
+      undefined,
+    );
+  });
+
+  it('sends the owner plus the added emails for a limited share', async () => {
+    shareService.createShare.mockResolvedValue({
+      ...SHARE,
+      accessLevel: 'specific',
+    });
+    await init();
+
+    api()['selectedAccess'].set('specific');
+    api()['emailInput'].set('friend@example.com');
+    api()['addEmail']();
+    await api()['onShare']();
+
+    expect(shareService.createShare).toHaveBeenCalledWith('art-1', 2, 'specific', [
+      'owner@example.com',
+      'friend@example.com',
+    ]);
+  });
+
+  it('says the link is pinned to one version after sharing', async () => {
+    shareService.createShare.mockResolvedValue(SHARE);
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Artifact shared');
+    // The pinning promise is the whole consent model — it must be stated.
+    expect(text()).toContain('always shows version 2');
+    expect(text()).toContain("Later versions aren't included");
+  });
+
+  it('does not list the just-created link twice', async () => {
+    shareService.listShares.mockResolvedValue([]);
+    shareService.createShare.mockResolvedValue(SHARE);
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(api()['shares']()).toHaveLength(1);
+    expect(api()['otherShares']()).toHaveLength(0);
+    expect(text()).not.toContain('Existing links');
+  });
+
+  // ----------------------------------------------------------------
+  // Email chips
+  // ----------------------------------------------------------------
+
+  it('shows the owner as a non-removable chip for a limited share', async () => {
+    await init();
+    api()['selectedAccess'].set('specific');
+    fixture.detectChanges();
+
+    expect(text()).toContain('People with access');
+    expect(text()).toContain('owner@example.com (you)');
+  });
+
+  it('adds and removes emails', async () => {
+    await init();
+    api()['selectedAccess'].set('specific');
+    api()['emailInput'].set('friend@example.com');
+    api()['addEmail']();
+    fixture.detectChanges();
+    expect(text()).toContain('friend@example.com');
+
+    api()['removeEmail']('friend@example.com');
+    fixture.detectChanges();
+    expect(text()).not.toContain('friend@example.com');
+  });
+
+  it('rejects a malformed, duplicate, or owner email', async () => {
+    await init();
+    api()['selectedAccess'].set('specific');
+
+    api()['emailInput'].set('not-an-email');
+    api()['addEmail']();
+    api()['emailInput'].set('owner@example.com');
+    api()['addEmail']();
+    api()['emailInput'].set('friend@example.com');
+    api()['addEmail']();
+    api()['emailInput'].set('friend@example.com');
+    api()['addEmail']();
+
+    expect(api()['allowedEmails']()).toEqual(['friend@example.com']);
+  });
+
+  // ----------------------------------------------------------------
+  // Revoke
+  // ----------------------------------------------------------------
+
+  it('revokes a link and drops it from the list', async () => {
+    shareService.listShares.mockResolvedValue([SHARE]);
+    await init();
+
+    await api()['revoke'](SHARE);
+    fixture.detectChanges();
+
+    expect(shareService.revokeShare).toHaveBeenCalledWith('share-1');
+    expect(api()['shares']()).toEqual([]);
+  });
+
+  it('retires the result panel when the link it shows is revoked', async () => {
+    shareService.createShare.mockResolvedValue(SHARE);
+    await init();
+    await api()['onShare']();
+
+    await api()['revoke'](SHARE);
+    fixture.detectChanges();
+
+    // Otherwise the dialog would keep offering a dead link to copy.
+    expect(api()['shareResult']()).toBeNull();
+    expect(text()).not.toContain('Artifact shared');
+  });
+
+  // ----------------------------------------------------------------
+  // Link building + copy
+  // ----------------------------------------------------------------
+
+  it('builds an absolute link from the server-supplied route', async () => {
+    await init();
+    expect(api()['absoluteUrl'](SHARE)).toBe(
+      `${window.location.origin}/shared-artifact/share-1`,
+    );
+  });
+
+  it('copies the absolute link and flags which link was copied', async () => {
+    shareService.listShares.mockResolvedValue([SHARE]);
+    await init();
+
+    await api()['copyLink'](SHARE);
+    fixture.detectChanges();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/shared-artifact/share-1`,
+    );
+    expect(api()['copiedShareId']()).toBe('share-1');
+  });
+
+  it('falls back to a message when the clipboard is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+      configurable: true,
+    });
+    await init();
+
+    await api()['copyLink'](SHARE);
+    fixture.detectChanges();
+
+    expect(text()).toContain('Could not copy automatically');
+  });
+
+  // ----------------------------------------------------------------
+  // Errors
+  // ----------------------------------------------------------------
+
+  it.each([
+    [404, 'That artifact version no longer exists.'],
+    [403, 'You do not have permission to change this share.'],
+    [503, 'Sharing is temporarily unavailable. Please try again.'],
+  ])('explains a %i from the share API', async (status, expected) => {
+    shareService.createShare.mockRejectedValue({ status });
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(text()).toContain(expected);
+  });
+
+  it('surfaces a backend detail message when there is one', async () => {
+    shareService.createShare.mockRejectedValue({
+      status: 400,
+      error: { detail: 'Something specific went wrong' },
+    });
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Something specific went wrong');
+  });
+
+  it('falls back to a generic message for an unrecognized failure', async () => {
+    shareService.createShare.mockRejectedValue(new Error('offline'));
+    await init();
+
+    await api()['onShare']();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Failed to create share');
+  });
+
+  // ----------------------------------------------------------------
+  // Close contract
+  // ----------------------------------------------------------------
+
+  it('closes with undefined when nothing was committed', async () => {
+    await init();
+    api()['onClose']();
+    // `undefined` means cancelled, per the dialog convention.
+    expect(dialogRef.close).toHaveBeenCalledWith(undefined);
+  });
+
+  it('closes with the current links after creating one', async () => {
+    shareService.createShare.mockResolvedValue(SHARE);
+    await init();
+
+    await api()['onShare']();
+    api()['onClose']();
+
+    expect(dialogRef.close).toHaveBeenCalledWith([SHARE]);
+  });
+
+  it('closes with a result after a revoke, even with nothing created', async () => {
+    shareService.listShares.mockResolvedValue([SHARE]);
+    await init();
+
+    await api()['revoke'](SHARE);
+    api()['onClose']();
+
+    // A revoke is a commit too — the opener needs to know something moved.
+    expect(dialogRef.close).toHaveBeenCalledWith([]);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.ts
@@ -1,0 +1,631 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroXMark,
+  heroClipboard,
+  heroArrowUpOnSquare,
+  heroCheck,
+  heroGlobeAlt,
+  heroLockClosed,
+} from '@ng-icons/heroicons/outline';
+import {
+  ArtifactShareService,
+  type ArtifactShare,
+  type ArtifactShareAccessLevel,
+} from '../../../../services/artifacts/artifact-share.service';
+import { DialogDismissDirective } from '../../../../../components/dialog/dialog-dismiss.directive';
+import { parseIso } from '../../../../../utils/date';
+
+/** Data passed to the artifact-share dialog. */
+export interface ArtifactShareModalData {
+  artifactId: string;
+  /** The version to share. A share pins one immutable version, never HEAD. */
+  version: number;
+  title: string;
+  ownerEmail: string;
+}
+
+/**
+ * Result returned when the dialog closes.
+ * - `ArtifactShare[]` — the links that exist now, after the user created
+ *   and/or revoked at least one. The opener can use it to refresh a
+ *   "shared" affordance without a round trip.
+ * - `undefined` — nothing was committed (cancelled, Escape, or backdrop).
+ */
+export type ArtifactShareModalResult = ArtifactShare[] | undefined;
+
+/**
+ * Share one artifact version, and manage the links that already exist
+ * for this artifact.
+ *
+ * Adapted from the conversation `ShareModalComponent` — same access-level
+ * radio, same email chips, same clipboard copy, same CDK dialog shell —
+ * with three deliberate differences:
+ *
+ *  - **A share pins one immutable version, never HEAD.** Artifact
+ *    versions are append-only, so the recipient's view can never change
+ *    under them. Existing links are therefore listed *with* their
+ *    version: a link made against v1 keeps showing v1 after the model
+ *    writes v2.
+ *  - **Create and manage live in one dialog.** Conversations split these
+ *    across the share modal and the manage-shares dialog because the
+ *    latter is reached from the sessions list; an artifact has no
+ *    equivalent management surface, so revoke lives here.
+ *  - **Redesign tokens, not the source dialog's.** Per the frontend
+ *    convention, an adapted dialog copies the older one's *structure*
+ *    (backdrop + centred panel + DialogRef wiring) and not its
+ *    pre-redesign styling — hence `rounded-2xl` / `text-sm/6` /
+ *    `bg-blue-600` throughout.
+ *
+ * The dialog never touches artifact content. Opening a shared artifact
+ * is a separate, access-checked mint on the recipient's side.
+ */
+@Component({
+  selector: 'app-artifact-share-modal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogDismissDirective, FormsModule, NgIcon],
+  providers: [
+    provideIcons({
+      heroXMark,
+      heroClipboard,
+      heroArrowUpOnSquare,
+      heroCheck,
+      heroGlobeAlt,
+      heroLockClosed,
+    }),
+  ],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onClose()',
+  },
+  template: `
+    <!-- Backdrop -->
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+    ></div>
+
+    <!-- Dialog Panel -->
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+      appDialogDismiss
+      (dismissed)="onClose()"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="artifact-share-title"
+        aria-describedby="artifact-share-description"
+      >
+        <!-- Header -->
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <div class="flex min-w-0 items-start gap-2">
+            <ng-icon
+              name="heroArrowUpOnSquare"
+              class="mt-1 size-5 shrink-0 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <div class="min-w-0">
+              <h2
+                id="artifact-share-title"
+                class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+              >
+                Share artifact
+              </h2>
+              <p
+                id="artifact-share-description"
+                class="mt-1 truncate text-sm/6 text-gray-600 dark:text-gray-400"
+              >
+                {{ data.title || 'Untitled artifact' }} · version
+                {{ data.version }}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            (click)="onClose()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <!-- Content -->
+        <div class="px-6 py-4">
+          <!-- Access level -->
+          <fieldset class="flex flex-col gap-2">
+            <legend class="sr-only">Access level</legend>
+
+            @for (option of accessOptions; track option.value) {
+              <label
+                class="flex cursor-pointer items-start gap-3 rounded-2xl border p-3 transition-colors"
+                [class]="
+                  selectedAccess() === option.value
+                    ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-500/10'
+                    : 'border-gray-200 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/40'
+                "
+              >
+                <input
+                  type="radio"
+                  name="artifactAccessLevel"
+                  [value]="option.value"
+                  [checked]="selectedAccess() === option.value"
+                  (change)="selectedAccess.set(option.value)"
+                  class="mt-1 size-4 text-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                />
+                <span class="min-w-0">
+                  <span
+                    class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                    >{{ option.label }}</span
+                  >
+                  <span
+                    class="block text-xs/5 text-gray-500 dark:text-gray-400"
+                    >{{ option.description }}</span
+                  >
+                </span>
+              </label>
+            }
+          </fieldset>
+
+          <!-- Email allowlist (specific access) -->
+          @if (selectedAccess() === 'specific') {
+            <div class="mt-4">
+              <label
+                for="artifact-share-email"
+                class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300"
+              >
+                People with access
+              </label>
+
+              <div class="mt-1 mb-2 flex flex-wrap gap-1.5">
+                <!-- Owner chip: the backend keeps the owner on every
+                     allowlist, so it isn't removable here either. -->
+                <span
+                  class="inline-flex items-center gap-1 rounded-2xl bg-blue-100 px-2.5 py-0.5 text-xs/5 font-medium text-blue-700 dark:bg-blue-500/20 dark:text-blue-300"
+                >
+                  {{ data.ownerEmail }} (you)
+                </span>
+
+                @for (email of allowedEmails(); track email) {
+                  <span
+                    class="inline-flex items-center gap-1 rounded-2xl bg-gray-100 px-2.5 py-0.5 text-xs/5 font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                  >
+                    {{ email }}
+                    <button
+                      type="button"
+                      (click)="removeEmail(email)"
+                      class="ml-0.5 inline-flex size-3.5 items-center justify-center rounded-2xl hover:bg-gray-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-600"
+                      [attr.aria-label]="'Remove ' + email"
+                    >
+                      <ng-icon
+                        name="heroXMark"
+                        class="size-3"
+                        aria-hidden="true"
+                      />
+                    </button>
+                  </span>
+                }
+              </div>
+
+              <div class="flex gap-2">
+                <input
+                  id="artifact-share-email"
+                  type="email"
+                  placeholder="Enter email address"
+                  [ngModel]="emailInput()"
+                  (ngModelChange)="emailInput.set($event)"
+                  (keydown.enter)="addEmail($event)"
+                  class="flex-1 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-sm/6 text-gray-900 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-500"
+                />
+                <button
+                  type="button"
+                  (click)="addEmail()"
+                  [disabled]="!emailInput().trim()"
+                  class="rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          }
+
+          <!-- Result of the share just created -->
+          @if (shareResult(); as result) {
+            <div
+              class="mt-4 rounded-2xl border border-green-200 bg-green-50 p-3 dark:border-green-700 dark:bg-green-500/10"
+            >
+              <p
+                class="text-sm/6 font-medium text-green-800 dark:text-green-300"
+              >
+                Artifact shared
+              </p>
+              <p class="mb-2 text-xs/5 text-green-700 dark:text-green-400">
+                This link always shows version {{ result.version }}. Later
+                versions aren't included.
+              </p>
+              <div class="flex items-center gap-2">
+                <input
+                  type="text"
+                  readonly
+                  [value]="absoluteUrl(result)"
+                  aria-label="Share link"
+                  class="min-w-0 flex-1 rounded-2xl border border-green-200 bg-white px-2.5 py-1.5 text-xs/5 text-gray-700 dark:border-green-700 dark:bg-gray-700 dark:text-gray-300"
+                />
+                <button
+                  type="button"
+                  (click)="copyLink(result)"
+                  class="inline-flex shrink-0 items-center gap-1 rounded-2xl border border-gray-300 bg-white px-3 py-1.5 text-xs/5 font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                  <ng-icon
+                    [name]="
+                      copiedShareId() === result.shareId
+                        ? 'heroCheck'
+                        : 'heroClipboard'
+                    "
+                    class="size-3.5"
+                    aria-hidden="true"
+                  />
+                  {{
+                    copiedShareId() === result.shareId ? 'Copied' : 'Copy link'
+                  }}
+                </button>
+              </div>
+            </div>
+          }
+
+          <!-- Existing links: manage / revoke -->
+          @if (otherShares().length > 0) {
+            <div class="mt-4">
+              <h3
+                class="text-xs/5 font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+              >
+                Existing links
+              </h3>
+              <ul
+                class="mt-1 max-h-48 divide-y divide-gray-200 overflow-y-auto dark:divide-gray-700"
+              >
+                @for (share of otherShares(); track share.shareId) {
+                  <li class="flex items-center justify-between gap-2 py-2">
+                    <span class="flex min-w-0 items-center gap-2">
+                      @if (share.accessLevel === 'public') {
+                        <ng-icon
+                          name="heroGlobeAlt"
+                          class="size-4 shrink-0 text-green-600 dark:text-green-400"
+                          aria-hidden="true"
+                        />
+                      } @else {
+                        <ng-icon
+                          name="heroLockClosed"
+                          class="size-4 shrink-0 text-amber-600 dark:text-amber-400"
+                          aria-hidden="true"
+                        />
+                      }
+                      <span
+                        class="truncate text-sm/6 text-gray-700 dark:text-gray-300"
+                      >
+                        <span class="font-medium"
+                          >Version {{ share.version }}</span
+                        >
+                        <span class="text-gray-500 dark:text-gray-400">
+                          · {{ audienceLabel(share) }}
+                          @if (formatDate(share.createdAt); as d) {
+                            · {{ d }}
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span class="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        (click)="copyLink(share)"
+                        class="rounded-2xl px-3 py-1 text-xs/5 font-medium text-gray-600 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-700"
+                        [attr.aria-label]="
+                          'Copy link for version ' + share.version
+                        "
+                      >
+                        {{
+                          copiedShareId() === share.shareId ? 'Copied' : 'Copy'
+                        }}
+                      </button>
+                      <button
+                        type="button"
+                        (click)="revoke(share)"
+                        [disabled]="revokingIds().has(share.shareId)"
+                        class="rounded-2xl px-3 py-1 text-xs/5 font-medium text-red-600 hover:bg-red-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-red-400 dark:hover:bg-red-500/10"
+                        [attr.aria-label]="
+                          'Revoke link for version ' + share.version
+                        "
+                      >
+                        {{
+                          revokingIds().has(share.shareId)
+                            ? 'Revoking…'
+                            : 'Revoke'
+                        }}
+                      </button>
+                    </span>
+                  </li>
+                }
+              </ul>
+            </div>
+          }
+
+          <!-- Error -->
+          @if (error()) {
+            <p
+              class="mt-4 rounded-2xl bg-red-50 p-3 text-sm/6 text-red-700 dark:bg-red-500/10 dark:text-red-300"
+              role="alert"
+            >
+              {{ error() }}
+            </p>
+          }
+        </div>
+
+        <!-- Actions -->
+        <div
+          class="flex items-center justify-end gap-2 border-t border-gray-200 px-6 py-3 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onClose()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            {{ shareResult() ? 'Done' : 'Cancel' }}
+          </button>
+
+          @if (!shareResult()) {
+            <button
+              type="button"
+              (click)="onShare()"
+              [disabled]="isSubmitting()"
+              class="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-4 py-2 text-sm/6 font-medium text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              @if (isSubmitting()) {
+                <span
+                  class="size-4 animate-spin rounded-2xl border-2 border-white border-t-transparent"
+                  aria-hidden="true"
+                ></span>
+              }
+              Create share link
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @import "tailwindcss";
+
+    @custom-variant dark (&:where(.dark, .dark *));
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+
+    @keyframes dialog-fade-in-up {
+      from {
+        opacity: 0;
+        transform: translateY(1rem) scale(0.97);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dialog-backdrop,
+      .dialog-panel {
+        animation: none;
+      }
+    }
+  `,
+})
+export class ArtifactShareModalComponent implements OnInit {
+  private dialogRef = inject(DialogRef<ArtifactShareModalResult>);
+  protected data = inject<ArtifactShareModalData>(DIALOG_DATA);
+  private shareService = inject(ArtifactShareService);
+
+  protected selectedAccess = signal<ArtifactShareAccessLevel>('public');
+  protected allowedEmails = signal<string[]>([]);
+  protected emailInput = signal('');
+  protected isSubmitting = signal(false);
+  protected error = signal<string | null>(null);
+  protected shareResult = signal<ArtifactShare | null>(null);
+  protected shares = signal<ArtifactShare[]>([]);
+  protected copiedShareId = signal<string | null>(null);
+  protected revokingIds = signal<Set<string>>(new Set());
+
+  /** Set once anything is committed, so closing reports a result rather
+   *  than `undefined` ("cancelled") even if the created link was then
+   *  revoked in the same dialog. */
+  private committed = false;
+
+  protected readonly accessOptions = [
+    {
+      value: 'public' as ArtifactShareAccessLevel,
+      label: 'Public link',
+      description: 'Any authenticated user with the link can view',
+    },
+    {
+      value: 'specific' as ArtifactShareAccessLevel,
+      label: 'Limited share',
+      description: 'Only you and designated email addresses can view',
+    },
+  ];
+
+  /** Existing links, minus the one just created — that has its own
+   *  result panel above and would otherwise be listed twice. */
+  protected readonly otherShares = computed(() => {
+    const justCreated = this.shareResult()?.shareId;
+    return this.shares().filter((s) => s.shareId !== justCreated);
+  });
+
+  async ngOnInit(): Promise<void> {
+    try {
+      this.shares.set(await this.shareService.listShares(this.data.artifactId));
+    } catch {
+      // No existing links, or the list call failed. Either way the
+      // create path still works, so don't block the dialog on it.
+    }
+  }
+
+  /** The server hands back a SPA-relative route; make it copyable. */
+  protected absoluteUrl(share: ArtifactShare): string {
+    return `${window.location.origin}${share.shareUrl}`;
+  }
+
+  protected audienceLabel(share: ArtifactShare): string {
+    if (share.accessLevel === 'public') return 'Anyone signed in';
+    const count = share.allowedEmails?.length ?? 0;
+    return count === 1 ? '1 person' : `${count} people`;
+  }
+
+  protected addEmail(event?: Event): void {
+    event?.preventDefault();
+    const email = this.emailInput().trim().toLowerCase();
+    if (!email || !email.includes('@')) return;
+    if (email === this.data.ownerEmail.toLowerCase()) return;
+    if (this.allowedEmails().includes(email)) return;
+
+    this.allowedEmails.update((list) => [...list, email]);
+    this.emailInput.set('');
+  }
+
+  protected removeEmail(email: string): void {
+    this.allowedEmails.update((list) => list.filter((e) => e !== email));
+  }
+
+  protected async onShare(): Promise<void> {
+    this.isSubmitting.set(true);
+    this.error.set(null);
+
+    try {
+      // The backend keeps the owner on the allowlist itself, but sending
+      // it keeps the request self-describing and satisfies the
+      // "specific needs at least one email" validator when the user
+      // shares with nobody but themselves.
+      const emails =
+        this.selectedAccess() === 'specific'
+          ? [this.data.ownerEmail, ...this.allowedEmails()]
+          : undefined;
+
+      const result = await this.shareService.createShare(
+        this.data.artifactId,
+        this.data.version,
+        this.selectedAccess(),
+        emails,
+      );
+
+      this.committed = true;
+      this.shareResult.set(result);
+      this.shares.update((list) => [...list, result]);
+    } catch (err: unknown) {
+      this.error.set(
+        describeShareError(err) ?? 'Failed to create share. Please try again.',
+      );
+    } finally {
+      this.isSubmitting.set(false);
+    }
+  }
+
+  protected async revoke(share: ArtifactShare): Promise<void> {
+    if (this.revokingIds().has(share.shareId)) return;
+    this.revokingIds.update((ids) => new Set(ids).add(share.shareId));
+    this.error.set(null);
+    try {
+      await this.shareService.revokeShare(share.shareId);
+      this.committed = true;
+      this.shares.update((list) =>
+        list.filter((s) => s.shareId !== share.shareId),
+      );
+      // Revoking the link that was just created retires its result panel
+      // too, so the dialog can't offer a dead link to copy.
+      if (this.shareResult()?.shareId === share.shareId) {
+        this.shareResult.set(null);
+      }
+    } catch (err: unknown) {
+      this.error.set(describeShareError(err) ?? 'Failed to revoke this link.');
+    } finally {
+      this.revokingIds.update((ids) => {
+        const next = new Set(ids);
+        next.delete(share.shareId);
+        return next;
+      });
+    }
+  }
+
+  protected async copyLink(share: ArtifactShare): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.absoluteUrl(share));
+      this.copiedShareId.set(share.shareId);
+      setTimeout(() => {
+        if (this.copiedShareId() === share.shareId) {
+          this.copiedShareId.set(null);
+        }
+      }, 2000);
+    } catch {
+      this.error.set(
+        'Could not copy automatically. Please copy the link manually.',
+      );
+    }
+  }
+
+  protected formatDate(value: string): string {
+    if (!value) return '';
+    try {
+      return parseIso(value).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Escape, backdrop click, Cancel and Done all converge here.
+   *
+   * Creating and revoking commit immediately, so "cancelled" can only
+   * mean *nothing was committed* — that is what returns `undefined`.
+   * Once anything has been committed the dialog resolves with the links
+   * that exist now.
+   */
+  protected onClose(): void {
+    this.dialogRef.close(this.committed ? this.shares() : undefined);
+  }
+}
+
+/** Map a backend failure to something a person can act on. The share
+ *  routes 404 an unknown share/version, 403 a non-owner, and 503 when
+ *  the backing store is briefly unavailable. */
+function describeShareError(err: unknown): string | null {
+  const status = (err as { status?: number } | null)?.status;
+  const detail = (err as { error?: { detail?: string } } | null)?.error?.detail;
+
+  if (status === 404) return 'That artifact version no longer exists.';
+  if (status === 403) return 'You do not have permission to change this share.';
+  if (status === 503) {
+    return 'Sharing is temporarily unavailable. Please try again.';
+  }
+  return detail ?? null;
+}

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ArtifactShareService } from './artifact-share.service';
+import { ConfigService } from '../../../services/config.service';
+
+const API = 'http://localhost:8000';
+
+const SHARE = {
+  shareId: 'share-1',
+  artifactId: 'art-1',
+  version: 2,
+  ownerId: 'owner-1',
+  accessLevel: 'public' as const,
+  title: 'My Chart',
+  contentType: 'text/html; charset=utf-8',
+  createdAt: '2026-09-03T00:00:00+00:00',
+  shareUrl: '/shared-artifact/share-1',
+};
+
+describe('ArtifactShareService', () => {
+  let service: ArtifactShareService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ArtifactShareService,
+        { provide: ConfigService, useValue: { appApiUrl: signal(API) } },
+      ],
+    });
+    service = TestBed.inject(ArtifactShareService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  // ----------------------------------------------------------------
+  // Owner CRUD
+  // ----------------------------------------------------------------
+
+  it('creates a share pinned to an explicit version', async () => {
+    const p = service.createShare('art-1', 2, 'public');
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/shares`);
+    expect(req.request.method).toBe('POST');
+    // The version is always sent explicitly — the backend never defaults
+    // a share to HEAD.
+    expect(req.request.body).toEqual({ version: 2, accessLevel: 'public' });
+    req.flush(SHARE);
+    await expect(p).resolves.toEqual(SHARE);
+  });
+
+  it('sends allowedEmails for a specific share', async () => {
+    const p = service.createShare('art-1', 1, 'specific', ['a@x.com']);
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/shares`);
+    expect(req.request.body).toEqual({
+      version: 1,
+      accessLevel: 'specific',
+      allowedEmails: ['a@x.com'],
+    });
+    req.flush(SHARE);
+    await p;
+  });
+
+  it('omits an empty allowedEmails rather than sending []', async () => {
+    const p = service.createShare('art-1', 1, 'public', []);
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/shares`);
+    expect(req.request.body).toEqual({ version: 1, accessLevel: 'public' });
+    req.flush(SHARE);
+    await p;
+  });
+
+  it('lists shares and defaults a missing array to empty', async () => {
+    const p = service.listShares('art-1');
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/shares`);
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+    await expect(p).resolves.toEqual([]);
+  });
+
+  it('lists shares across versions of one artifact', async () => {
+    const p = service.listShares('art-1');
+    httpMock
+      .expectOne(`${API}/artifacts/art-1/shares`)
+      .flush({ shares: [SHARE, { ...SHARE, shareId: 'share-2', version: 1 }] });
+    const shares = await p;
+    expect(shares.map((s) => s.version)).toEqual([2, 1]);
+  });
+
+  it('patches only the fields that were supplied', async () => {
+    const p = service.updateShare('share-1', 'specific', ['b@x.com']);
+    const req = httpMock.expectOne(`${API}/artifacts/shares/share-1`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({
+      accessLevel: 'specific',
+      allowedEmails: ['b@x.com'],
+    });
+    req.flush(SHARE);
+    await p;
+  });
+
+  it('patches with an empty body when nothing was supplied', async () => {
+    const p = service.updateShare('share-1');
+    const req = httpMock.expectOne(`${API}/artifacts/shares/share-1`);
+    expect(req.request.body).toEqual({});
+    req.flush(SHARE);
+    await p;
+  });
+
+  it('revokes a share', async () => {
+    const p = service.revokeShare('share-1');
+    const req = httpMock.expectOne(`${API}/artifacts/shares/share-1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await p;
+  });
+
+  // ----------------------------------------------------------------
+  // Recipient
+  // ----------------------------------------------------------------
+
+  it('reads recipient metadata', async () => {
+    const p = service.getSharedArtifact('share-1');
+    const req = httpMock.expectOne(`${API}/shared-artifacts/share-1`);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      shareId: 'share-1',
+      title: 'My Chart',
+      contentType: 'text/html; charset=utf-8',
+      version: 2,
+      createdAt: '2026-09-03T00:00:00+00:00',
+      ownerEmail: 'owner@x.com',
+      canDownload: true,
+    });
+    await expect(p).resolves.toMatchObject({
+      ownerEmail: 'owner@x.com',
+      canDownload: true,
+    });
+  });
+
+  it('mints a shared render token and maps expires_at', async () => {
+    const p = service.mintSharedRenderToken('share-1');
+    const req = httpMock.expectOne(
+      `${API}/shared-artifacts/share-1/render-token`,
+    );
+    expect(req.request.method).toBe('POST');
+    req.flush({
+      url: 'https://artifacts.x/?t=jwt',
+      expires_at: '2026-09-03T00:02:00+00:00',
+    });
+    // Same shape as the owner mint, so the iframe and the download
+    // service work against either path unchanged.
+    await expect(p).resolves.toEqual({
+      url: 'https://artifacts.x/?t=jwt',
+      expiresAt: '2026-09-03T00:02:00+00:00',
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Path safety
+  // ----------------------------------------------------------------
+
+  it('url-encodes ids in every path segment it builds', async () => {
+    const create = service.createShare('a/b 1', 1, 'public');
+    httpMock.expectOne(`${API}/artifacts/a%2Fb%201/shares`).flush(SHARE);
+    await create;
+
+    const list = service.listShares('a/b 1');
+    httpMock.expectOne(`${API}/artifacts/a%2Fb%201/shares`).flush({ shares: [] });
+    await list;
+
+    const revoke = service.revokeShare('s/1');
+    httpMock
+      .expectOne(`${API}/artifacts/shares/s%2F1`)
+      .flush(null, { status: 204, statusText: 'No Content' });
+    await revoke;
+
+    const mint = service.mintSharedRenderToken('s/1');
+    httpMock
+      .expectOne(`${API}/shared-artifacts/s%2F1/render-token`)
+      .flush({ url: 'u', expires_at: 'e' });
+    await mint;
+  });
+});

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
@@ -1,0 +1,169 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import type { RenderToken } from './artifact-http.service';
+
+/** Who may open a share. `public` means any *authenticated* tenant user
+ *  — never anonymous, matching conversation sharing. */
+export type ArtifactShareAccessLevel = 'public' | 'specific';
+
+/** One artifact share, as its owner sees it. */
+export interface ArtifactShare {
+  shareId: string;
+  artifactId: string;
+  /** The immutable version this share is pinned to — never HEAD. */
+  version: number;
+  ownerId: string;
+  accessLevel: ArtifactShareAccessLevel;
+  allowedEmails?: string[];
+  title: string;
+  contentType: string;
+  createdAt: string;
+  updatedAt?: string;
+  /** SPA-relative recipient route, e.g. `/shared-artifact/{id}`. */
+  shareUrl: string;
+}
+
+interface ArtifactShareListResponse {
+  shares: ArtifactShare[];
+}
+
+/** Recipient-facing share metadata. Never carries artifact content. */
+export interface SharedArtifact {
+  shareId: string;
+  title: string;
+  contentType: string;
+  version: number;
+  createdAt: string;
+  ownerEmail: string;
+  canDownload: boolean;
+}
+
+interface RenderTokenResponseDto {
+  url: string;
+  expires_at: string;
+}
+
+/**
+ * app-api client for artifact sharing. Auth rides the httpOnly BFF
+ * session cookie + csrfInterceptor automatically, same as every other
+ * app-api call — no Bearer here.
+ *
+ * Wire shape is camelCase (unlike `ArtifactHttpService`, whose endpoints
+ * are snake_case): the sharing API mirrors the conversation-sharing
+ * models this feature is adapted from. The render-token response is the
+ * one exception — it reuses the owner endpoint's shape verbatim,
+ * `expires_at` included, so the panel's iframe and the download service
+ * work against either path unchanged.
+ */
+@Injectable({ providedIn: 'root' })
+export class ArtifactShareService {
+  private http = inject(HttpClient);
+  private config = inject(ConfigService);
+
+  private artifactsUrl(): string {
+    return `${this.config.appApiUrl()}/artifacts`;
+  }
+
+  private sharedUrl(): string {
+    return `${this.config.appApiUrl()}/shared-artifacts`;
+  }
+
+  // ----------------------------------------------------------------
+  // Owner CRUD
+  // ----------------------------------------------------------------
+
+  /**
+   * Share one immutable artifact version. `allowedEmails` is required by
+   * the backend for `specific` and ignored for `public`; the owner is
+   * added to the allowlist server-side, so callers need not include it.
+   */
+  async createShare(
+    artifactId: string,
+    version: number,
+    accessLevel: ArtifactShareAccessLevel,
+    allowedEmails?: string[],
+  ): Promise<ArtifactShare> {
+    return firstValueFrom(
+      this.http.post<ArtifactShare>(
+        `${this.artifactsUrl()}/${encodeURIComponent(artifactId)}/shares`,
+        {
+          version,
+          accessLevel,
+          ...(allowedEmails?.length ? { allowedEmails } : {}),
+        },
+      ),
+    );
+  }
+
+  /** Every share the caller owns for this artifact, across all versions. */
+  async listShares(artifactId: string): Promise<ArtifactShare[]> {
+    const res = await firstValueFrom(
+      this.http.get<ArtifactShareListResponse>(
+        `${this.artifactsUrl()}/${encodeURIComponent(artifactId)}/shares`,
+      ),
+    );
+    return res.shares ?? [];
+  }
+
+  /** Change who may view an existing share. The pinned version is
+   *  immutable — only access can change. */
+  async updateShare(
+    shareId: string,
+    accessLevel?: ArtifactShareAccessLevel,
+    allowedEmails?: string[],
+  ): Promise<ArtifactShare> {
+    const body: Record<string, unknown> = {};
+    if (accessLevel) body['accessLevel'] = accessLevel;
+    if (allowedEmails) body['allowedEmails'] = allowedEmails;
+
+    return firstValueFrom(
+      this.http.patch<ArtifactShare>(
+        `${this.artifactsUrl()}/shares/${encodeURIComponent(shareId)}`,
+        body,
+      ),
+    );
+  }
+
+  /** Revoke a share. Effective within one render-token TTL (~120s):
+   *  already-issued tokens finish out their life, no new ones are minted. */
+  async revokeShare(shareId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.delete(
+        `${this.artifactsUrl()}/shares/${encodeURIComponent(shareId)}`,
+      ),
+    );
+  }
+
+  // ----------------------------------------------------------------
+  // Recipient
+  // ----------------------------------------------------------------
+
+  /** Metadata for a shared artifact. Never returns content. */
+  async getSharedArtifact(shareId: string): Promise<SharedArtifact> {
+    return firstValueFrom(
+      this.http.get<SharedArtifact>(
+        `${this.sharedUrl()}/${encodeURIComponent(shareId)}`,
+      ),
+    );
+  }
+
+  /**
+   * Mint a render URL for a shared artifact version.
+   *
+   * The returned URL embeds a short-lived (~120s) bearer credential — set
+   * it as an iframe `src` and re-mint on each open rather than caching
+   * it. The backend re-checks the share's ACL on every call, which is
+   * what bounds revocation at the token TTL instead of at session length.
+   */
+  async mintSharedRenderToken(shareId: string): Promise<RenderToken> {
+    const res = await firstValueFrom(
+      this.http.post<RenderTokenResponseDto>(
+        `${this.sharedUrl()}/${encodeURIComponent(shareId)}/render-token`,
+        {},
+      ),
+    );
+    return { url: res.url, expiresAt: res.expires_at };
+  }
+}


### PR DESCRIPTION
PR-2 of the artifact sharing spec (`docs/specs/artifact-sharing.md`). **Owner-side UI only** — recipient route/page is PR-3, session-delete cascade is PR-4.

> **Depends on [#919](https://github.com/Boise-State-Development/agentcore-public-stack/pull/919)** (PR-1, backend). Branched off `develop` rather than stacked on #919, so there is no stacked-PR merge hazard — but the Share button calls endpoints #919 adds, so **merge #919 first**. Frontend CI is independent and green either way.

## What this adds

**`ArtifactShareService`** (`session/services/artifacts/artifact-share.service.ts`) — owner CRUD (create / list / patch / revoke) plus the two recipient reads PR-1 ships: `getSharedArtifact` and `mintSharedRenderToken`. The shared mint returns the same `{url, expires_at}` shape as the owner endpoint, so the panel's iframe and `ArtifactDownloadService`'s hidden-iframe `?download=1` trick work against either path unchanged. (`GET /shared-artifacts/{id}/content` is deliberately absent — that endpoint is PR-3's backend half.)

**`ArtifactShareModalComponent`** — access-level radio, email chips, clipboard copy, and a manage/revoke list of the artifact's existing links. Create and manage live in one dialog because an artifact has no equivalent of the sessions list's manage-shares surface.

**Share button** beside Download on the artifact card and in the panel header.

## Two conventions worth calling out

**The dialog does not inherit its source's styling.** The spec says to adapt `share-modal.component.ts`, and the frontend `CLAUDE.md` says an adapted dialog copies an older one's *structure* (backdrop + centred panel + `DialogRef` wiring) and **not** its pre-redesign tokens. So this takes the conversation modal's shape and the canonical `add-curated-model-dialog` styling: `rounded-2xl`, `text-sm/6`, `bg-blue-600`, bordered panel, bordered action footer. It also honours the result contract — `undefined` from `closed` means cancelled, a concrete `ArtifactShare[]` means something was committed. Escape, backdrop and Cancel all converge on the same handler; since create and revoke commit immediately, "cancelled" can only mean *nothing was committed*.

**Labels vs. tooltips.** The card's two actions keep visible text labels (matching the existing Download button), so the visible label is contained in the accessible name per WCAG 2.5.3 and no tooltip is needed. The panel's Share button is icon-only, so it carries `[appTooltip]` per the accessibility rule in the root `CLAUDE.md`. Its icon-only siblings (Download, Close) predate that rule and are left alone — retrofitting them is out of scope here.

## The behaviour the tests are actually guarding

Both entry points share **the version the user is looking at, never HEAD**. The card renders one row per version, and the panel's ref follows its version menu — so `share()` reads the version off the same ref that drives what is on screen. A share that followed HEAD would silently change what a recipient sees, which is exactly the moving-pointer trap the spec rules out, so `artifact-card.component.spec.ts` asserts the dialog is opened with `version: 3` for a v3 card rather than trusting it.

The modal spec covers: create pinned to the opened version; owner-plus-added-emails on a limited share; the "always shows version N, later versions aren't included" copy; the just-created link not being listed twice; revoke dropping the link *and* retiring its result panel so the dialog can't offer a dead link to copy; absolute-URL building from the server's relative route; the clipboard-denied fallback; 404/403/503 error mapping; and the `undefined`-means-cancelled close contract.

## No feature flag

The card and panel only render when artifacts are enabled, which is the same `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` signal that mounts the share routes in `main.py`. If you can see an artifact card, the share endpoints exist.

## Verification

- **Full SPA suite: 177 files, 2032 tests, all passing** (27 new). DI token overrides throughout, not `vi.mock`.
- `ng build` clean. The bundle-budget warning it prints is pre-existing (2.11 MB over a 5 MB budget; this PR adds ~25 KB raw).
- `src/version.ts` not stamped — nothing extraneous in the diff.
- No browser clickthrough: `SKIP_AUTH` is not set in `backend/src/.env`, so per the local convention this ships with a manual test script instead (in the review thread below).

One thing worth an eyeball at mobile width: the card now carries two labelled buttons in its last grid column. The title truncates gracefully, but the density is a judgement call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
