### PR TITLE
fix(artifacts): session-delete cascade must not use BatchWriteItem

### DIFF
--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -964,30 +964,41 @@ class ArtifactShareService:
             # an unreachable owner row, which is inert; the reverse
             # order would leave a *live* share whose owner can no longer
             # see it to revoke.
-            with table.batch_writer() as batch:
-                for share in shares:
-                    batch.delete_item(
-                        Key=_share_lookup_key(str(share["share_id"]))
-                    )
-            with table.batch_writer() as batch:
-                for share in shares:
-                    batch.delete_item(
-                        Key={
-                            "PK": f"USER#{owner_id}",
-                            "SK": _owner_share_sk(
-                                str(share["artifact_id"]),
-                                int(share["version"]),
-                                str(share["share_id"]),
-                            ),
-                        }
-                    )
+            #
+            # Plain DeleteItem per row, NOT `table.batch_writer()`.
+            # `BatchWriteItem` is its own IAM action and is *not*
+            # authorized by the underlying item actions the way
+            # `TransactWriteItems` is — the task role is granted
+            # GetItem/PutItem/UpdateItem/DeleteItem/Query and nothing
+            # else, so a batch write fails closed with AccessDenied at
+            # runtime. Per-item deletes also isolate failures: one bad
+            # row can't strand the rest of the cascade.
+            revoked = 0
+            for share in shares:
+                if self._delete_quietly(
+                    table, _share_lookup_key(str(share["share_id"]))
+                ):
+                    revoked += 1
+            for share in shares:
+                self._delete_quietly(
+                    table,
+                    {
+                        "PK": f"USER#{owner_id}",
+                        "SK": _owner_share_sk(
+                            str(share["artifact_id"]),
+                            int(share["version"]),
+                            str(share["share_id"]),
+                        ),
+                    },
+                )
 
             logger.info(
-                "revoked %s artifact share(s) for deleted session %s",
+                "revoked %s of %s artifact share(s) for deleted session %s",
+                revoked,
                 len(shares),
                 scrub_log(session_id),
             )
-            return len(shares)
+            return revoked
         except Exception:
             logger.error(
                 "failed to revoke artifact shares for session %s",
@@ -995,6 +1006,23 @@ class ArtifactShareService:
                 exc_info=True,
             )
             return 0
+
+    @staticmethod
+    def _delete_quietly(table, key: dict) -> bool:
+        """Delete one row, reporting success rather than raising.
+
+        A single failed row must not strand the rest of the cascade —
+        every remaining share link would stay live."""
+        try:
+            table.delete_item(Key=key)
+            return True
+        except ClientError:
+            logger.warning(
+                "artifact share cascade could not delete %s",
+                scrub_log(key.get("PK", "")),
+                exc_info=True,
+            )
+            return False
 
     @staticmethod
     def _shares_for_session(

--- a/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_shares.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from moto import mock_aws
@@ -660,53 +661,120 @@ def test_cascade_swallows_a_backing_store_failure(env, monkeypatch) -> None:
     assert _cascade() == 0
 
 
+class _RecordingTable:
+    """Delegates to the real table, recording which DynamoDB API each
+    call uses and which key space it targets."""
+
+    def __init__(self, inner, calls: list):
+        self._inner = inner
+        self._calls = calls
+
+    def __getattr__(self, name):
+        # Anything not intercepted below (query, get_item, …) passes
+        # through — but record the API name so a test can assert on the
+        # surface actually used.
+        attr = getattr(self._inner, name)
+        if callable(attr):
+            def _recorded(*args, **kwargs):
+                self._calls.append((name, None))
+                return attr(*args, **kwargs)
+
+            return _recorded
+        return attr
+
+    def delete_item(self, Key):  # noqa: N803 — boto3 kwarg name
+        space = "lookup" if Key["PK"].startswith("SHARE#") else "owner"
+        self._calls.append(("delete_item", space))
+        return self._inner.delete_item(Key=Key)
+
+
+def _record_cascade(monkeypatch) -> list:
+    """Run the cascade against a table that records its API calls."""
+    calls: list = []
+    real = token_service._table()
+    monkeypatch.setattr(
+        token_service, "_table", lambda: _RecordingTable(real, calls)
+    )
+    return calls
+
+
 def test_cascade_deletes_the_lookup_row_before_the_owner_row(
     env, monkeypatch
 ) -> None:
     """Ordering is the safety property. The lookup row is what the
     recipient path resolves, so it goes first: a half-finished cascade
     then leaves an inert owner row rather than a live share its owner can
-    no longer see to revoke."""
+    no longer see to revoke. Both orders look identical when nothing
+    fails, so assert the order and not just the end state."""
     make_client, ddb = env
     _put_version(ddb)
     _put_head(ddb)
     _create_share(make_client())
 
-    seen: list[str] = []
-    real_table = token_service._table()
-
-    class _RecordingBatch:
-        def __init__(self, inner):
-            self._inner = inner
-
-        def delete_item(self, Key):  # noqa: N803 — boto3 kwarg name
-            seen.append("lookup" if Key["PK"].startswith("SHARE#") else "owner")
-            return self._inner.delete_item(Key=Key)
-
-    class _RecordingWriter:
-        def __init__(self, inner):
-            self._inner = inner
-
-        def __enter__(self):
-            return _RecordingBatch(self._inner.__enter__())
-
-        def __exit__(self, *exc):
-            return self._inner.__exit__(*exc)
-
-    class _RecordingTable:
-        """Delegates everything to the real table, recording which key
-        space each batched delete targets."""
-
-        def __getattr__(self, name):
-            return getattr(real_table, name)
-
-        def batch_writer(self, **kwargs):
-            return _RecordingWriter(real_table.batch_writer(**kwargs))
-
-    # Patch the module-level accessor: the service holds its own cached
-    # Table, and boto3 builds a distinct class per resource instance, so
-    # patching the class off a different resource would miss.
-    monkeypatch.setattr(token_service, "_table", lambda: _RecordingTable())
-
+    calls = _record_cascade(monkeypatch)
     assert _cascade() == 1
-    assert seen == ["lookup", "owner"], seen
+
+    deletes = [space for name, space in calls if name == "delete_item"]
+    assert deletes == ["lookup", "owner"], deletes
+
+
+def test_cascade_uses_only_iam_granted_dynamodb_actions(
+    env, monkeypatch
+) -> None:
+    """Regression guard for a real dev-environment failure.
+
+    The app-api task role is granted GetItem/PutItem/UpdateItem/
+    DeleteItem/Query on the artifacts table and nothing else. The rest of
+    this feature writes via `transact_write_items`, which DynamoDB
+    authorizes against those *underlying* item actions — but
+    `BatchWriteItem` is its own IAM action and is NOT covered by them, so
+    `table.batch_writer()` fails closed with AccessDenied in a deployed
+    environment while passing every moto test (moto does not enforce
+    IAM).
+
+    Pinning the API surface is the only way a unit test can catch that.
+    """
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    _create_share(make_client())
+
+    calls = _record_cascade(monkeypatch)
+    _cascade()
+
+    used = {name for name, _ in calls}
+    assert "batch_writer" not in used, used
+    assert used <= {"query", "delete_item"}, used
+
+
+def test_cascade_continues_after_one_row_fails(env, monkeypatch) -> None:
+    """One unlucky row must not strand the rest — every share left behind
+    is a link that keeps resolving."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _put_head(ddb)
+    tc = make_client()
+    _create_share(tc)
+    _create_share(tc)
+
+    real = token_service._table()
+    seen = {"n": 0}
+
+    class _FlakyTable:
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+        def delete_item(self, Key):  # noqa: N803
+            seen["n"] += 1
+            if seen["n"] == 1:
+                raise ClientError(
+                    {"Error": {"Code": "ProvisionedThroughputExceeded"}},
+                    "DeleteItem",
+                )
+            return real.delete_item(Key=Key)
+
+    monkeypatch.setattr(token_service, "_table", lambda: _FlakyTable())
+
+    # One lookup delete failed, the other succeeded — and the cascade
+    # reports what it actually revoked rather than what it attempted.
+    assert _cascade() == 1

--- a/docs-site/src/content/docs/features/artifacts.md
+++ b/docs-site/src/content/docs/features/artifacts.md
@@ -112,6 +112,12 @@ as a best-effort background task: a failure leaves an orphan row, never a blocke
 delete, and the lookup row is always deleted before the owner row so a
 half-finished cleanup can never leave a live link its owner can no longer see.
 
+One implementation note that is easy to get wrong: the cleanup deletes rows with
+individual `DeleteItem` calls rather than a batch write. `BatchWriteItem` is its
+own IAM action and is **not** authorized by the underlying item permissions the
+way `TransactWriteItems` is, so a batch write fails closed with `AccessDenied` in
+a deployed environment while passing every local test.
+
 Deleting the artifact **content** on conversation delete is deliberately a
 separate question — that is a retention decision about artifacts as a whole,
 not about sharing.


### PR DESCRIPTION
Follow-up to [#931](https://github.com/Boise-State-Development/agentcore-public-stack/pull/931). **The cascade shipped broken and I caught it verifying on dev**, not in review.

## What happened

Right after #931 deployed I ran the real path: created an artifact, shared it (metadata 200, mint 200), deleted the conversation, and polled. The link stayed live for six seconds. The delete returned 204 and the cascade *did* run — it just failed, swallowed exactly as designed:

```
AccessDeniedException … not authorized to perform:
dynamodb:BatchWriteItem on …/dev-boisestateai-v2-user-artifacts
```

So the share link survived the conversation — precisely the state the cascade exists to prevent.

## Why every test passed

`BatchWriteItem` **is its own IAM action**. It is *not* authorized by the underlying item actions the way `TransactWriteItems` is — which is why the rest of this feature, built on `transact_write_items`, needed no IAM change and works fine. The task role has `GetItem/PutItem/UpdateItem/DeleteItem/Query` on the artifacts table and nothing more.

I reached for `batch_writer()` because the conversation-share cascade uses it — but that runs against a *different table with a different grant*. The spec's "no IAM change needed" reasoning is specific to `TransactWriteItems`, and I carried it over to a call it doesn't cover.

**moto does not enforce IAM**, so all 14 tests passed against an API call the deployed role cannot make.

## The fix

Plain `DeleteItem` per row. This keeps the feature's zero-IAM-change property — no `platform.yml` deploy, no sequencing risk — and is better here regardless: per-item deletes isolate failures, so one bad row can no longer strand the rest of the cascade and leave the remaining links resolving. Lookup-before-owner ordering is unchanged.

The alternative was granting `dynamodb:BatchWriteItem` in CDK, which would have meant an infra deploy that must land before the code — for no benefit over `DeleteItem` at this scale (a cascade is bounded by the shares in one conversation).

## Making the test suite able to catch this

`test_cascade_uses_only_iam_granted_dynamodb_actions` pins the DynamoDB API surface the cascade may touch — asserting `batch_writer` is never called and that usage stays within `{query, delete_item}`.

**Mutation-checked:** I reintroduced `batch_writer()` and confirmed the test fails, then restored the fix and confirmed it passes. A regression guard that can't fail isn't a guard. Pinning the API surface is the only way a unit test can catch an IAM mismatch that moto silently permits.

Also adds `_delete_quietly` (logs and reports failure rather than raising, since the cascade must never raise) plus a test that one failing row doesn't abort the rest.

The docs page gains the same note — this is a live trap for anyone adding another write path to this table.

**Backend suite: 7139 passed, 6 skipped.**

I'll re-verify the full delete→revoke path on dev once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
