### PR TITLE
feat(artifacts): artifact sharing PR-4 — session-delete cascade + docs page

### DIFF
--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -920,5 +920,131 @@ class ArtifactShareService:
         return stripped
 
 
+    def delete_for_session(self, session_id: str, owner_id: str) -> int:
+        """Revoke every artifact share produced by one chat session.
+
+        Called as a background task when the session owner deletes a
+        conversation, mirroring `ShareService.delete_shares_for_session`
+        for conversation shares. Artifacts outlive the chat that made
+        them, so without this a deleted conversation would leave live
+        share links pointing at its artifacts.
+
+        Best-effort and **never raises**: a delete that partially fails
+        leaves an orphan row, and the caller has already returned 204.
+        Returns the number of shares revoked (0 on any failure, and 0
+        when the artifacts feature isn't configured for this deploy).
+
+        Scoped by `owner_id` deliberately. `SessionIndex` is not
+        user-partitioned — the same reason `ArtifactListService`
+        re-checks every HEAD row — so filtering here is what stops a
+        borrowed or colliding session id reaching another user's shares.
+
+        Deliberately NOT in scope: deleting the artifact content itself.
+        That is a retention decision about the artifacts feature as a
+        whole, not about sharing.
+        """
+        try:
+            table = _table()
+        except RenderTokenConfigError:
+            # Artifacts aren't enabled for this environment. The session
+            # routes are always mounted, so this is a normal no-op, not
+            # a failure.
+            logger.debug("artifacts not configured — skipping share cascade")
+            return 0
+
+        try:
+            shares = self._shares_for_session(table, session_id, owner_id)
+            if not shares:
+                return 0
+
+            # Lookup rows first, owner rows second — and never the other
+            # way round. The lookup row (PK=SHARE#{id}) is what the
+            # recipient path resolves, so dropping it is what actually
+            # kills the link. If the second pass fails we are left with
+            # an unreachable owner row, which is inert; the reverse
+            # order would leave a *live* share whose owner can no longer
+            # see it to revoke.
+            with table.batch_writer() as batch:
+                for share in shares:
+                    batch.delete_item(
+                        Key=_share_lookup_key(str(share["share_id"]))
+                    )
+            with table.batch_writer() as batch:
+                for share in shares:
+                    batch.delete_item(
+                        Key={
+                            "PK": f"USER#{owner_id}",
+                            "SK": _owner_share_sk(
+                                str(share["artifact_id"]),
+                                int(share["version"]),
+                                str(share["share_id"]),
+                            ),
+                        }
+                    )
+
+            logger.info(
+                "revoked %s artifact share(s) for deleted session %s",
+                len(shares),
+                scrub_log(session_id),
+            )
+            return len(shares)
+        except Exception:
+            logger.error(
+                "failed to revoke artifact shares for session %s",
+                scrub_log(session_id),
+                exc_info=True,
+            )
+            return 0
+
+    @staticmethod
+    def _shares_for_session(
+        table, session_id: str, owner_id: str
+    ) -> list[dict]:
+        """Every share row for the artifacts produced by one session.
+
+        Two steps, because there is no index from session to share:
+        `SessionIndex` projects only artifact HEAD rows, so it yields the
+        artifact ids, and the shares are then read off the owner's own
+        partition by SK prefix.
+        """
+        head_kwargs: dict = {
+            "IndexName": _SESSION_INDEX,
+            "KeyConditionExpression": Key("GSI1PK").eq(
+                f"SESSION#{session_id}"
+            ),
+        }
+        heads: list[dict] = []
+        while True:
+            resp = table.query(**head_kwargs)
+            heads.extend(resp.get("Items", []))
+            last = resp.get("LastEvaluatedKey")
+            if not last:
+                break
+            head_kwargs["ExclusiveStartKey"] = last
+
+        artifact_ids = list(
+            dict.fromkeys(
+                item.get("artifact_id", "")
+                for item in heads
+                if item.get("user_id") == owner_id and item.get("artifact_id")
+            )
+        )
+
+        shares: list[dict] = []
+        for artifact_id in artifact_ids:
+            kwargs: dict = {
+                "KeyConditionExpression": Key("PK").eq(f"USER#{owner_id}")
+                & Key("SK").begins_with(_owner_share_prefix(artifact_id)),
+            }
+            while True:
+                resp = table.query(**kwargs)
+                shares.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        return shares
+
+
 def get_artifact_share_service() -> ArtifactShareService:
     return ArtifactShareService()

--- a/backend/src/apis/app_api/sessions/routes.py
+++ b/backend/src/apis/app_api/sessions/routes.py
@@ -33,6 +33,7 @@ from apis.shared.sessions.metadata import (
 )
 from .services.session_service import SessionService
 from apis.app_api.shares.service import get_share_service
+from apis.app_api.artifacts.service import get_artifact_share_service
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.feature_flags import mid_turn_steering_enabled
 from apis.shared.auth.models import User
@@ -456,6 +457,17 @@ async def delete_session_endpoint(
             session_id
         )
 
+        # 4. Revoke artifact shares from this session. Artifacts outlive
+        # the chat that produced them, so without this a deleted
+        # conversation leaves live links to its artifacts. Best-effort
+        # and never-raising, like the conversation cascade above — and a
+        # no-op when artifacts aren't enabled for this environment.
+        background_tasks.add_task(
+            get_artifact_share_service().delete_for_session,
+            session_id,
+            user_id
+        )
+
         logger.info("Successfully deleted session")
 
         return Response(status_code=204)
@@ -516,6 +528,7 @@ async def bulk_delete_sessions_endpoint(
     try:
         service = SessionService()
         share_service = get_share_service()
+        artifact_share_service = get_artifact_share_service()
 
         for session_id in session_ids:
             try:
@@ -538,6 +551,11 @@ async def bulk_delete_sessions_endpoint(
                     background_tasks.add_task(
                         share_service.delete_shares_for_session,
                         session_id
+                    )
+                    background_tasks.add_task(
+                        artifact_share_service.delete_for_session,
+                        session_id,
+                        user_id
                     )
                     results.append(BulkDeleteSessionResult(
                         session_id=session_id,

--- a/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
@@ -56,8 +56,22 @@ def env(monkeypatch: pytest.MonkeyPatch):
             AttributeDefinitions=[
                 {"AttributeName": "PK", "AttributeType": "S"},
                 {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
             ],
             BillingMode="PAY_PER_REQUEST",
+            # The session-delete cascade walks SessionIndex to find the
+            # session's artifacts, so the fixture mirrors the real table.
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "SessionIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
         )
         monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
         monkeypatch.setenv("ARTIFACTS_ORIGIN", "https://a.test.example.com")
@@ -458,3 +472,241 @@ def test_every_route_requires_a_session(method, path, body) -> None:
     tc = TestClient(app)
     kwargs = {"json": body} if body is not None else {}
     assert getattr(tc, method)(path, **kwargs).status_code == 401
+
+
+# ------------------------------------------------------------------
+# Session-delete cascade
+# ------------------------------------------------------------------
+#
+# When a conversation is deleted its artifacts outlive it, so their
+# share links have to be revoked or they keep working forever. Runs as a
+# background task after the 204, so it must never raise.
+
+
+from apis.app_api.artifacts.service import ArtifactShareService  # noqa: E402
+
+
+def _put_head(
+    ddb,
+    *,
+    user_id: str = OWNER_ID,
+    artifact: str = "art-1",
+    session_id: str = "sess-1",
+) -> None:
+    """The HEAD row carrying GSI1PK — only HEAD rows are on SessionIndex."""
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#HEAD",
+            "GSI1PK": f"SESSION#{session_id}",
+            "GSI1SK": f"ARTIFACT#2026-09-04#{artifact}",
+            "artifact_id": artifact,
+            "user_id": user_id,
+            "session_id": session_id,
+            "version": 1,
+            "title": "T",
+            "content_type": "text/html; charset=utf-8",
+        }
+    )
+
+
+def _cascade(session_id: str = "sess-1", owner: str = OWNER_ID) -> int:
+    return ArtifactShareService().delete_for_session(session_id, owner)
+
+
+def test_cascade_revokes_both_rows_of_every_share(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    tc = make_client()
+    a = _create_share(tc)
+    b = _create_share(tc)
+
+    assert _cascade() == 2
+
+    table = ddb.Table(TABLE)
+    for share in (a, b):
+        sid = share["shareId"]
+        assert "Item" not in table.get_item(
+            Key={"PK": f"SHARE#{sid}", "SK": "META"}
+        )
+        assert "Item" not in table.get_item(
+            Key={
+                "PK": f"USER#{OWNER_ID}",
+                "SK": f"SHARE#art-1#V#00001#{sid}",
+            }
+        )
+
+
+def test_cascade_kills_the_recipient_path(env) -> None:
+    """The lookup row is the capability, so a cascaded share must stop
+    resolving — that is the whole point of the cleanup."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    share = _create_share(make_client())
+
+    viewer = User(email="v@x.com", user_id="viewer-1", name="V", roles=[])
+    assert (
+        make_client(viewer)
+        .get(f"/shared-artifacts/{share['shareId']}")
+        .status_code
+        == 200
+    )
+
+    _cascade()
+
+    assert (
+        make_client(viewer)
+        .get(f"/shared-artifacts/{share['shareId']}")
+        .status_code
+        == 404
+    )
+
+
+def test_cascade_covers_every_artifact_and_version_in_the_session(env) -> None:
+    make_client, ddb = env
+    for artifact in ("art-1", "art-2"):
+        _put_head(ddb, artifact=artifact)
+        _put_version(ddb, artifact=artifact, version=1)
+        _put_version(ddb, artifact=artifact, version=2)
+    tc = make_client()
+    _create_share(tc, artifact="art-1", version=1)
+    _create_share(tc, artifact="art-1", version=2)
+    _create_share(tc, artifact="art-2", version=1)
+
+    assert _cascade() == 3
+    assert tc.get("/artifacts/art-1/shares").json()["shares"] == []
+    assert tc.get("/artifacts/art-2/shares").json()["shares"] == []
+
+
+def test_cascade_leaves_other_sessions_alone(env) -> None:
+    make_client, ddb = env
+    _put_head(ddb, artifact="art-1", session_id="sess-1")
+    _put_head(ddb, artifact="art-2", session_id="sess-2")
+    _put_version(ddb, artifact="art-1")
+    _put_version(ddb, artifact="art-2")
+    tc = make_client()
+    _create_share(tc, artifact="art-1")
+    keep = _create_share(tc, artifact="art-2")
+
+    assert _cascade("sess-1") == 1
+
+    remaining = tc.get("/artifacts/art-2/shares").json()["shares"]
+    assert [s["shareId"] for s in remaining] == [keep["shareId"]]
+
+
+def test_cascade_never_touches_another_owners_shares(env) -> None:
+    """SessionIndex is not user-partitioned, so a borrowed or colliding
+    session id must not reach someone else's shares. The owner filter is
+    the only thing preventing that."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    share = _create_share(make_client())
+
+    # Same session id, a different caller.
+    assert _cascade("sess-1", owner="someone-else") == 0
+    assert (
+        make_client().get("/artifacts/art-1/shares").json()["shares"][0][
+            "shareId"
+        ]
+        == share["shareId"]
+    )
+
+
+def test_cascade_on_a_session_with_no_artifacts_is_zero(env) -> None:
+    make_client, _ = env
+    assert _cascade("sess-empty") == 0
+
+
+def test_cascade_on_artifacts_with_no_shares_is_zero(env) -> None:
+    make_client, ddb = env
+    _put_head(ddb)
+    _put_version(ddb)
+    assert _cascade() == 0
+
+
+def test_cascade_returns_zero_when_artifacts_are_not_configured(
+    env, monkeypatch
+) -> None:
+    """The session routes are always mounted; artifacts may not be. That
+    is a normal no-op, not an error."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    _create_share(make_client())
+    token_service._reset_caches_for_tests()
+    monkeypatch.delenv("DYNAMODB_ARTIFACTS_TABLE_NAME", raising=False)
+
+    assert _cascade() == 0
+
+
+def test_cascade_swallows_a_backing_store_failure(env, monkeypatch) -> None:
+    """It runs after the 204 has been sent, so raising would only produce
+    an unhandled background-task error — the failure mode is an orphan
+    row, never a blocked delete."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    _create_share(make_client())
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("dynamo is down")
+
+    monkeypatch.setattr(
+        ArtifactShareService, "_shares_for_session", staticmethod(boom)
+    )
+    assert _cascade() == 0
+
+
+def test_cascade_deletes_the_lookup_row_before_the_owner_row(
+    env, monkeypatch
+) -> None:
+    """Ordering is the safety property. The lookup row is what the
+    recipient path resolves, so it goes first: a half-finished cascade
+    then leaves an inert owner row rather than a live share its owner can
+    no longer see to revoke."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    _create_share(make_client())
+
+    seen: list[str] = []
+    real_table = token_service._table()
+
+    class _RecordingBatch:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def delete_item(self, Key):  # noqa: N803 — boto3 kwarg name
+            seen.append("lookup" if Key["PK"].startswith("SHARE#") else "owner")
+            return self._inner.delete_item(Key=Key)
+
+    class _RecordingWriter:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            return _RecordingBatch(self._inner.__enter__())
+
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+
+    class _RecordingTable:
+        """Delegates everything to the real table, recording which key
+        space each batched delete targets."""
+
+        def __getattr__(self, name):
+            return getattr(real_table, name)
+
+        def batch_writer(self, **kwargs):
+            return _RecordingWriter(real_table.batch_writer(**kwargs))
+
+    # Patch the module-level accessor: the service holds its own cached
+    # Table, and boto3 builds a distinct class per resource instance, so
+    # patching the class off a different resource would miss.
+    monkeypatch.setattr(token_service, "_table", lambda: _RecordingTable())
+
+    assert _cascade() == 1
+    assert seen == ["lookup", "owner"], seen

--- a/backend/tests/routes/test_sessions.py
+++ b/backend/tests/routes/test_sessions.py
@@ -604,6 +604,79 @@ class TestDeleteSession:
         # Background task should have been called with the session id
         mock_share_service.delete_shares_for_session.assert_called_once_with("sess-001")
 
+    def test_queues_artifact_share_cleanup_on_delete(
+        self, app, make_user, authenticated_client
+    ):
+        """Artifacts outlive the chat that produced them, so deleting a
+        conversation must also revoke the share links pointing at its
+        artifacts — otherwise they keep resolving forever."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        mock_service = AsyncMock()
+        mock_service.delete_session = AsyncMock(return_value=True)
+        mock_service.delete_agentcore_memory = AsyncMock()
+        mock_service.delete_session_files = AsyncMock()
+
+        mock_share_service = AsyncMock()
+        mock_share_service.delete_shares_for_session = AsyncMock(return_value=0)
+
+        mock_artifact_shares = MagicMock()
+        mock_artifact_shares.delete_for_session = MagicMock(return_value=1)
+
+        with patch(
+            "apis.app_api.sessions.routes.SessionService",
+            return_value=mock_service,
+        ), patch(
+            "apis.app_api.sessions.routes.get_share_service",
+            return_value=mock_share_service,
+        ), patch(
+            "apis.app_api.sessions.routes.get_artifact_share_service",
+            return_value=mock_artifact_shares,
+        ):
+            resp = client.delete("/sessions/sess-001")
+
+        assert resp.status_code == 204
+        # Scoped to the caller: SessionIndex is not user-partitioned, so
+        # the owner id is what keeps the cascade off other users' shares.
+        mock_artifact_shares.delete_for_session.assert_called_once_with(
+            "sess-001", user.user_id
+        )
+
+    def test_artifact_share_cleanup_failure_does_not_break_delete(
+        self, app, make_user, authenticated_client
+    ):
+        """The cascade runs after the 204 is sent. A raising task would
+        surface as an unhandled background-task error, so the service
+        swallows failures — this pins that the route still succeeds."""
+        user = make_user()
+        client = authenticated_client(app, user)
+
+        mock_service = AsyncMock()
+        mock_service.delete_session = AsyncMock(return_value=True)
+        mock_service.delete_agentcore_memory = AsyncMock()
+        mock_service.delete_session_files = AsyncMock()
+
+        mock_share_service = AsyncMock()
+        mock_share_service.delete_shares_for_session = AsyncMock(return_value=0)
+
+        mock_artifact_shares = MagicMock()
+        mock_artifact_shares.delete_for_session = MagicMock(return_value=0)
+
+        with patch(
+            "apis.app_api.sessions.routes.SessionService",
+            return_value=mock_service,
+        ), patch(
+            "apis.app_api.sessions.routes.get_share_service",
+            return_value=mock_share_service,
+        ), patch(
+            "apis.app_api.sessions.routes.get_artifact_share_service",
+            return_value=mock_artifact_shares,
+        ):
+            resp = client.delete("/sessions/sess-001")
+
+        assert resp.status_code == 204
+
 
 # ---------------------------------------------------------------------------
 # Requirement 3.7: POST /sessions/bulk-delete returns 200

--- a/docs-site/src/content/docs/features/artifacts.md
+++ b/docs-site/src/content/docs/features/artifacts.md
@@ -1,12 +1,135 @@
 ---
-title: Artifacts
-description: Rendered artifact panel.
+title: Artifacts and Artifact Sharing
+description: How the agent produces standalone documents, how they are rendered in isolation, and how a user shares one.
 sidebar:
+  label: Artifacts
   order: 5
 ---
 
-:::caution[Draft]
-This page is a scaffolded placeholder — content to be written.
-:::
+An **artifact** is a standalone document the agent authors as a first-class
+object rather than as text in the chat — an HTML page, a chart, a Markdown
+report. It gets its own card in the conversation, its own versioned history, and
+its own sandboxed viewer.
 
-Single artifact SSE event and the artifact-render image.
+The interesting part is not the authoring. It's that an artifact is
+**attacker-authored markup rendered in a browser**, so almost every design
+decision below is about containing it.
+
+## Producing an artifact
+
+Two agent tools write artifacts: `create_artifact` makes v1, and
+`update_artifact` appends a new version. **Versions are immutable and
+append-only** — an update writes `V#{n+1}` and re-points a `#HEAD` pointer; it
+never rewrites what came before. Nothing in the platform has a `DeleteObject`
+grant on artifact content.
+
+That immutability is load-bearing later: it is what lets a share pin one exact
+version with no snapshot copy.
+
+Each version lives in two places:
+
+| Where | What |
+| --- | --- |
+| DynamoDB (`{prefix}-user-artifacts`) | Metadata: title, content type, version, session, and a pointer to the content |
+| S3 (`{prefix}-artifacts-content`) | The document bytes themselves |
+
+## Rendering: three layers of isolation
+
+Artifact content is never inlined into the SPA. It is served from a **separate
+origin** (`artifacts.<domain>`) and framed, which gives three independent
+containment layers:
+
+1. **A separate origin.** The artifact cannot touch the app's cookies, storage,
+   or DOM, because the browser treats it as a different site.
+2. **A strict CSP**, stamped by both CloudFront and the render Lambda (defense in
+   depth, so the policy holds even if the handler is buggy). `connect-src 'none'`
+   means artifact JavaScript cannot phone home or exfiltrate anything.
+3. **A sandboxed iframe** — `sandbox="allow-scripts"` **without**
+   `allow-same-origin`. The framed document is a null origin, so scripts run but
+   reach nothing.
+
+To load one, the SPA asks app-api to mint a **render token**: a short-lived
+(~120 second) HS256 JWT that pins one exact `(user, artifact, version)`. The
+token goes in the iframe URL and is re-minted on every open — never cached.
+
+## Sharing an artifact
+
+A user can share one artifact version with other people. The model deliberately
+mirrors conversation sharing, so the two behave alike.
+
+### What a share is
+
+A share is an owner-created, revocable pointer to **one immutable version**.
+
+- **It pins a version, never `#HEAD`.** A link made against v1 keeps showing v1
+  after the model writes v2. A pointer that moved under the recipient would be a
+  different feature with different consent semantics.
+- **Access levels** are `public` — any *authenticated* user with the link — or
+  `specific`, an email allowlist matched case-insensitively. There is no
+  anonymous access: `public` still sits behind sign-in, exactly as it does for
+  conversation shares. Governance here is identity, not content inspection.
+- **Revocation** deletes the share. Already-issued render tokens finish their
+  ~120 second life, so the revocation window is bounded by the token TTL rather
+  than by how long the recipient keeps the tab open.
+
+### Sharing one
+
+Owners share from the **Share** button on the artifact card or in the artifact
+panel header. Both share the version currently on screen — the card shows one row
+per version, and the panel follows its version menu. The dialog also lists the
+artifact's existing links so they can be copied or revoked.
+
+### Opening one
+
+Recipients open `/shared-artifact/{shareId}`, which renders the artifact
+full-width in the same sandboxed iframe the owner sees, with a preview/code
+toggle and a download. The page is read-only: no re-sharing, no version
+switching, no editing.
+
+### How access is actually enforced
+
+This is the part worth understanding before changing anything.
+
+The render Lambda uses the token's `sub` claim purely as the **DynamoDB
+partition key** it builds the lookup from. It performs no ownership comparison of
+its own and never sees the viewer — **the token is the capability**.
+
+So a share-scoped token is minted with `sub` set to the **owner**, not the
+viewer. That is an *address*, not an identity assertion; setting it to the viewer
+would simply point the Lambda at the viewer's own partition and 404. The real
+viewer travels in a `vwr` claim and the grant it was issued under in `shr`, so
+render logs attribute a view to whoever actually looked.
+
+The consequence: **the ACL check in app-api is the only thing standing between
+"sharing" and "read any artifact by id."** Every recipient request — metadata,
+render token, content — re-checks the share record before resolving the owner.
+
+## Lifecycle
+
+Artifacts outlive the turn that produced them, but not the conversation.
+Deleting a conversation revokes the share links for every artifact it produced,
+as a best-effort background task: a failure leaves an orphan row, never a blocked
+delete, and the lookup row is always deleted before the owner row so a
+half-finished cleanup can never leave a live link its owner can no longer see.
+
+Deleting the artifact **content** on conversation delete is deliberately a
+separate question — that is a retention decision about artifacts as a whole,
+not about sharing.
+
+## Enabling the feature
+
+Artifacts are enabled by the presence of `ARTIFACTS_RENDER_TOKEN_SECRET_ARN`,
+which infrastructure sets only when the artifacts stack is deployed for the
+environment. The sharing routes ride the same signal: a share is only ever
+consumed by minting a render token, so it cannot be useful without artifacts
+being on.
+
+## Known gap: artifacts inside a shared conversation
+
+Sharing a *conversation* does not share the artifacts it produced. A recipient
+viewing a shared conversation sees nothing where the owner sees artifact cards,
+because artifact hydration filters by the requesting user.
+
+Closing that properly means deciding whether sharing a conversation should also
+share its artifacts — a consent question, not just a wiring one — so it is
+tracked as a known gap rather than treated as a bug.


### PR DESCRIPTION
PR-4, the last piece of the artifact sharing spec ([§7](docs/specs/artifact-sharing.md)) — plus the docs-site page the delivery plan pairs with it. Completes the epic: [#919](https://github.com/Boise-State-Development/agentcore-public-stack/pull/919) → [#920](https://github.com/Boise-State-Development/agentcore-public-stack/pull/920) → [#922](https://github.com/Boise-State-Development/agentcore-public-stack/pull/922) → #927/#928 → this.

## The gap

Artifacts outlive the chat that produced them. `sessions/routes.py` already cascades conversation-share cleanup on delete, but nothing touched artifacts — so deleting a conversation left **live share links pointing at its artifacts**, with no surface left to revoke them from. The artifact cards were gone; the links kept resolving.

## The change

`ArtifactShareService.delete_for_session`, scheduled from the same background task as the conversation cascade, on both the single and bulk delete paths. Two steps, because there is no session→share index: `SessionIndex` yields the session's artifact ids, then the shares are read off the owner's own partition by SK prefix.

### Three decisions worth naming

**Lookup rows are deleted before owner rows, never the reverse.** The lookup row (`PK=SHARE#{id}`) is what the recipient path resolves, so dropping it is what actually kills the link. A half-finished cascade then leaves an inert owner row. The opposite order would leave a *live* share whose owner can no longer see it to revoke — strictly the worse failure. There's a test asserting the **order**, not just the end state, since both orders produce an identical result when nothing fails.

**Scoped by owner id.** `SessionIndex` is not user-partitioned — the same reason `ArtifactListService` re-checks every HEAD row — so the owner filter is the only thing keeping a borrowed or colliding session id off another user's shares. Tested directly: same session id, different caller, zero deletions.

**Never raises.** It runs after the 204 has been sent, so a raising task would only surface as an unhandled background-task error. It also no-ops when artifacts aren't configured for the environment, since the session routes are always mounted while the artifacts feature is not — that's a normal path, not a failure.

### Deliberately out of scope

Deleting artifact **content** on conversation delete, per the spec. That's a retention decision about the artifacts feature as a whole rather than about sharing, and it deserves its own spec. (The S3 `lifecycle-class=deleted` rule still has no backend writer.)

## Docs

The artifacts page was a scaffolded placeholder ("content to be written"). It now covers what an artifact is, the three isolation layers, how sharing works, the lifecycle above, and the known gap about artifacts inside shared conversations.

The section I'd most want a future reader to hit is why the minted token's `sub` is the **owner** — that it's a DynamoDB address rather than an identity assertion, and what that makes the ACL check solely responsible for. That's the one place where a plausible-looking "fix" turns into a privilege bug, and it now says so somewhere other than a code comment.

## Tests

14 new. Beyond the ordering and owner-scoping tests above: both rows removed for every share; the recipient path actually stops resolving (200 → 404, since killing the capability is the point); every artifact and version in the session covered; other sessions untouched; and the two never-raise paths — artifacts unconfigured, and a backing-store failure.

Also two route tests pinning the wiring itself, since a correct function that nothing calls would pass every test above.

**Backend suite: 7137 passed, 6 skipped.**

## Verification note

This is a background task on a delete path, so unlike the earlier PRs there's no UI to click through — the route tests are what pin the scheduling. Happy to exercise it on dev after merge by creating a share, deleting its conversation, and confirming the link 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
