### PR TITLE
feat(artifacts): artifact sharing PR-3 — recipient UI + shared content endpoint

### DIFF
--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -128,7 +128,9 @@ async def get_artifact_content(
     """
     try:
         content, content_type = service.get(
-            user_id=user.user_id,
+            # The authenticated session user — self-scoping. See the
+            # access-control note on ArtifactContentService.
+            owner_id=user.user_id,
             artifact_id=artifact_id,
             version=version,
         )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -463,17 +463,28 @@ def _s3():
 
 
 def _get_version_item(
-    user_id: str, artifact_id: str, version: int
+    owner_id: str, artifact_id: str, version: int
 ) -> dict:
-    """Fetch the exact version row, scoped to the authenticated user.
+    """Fetch the exact version row from `owner_id`'s partition.
 
-    Building the PK from the session user's id is what prevents reading
-    another user's artifact. SK zero-pad matches the writer/verifier
-    `V#{version:05d}` contract."""
+    `owner_id` is an ADDRESS — the partition this read targets — not an
+    identity assertion, exactly like the render token's `sub` claim.
+    Two callers pass two different things, and the difference is the
+    whole access-control model:
+
+      - Owner routes pass the *authenticated session user*. Building the
+        PK from the session is what prevents reading someone else's
+        artifact; there is no other check.
+      - Share routes pass the share's *owner*, and may only do so AFTER
+        `_check_share_access` has admitted the viewer. Reaching this
+        function with an owner id the caller has not ACL-checked is a
+        read-any-artifact-by-id bug.
+
+    SK zero-pad matches the writer/verifier `V#{version:05d}` contract."""
     sk = f"ARTIFACT#{artifact_id}#V#{version:05d}"
     try:
         result = _table().get_item(
-            Key={"PK": f"USER#{user_id}", "SK": sk}
+            Key={"PK": f"USER#{owner_id}", "SK": sk}
         )
     except ClientError as exc:
         raise ArtifactQueryError(
@@ -508,20 +519,26 @@ def _unwrap_markdown(html_body: str) -> Optional[str]:
 
 
 class ArtifactContentService:
-    """Return one artifact version's raw source for the panel code view.
+    """Return one artifact version's raw source for the code view.
 
-    Ownership is enforced by the PK lookup. For Markdown the stored S3
-    object is a rendered HTML wrapper; we unwrap it back to the authored
-    Markdown so code view shows what the model actually wrote, and
-    normalize `content_type` to `text/markdown` to match. Anything that
-    can't be unwrapped falls back to the raw stored bytes + real type so
-    the view still shows something truthful instead of erroring."""
+    For Markdown the stored S3 object is a rendered HTML wrapper; we
+    unwrap it back to the authored Markdown so code view shows what the
+    model actually wrote, and normalize `content_type` to
+    `text/markdown` to match. Anything that can't be unwrapped falls
+    back to the raw stored bytes + real type so the view still shows
+    something truthful instead of erroring.
+
+    ACCESS CONTROL: this service performs none of its own. It reads
+    whichever partition `owner_id` names — see `_get_version_item`. The
+    owner route passes the authenticated session user (self-scoping);
+    the shared route passes the share's owner and is responsible for
+    having run the share ACL first."""
 
     def get(
-        self, *, user_id: str, artifact_id: str, version: int
+        self, *, owner_id: str, artifact_id: str, version: int
     ) -> tuple[str, str]:
         bucket = _bucket_name()
-        item = _get_version_item(user_id, artifact_id, version)
+        item = _get_version_item(owner_id, artifact_id, version)
         content_key = item.get("content_key")
         stored_type = item.get(
             "content_type", "text/html; charset=utf-8"

--- a/backend/src/apis/app_api/artifacts/shares.py
+++ b/backend/src/apis/app_api/artifacts/shares.py
@@ -28,6 +28,7 @@ from apis.shared.auth import User, get_current_user_from_session
 from apis.shared.security.log_sanitize import scrub_log
 
 from .models import (
+    ArtifactContentResponse,
     ArtifactShareListResponse,
     ArtifactShareResponse,
     CreateArtifactShareRequest,
@@ -36,14 +37,17 @@ from .models import (
     UpdateArtifactShareRequest,
 )
 from .service import (
+    ArtifactContentService,
     ArtifactNotFoundError,
     ArtifactQueryError,
     ArtifactShareService,
+    ArtifactTooLargeError,
     NotShareOwnerError,
     RenderTokenConfigError,
     RenderTokenService,
     ShareAccessDeniedError,
     ShareNotFoundError,
+    get_artifact_content_service,
     get_artifact_share_service,
     get_render_token_service,
 )
@@ -351,4 +355,79 @@ async def mint_shared_render_token(
     return RenderTokenResponse(
         url=url,
         expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
+    )
+
+
+@shared_artifacts_router.get(
+    "/{share_id}/content", response_model=ArtifactContentResponse
+)
+async def get_shared_artifact_content(
+    share_id: str,
+    user: User = Depends(get_current_user_from_session),
+    shares: ArtifactShareService = Depends(get_artifact_share_service),
+    content: ArtifactContentService = Depends(get_artifact_content_service),
+) -> ArtifactContentResponse:
+    """Raw source of a shared artifact version, for the recipient's code view.
+
+    The parallel of ``GET /artifacts/{id}/content``, which builds its
+    lookup key from the authenticated session and must stay that way —
+    a recipient is not the owner, so that route can never serve them.
+
+    ############################################################
+    # SECURITY: the ACL check is the first thing that happens, and
+    # `get_for_viewer` is what performs it. Only after it admits the
+    # viewer may the owner's id be handed to ArtifactContentService,
+    # which does no access control of its own and will read whatever
+    # partition it is given. Resolving the owner before (or without)
+    # the ACL check turns this route into read-any-artifact-by-id.
+    ############################################################
+
+    The bytes are inert text the SPA highlights client-side — never
+    executed. Markdown is unwrapped back to the authored source, and an
+    oversized artifact 413s so the recipient is steered to download.
+    """
+    try:
+        share = shares.get_for_viewer(share_id=share_id, viewer=user)
+        body, content_type = content.get(
+            owner_id=str(share["owner_id"]),
+            artifact_id=str(share["artifact_id"]),
+            version=int(share["version"]),
+        )
+    except ShareNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Share not found")
+    except ShareAccessDeniedError:
+        logger.info(
+            "shared artifact content denied share=%s viewer=%s",
+            scrub_log(share_id),
+            scrub_log(user.user_id),
+        )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Access denied")
+    except ArtifactNotFoundError:
+        # The share outlived the version it points at, or its content
+        # object is gone.
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Artifact version not found"
+        )
+    except ArtifactTooLargeError:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "Artifact is too large to preview — download it instead",
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact content service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact content is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("shared artifact content fetch failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact content is temporarily unavailable",
+        )
+
+    return ArtifactContentResponse(
+        content=body,
+        content_type=content_type,
+        version=int(share["version"]),
     )

--- a/backend/tests/apis/app_api/artifacts/test_shared_render_token.py
+++ b/backend/tests/apis/app_api/artifacts/test_shared_render_token.py
@@ -432,3 +432,157 @@ def test_token_is_never_logged(env, caplog) -> None:
     assert url not in logged
     # Identifiers are expected — that is the point of `vwr`/`shr`.
     assert share_id in logged
+
+
+# ------------------------------------------------------------------
+# Shared content (recipient code view)
+# ------------------------------------------------------------------
+#
+# `GET /shared-artifacts/{id}/content` resolves the OWNER's S3 object
+# after the share ACL admits the viewer. ArtifactContentService performs
+# no access control of its own, so these tests are the boundary.
+
+
+import boto3 as _boto3  # noqa: E402  (grouped with the content tests below)
+
+BUCKET = "test-artifacts-content"
+BODY = "<html><body>shared artifact source</body></html>"
+
+
+def _put_content(
+    *, user_id: str = OWNER_ID, artifact="art-1", version=1, body: str = BODY
+) -> None:
+    """Write the S3 object the version row's content_key points at."""
+    s3 = _boto3.client("s3", region_name=REGION)
+    try:
+        # us-east-1 rejects an explicit LocationConstraint.
+        s3.create_bucket(Bucket=BUCKET)
+    except s3.exceptions.BucketAlreadyOwnedByYou:
+        pass
+    s3.put_object(
+        Bucket=BUCKET,
+        Key=f"{user_id}/{artifact}/v{version}/index.html",
+        Body=body.encode("utf-8"),
+        ContentType="text/html; charset=utf-8",
+    )
+
+
+def _content(make_client, user: User, share_id: str):
+    return make_client(user).get(f"/shared-artifacts/{share_id}/content")
+
+
+def test_recipient_reads_the_owners_content(env, monkeypatch) -> None:
+    """The whole point: a viewer who is not the owner gets the owner's
+    bytes, because the route resolves the owner from the share row after
+    the ACL admits them."""
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    share_id = _share(make_client)
+
+    resp = _content(make_client, VIEWER, share_id)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == BODY
+    assert body["version"] == 1
+
+
+def test_shared_content_denies_a_disallowed_viewer(env, monkeypatch) -> None:
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    share_id = _share(
+        make_client, access_level="specific", allowed=["friend@x.com"]
+    )
+
+    stranger = _user("stranger-1", "stranger@x.com")
+    resp = _content(make_client, stranger, share_id)
+    assert resp.status_code == 403
+    assert "content" not in resp.json()
+
+
+def test_shared_content_404s_after_revoke(env, monkeypatch) -> None:
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    share_id = _share(make_client)
+    assert _content(make_client, VIEWER, share_id).status_code == 200
+
+    make_client(OWNER).delete(f"/artifacts/shares/{share_id}")
+
+    resp = _content(make_client, VIEWER, share_id)
+    assert resp.status_code == 404
+    assert "content" not in resp.json()
+
+
+def test_shared_content_404s_for_an_unknown_share(env, monkeypatch) -> None:
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    assert _content(make_client, VIEWER, "nope").status_code == 404
+
+
+def test_shared_content_404s_when_the_version_row_is_gone(
+    env, monkeypatch
+) -> None:
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    share_id = _share(make_client)
+    ddb.Table(TABLE).delete_item(
+        Key={"PK": f"USER#{OWNER_ID}", "SK": "ARTIFACT#art-1#V#00001"}
+    )
+    assert _content(make_client, VIEWER, share_id).status_code == 404
+
+
+def test_shared_content_serves_the_pinned_version_only(
+    env, monkeypatch
+) -> None:
+    """A newer version must not leak through a share pinned to an older
+    one — the share row's version is what addresses the object."""
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb, version=1)
+    _put_content(version=1, body="V1 BODY")
+    share_id = _share(make_client, version=1)
+
+    _put_version(ddb, version=2)
+    _put_content(version=2, body="V2 BODY")
+
+    body = _content(make_client, VIEWER, share_id).json()
+    assert body["content"] == "V1 BODY"
+    assert body["version"] == 1
+
+
+def test_shared_content_413s_an_oversized_artifact(env, monkeypatch) -> None:
+    """Recipients get the same steer-to-download signal owners do."""
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content(body="x" * (2 * 1024 * 1024 + 10))
+    share_id = _share(make_client)
+
+    assert _content(make_client, VIEWER, share_id).status_code == 413
+
+
+def test_owner_content_route_is_unchanged_for_a_recipient(
+    env, monkeypatch
+) -> None:
+    """The owner route must stay self-scoped: it builds its key from the
+    session user, so a recipient asking it for the owner's artifact gets
+    a 404 no matter what share they hold. If this ever starts returning
+    200, the owner route has been made share-aware and the two access
+    models have been conflated."""
+    make_client, ddb = env
+    monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+    _put_version(ddb)
+    _put_content()
+    _share(make_client)
+
+    resp = make_client(VIEWER).get("/artifacts/art-1/content?version=1")
+    assert resp.status_code == 404

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -25,6 +25,18 @@ export const routes: Routes = [
         loadComponent: () => import('./shared/shared-view.page').then(m => m.SharedViewPage),
         canActivate: [authGuard],
     },
+    // Recipient view for a shared artifact. Behind authGuard like every
+    // other share surface: "public" means any authenticated tenant user,
+    // never anonymous. The share's own ACL is enforced server-side on
+    // top of this.
+    {
+        path: 'shared-artifact/:shareId',
+        loadComponent: () =>
+            import('./shared/artifact/shared-artifact-view.page').then(
+                m => m.SharedArtifactViewPage,
+            ),
+        canActivate: [authGuard],
+    },
     {
         path: 'auth/login',
         loadComponent: () => import('./auth/login/login.page').then(m => m.LoginPage),

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { ArtifactPanelComponent } from './artifact-panel.component';
+import { ArtifactViewerComponent } from './artifact-viewer.component';
+import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
+import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
+import { SessionService } from '../../../../services/session/session.service';
+import { UserService } from '../../../../../auth/user.service';
+
+/**
+ * Guards the PR-3 extraction: the panel's viewer body moved into
+ * `ArtifactViewerComponent`, and the panel must keep driving it with the
+ * same state it used to render inline. The panel had no spec before, so
+ * these assertions exist specifically so that refactor can't silently
+ * regress the owner's view.
+ */
+describe('ArtifactPanelComponent', () => {
+  let fixture: ComponentFixture<ArtifactPanelComponent>;
+  let http: {
+    mintRenderToken: ReturnType<typeof vi.fn>;
+    getArtifactContent: ReturnType<typeof vi.fn>;
+  };
+
+  const OPEN = { artifactId: 'art-1', version: 2, title: 'Chart' };
+  const openArtifact = signal<typeof OPEN | null>(OPEN);
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  /** The child instance, so we can read what the panel handed down. */
+  const viewerInstance = (): ArtifactViewerComponent | null => {
+    const de = fixture.debugElement.query(
+      (n) => n.componentInstance instanceof ArtifactViewerComponent,
+    );
+    return de ? (de.componentInstance as ArtifactViewerComponent) : null;
+  };
+
+  async function flush(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  }
+
+  beforeEach(async () => {
+    openArtifact.set(OPEN);
+    http = {
+      mintRenderToken: vi
+        .fn()
+        .mockResolvedValue({ url: 'https://artifacts.x/?t=jwt', expiresAt: 'e' }),
+      getArtifactContent: vi.fn().mockResolvedValue({
+        content: 'source text',
+        contentType: 'text/html',
+        version: 2,
+      }),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ArtifactPanelComponent],
+      providers: [
+        {
+          provide: ArtifactStateService,
+          useValue: {
+            openArtifact,
+            paneWidth: signal(672),
+            paneWidthMin: 360,
+            paneWidthMax: 1200,
+            versionsFor: () => [],
+            openArtifactPanel: vi.fn(),
+            closeArtifactPanel: vi.fn(),
+            setPaneWidth: vi.fn(),
+          },
+        },
+        { provide: ArtifactHttpService, useValue: http },
+        { provide: ArtifactDownloadService, useValue: { download: vi.fn() } },
+        {
+          provide: SessionService,
+          useValue: { currentSession: signal({ sessionId: 'sess-1' }) },
+        },
+        {
+          provide: UserService,
+          useValue: { currentUser: signal({ email: 'owner@example.com' }) },
+        },
+        { provide: Dialog, useValue: { open: vi.fn() } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ArtifactPanelComponent);
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  it('renders the extracted viewer rather than its own iframe markup', () => {
+    expect(viewerInstance()).not.toBeNull();
+  });
+
+  it('hands the viewer the minted URL and the artifact title', () => {
+    expect(http.mintRenderToken).toHaveBeenCalledWith('art-1', 2, 'sess-1');
+    expect(viewerInstance()!.safeUrl()).not.toBeNull();
+    expect(viewerInstance()!.title()).toBe('Chart');
+  });
+
+  it('starts in preview with the skeleton showing', () => {
+    const v = viewerInstance()!;
+    expect(v.view()).toBe('preview');
+    // The iframe hasn't fired `load` yet, so the skeleton must remain.
+    expect(v.previewReady()).toBe(false);
+    expect(el().querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('clears the skeleton once the viewer reports the iframe painted', () => {
+    viewerInstance()!.iframeLoad.emit();
+    fixture.detectChanges();
+
+    expect(viewerInstance()!.previewReady()).toBe(true);
+    expect(el().querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('fetches source and switches the viewer to code view', async () => {
+    const codeButton = Array.from(el().querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'View code',
+    )!;
+    codeButton.click();
+    await flush();
+    fixture.detectChanges();
+
+    expect(http.getArtifactContent).toHaveBeenCalledWith('art-1', 2);
+    expect(viewerInstance()!.view()).toBe('code');
+    expect(viewerInstance()!.source()?.content).toBe('source text');
+  });
+
+  it('surfaces a mint failure through the viewer, retryable', async () => {
+    http.mintRenderToken.mockRejectedValue(new Error('nope'));
+    (fixture.componentInstance as unknown as Record<string, any>)['retry']();
+    await flush();
+    fixture.detectChanges();
+
+    expect(viewerInstance()!.error()).toBeTruthy();
+    expect(viewerInstance()!.safeUrl()).toBeNull();
+  });
+
+  it('marks the viewer inert only while the resize handle is dragged', () => {
+    const panel = fixture.componentInstance as unknown as Record<string, any>;
+    expect(viewerInstance()!.inert()).toBe(false);
+
+    panel['dragging'].set(true);
+    fixture.detectChanges();
+    // The iframe would otherwise swallow the pointer stream mid-drag.
+    expect(viewerInstance()!.inert()).toBe(true);
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -10,13 +10,11 @@ import {
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
-import { NgTemplateOutlet } from '@angular/common';
 import { Dialog } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroXMark,
   heroArrowPath,
-  heroExclamationTriangle,
   heroArrowDownTray,
   heroArrowUpOnSquare,
   heroEye,
@@ -36,7 +34,7 @@ import {
 } from '../../../../services/artifacts/artifact-http.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { SessionService } from '../../../../services/session/session.service';
-import { ArtifactSourceComponent } from './artifact-source.component';
+import { ArtifactViewerComponent } from './artifact-viewer.component';
 import {
   ArtifactShareModalComponent,
   type ArtifactShareModalData,
@@ -64,12 +62,11 @@ import { TooltipDirective } from '../../../../../components/tooltip/tooltip.dire
 @Component({
   selector: 'app-artifact-panel',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, NgTemplateOutlet, ArtifactSourceComponent, TooltipDirective],
+  imports: [NgIcon, ArtifactViewerComponent, TooltipDirective],
   providers: [
     provideIcons({
       heroXMark,
       heroArrowPath,
-      heroExclamationTriangle,
       heroArrowDownTray,
       heroArrowUpOnSquare,
       heroEye,
@@ -295,158 +292,25 @@ import { TooltipDirective } from '../../../../../components/tooltip/tooltip.dire
           </button>
         </header>
 
-        <div class="relative min-h-0 flex-1">
-          @if (view() === 'code') {
-            @if (sourceError()) {
-              <div
-                class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
-                role="alert"
-              >
-                <ng-icon
-                  name="heroExclamationTriangle"
-                  class="text-3xl text-amber-500"
-                  aria-hidden="true"
-                />
-                <p class="text-sm text-gray-700 dark:text-gray-300">
-                  {{ sourceError() }}
-                </p>
-                <button
-                  type="button"
-                  class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
-                  (click)="retrySource()"
-                >
-                  Try again
-                </button>
-              </div>
-            } @else if (source(); as src) {
-              <app-artifact-source
-                [content]="src.content"
-                [contentType]="src.contentType"
-              />
-            } @else {
-              <ng-container
-                [ngTemplateOutlet]="skeleton"
-                [ngTemplateOutletContext]="{ label: 'Building source view…' }"
-              />
-            }
-          } @else {
-            @if (error()) {
-              <div
-                class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
-                role="alert"
-              >
-                <ng-icon
-                  name="heroExclamationTriangle"
-                  class="text-3xl text-amber-500"
-                  aria-hidden="true"
-                />
-                <p class="text-sm text-gray-700 dark:text-gray-300">
-                  {{ error() }}
-                </p>
-                <button
-                  type="button"
-                  class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
-                  (click)="retry()"
-                >
-                  Try again
-                </button>
-              </div>
-            } @else {
-              @if (safeUrl(); as url) {
-                <iframe
-                  [src]="url"
-                  class="h-full w-full border-0 bg-white"
-                  [class.pointer-events-none]="dragging()"
-                  [title]="ref.title || 'Artifact'"
-                  sandbox="allow-scripts"
-                  referrerpolicy="no-referrer"
-                  loading="lazy"
-                  (load)="onIframeLoad()"
-                ></iframe>
-              }
-              @if (!previewReady()) {
-                <ng-container
-                  [ngTemplateOutlet]="skeleton"
-                  [ngTemplateOutletContext]="{ label: 'Rendering artifact…' }"
-                />
-              }
-            }
-          }
-        </div>
+        <app-artifact-viewer
+          [safeUrl]="safeUrl()"
+          [title]="ref.title"
+          [view]="view()"
+          [source]="source()"
+          [error]="error()"
+          [sourceError]="sourceError()"
+          [previewReady]="previewReady()"
+          [inert]="dragging()"
+          (retry)="retry()"
+          (retrySource)="retrySource()"
+          (iframeLoad)="onIframeLoad()"
+        />
       </aside>
-      <ng-template #skeleton let-label="label">
-        <div
-          class="absolute inset-0 overflow-hidden bg-white p-8 dark:bg-gray-900"
-          role="status"
-          [attr.aria-label]="label"
-        >
-          <div aria-hidden="true" class="mx-auto flex max-w-2xl flex-col gap-6">
-            <div class="flex flex-col gap-3">
-              <div
-                class="skeleton-shimmer h-8 w-1/2 rounded-lg bg-gray-200 dark:bg-gray-700"
-              ></div>
-              <div
-                class="skeleton-shimmer h-4 w-1/4 rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-            </div>
-            <div class="flex flex-col gap-3">
-              <div
-                class="skeleton-shimmer h-3.5 w-full rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-              <div
-                class="skeleton-shimmer h-3.5 w-11/12 rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-              <div
-                class="skeleton-shimmer h-3.5 w-4/5 rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-            </div>
-            <div
-              class="skeleton-shimmer h-48 w-full rounded-xl bg-gray-200 dark:bg-gray-700"
-            ></div>
-            <div class="flex flex-col gap-3">
-              <div
-                class="skeleton-shimmer h-3.5 w-full rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-              <div
-                class="skeleton-shimmer h-3.5 w-10/12 rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-              <div
-                class="skeleton-shimmer h-3.5 w-2/3 rounded bg-gray-200 dark:bg-gray-700"
-              ></div>
-            </div>
-          </div>
-          <span class="sr-only">{{ label }}</span>
-        </div>
-      </ng-template>
     }
   `,
   styles: `
     :host {
       display: contents;
-    }
-    .skeleton-shimmer {
-      background-image: linear-gradient(
-        90deg,
-        transparent 0%,
-        rgba(255, 255, 255, 0.45) 50%,
-        transparent 100%
-      );
-      background-size: 220% 100%;
-      background-repeat: no-repeat;
-      animation: artifact-skeleton-shimmer 1.5s ease-in-out infinite;
-    }
-    @keyframes artifact-skeleton-shimmer {
-      0% {
-        background-position: 130% 0;
-      }
-      100% {
-        background-position: -130% 0;
-      }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      .skeleton-shimmer {
-        animation: none;
-      }
     }
   `,
 })

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-share-modal.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import {
   ArtifactShareModalComponent,
@@ -42,6 +42,8 @@ describe('ArtifactShareModalComponent', () => {
 
   /** Reach past `protected` for interaction tests, matching the
    *  conversation share-modal spec's approach. */
+  let originalClipboard: PropertyDescriptor | undefined;
+
   const api = () => component as unknown as Record<string, any>;
   const text = () => (fixture.nativeElement as HTMLElement).textContent ?? '';
 
@@ -69,12 +71,40 @@ describe('ArtifactShareModalComponent', () => {
     fixture = TestBed.createComponent(ArtifactShareModalComponent);
     component = fixture.componentInstance;
 
-    // jsdom has no clipboard; the copy path is exercised explicitly below.
+    stubClipboard();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    restoreClipboard();
+  });
+  /**
+   * `navigator.clipboard` doesn't exist in jsdom, so it has to be
+   * defined rather than stubbed — and `Object.defineProperty` is NOT
+   * undone by the `vi.unstubAllGlobals()` backstop in test-setup.ts.
+   * The builder runs vitest with `isolate: false`, so a leaked global
+   * here would follow the worker into unrelated spec files and surface
+   * as one randomly-chosen file timing out. Restore it explicitly.
+   */
+  function stubClipboard(writeText = vi.fn().mockResolvedValue(undefined)) {
+    originalClipboard = Object.getOwnPropertyDescriptor(
+      navigator,
+      'clipboard',
+    );
     Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      value: { writeText },
       configurable: true,
     });
-  });
+  }
+
+  function restoreClipboard(): void {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      delete (navigator as unknown as Record<string, unknown>)['clipboard'];
+    }
+    originalClipboard = undefined;
+  }
 
   async function init(): Promise<void> {
     await component.ngOnInit();
@@ -276,10 +306,7 @@ describe('ArtifactShareModalComponent', () => {
   });
 
   it('falls back to a message when the clipboard is unavailable', async () => {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
-      configurable: true,
-    });
+    stubClipboard(vi.fn().mockRejectedValue(new Error('denied')));
     await init();
 
     await api()['copyLink'](SHARE);

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-viewer.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-viewer.component.spec.ts
@@ -1,0 +1,133 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DomSanitizer } from '@angular/platform-browser';
+import { ArtifactViewerComponent } from './artifact-viewer.component';
+
+describe('ArtifactViewerComponent', () => {
+  let fixture: ComponentFixture<ArtifactViewerComponent>;
+  /** `[src]` is a resource-URL sink — Angular rejects a bare string,
+   *  so the spec must trust the URL the same way the parents do. */
+  let url: unknown;
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  const iframe = () => el().querySelector('iframe');
+
+  function render(inputs: Record<string, unknown> = {}): void {
+    for (const [k, v] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(k, v);
+    }
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({ imports: [ArtifactViewerComponent] });
+    fixture = TestBed.createComponent(ArtifactViewerComponent);
+    url = TestBed.inject(DomSanitizer).bypassSecurityTrustResourceUrl(
+      'https://artifacts.x/?t=jwt',
+    );
+  });
+
+  afterEach(() => {
+    // isolate:false shares one DOM across every spec file, so a fixture
+    // left mounted keeps its skeleton's infinite shimmer animation
+    // running for the rest of the suite. Tear it down.
+    fixture?.destroy();
+  });
+
+  // ----------------------------------------------------------------
+  // Isolation — the reason this component exists in one place
+  // ----------------------------------------------------------------
+
+  it('sandboxes the iframe without allow-same-origin', () => {
+    render({ safeUrl: url, title: 'Chart' });
+
+    const sandbox = iframe()!.getAttribute('sandbox');
+    expect(sandbox).toBe('allow-scripts');
+    // `allow-same-origin` alongside `allow-scripts` would hand
+    // attacker-authored markup the artifact origin itself. Both the
+    // owner panel and the recipient page depend on this staying absent.
+    expect(sandbox).not.toContain('allow-same-origin');
+    expect(iframe()!.getAttribute('referrerpolicy')).toBe('no-referrer');
+  });
+
+  it('names the iframe for screen readers, with a fallback', () => {
+    render({ safeUrl: url, title: 'Chart' });
+    expect(iframe()!.getAttribute('title')).toBe('Chart');
+
+    render({ title: '' });
+    expect(iframe()!.getAttribute('title')).toBe('Artifact');
+  });
+
+  it('renders no iframe until a URL is minted', () => {
+    render({ safeUrl: null });
+    expect(iframe()).toBeNull();
+    // The skeleton stands in so the pane is never blank.
+    expect(el().querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('keeps the skeleton until the parent says the preview painted', () => {
+    render({ safeUrl: url, previewReady: false });
+    expect(el().querySelector('[role="status"]')).not.toBeNull();
+
+    render({ previewReady: true });
+    expect(el().querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('disables pointer events while the parent marks it inert', () => {
+    render({ safeUrl: url, inert: true });
+    expect(iframe()!.classList).toContain('pointer-events-none');
+
+    render({ inert: false });
+    expect(iframe()!.classList).not.toContain('pointer-events-none');
+  });
+
+  // ----------------------------------------------------------------
+  // Error branches
+  // ----------------------------------------------------------------
+
+  it('shows the preview error instead of the iframe, and can retry', () => {
+    let retried = 0;
+    render({ safeUrl: url, error: 'Boom' });
+    fixture.componentInstance.retry.subscribe(() => retried++);
+
+    expect(el().querySelector('[role="alert"]')?.textContent).toContain('Boom');
+    expect(iframe()).toBeNull();
+
+    el().querySelector<HTMLButtonElement>('[role="alert"] button')!.click();
+    expect(retried).toBe(1);
+  });
+
+  it('shows the code-view error, and can retry it separately', () => {
+    let retried = 0;
+    render({ view: 'code', sourceError: 'Too large' });
+    fixture.componentInstance.retrySource.subscribe(() => retried++);
+
+    expect(el().querySelector('[role="alert"]')?.textContent).toContain(
+      'Too large',
+    );
+
+    el().querySelector<HTMLButtonElement>('[role="alert"] button')!.click();
+    expect(retried).toBe(1);
+  });
+
+  it('does not leak a preview error into code view', () => {
+    // The two paths fail independently: a dead render token must not
+    // blank out source the page already fetched.
+    render({
+      view: 'code',
+      error: 'preview blew up',
+      source: { content: 'hello source', contentType: 'text/html', version: 1 },
+    });
+    expect(el().textContent).not.toContain('preview blew up');
+    expect(el().textContent).toContain('hello source');
+  });
+
+  it('renders the source once it arrives', () => {
+    render({
+      view: 'code',
+      source: { content: 'const x = 1;', contentType: 'text/javascript', version: 2 },
+    });
+    expect(el().textContent).toContain('const x = 1;');
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-viewer.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-viewer.component.ts
@@ -1,0 +1,218 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { ArtifactSourceComponent } from './artifact-source.component';
+import type { ArtifactContent } from '../../../../services/artifacts/artifact-http.service';
+
+/**
+ * The body of an artifact view: the sandboxed preview iframe, the code
+ * view, their error branches, and the loading skeleton.
+ *
+ * Purely presentational — it fetches nothing and owns no access
+ * control. The parent mints the render URL and loads the source, then
+ * hands both down; that is what lets the docked owner panel and the
+ * recipient page share one viewer while minting through two different
+ * endpoints (`/artifacts/…` vs `/shared-artifacts/…`).
+ *
+ * Isolation model (unchanged from the panel it was extracted from): the
+ * artifact origin is a separate subdomain, the render Lambda and
+ * CloudFront stamp a strict CSP, and the iframe carries
+ * `sandbox="allow-scripts"` *without* `allow-same-origin`, so the framed
+ * document is a null origin and cannot reach the artifact origin's
+ * storage or cookies. Do not add `allow-same-origin` here — it would
+ * hand attacker-authored markup the artifact origin itself.
+ */
+@Component({
+  selector: 'app-artifact-viewer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, NgTemplateOutlet, ArtifactSourceComponent],
+  providers: [provideIcons({ heroExclamationTriangle })],
+  template: `
+    <div class="relative min-h-0 flex-1">
+      @if (view() === 'code') {
+        @if (sourceError()) {
+          <div
+            class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+            role="alert"
+          >
+            <ng-icon
+              name="heroExclamationTriangle"
+              class="text-3xl text-amber-500"
+              aria-hidden="true"
+            />
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              {{ sourceError() }}
+            </p>
+            <button
+              type="button"
+              class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
+              (click)="retrySource.emit()"
+            >
+              Try again
+            </button>
+          </div>
+        } @else if (source(); as src) {
+          <app-artifact-source
+            [content]="src.content"
+            [contentType]="src.contentType"
+          />
+        } @else {
+          <ng-container
+            [ngTemplateOutlet]="skeleton"
+            [ngTemplateOutletContext]="{ label: 'Building source view…' }"
+          />
+        }
+      } @else {
+        @if (error()) {
+          <div
+            class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+            role="alert"
+          >
+            <ng-icon
+              name="heroExclamationTriangle"
+              class="text-3xl text-amber-500"
+              aria-hidden="true"
+            />
+            <p class="text-sm text-gray-700 dark:text-gray-300">
+              {{ error() }}
+            </p>
+            <button
+              type="button"
+              class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900"
+              (click)="retry.emit()"
+            >
+              Try again
+            </button>
+          </div>
+        } @else {
+          @if (safeUrl(); as url) {
+            <iframe
+              [src]="url"
+              class="h-full w-full border-0 bg-white"
+              [class.pointer-events-none]="inert()"
+              [title]="title() || 'Artifact'"
+              sandbox="allow-scripts"
+              referrerpolicy="no-referrer"
+              loading="lazy"
+              (load)="iframeLoad.emit()"
+            ></iframe>
+          }
+          @if (!previewReady()) {
+            <ng-container
+              [ngTemplateOutlet]="skeleton"
+              [ngTemplateOutletContext]="{ label: 'Rendering artifact…' }"
+            />
+          }
+        }
+      }
+    </div>
+
+    <ng-template #skeleton let-label="label">
+      <div
+        class="absolute inset-0 overflow-hidden bg-white p-8 dark:bg-gray-900"
+        role="status"
+        [attr.aria-label]="label"
+      >
+        <div aria-hidden="true" class="mx-auto flex max-w-2xl flex-col gap-6">
+          <div class="flex flex-col gap-3">
+            <div
+              class="skeleton-shimmer h-8 w-1/2 rounded-lg bg-gray-200 dark:bg-gray-700"
+            ></div>
+            <div
+              class="skeleton-shimmer h-4 w-1/4 rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+          </div>
+          <div class="flex flex-col gap-3">
+            <div
+              class="skeleton-shimmer h-3.5 w-full rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+            <div
+              class="skeleton-shimmer h-3.5 w-11/12 rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+            <div
+              class="skeleton-shimmer h-3.5 w-4/5 rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+          </div>
+          <div
+            class="skeleton-shimmer h-48 w-full rounded-xl bg-gray-200 dark:bg-gray-700"
+          ></div>
+          <div class="flex flex-col gap-3">
+            <div
+              class="skeleton-shimmer h-3.5 w-full rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+            <div
+              class="skeleton-shimmer h-3.5 w-10/12 rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+            <div
+              class="skeleton-shimmer h-3.5 w-2/3 rounded bg-gray-200 dark:bg-gray-700"
+            ></div>
+          </div>
+        </div>
+        <span class="sr-only">{{ label }}</span>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+    .skeleton-shimmer {
+      background-image: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255, 255, 255, 0.45) 50%,
+        transparent 100%
+      );
+      background-size: 220% 100%;
+      background-repeat: no-repeat;
+      animation: artifact-skeleton-shimmer 1.5s ease-in-out infinite;
+    }
+    @keyframes artifact-skeleton-shimmer {
+      0% {
+        background-position: 130% 0;
+      }
+      100% {
+        background-position: -130% 0;
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .skeleton-shimmer {
+        animation: none;
+      }
+    }
+  `,
+})
+export class ArtifactViewerComponent {
+  /** Artifact-origin URL carrying the render token. Null while minting. */
+  readonly safeUrl = input<SafeResourceUrl | null>(null);
+  /** Accessible name for the iframe. */
+  readonly title = input<string>('');
+  readonly view = input<'preview' | 'code'>('preview');
+  readonly source = input<ArtifactContent | null>(null);
+  /** Preview-path failure message; null when healthy. */
+  readonly error = input<string | null>(null);
+  /** Code-path failure message; null when healthy. */
+  readonly sourceError = input<string | null>(null);
+  /**
+   * Skeleton clears only when the parent says the preview has actually
+   * painted — a minted URL alone is not enough.
+   */
+  readonly previewReady = input<boolean>(false);
+  /**
+   * Disables pointer events on the iframe. The panel sets it while the
+   * resize handle is being dragged, since the iframe would otherwise
+   * swallow the pointer stream.
+   */
+  readonly inert = input<boolean>(false);
+
+  readonly retry = output<void>();
+  readonly retrySource = output<void>();
+  readonly iframeLoad = output<void>();
+}

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-download.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-download.service.ts
@@ -1,13 +1,19 @@
 import { Injectable, inject } from '@angular/core';
 import { ArtifactHttpService } from './artifact-http.service';
+import { ArtifactShareService } from './artifact-share.service';
 import { SessionService } from '../session/session.service';
 import { ToastService } from '../../../services/toast/toast.service';
 
-/** Minimal identity of the artifact version to save. */
-export interface DownloadableArtifact {
-  artifactId: string;
-  version: number;
-}
+/**
+ * Which artifact version to save, and by what authority.
+ *
+ * An owner identifies the version directly. A recipient has no artifact
+ * id they are allowed to mint against, so they pass `shareId` instead
+ * and the mint goes through the access-checked share endpoint.
+ */
+export type DownloadableArtifact =
+  | { artifactId: string; version: number; shareId?: undefined }
+  | { shareId: string; artifactId?: undefined; version?: undefined };
 
 /**
  * Saves an artifact version to disk. Shared by the inline card and the
@@ -25,19 +31,28 @@ export interface DownloadableArtifact {
 @Injectable({ providedIn: 'root' })
 export class ArtifactDownloadService {
   private artifactHttp = inject(ArtifactHttpService);
+  private artifactShares = inject(ArtifactShareService);
   private sessionService = inject(SessionService);
   private toast = inject(ToastService);
 
   /** Mint a token and kick off the save. Surfaces a toast and resolves
-   *  `false` on failure so callers can clear their own busy state. */
+   *  `false` on failure so callers can clear their own busy state.
+   *
+   *  Both mint paths return the same `{url}` shape, so everything below
+   *  the mint — the `?download=1` suffix and the hidden iframe — is
+   *  identical for an owner and a recipient. */
   async download(ref: DownloadableArtifact): Promise<boolean> {
     try {
-      const sessionId = this.sessionService.currentSession().sessionId;
-      const token = await this.artifactHttp.mintRenderToken(
-        ref.artifactId,
-        ref.version,
-        sessionId,
-      );
+      // `!== undefined` (not truthiness) so the union discriminates:
+      // it is what narrows the else branch to the owner variant.
+      const token =
+        ref.shareId !== undefined
+          ? await this.artifactShares.mintSharedRenderToken(ref.shareId)
+          : await this.artifactHttp.mintRenderToken(
+              ref.artifactId,
+              ref.version,
+              this.sessionService.currentSession().sessionId,
+            );
       const sep = token.url.includes('?') ? '&' : '?';
       this.trigger(`${token.url}${sep}download=1`);
       return true;

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
@@ -2,7 +2,10 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
-import type { RenderToken } from './artifact-http.service';
+import type {
+  ArtifactContent,
+  RenderToken,
+} from './artifact-http.service';
 
 /** Who may open a share. `public` means any *authenticated* tenant user
  *  — never anonymous, matching conversation sharing. */
@@ -43,6 +46,12 @@ export interface SharedArtifact {
 interface RenderTokenResponseDto {
   url: string;
   expires_at: string;
+}
+
+interface ArtifactContentResponseDto {
+  content: string;
+  content_type: string;
+  version: number;
 }
 
 /**
@@ -165,5 +174,28 @@ export class ArtifactShareService {
       ),
     );
     return { url: res.url, expiresAt: res.expires_at };
+  }
+
+  /**
+   * Raw source of a shared artifact version, for the recipient's code
+   * view. The parallel of `ArtifactHttpService.getArtifactContent`,
+   * which builds its key from the authenticated user and so can only
+   * ever serve an owner.
+   *
+   * The bytes are inert text the page highlights client-side — never
+   * executed. Oversized artifacts 413 here exactly as they do for the
+   * owner, so callers steer to download.
+   */
+  async getSharedArtifactContent(shareId: string): Promise<ArtifactContent> {
+    const res = await firstValueFrom(
+      this.http.get<ArtifactContentResponseDto>(
+        `${this.sharedUrl()}/${encodeURIComponent(shareId)}/content`,
+      ),
+    );
+    return {
+      content: res.content,
+      contentType: res.content_type,
+      version: res.version,
+    };
   }
 }

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.spec.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.spec.ts
@@ -1,0 +1,298 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ActivatedRoute } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { SharedArtifactViewPage } from './shared-artifact-view.page';
+import {
+  ArtifactShareService,
+  type SharedArtifact,
+} from '../../session/services/artifacts/artifact-share.service';
+import { ArtifactDownloadService } from '../../session/services/artifacts/artifact-download.service';
+
+const SHARE_ID = 'share-1';
+
+const META: SharedArtifact = {
+  shareId: SHARE_ID,
+  title: 'Quarterly Chart',
+  contentType: 'text/html; charset=utf-8',
+  version: 3,
+  createdAt: '2026-09-03T00:00:00+00:00',
+  ownerEmail: 'owner@example.com',
+  canDownload: true,
+};
+
+describe('SharedArtifactViewPage', () => {
+  let fixture: ComponentFixture<SharedArtifactViewPage>;
+  let component: SharedArtifactViewPage;
+  let shares: {
+    getSharedArtifact: ReturnType<typeof vi.fn>;
+    mintSharedRenderToken: ReturnType<typeof vi.fn>;
+    getSharedArtifactContent: ReturnType<typeof vi.fn>;
+  };
+  let download: { download: ReturnType<typeof vi.fn> };
+
+  let originalClipboard: PropertyDescriptor | undefined;
+
+  const api = () => component as unknown as Record<string, any>;
+  const text = () => (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  function build(shareId: string | null = SHARE_ID): void {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [SharedArtifactViewPage],
+      providers: [
+        // DI token overrides, not vi.mock — module mocks leak across specs.
+        { provide: ArtifactShareService, useValue: shares },
+        { provide: ArtifactDownloadService, useValue: download },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => shareId } } },
+        },
+      ],
+    });
+    fixture = TestBed.createComponent(SharedArtifactViewPage);
+    component = fixture.componentInstance;
+  }
+
+  beforeEach(() => {
+    shares = {
+      getSharedArtifact: vi.fn().mockResolvedValue(META),
+      mintSharedRenderToken: vi
+        .fn()
+        .mockResolvedValue({ url: 'https://artifacts.x/?t=jwt', expiresAt: 'e' }),
+      getSharedArtifactContent: vi.fn().mockResolvedValue({
+        content: '<h1>hi</h1>',
+        contentType: 'text/html',
+        version: 3,
+      }),
+    };
+    download = { download: vi.fn().mockResolvedValue(true) };
+    build();
+    stubClipboard();
+  });
+  /**
+   * `navigator.clipboard` doesn't exist in jsdom, so it has to be
+   * defined rather than stubbed — and `Object.defineProperty` is NOT
+   * undone by the `vi.unstubAllGlobals()` backstop in test-setup.ts.
+   * The builder runs vitest with `isolate: false`, so a leaked global
+   * here would follow the worker into unrelated spec files and surface
+   * as one randomly-chosen file timing out. Restore it explicitly.
+   */
+  function stubClipboard(writeText = vi.fn().mockResolvedValue(undefined)) {
+    originalClipboard = Object.getOwnPropertyDescriptor(
+      navigator,
+      'clipboard',
+    );
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  }
+
+  function restoreClipboard(): void {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      delete (navigator as unknown as Record<string, unknown>)['clipboard'];
+    }
+    originalClipboard = undefined;
+  }
+
+  afterEach(() => {
+    // isolate:false shares one DOM across every spec file, so a fixture
+    // left mounted keeps its skeleton's infinite shimmer animation
+    // running for the rest of the suite. Tear it down.
+    fixture?.destroy();
+    restoreClipboard();
+  });
+
+  /** Flush the promise chain the page's async init walks. */
+  async function flush(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  }
+
+  /**
+   * `detectChanges()` runs `ngOnInit` itself, so calling it manually as
+   * well would mint twice and make every call-count assertion lie.
+   */
+  async function init(): Promise<void> {
+    fixture.detectChanges();
+    await flush();
+    fixture.detectChanges();
+  }
+
+  // ----------------------------------------------------------------
+  // Happy path
+  // ----------------------------------------------------------------
+
+  it('loads metadata, then mints — in that order', async () => {
+    await init();
+    // Metadata is the access check, so a denied viewer must never reach
+    // the mint at all.
+    expect(shares.getSharedArtifact).toHaveBeenCalledWith(SHARE_ID);
+    expect(shares.mintSharedRenderToken).toHaveBeenCalledWith(SHARE_ID);
+    expect(api()['safeUrl']()).not.toBeNull();
+  });
+
+  it('shows the read-only banner, title, version and owner', async () => {
+    await init();
+    expect(text()).toContain('Shared read-only snapshot');
+    expect(text()).toContain('Quarterly Chart');
+    expect(text()).toContain('Version 3');
+    expect(text()).toContain('owner@example.com');
+  });
+
+  it('never asks for an artifact id — the share id is the only handle', async () => {
+    await init();
+    const allArgs = [
+      ...shares.getSharedArtifact.mock.calls,
+      ...shares.mintSharedRenderToken.mock.calls,
+    ].flat();
+    expect(allArgs).toEqual([SHARE_ID, SHARE_ID]);
+  });
+
+  it('offers no share or version-switching affordance', async () => {
+    await init();
+    const labels = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).map((b) => b.getAttribute('aria-label') ?? '');
+    // A recipient view is read-only: no re-sharing, no moving between
+    // versions (a share pins one immutable version).
+    expect(labels.some((l) => /share/i.test(l))).toBe(false);
+    expect(labels.some((l) => /change version/i.test(l))).toBe(false);
+  });
+
+  // ----------------------------------------------------------------
+  // Error branches
+  // ----------------------------------------------------------------
+
+  it.each([
+    [403, 'Access denied', "don't have permission"],
+    [404, 'Artifact not found', 'may have been revoked'],
+    [500, 'Something went wrong', 'Failed to load'],
+  ])('renders the %i branch', async (status, heading, detail) => {
+    shares.getSharedArtifact.mockRejectedValue({ status });
+    await init();
+
+    expect(text()).toContain(heading);
+    expect(text()).toContain(detail);
+    // Denied or missing means no credential is ever minted.
+    expect(shares.mintSharedRenderToken).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing route param as a 404 without calling the API', async () => {
+    build(null);
+    await init();
+    expect(text()).toContain('Artifact not found');
+    expect(shares.getSharedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('falls back to 500 for a failure that never reached the server', async () => {
+    shares.getSharedArtifact.mockRejectedValue(new Error('offline'));
+    await init();
+    expect(text()).toContain('Something went wrong');
+  });
+
+  it('turns a revoke-while-open into the dead-link page, not a retry box', async () => {
+    shares.mintSharedRenderToken.mockRejectedValue({ status: 404 });
+    await init();
+
+    // Otherwise the viewer would show a "Try again" that can never work.
+    expect(text()).toContain('Artifact not found');
+    expect(api()['renderError']()).toBeNull();
+  });
+
+  it('shows a retryable message for a transient mint failure', async () => {
+    shares.mintSharedRenderToken.mockRejectedValue({ status: 503 });
+    await init();
+
+    expect(api()['renderError']()).toContain("couldn't be loaded");
+    // Still a live share — the page stays, only the viewer shows an error.
+    expect(text()).toContain('Quarterly Chart');
+  });
+
+  it('re-mints on retry rather than reusing the expired token', async () => {
+    await init();
+    api()['retry']();
+    await flush();
+    // The token is a ~120s bearer credential; retry must mint a fresh one.
+    expect(shares.mintSharedRenderToken).toHaveBeenCalledTimes(2);
+  });
+
+  // ----------------------------------------------------------------
+  // Code view
+  // ----------------------------------------------------------------
+
+  it('fetches the source only when code view is opened', async () => {
+    await init();
+    expect(shares.getSharedArtifactContent).not.toHaveBeenCalled();
+
+    api()['setView']('code');
+    await flush();
+    expect(shares.getSharedArtifactContent).toHaveBeenCalledWith(SHARE_ID);
+  });
+
+  it('does not refetch the source on a second switch to code', async () => {
+    await init();
+    api()['setView']('code');
+    await flush();
+    api()['setView']('preview');
+    api()['setView']('code');
+    await flush();
+
+    expect(shares.getSharedArtifactContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('steers an oversized artifact to download', async () => {
+    shares.getSharedArtifactContent.mockRejectedValue(
+      new HttpErrorResponse({ status: 413 }),
+    );
+    await init();
+    api()['setView']('code');
+    await flush();
+
+    expect(api()['sourceError']()).toContain('too large');
+  });
+
+  it('reports a generic source failure for anything else', async () => {
+    shares.getSharedArtifactContent.mockRejectedValue({ status: 500 });
+    await init();
+    api()['setView']('code');
+    await flush();
+
+    expect(api()['sourceError']()).toContain("couldn't be loaded");
+  });
+
+  it('copies the source to the clipboard', async () => {
+    await init();
+    api()['setView']('code');
+    await flush();
+    await api()['copy']();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('<h1>hi</h1>');
+    expect(api()['copied']()).toBe(true);
+  });
+
+  // ----------------------------------------------------------------
+  // Download
+  // ----------------------------------------------------------------
+
+  it('downloads by share id, never by artifact id', async () => {
+    await init();
+    await api()['download']();
+
+    // A recipient holds no artifact id they may mint against; the share
+    // id is the authority and routes through the access-checked endpoint.
+    expect(download.download).toHaveBeenCalledWith({ shareId: SHARE_ID });
+  });
+
+  it('hides the download button when the share disallows it', async () => {
+    shares.getSharedArtifact.mockResolvedValue({ ...META, canDownload: false });
+    await init();
+
+    const labels = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).map((b) => b.getAttribute('aria-label') ?? '');
+    expect(labels.some((l) => /download/i.test(l))).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.ts
@@ -1,0 +1,414 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroLockClosed,
+  heroExclamationTriangle,
+  heroArrowDownTray,
+  heroArrowPath,
+  heroEye,
+  heroCodeBracket,
+  heroClipboard,
+  heroCheck,
+} from '@ng-icons/heroicons/outline';
+import {
+  ArtifactShareService,
+  type SharedArtifact,
+} from '../../session/services/artifacts/artifact-share.service';
+import { ArtifactDownloadService } from '../../session/services/artifacts/artifact-download.service';
+import { ArtifactViewerComponent } from '../../session/components/message-list/components/artifact/artifact-viewer.component';
+import type { ArtifactContent } from '../../session/services/artifacts/artifact-http.service';
+import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+
+/**
+ * Recipient view for a shared artifact, at `/shared-artifact/:shareId`.
+ *
+ * Modelled on `shared-view.page.ts` (the conversation equivalent): the
+ * same sticky read-only banner and the same 403 / 404 / other error
+ * branches, so a recipient sees one consistent story whichever kind of
+ * link they were sent.
+ *
+ * It renders through the same `ArtifactViewerComponent` the owner's
+ * docked panel uses — same sandboxed iframe, same code view — but every
+ * call goes to the access-checked `/shared-artifacts/…` endpoints. It
+ * never learns the artifact id: the share id is the only handle it has,
+ * and the backend resolves the owner behind the ACL.
+ *
+ * Read-only by construction. There is no share button, no version menu
+ * (a share pins one immutable version), and no way to edit.
+ */
+@Component({
+  selector: 'app-shared-artifact-view',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, DatePipe, ArtifactViewerComponent, TooltipDirective],
+  providers: [
+    provideIcons({
+      heroLockClosed,
+      heroExclamationTriangle,
+      heroArrowDownTray,
+      heroArrowPath,
+      heroEye,
+      heroCodeBracket,
+      heroClipboard,
+      heroCheck,
+    }),
+  ],
+  template: `
+    <div class="flex h-dvh flex-col bg-white dark:bg-gray-900">
+      <!-- Read-only banner: the same promise the shared-conversation
+           page makes, so the two recipient surfaces read alike. -->
+      <div
+        class="border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95"
+      >
+        <div class="mx-auto flex max-w-4xl items-center justify-center px-4 py-3">
+          <div class="flex items-center gap-2">
+            <ng-icon
+              name="heroLockClosed"
+              class="size-4 text-gray-400"
+              aria-hidden="true"
+            />
+            <span
+              class="text-xs font-medium text-gray-500 dark:text-gray-400"
+              >Shared read-only snapshot</span
+            >
+            @if (artifact(); as a) {
+              <span class="text-xs text-gray-400 dark:text-gray-500">
+                · {{ a.createdAt | date: 'medium' }}
+              </span>
+            }
+          </div>
+        </div>
+      </div>
+
+      @if (isLoading()) {
+        <div class="flex flex-1 items-center justify-center py-20">
+          <div class="text-center">
+            <div
+              class="mx-auto size-8 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500"
+            ></div>
+            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+              Loading shared artifact…
+            </p>
+          </div>
+        </div>
+      } @else if (errorStatus()) {
+        <div class="flex flex-1 items-center justify-center py-20">
+          <div class="text-center">
+            <ng-icon
+              name="heroExclamationTriangle"
+              class="mx-auto size-12 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            @if (errorStatus() === 403) {
+              <h1 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Access denied
+              </h1>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                You don't have permission to view this artifact.
+              </p>
+            } @else if (errorStatus() === 404) {
+              <h1 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Artifact not found
+              </h1>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                This share link may have been revoked.
+              </p>
+            } @else {
+              <h1 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+                Something went wrong
+              </h1>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Failed to load the shared artifact.
+              </p>
+            }
+          </div>
+        </div>
+      } @else if (artifact(); as a) {
+        <header
+          class="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700"
+        >
+          <div class="min-w-0 flex-1">
+            <h1
+              class="truncate text-sm font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {{ a.title || 'Untitled artifact' }}
+            </h1>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              Version {{ a.version }} · shared by {{ a.ownerEmail }}
+            </p>
+          </div>
+
+          <div
+            role="group"
+            aria-label="Artifact view mode"
+            class="flex items-center gap-0.5 rounded-md border border-gray-200 p-0.5 dark:border-gray-700"
+          >
+            <button
+              type="button"
+              class="flex size-7 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              [class]="
+                view() === 'preview'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+              "
+              [attr.aria-pressed]="view() === 'preview'"
+              aria-label="Preview"
+              [appTooltip]="'Preview'"
+              appTooltipPosition="bottom"
+              (click)="setView('preview')"
+            >
+              <ng-icon name="heroEye" class="text-base" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              class="flex size-7 items-center justify-center rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              [class]="
+                view() === 'code'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+              "
+              [attr.aria-pressed]="view() === 'code'"
+              aria-label="View code"
+              [appTooltip]="'View code'"
+              appTooltipPosition="bottom"
+              (click)="setView('code')"
+            >
+              <ng-icon
+                name="heroCodeBracket"
+                class="text-base"
+                aria-hidden="true"
+              />
+            </button>
+          </div>
+
+          @if (view() === 'code') {
+            <button
+              type="button"
+              class="flex size-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+              [attr.aria-label]="copied() ? 'Copied' : 'Copy code'"
+              [appTooltip]="copied() ? 'Copied' : 'Copy code'"
+              appTooltipPosition="bottom"
+              [disabled]="!source()"
+              (click)="copy()"
+            >
+              <ng-icon
+                [name]="copied() ? 'heroCheck' : 'heroClipboard'"
+                class="text-lg"
+                [class.text-green-600]="copied()"
+                aria-hidden="true"
+              />
+            </button>
+          }
+
+          @if (a.canDownload) {
+            <button
+              type="button"
+              class="flex size-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+              [attr.aria-label]="
+                downloading() ? 'Downloading artifact…' : 'Download artifact'
+              "
+              [appTooltip]="'Download'"
+              appTooltipPosition="bottom"
+              [attr.aria-busy]="downloading()"
+              [disabled]="downloading() || !safeUrl()"
+              (click)="download()"
+            >
+              <ng-icon
+                [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
+                class="text-lg"
+                [class.animate-spin]="downloading()"
+                aria-hidden="true"
+              />
+            </button>
+          }
+        </header>
+
+        <div class="relative flex min-h-0 flex-1 flex-col">
+          <app-artifact-viewer
+            [safeUrl]="safeUrl()"
+            [title]="a.title"
+            [view]="view()"
+            [source]="source()"
+            [error]="renderError()"
+            [sourceError]="sourceError()"
+            [previewReady]="previewReady()"
+            (retry)="retry()"
+            (retrySource)="retrySource()"
+            (iframeLoad)="onIframeLoad()"
+          />
+        </div>
+      }
+    </div>
+  `,
+})
+export class SharedArtifactViewPage implements OnInit {
+  private route = inject(ActivatedRoute);
+  private shareService = inject(ArtifactShareService);
+  private downloadService = inject(ArtifactDownloadService);
+  private sanitizer = inject(DomSanitizer);
+
+  private shareId = '';
+
+  protected readonly artifact = signal<SharedArtifact | null>(null);
+  protected readonly isLoading = signal(true);
+  protected readonly errorStatus = signal<number | null>(null);
+
+  protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
+  protected readonly renderError = signal<string | null>(null);
+  protected readonly iframeLoaded = signal(false);
+  protected readonly previewReady = computed(
+    () => !!this.safeUrl() && this.iframeLoaded(),
+  );
+
+  protected readonly view = signal<'preview' | 'code'>('preview');
+  protected readonly source = signal<ArtifactContent | null>(null);
+  protected readonly sourceError = signal<string | null>(null);
+  private sourceLoading = false;
+
+  protected readonly copied = signal(false);
+  protected readonly downloading = signal(false);
+  private copiedTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Bumped per mint so a slow response that resolves after a retry is
+   *  discarded rather than overwriting the newer one. */
+  private requestSeq = 0;
+
+  async ngOnInit(): Promise<void> {
+    const shareId = this.route.snapshot.paramMap.get('shareId');
+    if (!shareId) {
+      this.errorStatus.set(404);
+      this.isLoading.set(false);
+      return;
+    }
+    this.shareId = shareId;
+
+    try {
+      // Metadata first: it is the access check. A 403 or 404 here means
+      // no token is ever minted.
+      this.artifact.set(await this.shareService.getSharedArtifact(shareId));
+    } catch (err: unknown) {
+      this.errorStatus.set(statusOf(err));
+      this.isLoading.set(false);
+      return;
+    }
+    this.isLoading.set(false);
+    await this.mint();
+  }
+
+  protected retry(): void {
+    void this.mint();
+  }
+
+  protected onIframeLoad(): void {
+    this.iframeLoaded.set(true);
+  }
+
+  protected setView(next: 'preview' | 'code'): void {
+    if (this.view() === next) return;
+    this.view.set(next);
+    if (next === 'code') void this.ensureSource();
+  }
+
+  protected retrySource(): void {
+    this.source.set(null);
+    this.sourceError.set(null);
+    void this.ensureSource();
+  }
+
+  protected async copy(): Promise<void> {
+    const src = this.source();
+    if (!src) return;
+    try {
+      await navigator.clipboard.writeText(src.content);
+      this.copied.set(true);
+      if (this.copiedTimer) clearTimeout(this.copiedTimer);
+      this.copiedTimer = setTimeout(() => this.copied.set(false), 2000);
+    } catch {
+      /* clipboard blocked (permissions/insecure context) — the user can
+         still select the visible source manually */
+    }
+  }
+
+  protected async download(): Promise<void> {
+    if (this.downloading()) return;
+    this.downloading.set(true);
+    try {
+      // Recipients have no artifact id to mint against; the share id is
+      // the authority, and the download service routes it through the
+      // access-checked endpoint.
+      await this.downloadService.download({ shareId: this.shareId });
+    } finally {
+      this.downloading.set(false);
+    }
+  }
+
+  /** Mint a fresh render URL. The token is a ~120s bearer credential —
+   *  never cached, re-minted on retry. */
+  private async mint(): Promise<void> {
+    const seq = ++this.requestSeq;
+    this.renderError.set(null);
+    this.safeUrl.set(null);
+    this.iframeLoaded.set(false);
+    try {
+      const token = await this.shareService.mintSharedRenderToken(
+        this.shareId,
+      );
+      if (seq !== this.requestSeq) return; // superseded — drop
+      this.safeUrl.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(token.url),
+      );
+    } catch (err: unknown) {
+      if (seq !== this.requestSeq) return;
+      const status = statusOf(err);
+      // A share revoked while the page was open stops being a render
+      // problem and becomes a dead link — say so on the page, not in a
+      // retryable error box inside a viewer that will never load.
+      if (status === 403 || status === 404) {
+        this.errorStatus.set(status);
+        this.artifact.set(null);
+        return;
+      }
+      this.renderError.set(
+        "This artifact couldn't be loaded. The link may have expired or been revoked.",
+      );
+    }
+  }
+
+  /** Fetch the raw source once. No-op while a fetch is in flight or the
+   *  source is already loaded — the version is pinned, so it can't go
+   *  stale under us the way the owner panel's can. */
+  private async ensureSource(): Promise<void> {
+    if (this.sourceLoading || this.source()) return;
+    this.sourceLoading = true;
+    this.sourceError.set(null);
+    try {
+      this.source.set(
+        await this.shareService.getSharedArtifactContent(this.shareId),
+      );
+    } catch (err: unknown) {
+      this.sourceError.set(
+        err instanceof HttpErrorResponse && err.status === 413
+          ? 'This artifact is too large to preview here — download it instead.'
+          : "This artifact's source couldn't be loaded. It may have expired or been removed.",
+      );
+    } finally {
+      this.sourceLoading = false;
+    }
+  }
+}
+
+/** HTTP status of a failed call, defaulting to 500 for anything that
+ *  didn't reach the server (offline, DNS, aborted). */
+function statusOf(err: unknown): number {
+  return (err as { status?: number } | null)?.status ?? 500;
+}


### PR DESCRIPTION
PR-3 of the artifact sharing spec (`docs/specs/artifact-sharing.md`). This completes the user-visible feature: a recipient can now actually open a shared artifact. PR-4 (session-delete cascade) is the remaining piece.

Follows [#919](https://github.com/Boise-State-Development/agentcore-public-stack/pull/919) (data model + owner API) and [#920](https://github.com/Boise-State-Development/agentcore-public-stack/pull/920) (owner UI), both merged. Before this PR, `/shared-artifact/{id}` — the link the share modal hands out — 404'd in the SPA router.

## Backend

**`GET /shared-artifacts/{share_id}/content`**, the parallel of `GET /artifacts/{id}/content`. The owner route builds its lookup key from the authenticated session and **must stay that way** — that self-scoping is its only access control, so it can never serve a recipient. The shared route runs the share ACL first, then hands the resolved owner id to the existing `ArtifactContentService`.

That service performs no access control of its own: it reads whichever partition it is given, exactly the way the render token's `sub` claim addresses one. Its `user_id` parameter is renamed **`owner_id`** to say so out loud, and both it and `_get_version_item` now carry the note that the owner route passes the session user while the share route passes the share's *owner* and owes the ACL check first. Reaching that helper with an un-ACL-checked owner id is a read-any-artifact-by-id bug, and it should read that way to the next person.

## Frontend

**`ArtifactViewerComponent`** — the panel's iframe, code view, error branches and skeleton, extracted as a **presentational** child. It fetches nothing and owns no access control; the parent mints and loads, then hands both down. That is exactly what lets the owner's docked panel and the recipient page share one viewer while minting through two different endpoints. The panel keeps its docking, resize and version-menu chrome — net **-166 lines** there, logic untouched.

**`SharedArtifactViewPage`** at `/shared-artifact/:shareId`, behind `authGuard` like every other share surface — "public" means any authenticated tenant user, never anonymous. Modelled on `shared-view.page.ts`: same sticky read-only banner, same 403 / 404 / other branches, so a recipient gets one consistent story whichever kind of link they were sent. Read-only by construction: no share button, no version menu (a share pins one immutable version).

**`ArtifactDownloadService`** takes an optional `shareId`. A recipient holds no artifact id they are allowed to mint against, so the share id is the authority. Both mint paths return the same `{url}` shape, so everything below the mint — the `?download=1` suffix and the hidden iframe — is identical for owner and recipient.

## A latent test defect from PR-2, fixed here

Both share specs stubbed `navigator.clipboard` with `Object.defineProperty`, which **`vi.unstubAllGlobals()` does not undo**. Under the builder's `isolate: false`, that mocked clipboard followed the worker into unrelated spec files and surfaced as one randomly-chosen file timing out at 5s — precisely the failure mode `src/test-setup.ts` documents in its own comments.

It reproduced at roughly **one run in three** on this branch while `develop` was clean, which is what made it worth chasing rather than retrying. (My first bisect blamed the new viewer spec; with a ~30% flake rate, one- and two-run samples are noise, and I over-read them.) Both specs now save and restore the property descriptor. **Five consecutive full suite runs clean.**

## Tests — 44 new

Backend (8): a recipient reads the *owner's* bytes; a disallowed viewer 403s with no content; revoked and unknown shares 404; a missing version row 404s; a share pinned to v1 keeps serving v1 after v2 exists; oversized 413s. Plus the one that guards the split — **the owner content route still 404s for a recipient holding a valid share**, so if it ever starts returning 200 the two access models have been conflated.

Frontend (36): the viewer's sandbox contract (`allow-scripts`, and `allow-same-origin` asserted *absent*), skeleton/inert/error wiring, and that a preview error doesn't blank out code view. The page: metadata-before-mint ordering (so a denied viewer never reaches a mint), all three error branches, revoke-while-open becoming a dead-link page rather than an unusable "Try again", lazy source fetch, 413 steering, and download-by-share-id.

Also a **new panel spec** — the panel had none, and the extraction is this PR's real regression risk for existing owners, so it now has assertions that it still drives the viewer with the same state it used to render inline.

## Verification

- SPA suite: **180 files / 2067 tests green**, `ng build` clean, `version.ts` untouched.
- Backend artifacts + shares suites green (84 tests); full backend suite running — CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
