### PR TITLE
fix(spa): queue a follow-up typed while a turn is paused

### DIFF
--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.spec.ts
@@ -725,6 +725,61 @@ describe('ChatInputComponent — a queue held behind a paused turn (PR-6)', () =
     setStreaming(false);
   }
 
+  it('queues a follow-up typed AFTER the pause, rather than sending it', () => {
+    // The sequence a real user performs, and the one the original PR-6 tests
+    // missed: they queued while streaming and then paused. A pause closes the
+    // stream, so `isChatLoading` is already false by the time the prompt is on
+    // screen — and gating the queue on loading alone routed Enter straight to
+    // `submitChatRequest`, firing a brand-new turn that abandoned the paused
+    // one. Observed live on dev.
+    pauseTurn();
+
+    type('after the greeting, also tell me the day');
+    pressEnter();
+
+    expect(submitted).toEqual([]);
+    expect(component.queuedMessages().map((q) => q.content)).toEqual([
+      'after the greeting, also tell me the day',
+    ]);
+  });
+
+  it('the Send button makes the same decision as Enter while held', () => {
+    // Two affordances that disagree about what "send" means is worse than
+    // either behaviour on its own.
+    pauseTurn();
+
+    type('via the button');
+    component.onPrimaryButtonClick();
+
+    expect(submitted).toEqual([]);
+    expect(component.queuedMessages().map((q) => q.content)).toEqual(['via the button']);
+  });
+
+  it('does not try to arm an entry queued while paused', async () => {
+    // The paused turn released its lease when the stream closed, so there is
+    // no inbox to arm against — the entry rides the resume request instead.
+    pauseTurn();
+
+    type('rides the resume');
+    pressEnter();
+    await Promise.resolve();
+
+    expect(steering.armCalls).toEqual([]);
+    expect(steering.published.map((e) => e.text)).toEqual(['rides the resume']);
+  });
+
+  it('still sends immediately when nothing is paused and nothing is streaming', () => {
+    // The ordinary idle path must not become a queue.
+    steering.held.set(false);
+    setStreaming(false);
+
+    type('just a normal message');
+    pressEnter();
+
+    expect(submitted.map((m) => m.content)).toEqual(['just a normal message']);
+    expect(component.queuedMessages()).toEqual([]);
+  });
+
   it('does not send a follow-up while a prompt is awaiting an answer', () => {
     setStreaming(true);
     type('actually use the local file');

--- a/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/chat-input.component.ts
@@ -448,9 +448,17 @@ export class ChatInputComponent {
    * Stopping stays on the button, deliberately. Making Enter ambiguous — send
    * when idle, abort when busy — is what let a reflex keystroke kill a run the
    * user was waiting on, and stopping is the rarer, more destructive of the two.
+   *
+   * `queueHeld()` is the second reason to queue, and it is NOT covered by
+   * `isLoading()`: a turn paused for consent or approval has already closed its
+   * stream, so loading is false while the prompt sits there waiting. Gating on
+   * loading alone sent the follow-up as a brand-new turn — abandoning the
+   * paused turn the user was mid-answer on — while the placeholder promised it
+   * would go in when they answered. See docs/specs/mid-turn-steering.md
+   * ("Paused turns").
    */
   onSubmit() {
-    if (this.isLoading()) {
+    if (this.isLoading() || this.queueHeld()) {
       this.queueChatRequest();
     } else {
       this.submitChatRequest();
@@ -466,7 +474,9 @@ export class ChatInputComponent {
     if (this.isLoading()) {
       this.cancelChatRequest();
     } else {
-      this.submitChatRequest();
+      // Not streaming, so this is Send — but it must make the same decision
+      // Enter does, or the two disagree while a prompt is holding the queue.
+      this.onSubmit();
     }
   }
 
@@ -526,6 +536,9 @@ export class ChatInputComponent {
     const sessionId = this.sessionId();
     if (!sessionId) return;
     if (entry.fileUploadIds?.length || entry.mentionAgentId) return;
+    // A paused turn released its lease when the stream closed, so there is no
+    // inbox to arm against. This entry rides the resume request instead.
+    if (this.queueHeld()) return;
 
     const armed = await this.steering.arm(sessionId, entry.id, entry.content);
     if (!armed) return;


### PR DESCRIPTION
Follow-up to #930, from the same validation pass against dev. #930 covered the duplicate-render bug; this is the second defect, and it is the more consequential of the two because it makes PR-6 of `docs/specs/mid-turn-steering.md` unreachable in practice.

## What happens today

Reproduced on dev with a genuine tool-approval interrupt (`sk_hello_approval`, whose `say_hello` is flagged `needsApproval` — a real Strands pause, and unlike the OAuth path it needs no credentials to set up or to resume).

With the approval prompt on screen, typing a follow-up and pressing Enter **sends it as a brand-new turn**, abandoning the paused turn the user is mid-answer on — while the composer's placeholder is promising *"it goes in when you answer above"*.

## Cause

`onSubmit` queued only when `isLoading()` was true:

```ts
if (this.isLoading()) { this.queueChatRequest(); } else { this.submitChatRequest(); }
```

**A pause closes the stream**, so `isChatLoading` is already false while the prompt sits there waiting. Enter took the `submitChatRequest` branch and nothing ever entered the queue. PR-6's hold only ever gated the *flush* of an already-queued entry — so on the one path it was built for, it never ran, and the carry-through it feeds could never fire either.

## Fix

Queue when the queue is held as well as when a turn is streaming, and route the Send button through the same decision so the two affordances cannot disagree about what "send" means.

An entry queued while paused is also **not** armed against `/steer`: the paused turn released its lease when its stream closed, so there is no inbox to arm. It rides the resume request instead, which is exactly what PR-6 built.

## Why #921's tests missed it

They queued *while streaming* and then paused:

```ts
setStreaming(true); type(...); pressEnter();   // queue
pauseTurn();                                    // then pause
```

A real user types *after* the pause. The new tests do it in that order — `pauseTurn()` first, then type — and fail against the old condition:

```
FAIL  queues a follow-up typed AFTER the pause, rather than sending it
FAIL  the Send button makes the same decision as Enter while held
FAIL  does not try to arm an entry queued while paused
```

There is also a guard that the ordinary idle path still sends immediately rather than becoming a queue.

Tests: **2132 passing**, with the negative control above.

## Still unverified

The PR-6 carry-through end to end — resume request carries `steering`, backend seeds it onto the resumed turn's lease, hook injects at the first tool boundary. It could not be reached on dev because this bug blocked entry to the queue, and could not be reached locally because the SPA's auth guard needs a real BFF cookie (the localhost OAuth callback isn't registered, and `SKIP_AUTH` alone doesn't satisfy the guard). I'll re-run it against dev once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
