### PR TITLE
fix(spa): two mid-turn steering defects found validating #921

### DIFF
--- a/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.spec.ts
@@ -237,6 +237,66 @@ describe('MessageMapService', () => {
     expect(bMessages[1].content).toEqual([{ type: 'text', text: 'answer B' }]);
   });
 
+  it('renders a mid-turn steer exactly once across many sync ticks', () => {
+    // Regression, caught live in dev: a steer rendered ~36 times.
+    //
+    // `syncStreamingMessages` truncates the map back to the last user message
+    // and appends the stream's messages. A mid-turn steer IS a user message,
+    // so once it lands in the map it became the truncation point — moving that
+    // point forward past itself, so the stream's copy (which the parser keeps
+    // emitting every tick) was appended again on every subsequent tick.
+    //
+    // Each parse below drives one sync tick, which is what makes this able to
+    // fail: with one event it looked fine.
+    const parser = TestBed.inject(StreamParserService);
+
+    // Each event is followed by TestBed.tick(), which runs the parser->map sync
+    // effect. That is what makes this test able to fail at all: the duplication
+    // is one extra copy per SYNC, so a version that only syncs once at
+    // endStreaming looks perfectly healthy.
+    const send = (event: string, data: unknown) => {
+      parser.parseEventSourceMessage('steer-1', event, data);
+      TestBed.tick();
+    };
+
+    service.addUserMessage('steer-1', 'do a long thing');
+    service.startStreaming('steer-1');
+
+    send('message_start', { role: 'assistant' });
+    send('content_block_delta', { contentBlockIndex: 0, text: 'working' });
+    // The tool-calling message stays active on a tool_use stop reason, which is
+    // the state a steer actually lands in.
+    send('message_stop', { stopReason: 'tool_use' });
+    send('steering_applied', {
+      type: 'steering_applied',
+      sessionId: 'steer-1',
+      entryId: 'entry-1',
+      text: 'actually stop after two',
+    });
+
+    // Keep the stream going: every one of these is another chance to duplicate.
+    send('message_start', { role: 'assistant' });
+    for (const text of [' more', ' and', ' more', ' still']) {
+      send('content_block_delta', { contentBlockIndex: 0, text });
+    }
+    send('message_stop', { stopReason: 'end_turn' });
+    service.endStreaming('steer-1');
+
+    const messages = service.getMessagesForSession('steer-1')();
+    const steers = messages.filter(m => m.steering);
+    expect(steers).toHaveLength(1);
+    expect(steers[0].content).toEqual([{ type: 'text', text: 'actually stop after two' }]);
+
+    // And it stays in place: after the assistant turn it interrupted, before
+    // the one that follows.
+    expect(messages.map(m => (m.steering ? 'steer' : m.role))).toEqual([
+      'user',
+      'assistant',
+      'steer',
+      'assistant',
+    ]);
+  });
+
   it('endStreaming for one session leaves another session streaming', () => {
     service.startStreaming('conc-c');
     service.startStreaming('conc-d');

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -298,10 +298,20 @@ export class MessageMapService {
         return [...continuationPrefix, ...streamMessages];
       }
 
-      // Find the index of the last user message
+      // Find the index of the last TURN-STARTING user message.
+      //
+      // A mid-turn steer is a user message that does not start a turn — it is
+      // part of the response already streaming, and the parser is still
+      // emitting it in `streamMessages` every tick. Treating it as the
+      // truncation point moves that point forward past itself, so the stream's
+      // copy is appended again on the next tick, and the next, and the next:
+      // one bubble per sync tick (observed live in dev as ~36 copies of one
+      // follow-up). Skipping it keeps the truncation anchored on the user
+      // message that actually opened the turn, which is what makes repeated
+      // syncs idempotent. Same predicate turn grouping uses.
       let lastUserMessageIndex = -1;
       for (let i = existingMessages.length - 1; i >= 0; i--) {
-        if (existingMessages[i].role === 'user') {
+        if (existingMessages[i].role === 'user' && !existingMessages[i].steering) {
           lastUserMessageIndex = i;
           break;
         }


### PR DESCRIPTION
Two defects in mid-turn steering (#921), both found by exercising it against dev rather than by reading it. Neither is caught by the tests that shipped with #921.

---

## 1. A steer rendered ~36 times in the live thread

`syncStreamingMessages` truncates the map back to the last user message and appends the stream's messages — that truncation is what makes repeated syncs idempotent. A mid-turn steer is a user message that does **not** start a turn, and the parser keeps emitting it in `allMessages` on every tick, so once it landed in the map it *became* the truncation point — moving that point past itself and re-appending its own copy on the next tick, and the next. One extra bubble per sync.

Persisted history was always correct — one injection, one message, and a reload showed exactly one bubble. So it was invisible except by counting bubbles live.

**Fix:** anchor the truncation on the last turn-*starting* user message. Same `!steering` predicate turn grouping already uses, and for the same reason.

**The test needs `TestBed.tick()` between events** so the parser→map sync effect runs per tick. Without that it reproduces nothing — the bug is one copy per *sync*, and a version that only syncs once at `endStreaming` looks perfectly healthy. My first attempt at this test passed against the broken code. Verified to fail with the fix reverted: `expected [ … ] to have a length of 1 but got 8`.

---

## 2. PR-6's hold was unreachable — a follow-up typed while paused sent a new turn

Reproduced on dev with a genuine tool-approval interrupt (`sk_hello_approval`, whose `say_hello` is flagged `needsApproval` — a real Strands pause, no credentials needed). With the approval prompt on screen, typing a follow-up and pressing Enter **sent it as a brand-new turn**, abandoning the paused turn — while the placeholder promised "it goes in when you answer above".

`onSubmit` queued only when `isLoading()` was true. **A pause closes the stream, so loading is already false** while the prompt sits there waiting: Enter took the `submitChatRequest` branch and nothing ever entered the queue. PR-6's hold only gated the *flush* of an already-queued entry, so on the one path it was built for, it never ran.

**Fix:** queue when the queue is held as well as when a turn is streaming, and route the Send button through the same decision so the two affordances cannot disagree. An entry queued while paused is also not armed against `/steer` — the paused turn released its lease when its stream closed, so there is no inbox to arm; it rides the resume request, which is what PR-6 built.

**Why #921's tests missed it:** they queued *while streaming* and then paused. A real user types *after* the pause. The new tests do it in that order and fail against the old condition.

---

## Verified working on dev (unchanged by this PR)

- `POST /sessions/{id}/steer` → 200 armed; conditional placeholder flips to "it goes in at the next step" once the turn calls a tool; injection lands at the next boundary; the ack drops the queued entry with no duplicate send; reload renders it unwrapped and captioned, inside the turn it interrupted.
- The end-of-turn fallback fires correctly when the turn ends before a boundary.
- **Risk 2 (model compliance) is answered.** A mid-turn "Stop generating diagrams right now. Do not call any more tools. Just reply with the single word DONE." landed at a tool boundary partway through an eight-diagram run; the agent stopped and replied `DONE.`

## Still to verify after this deploys

The PR-6 carry-through itself — resume request carries `steering`, backend seeds it onto the resumed turn's lease, hook injects at the first boundary. It could not be reached on dev because fix #2 blocked entry to the queue, and could not be reached locally because the SPA's auth guard needs a real BFF cookie (the localhost OAuth callback isn't registered). I'll re-run it against dev once this is deployed.

Tests: **2132 passing**, both fixes with negative controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
