### PR TITLE
feat(spa): minimal-chrome shell for the shared-artifact view

### DIFF
--- a/frontend/ai.client/src/app/app.html
+++ b/frontend/ai.client/src/app/app.html
@@ -1,5 +1,5 @@
 <!-- Mobile sidenav overlay -->
-@if (sidenavService.isVisible() && !sidenavService.isHidden()) {
+@if (sidenavService.isVisible() && !chromeHidden()) {
     <div class="relative z-50 lg:hidden" role="dialog" aria-modal="true">
       <!-- Backdrop -->
       <div
@@ -30,7 +30,7 @@
   }
 
   <!-- Static sidebar for desktop -->
-  @if (!sidenavService.isHidden()) {
+  @if (!chromeHidden()) {
     <div
       class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex size-auto transition-transform duration-300"
       [class.-translate-x-full]="sidenavService.isCollapsed()">
@@ -40,7 +40,7 @@
   }
 
   <!-- Desktop controls (when sidenav collapsed) -->
-  @if (sidenavService.isCollapsed() && !sidenavService.isHidden()) {
+  @if (sidenavService.isCollapsed() && !chromeHidden()) {
     <div class="hidden lg:flex fixed top-4 left-4 z-50 gap-2">
       <!-- Expand sidebar button -->
       <button
@@ -71,7 +71,7 @@
   }
 
   <!-- Mobile controls (when header content hidden and sidenav not visible) -->
-  @if (!headerService.showContent() && !sidenavService.isVisible() && !sidenavService.isHidden()) {
+  @if (!headerService.showContent() && !sidenavService.isVisible() && !chromeHidden()) {
     <div class="flex lg:hidden fixed top-4 left-4 z-50 gap-2">
       <!-- Open sidenav button -->
       <button
@@ -104,15 +104,24 @@
   <div
     class="transition-[padding] duration-300"
     [style.--artifact-pane-width]="artifactPaneWidthCss()"
-    [class.lg:pl-72]="!sidenavService.isCollapsed() && !sidenavService.isHidden()"
-    [class.lg:pl-0]="sidenavService.isCollapsed() || sidenavService.isHidden()"
+    [class.lg:pl-72]="!sidenavService.isCollapsed() && !chromeHidden()"
+    [class.lg:pl-0]="sidenavService.isCollapsed() || chromeHidden()"
     [class.artifact-pane-open]="artifactPanelOpen()">
     <main class="flex h-dvh flex-col">
       <!-- Scrollable Content. The id is a stable hook for code that reads
            or sets the scroll position (session scroll save/restore) — the
            window itself no longer scrolls now that this container is real. -->
       <div id="app-scroll-container" class="flex-1 overflow-y-auto">
-        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10">
+        <!-- A minimal-chrome route (e.g. a shared artifact) opts out of
+             the centred, padded content box so its own layout can fill
+             the shell edge to edge. -->
+        <div
+          [class]="
+            minimalChrome()
+              ? 'h-full'
+              : 'mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10'
+          "
+        >
           <router-outlet />
         </div>
       </div>

--- a/frontend/ai.client/src/app/app.routes.spec.ts
+++ b/frontend/ai.client/src/app/app.routes.spec.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
 import { provideRouter, Router, Routes } from '@angular/router';
 import { provideLocationMocks } from '@angular/common/testing';
 import { routes } from './app.routes';
+import { MINIMAL_CHROME } from './shared/utils/route-chrome';
 
 /**
  * Assistant deprecation (Designer Phase 5, #746).
@@ -81,5 +82,24 @@ describe('app routes — assistant deprecation redirects', () => {
 
     await router.navigateByUrl('/agents/ast-001');
     expect(router.url).toBe('/agents/ast-001');
+  });
+});
+
+describe('app routes — shell chrome', () => {
+  it('asks for a minimal shell on the shared-artifact route', () => {
+    const route = routes.find(r => r.path === 'shared-artifact/:shareId');
+    expect(route).toBeDefined();
+    // A recipient followed a link to view one thing; the shell reads
+    // this to drop the sidenav and the centred content box.
+    expect(route!.data?.['chrome']).toBe(MINIMAL_CHROME);
+  });
+
+  it('leaves every other route on the full shell', () => {
+    // Opt-in by design: the flag strips app navigation, so it should
+    // never spread by accident.
+    const minimal = routes
+      .filter(r => r.data?.['chrome'] === MINIMAL_CHROME)
+      .map(r => r.path);
+    expect(minimal).toEqual(['shared-artifact/:shareId']);
   });
 });

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -36,6 +36,10 @@ export const routes: Routes = [
                 m => m.SharedArtifactViewPage,
             ),
         canActivate: [authGuard],
+        // A recipient opened a link to view one thing. Drop the sidenav
+        // and the centred content box so the artifact fills the shell —
+        // the app reads this in `app.html`.
+        data: { chrome: 'minimal' },
     },
     {
         path: 'auth/login',

--- a/frontend/ai.client/src/app/app.ts
+++ b/frontend/ai.client/src/app/app.ts
@@ -1,5 +1,7 @@
 import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
-import { Router, RouterOutlet } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { Sidenav } from './components/sidenav/sidenav';
 import { ErrorToastComponent } from './components/error-toast/error-toast.component';
 import { ToastComponent } from './components/toast';
@@ -10,6 +12,7 @@ import { TooltipDirective } from './components/tooltip/tooltip.directive';
 import { SessionService } from './auth/session.service';
 import { SessionService as SessionListService } from './session/services/session/session.service';
 import { ArtifactStateService } from './session/services/artifacts/artifact-state.service';
+import { isMinimalChromeRoute } from './shared/utils/route-chrome';
 
 @Component({
   selector: 'app-root',
@@ -32,6 +35,38 @@ export class App {
   private session = inject(SessionService);
   private sessionList = inject(SessionListService);
   private artifactState = inject(ArtifactStateService);
+
+  /** Re-read on every completed navigation; the value itself is unused,
+   *  it exists so `minimalChrome` recomputes when the route changes. */
+  private readonly navigated = toSignal(
+    this.router.events.pipe(filter((e) => e instanceof NavigationEnd)),
+    { initialValue: null },
+  );
+
+  /**
+   * True when the active route asks for a stripped shell via
+   * `data: { chrome: 'minimal' }`.
+   *
+   * Declarative on purpose. The older way to do this is an imperative
+   * `sidenavService.hide()` in `ngOnInit` paired with `show()` in
+   * `ngOnDestroy` (login, first-boot, not-found, agent-form all do it),
+   * but that leaves the chrome hidden app-wide if the restore is ever
+   * missed. Deriving it from the route means there is nothing to
+   * restore: navigate away and the shell comes back on its own.
+   */
+  protected readonly minimalChrome = computed(() => {
+    this.navigated();
+    return isMinimalChromeRoute(this.router.routerState.snapshot.root);
+  });
+
+  /**
+   * Whether the sidenav and its floating controls are suppressed —
+   * either because a page hid them imperatively or because the active
+   * route asked for a minimal shell.
+   */
+  protected readonly chromeHidden = computed(
+    () => this.sidenavService.isHidden() || this.minimalChrome(),
+  );
 
   /** True while an artifact pane is docked — content reserves right-side
    *  space for it (desktop only) so the fixed panel doesn't occlude chat. */

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.spec.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { SharedArtifactViewPage } from './shared-artifact-view.page';
 import {
@@ -41,6 +41,9 @@ describe('SharedArtifactViewPage', () => {
     TestBed.configureTestingModule({
       imports: [SharedArtifactViewPage],
       providers: [
+        // The banner's home link is a real routerLink, so the template
+        // needs a router — a bare Router mock breaks rendering.
+        provideRouter([]),
         // DI token overrides, not vi.mock — module mocks leak across specs.
         { provide: ArtifactShareService, useValue: shares },
         { provide: ArtifactDownloadService, useValue: download },
@@ -294,5 +297,14 @@ describe('SharedArtifactViewPage', () => {
       (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
     ).map((b) => b.getAttribute('aria-label') ?? '');
     expect(labels.some((l) => /download/i.test(l))).toBe(false);
+  });
+
+  it('offers a way back into the app', async () => {
+    await init();
+    // The route strips the shell chrome, so there is no sidenav to
+    // navigate from — without this a recipient is stranded on the page.
+    const home = (fixture.nativeElement as HTMLElement).querySelector('a[href="/"]');
+    expect(home).not.toBeNull();
+    expect(home!.textContent).toContain('boisestate.ai');
   });
 });

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-view.page.ts
@@ -6,7 +6,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
@@ -50,7 +50,13 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
 @Component({
   selector: 'app-shared-artifact-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, DatePipe, ArtifactViewerComponent, TooltipDirective],
+  imports: [
+    NgIcon,
+    DatePipe,
+    RouterLink,
+    ArtifactViewerComponent,
+    TooltipDirective,
+  ],
   providers: [
     provideIcons({
       heroLockClosed,
@@ -64,14 +70,23 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
     }),
   ],
   template: `
-    <div class="flex h-dvh flex-col bg-white dark:bg-gray-900">
+    <div class="flex h-full min-h-0 flex-col bg-white dark:bg-gray-900">
       <!-- Read-only banner: the same promise the shared-conversation
            page makes, so the two recipient surfaces read alike. -->
       <div
         class="border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95"
       >
-        <div class="mx-auto flex max-w-4xl items-center justify-center px-4 py-3">
-          <div class="flex items-center gap-2">
+        <div class="flex items-center gap-3 px-4 py-3">
+          <!-- With the shell chrome stripped there is no sidenav to
+               navigate from, so this is the recipient's only way into
+               the app. Deliberately understated — one link, not a nav. -->
+          <a
+            routerLink="/"
+            class="shrink-0 rounded-md px-2 py-1 text-xs font-semibold text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          >
+            boisestate.ai
+          </a>
+          <div class="flex flex-1 items-center justify-center gap-2">
             <ng-icon
               name="heroLockClosed"
               class="size-4 text-gray-400"
@@ -87,6 +102,9 @@ import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
               </span>
             }
           </div>
+          <!-- Balances the link so the banner text stays optically
+               centred; width tracks the link via the same font metrics. -->
+          <span class="w-[6.5rem] shrink-0" aria-hidden="true"></span>
         </div>
       </div>
 

--- a/frontend/ai.client/src/app/shared/utils/route-chrome.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/route-chrome.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import type { ActivatedRouteSnapshot } from '@angular/router';
+import { isMinimalChromeRoute, MINIMAL_CHROME } from './route-chrome';
+
+/** Minimal stand-in for the bits of the snapshot the walk touches. */
+function node(
+  data: Record<string, unknown>,
+  firstChild: unknown = null,
+): ActivatedRouteSnapshot {
+  return { data, firstChild } as unknown as ActivatedRouteSnapshot;
+}
+
+describe('isMinimalChromeRoute', () => {
+  it('reads the flag off the deepest route, not the root', () => {
+    // The shell reads from the router's ROOT snapshot, but `data` is
+    // declared on the route that owns the page. Stopping at the root
+    // would never see it — this is the whole reason for the walk.
+    const tree = node({}, node({}, node({ chrome: MINIMAL_CHROME })));
+    expect(isMinimalChromeRoute(tree)).toBe(true);
+  });
+
+  it('is false when no route in the chain asks for it', () => {
+    expect(isMinimalChromeRoute(node({}, node({}, node({}))))).toBe(false);
+  });
+
+  it('ignores a flag on an ancestor whose leaf does not ask for it', () => {
+    // Angular inherits `data` downward, so a leaf that wants full chrome
+    // would still report the ancestor's value if we read the wrong node.
+    // Reading the leaf is what makes the flag opt-in per page.
+    const tree = node({ chrome: MINIMAL_CHROME }, node({ chrome: 'full' }));
+    expect(isMinimalChromeRoute(tree)).toBe(false);
+  });
+
+  it('handles a single-node tree', () => {
+    expect(isMinimalChromeRoute(node({ chrome: MINIMAL_CHROME }))).toBe(true);
+  });
+
+  it('is false for a null or undefined root', () => {
+    // The shell computes this before the first navigation resolves.
+    expect(isMinimalChromeRoute(null)).toBe(false);
+    expect(isMinimalChromeRoute(undefined)).toBe(false);
+  });
+
+  it('is false for an unrecognized chrome value', () => {
+    expect(isMinimalChromeRoute(node({ chrome: 'nope' }))).toBe(false);
+  });
+
+  it('tolerates a route with no data at all', () => {
+    const bare = { firstChild: null } as unknown as ActivatedRouteSnapshot;
+    expect(isMinimalChromeRoute(bare)).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/shared/utils/route-chrome.ts
+++ b/frontend/ai.client/src/app/shared/utils/route-chrome.ts
@@ -1,0 +1,32 @@
+import type { ActivatedRouteSnapshot } from '@angular/router';
+
+/**
+ * Route `data` flag a page sets to ask the app shell for a stripped
+ * layout: no sidenav, no centred/padded content box.
+ *
+ * Used by a page that is the whole point of the visit rather than one
+ * view inside the app — a shared artifact opened from a link, say.
+ */
+export const MINIMAL_CHROME = 'minimal';
+
+/**
+ * Whether the *deepest* activated route asks for minimal chrome.
+ *
+ * The walk to the leaf matters: `data` is declared on the route that
+ * owns the page, and the shell reads it from the router's root
+ * snapshot, so stopping at the root would never see it. Angular does
+ * inherit `data` down to children, but not *up* — a parent cannot tell
+ * you what its child asked for.
+ *
+ * Split out of the shell component so the traversal is testable without
+ * mounting the whole app (see the note in `app.spec.ts` about why that
+ * spec avoids static Angular imports).
+ */
+export function isMinimalChromeRoute(
+  root: ActivatedRouteSnapshot | null | undefined,
+): boolean {
+  let route = root;
+  if (!route) return false;
+  while (route.firstChild) route = route.firstChild;
+  return route.data?.['chrome'] === MINIMAL_CHROME;
+}


### PR DESCRIPTION
Options 1 + 2 from the chrome discussion, as its own PR. Independent of [#927](https://github.com/Boise-State-Development/agentcore-public-stack/pull/927) — no overlapping files, either order merges fine.

## The problem

A recipient opening a share link is there to look at one artifact, but got the full app shell around it: the sidenav — listing *their own* conversations, which have nothing to do with what they were sent — plus the centred, padded `max-w-7xl` box every route sits in. The artifact rendered in a small window next to an irrelevant chat list.

## The change

An opt-in route flag the shell reads:

```ts
{ path: 'shared-artifact/:shareId', …, data: { chrome: 'minimal' } }
```

`app.html` drops the sidenav (and its floating controls) and swaps the padded content box for `h-full`, so the page fills the shell edge to edge. Only this one route sets it, and a test asserts no other route does — the flag removes app navigation, so it shouldn't spread by accident.

**Declarative, not the existing imperative idiom.** Login, first-boot, not-found and agent-form all call `sidenavService.hide()` in `ngOnInit` and `show()` in `ngOnDestroy`. Deriving the shell from the active route instead means there's nothing to restore — navigate away and the chrome returns on its own, where a missed `show()` leaves the *whole app* without a sidenav.

The route walk lives in `shared/utils/route-chrome.ts` rather than inline in the component, so it's testable without mounting the shell (`app.spec.ts` deliberately avoids static Angular imports to preserve the JIT/PlatformLocation guard, so a TestBed test of `App` isn't an option there). Walking to the leaf is the part worth testing: `data` is declared on the page's own route but read from the router's *root* snapshot, and Angular inherits data downward — so reading the wrong node silently inverts the result. That case has a test.

## One addition beyond what you asked for

A single understated `boisestate.ai` link in the banner. With the chrome gone there's otherwise no navigation whatsoever and a recipient is stranded — URL editing is the only way out. It's one link, not a nav bar, but say the word and I'll drop it.

## Verification

Verified in a real browser rather than by assertion alone: with the flag applied, an in-flow probe element injected into the routed outlet renders at `left: 0` spanning the full viewport width, with the wrapper's sidenav gutter computing to `0px`.

Worth recording how I nearly got this wrong: I first checked it against the first-boot page, which *looked* perfectly full-bleed — but that page is `fixed`-positioned and escapes the content wrapper entirely, so it would have looked identical with the change reverted. It proved nothing. The recipient page is in-flow, which is why the in-flow probe is the measurement that actually settles it.

I also confirmed separately, while a local app-api was up, that all eight artifact routes mount in `main.py` — including the three `/shared-artifacts/*` ones. That closes a gap I'd flagged earlier: the unit tests build a bare FastAPI app and so never exercised the real mounting under the `ARTIFACTS_RENDER_TOKEN_SECRET_ARN` guard.

SPA suite: **183 files, 2124 tests** green. `ng build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
