### PR TITLE
fix(spa): re-measure a user bubble instead of latching one reading

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.spec.ts
@@ -1,0 +1,123 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserMessageComponent } from './user-message.component';
+import { LocalSettingsService } from '../../../../services/local-settings.service';
+import type { Message } from '../../../services/models/message.model';
+
+/**
+ * The "Show more" affordance on a user bubble is driven by ONE measurement of
+ * the content wrapper. It used to be taken once in `ngAfterViewInit` and never
+ * revisited, so a reading taken before layout settled latched forever: a
+ * one-line mid-turn steer rendered a "Show more" and a fade dimming its own
+ * single line, on dev, permanently.
+ *
+ * jsdom has no layout engine, so `scrollHeight` is whatever we say it is —
+ * which is exactly what makes the *sequence* testable: an early wrong reading
+ * followed by a correct one must end at the correct answer.
+ */
+describe('UserMessageComponent — overflow measurement', () => {
+  let fixture: ComponentFixture<UserMessageComponent>;
+  let component: UserMessageComponent;
+  let observed: Element | null;
+  let fireResize: () => void;
+
+  const message = (text: string, steering = false): Message => ({
+    id: 'msg-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+    ...(steering ? { steering: true } : {}),
+  });
+
+  /** Pretend the wrapper measures `height` px of content. */
+  function setScrollHeight(height: number): void {
+    const wrapper = fixture.nativeElement.querySelector('.overflow-hidden');
+    Object.defineProperty(wrapper, 'scrollHeight', { value: height, configurable: true });
+  }
+
+  beforeEach(async () => {
+    observed = null;
+    fireResize = () => undefined;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(cb: () => void) {
+          fireResize = cb;
+        }
+        observe(el: Element) {
+          observed = el;
+        }
+        disconnect() {
+          observed = null;
+        }
+      },
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [UserMessageComponent],
+      providers: [
+        { provide: LocalSettingsService, useValue: { showDebugOutput: signal(false) } },
+      ],
+    })
+      .overrideComponent(UserMessageComponent, {
+        set: { imports: [], schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(UserMessageComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('message', message('a short follow-up'));
+    fixture.detectChanges();
+  });
+
+  it('observes the content wrapper rather than measuring once', () => {
+    expect(observed).not.toBeNull();
+    expect((observed as unknown as Element).classList.contains('overflow-hidden')).toBe(true);
+  });
+
+  it('corrects an early mis-measurement once the box settles', () => {
+    // The bug, in sequence: an unsettled container wraps a short line into
+    // dozens of wrapped ones...
+    setScrollHeight(960);
+    fireResize();
+    fixture.detectChanges();
+    expect(component.isOverflowing()).toBe(true);
+
+    // ...and then layout settles and it is one line again. Before the fix
+    // nothing measured a second time, so the bubble kept a "Show more" and a
+    // fade over its own single line forever.
+    setScrollHeight(24);
+    fireResize();
+    fixture.detectChanges();
+
+    expect(component.isOverflowing()).toBe(false);
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('still shows the affordance for genuinely long content', () => {
+    setScrollHeight(960);
+    fireResize();
+    fixture.detectChanges();
+
+    expect(component.isOverflowing()).toBe(true);
+    expect(fixture.nativeElement.querySelector('button').textContent.trim()).toBe('Show more');
+  });
+
+  it('gives a steering message the same bubble as any other user message', () => {
+    const bubbleOf = (steering: boolean) => {
+      const f = TestBed.createComponent(UserMessageComponent);
+      f.componentRef.setInput('message', message('hello', steering));
+      f.detectChanges();
+      return f.nativeElement.querySelector('.rounded-2xl').className;
+    };
+    // The caption is the only distinction; a second visual treatment made a
+    // steer read as a different kind of object rather than the same kind of
+    // message sent at an unusual moment.
+    expect(bubbleOf(true)).toBe(bubbleOf(false));
+  });
+
+  it('disconnects the observer on destroy', () => {
+    fixture.destroy();
+    expect(observed).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/user-message.component.ts
@@ -7,6 +7,7 @@ import {
   ElementRef,
   viewChild,
   AfterViewInit,
+  OnDestroy,
   inject,
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -124,7 +125,7 @@ const MAX_HEIGHT_PX = 200;
     }
   `,
 })
-export class UserMessageComponent implements AfterViewInit {
+export class UserMessageComponent implements AfterViewInit, OnDestroy {
   message = input.required<Message>();
 
   contentWrapper = viewChild<ElementRef<HTMLDivElement>>('contentWrapper');
@@ -211,8 +212,35 @@ export class UserMessageComponent implements AfterViewInit {
     this.fileAttachments().filter((a) => !isImageMimeType(a.mimeType)),
   );
 
+  /** Re-measures whenever the bubble's box settles. See {@link ngAfterViewInit}. */
+  private resizeObserver?: ResizeObserver;
+
   ngAfterViewInit(): void {
+    const wrapper = this.contentWrapper()?.nativeElement;
+    if (!wrapper) {
+      return;
+    }
+
+    // Measure whenever the box settles, not once and for all.
+    //
+    // A single `ngAfterViewInit` reading can land before layout has settled,
+    // and it latched: a one-line mid-turn steer measured its 40 characters as
+    // dozens of wrapped lines in a not-yet-widened container, set
+    // `isOverflowing`, and rendered a "Show more" plus a fade dimming its own
+    // single line — permanently, because nothing ever measured again.
+    // Observed live on dev.
+    //
+    // The observed element is the inner wrapper, whose box is pinned by
+    // `max-height` and unaffected by the fade (absolutely positioned) and the
+    // button (a sibling outside it), so reacting here cannot feed back into a
+    // resize loop.
+    this.resizeObserver = new ResizeObserver(() => this.checkOverflow());
+    this.resizeObserver.observe(wrapper);
     this.checkOverflow();
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
   }
 
   toggleExpanded(): void {


### PR DESCRIPTION
Found validating #935 on dev. A one-line mid-turn steer rendered a **"Show more" button and a fade gradient dimming its own single line** — permanently.

![the bubble measured 24px of content against a 200px clamp and still claimed to overflow]

## Cause

`isOverflowing` came from a single `scrollHeight` reading taken in `ngAfterViewInit`, and nothing ever measured again.

A reading taken before layout settles is wrong in the expensive direction: a message inserted into a still-streaming turn measures its short text as dozens of wrapped lines in a not-yet-widened container, sets the flag, and keeps it for the life of the component. Measured live: `scrollHeight: 24`, `maxHeight: 200px`, `isOverflowing: true`.

## Fix

Observe the wrapper with a `ResizeObserver` so a later, correct measurement wins.

No resize-loop risk: the observed element's box is pinned by `max-height`, and neither the fade (absolutely positioned) nor the button (a sibling outside it) can change it.

## Scope

**Not steering-specific.** A steer is just how it surfaced — a message appended mid-stream is the most likely thing to be measured before its container has settled. Any user bubble could latch this way.

## Testing

jsdom has no layout engine, which is what makes the *sequence* testable: the spec drives an early wrong reading followed by a correct one and asserts the component ends on the correct answer.

Verified to fail with the fix reverted:

```
FAIL > observes the content wrapper rather than measuring once
FAIL > corrects an early mis-measurement once the box settles
FAIL > still shows the affordance for genuinely long content
Test Files  1 failed | 204 passed (205)
```

and pass with it: **2234 passing**. This is the component's first spec file; it also pins that a steering message uses the same bubble as any other user message (#935).

🤖 Generated with [Claude Code](https://claude.com/claude-code)