### PR TITLE
fix(artifacts): duplicate error toast + card overlap on a narrow card

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
@@ -127,4 +127,14 @@ describe('ArtifactCardComponent', () => {
       version: 3,
     });
   });
+
+  it('keeps both action labels in the accessible name at any card width', () => {
+    // On a narrow card (artifact panel docked open, split view, mobile) a
+    // container query hides these labels visually so the title isn't
+    // squeezed to nothing — but they are only *visually* hidden, never
+    // removed, so the visible-label-in-accessible-name rule (WCAG 2.5.3)
+    // still holds and the buttons keep their [appTooltip].
+    expect(button(/^Share /).textContent).toContain('Share');
+    expect(button(/^Download /).textContent).toContain('Download');
+  });
 });

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -23,6 +23,7 @@ import {
   type ArtifactShareModalData,
 } from './artifact-share-modal.component';
 import { UserService } from '../../../../../auth/user.service';
+import { TooltipDirective } from '../../../../../components/tooltip/tooltip.directive';
 import { parseIso } from '../../../../../utils/date';
 
 /** Visual treatment derived from an artifact's content type. */
@@ -58,7 +59,7 @@ interface ArtifactKind {
 @Component({
   selector: 'app-artifact-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon],
+  imports: [NgIcon, TooltipDirective],
   providers: [
     provideIcons({
       heroCodeBracket,
@@ -112,6 +113,7 @@ interface ArtifactKind {
             type="button"
             class="artifact-card__action"
             [attr.aria-label]="shareAriaLabel()"
+            [appTooltip]="'Share version ' + artifact().version"
             (click)="share()"
           >
             <ng-icon name="heroArrowUpOnSquare" aria-hidden="true" />
@@ -124,6 +126,7 @@ interface ArtifactKind {
             [class.is-busy]="downloading()"
             [attr.aria-label]="downloadAriaLabel()"
             [attr.aria-busy]="downloading()"
+            [appTooltip]="'Download version ' + artifact().version"
             [disabled]="downloading()"
             (click)="download()"
           >
@@ -152,6 +155,11 @@ interface ArtifactKind {
       isolation: isolate;
       display: block;
       width: 100%;
+      /* Establishes the query container for the narrow-card rules at the
+         bottom of this block. The card is sized by the chat column, not
+         the viewport — the artifact panel docking open halves it — so a
+         container query is correct here and a media query is not. */
+      container-type: inline-size;
       /* matches the chat input's rounded-2xl so the focus ring and the
          surface share the app's corner radius */
       border-radius: 1rem;
@@ -256,8 +264,13 @@ interface ArtifactKind {
       line-height: 1;
     }
 
+    /* min-width:0 lets the 1fr column actually shrink; overflow:hidden
+       is what stops its contents painting outside it. Without the
+       latter the metadata line spills under the action buttons once the
+       chat column narrows (e.g. with the artifact panel docked open). */
     .artifact-card__body {
       min-width: 0;
+      overflow: hidden;
     }
 
     .artifact-card__title {
@@ -276,6 +289,9 @@ interface ArtifactKind {
     }
 
     /* Metadata line — the app's sans, small and quiet. */
+    /* Truncates as one line rather than wrapping or overflowing: the
+       type/version/time chunks are progressively less important, so
+       clipping from the right degrades in the right order. */
     .artifact-card__meta {
       display: flex;
       align-items: center;
@@ -283,6 +299,12 @@ interface ArtifactKind {
       margin-top: 0.2rem;
       font-size: 0.75rem;
       color: #4b5563;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .artifact-card__meta > * {
+      flex: 0 0 auto;
     }
 
     :host-context(html.dark) .artifact-card__meta {
@@ -313,6 +335,10 @@ interface ArtifactKind {
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
+      /* The grid's last column is sized auto, so the actions always get
+         the width they ask for; this just stops them being the thing
+         that wraps. */
+      flex: 0 0 auto;
     }
 
     /* A bordered, labelled action button. Both actions keep a visible
@@ -388,6 +414,32 @@ interface ArtifactKind {
     @keyframes artifact-card-spin {
       to {
         transform: rotate(360deg);
+      }
+    }
+
+    /* Narrow card (docked artifact panel, split view, mobile): the two
+       labelled buttons would otherwise consume the whole row and the
+       title would clip to nothing. Drop the labels to icons and let the
+       title win the space back.
+
+       The label is visually hidden rather than removed, so it stays in
+       the accessible name (WCAG 2.5.3) — and the buttons carry
+       [appTooltip], which is what a sighted user gets in place of the
+       text they can no longer see. */
+    @container (max-width: 26rem) {
+      .artifact-card__action-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+      .artifact-card__action {
+        padding-left: 0.45rem;
+        padding-right: 0.45rem;
       }
     }
 

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
@@ -6,6 +6,8 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
+import { HttpContext } from '@angular/common/http';
+import { SUPPRESS_ERROR_TOAST } from '../../../auth/error.interceptor';
 import { ArtifactShareService } from './artifact-share.service';
 import { ConfigService } from '../../../services/config.service';
 
@@ -190,5 +192,44 @@ describe('ArtifactShareService', () => {
       .expectOne(`${API}/shared-artifacts/s%2F1/render-token`)
       .flush({ url: 'u', expires_at: 'e' });
     await mint;
+  });
+
+  // ----------------------------------------------------------------
+  // Global error toast
+  // ----------------------------------------------------------------
+
+  it('opts calls with inline error UI out of the global toast', async () => {
+    // The share modal and the recipient page render their own error
+    // messages; without this a dead link shows the page's "Artifact not
+    // found" AND a generic toast repeating the backend detail.
+    const cases: Array<[string, () => Promise<unknown>, string]> = [
+      ['create', () => service.createShare('art-1', 1, 'public'), `${API}/artifacts/art-1/shares`],
+      ['update', () => service.updateShare('s1'), `${API}/artifacts/shares/s1`],
+      ['revoke', () => service.revokeShare('s1'), `${API}/artifacts/shares/s1`],
+      ['metadata', () => service.getSharedArtifact('s1'), `${API}/shared-artifacts/s1`],
+      ['mint', () => service.mintSharedRenderToken('s1'), `${API}/shared-artifacts/s1/render-token`],
+      ['content', () => service.getSharedArtifactContent('s1'), `${API}/shared-artifacts/s1/content`],
+    ];
+
+    for (const [label, call, url] of cases) {
+      const p = call();
+      const req = httpMock.expectOne(url);
+      expect(
+        req.request.context.get(SUPPRESS_ERROR_TOAST),
+        `${label} should suppress the global toast`,
+      ).toBe(true);
+      req.flush({ url: 'u', expires_at: 'e', content: '', content_type: '', version: 1 });
+      await p;
+    }
+  });
+
+  it('leaves the toast on for the share list, which degrades silently', async () => {
+    // listShares has no inline error UI — the dialog still opens and can
+    // create a link — so the toast is the only signal the list is stale.
+    const p = service.listShares('art-1');
+    const req = httpMock.expectOne(`${API}/artifacts/art-1/shares`);
+    expect(req.request.context.get(SUPPRESS_ERROR_TOAST)).toBe(false);
+    req.flush({ shares: [] });
+    await p;
   });
 });

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../../auth/error.interceptor';
 import type {
   ArtifactContent,
   RenderToken,
@@ -79,6 +80,23 @@ export class ArtifactShareService {
     return `${this.config.appApiUrl()}/shared-artifacts`;
   }
 
+  /**
+   * Opt a request out of the global error toast.
+   *
+   * Applied to every call whose caller renders its own inline error —
+   * the share modal's message box and the recipient page's 403/404/500
+   * screens. Without it a dead share link produces two notices at once:
+   * the page's "Artifact not found" *and* a generic toast repeating the
+   * backend detail.
+   *
+   * Deliberately NOT applied to `listShares`: it degrades silently by
+   * design (the dialog still opens and can create a link), so the toast
+   * is the only signal that the existing-links list is incomplete.
+   */
+  private inlineErrors(): { context: HttpContext } {
+    return { context: new HttpContext().set(SUPPRESS_ERROR_TOAST, true) };
+  }
+
   // ----------------------------------------------------------------
   // Owner CRUD
   // ----------------------------------------------------------------
@@ -102,6 +120,7 @@ export class ArtifactShareService {
           accessLevel,
           ...(allowedEmails?.length ? { allowedEmails } : {}),
         },
+        this.inlineErrors(),
       ),
     );
   }
@@ -131,6 +150,7 @@ export class ArtifactShareService {
       this.http.patch<ArtifactShare>(
         `${this.artifactsUrl()}/shares/${encodeURIComponent(shareId)}`,
         body,
+        this.inlineErrors(),
       ),
     );
   }
@@ -141,6 +161,7 @@ export class ArtifactShareService {
     await firstValueFrom(
       this.http.delete(
         `${this.artifactsUrl()}/shares/${encodeURIComponent(shareId)}`,
+        this.inlineErrors(),
       ),
     );
   }
@@ -154,6 +175,7 @@ export class ArtifactShareService {
     return firstValueFrom(
       this.http.get<SharedArtifact>(
         `${this.sharedUrl()}/${encodeURIComponent(shareId)}`,
+        this.inlineErrors(),
       ),
     );
   }
@@ -171,6 +193,7 @@ export class ArtifactShareService {
       this.http.post<RenderTokenResponseDto>(
         `${this.sharedUrl()}/${encodeURIComponent(shareId)}/render-token`,
         {},
+        this.inlineErrors(),
       ),
     );
     return { url: res.url, expiresAt: res.expires_at };
@@ -190,6 +213,7 @@ export class ArtifactShareService {
     const res = await firstValueFrom(
       this.http.get<ArtifactContentResponseDto>(
         `${this.sharedUrl()}/${encodeURIComponent(shareId)}/content`,
+        this.inlineErrors(),
       ),
     );
     return {


### PR DESCRIPTION
Two defects found while validating the shipped artifact-sharing PRs ([#919](https://github.com/Boise-State-Development/agentcore-public-stack/pull/919) / [#920](https://github.com/Boise-State-Development/agentcore-public-stack/pull/920) / [#922](https://github.com/Boise-State-Development/agentcore-public-stack/pull/922)) end-to-end against dev. Both are mine.

## 1. Duplicate error notice on a dead share link

Opening a revoked share showed the recipient page's "Artifact not found" **and** a global error toast repeating the raw backend detail:

> Not Found — Share not found

The error interceptor already exposes `SUPPRESS_ERROR_TOAST`, documented for precisely this case — *"used where a feature renders its own inline, actionable error UI"*. The share service simply wasn't setting it. Now applied to every call whose caller renders its own message: the recipient page's 403/404/500 screens and the share modal's error box.

Deliberately **not** applied to `listShares`. That one degrades silently by design — the dialog still opens and can create a link — so the toast is the only signal that the existing-links list is stale. There's a test pinning both halves of that decision.

## 2. Card overlap once the chat column narrows

With the artifact panel docked open the chat column roughly halves, and the card's two labelled buttons consumed the entire row: the title clipped to nothing and the metadata line painted *underneath* the buttons. Adding the Share button in #920 is what pushed it over.

My first fix was wrong and I want to flag it, because the measurement that "proved" it was invalid: I added `overflow: hidden` and re-measured with `getBoundingClientRect()`, which reports layout position and **ignores ancestor clipping** — so the numbers looked unchanged while the visual bug was actually gone. A screenshot showed what the numbers couldn't: the overlap had gone because the title and metadata had *both* disappeared. Removing the bug by removing the content is not a fix.

The actual cause is the actions consuming the width, so the fix reclaims it: a container query drops the button labels to icons below 26rem. A container query rather than a media query because the card is sized by the chat column, not the viewport — the panel docking open changes the card's width with the viewport unchanged.

The labels are *visually* hidden, never removed, so they stay in the accessible name (WCAG 2.5.3), and both buttons now carry `[appTooltip]` — which is what a sighted user gets in place of the text they can no longer see, per the icon-only rule in `CLAUDE.md`.

Verified by injecting the candidate rules into the live dev DOM and measuring: actions 110px → 86px, title 0px → 81px visible, no overlap, title ellipsised and metadata clipped cleanly.

| | before | after |
|---|---|---|
| actions width | 110px | 86px |
| title visible width | 0px | 81px |
| worst overlap | 90px | none |

## Verification

SPA suite **180 files / 2070 tests** green; `ng build` clean.

Everything else in the three merged PRs validated correctly against dev and needed no change — recipient page, code view through the new shared-content endpoint, download by share id, revocation, the sandbox attributes surviving the viewer extraction, and the owner panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
