### PR TITLE
feat(artifacts): stamp user-index keys on HEAD rows ahead of the index

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -9,10 +9,31 @@ Frozen cross-PR contract (must stay in sync with the render Lambda
   HEAD row    : PK=USER#{user_id}  SK=ARTIFACT#{aid}#HEAD
                 + GSI1PK=SESSION#{session_id}
                 + GSI1SK=ARTIFACT#{updated_at}#{aid}   (SessionIndex)
+                + GSI2PK=USER#{user_id}
+                + GSI2SK=ARTIFACT#{updated_at}#{aid}   (index NOT YET CREATED)
   S3 layout   : {user_id}/{aid}/v{n}/index.html
 
 Versions are immutable (no DeleteObject grant in inference-api) — an
 update writes a new version and re-points HEAD.
+
+GSI2PK/GSI2SK are written ahead of the index that will consume them.
+Nothing queries them today — a user-wide artifact list is served by a
+base-table Query on PK=USER#{uid}, which is adequate while the heaviest
+user holds well under a 1MB page. They are stamped now because a sparse
+GSI only ever contains rows that already carry its key attributes: rows
+written before the attributes exist stay invisible to it forever unless
+a migration script backfills them, and that omission fails silently (a
+library page that lists only artifacts created after the deploy, with no
+error anywhere). Writing them from now on means the eventual
+`UserArtifactsIndex` — GSI2PK hash, GSI2SK range, queried with
+ScanIndexForward=False for newest-first — backfills every row stamped
+since this change, shrinking the manual backfill to the rows that
+predate it. Until then they are inert ordinary attributes: DynamoDB
+charges no index write when no index consumes them.
+
+Stamped on HEAD rows only, deliberately: one indexed row per artifact
+rather than one per version. Both write paths below must stamp them, or
+an artifact's HEAD loses the attributes on its next update.
 
 Markdown artifacts: when `content_type` is a Markdown type, the model
 authors raw Markdown but S3 stores a self-contained HTML render wrapper
@@ -340,6 +361,8 @@ def create_artifact_record(
                 "updated_at": now,
                 "GSI1PK": f"SESSION#{session_id}",
                 "GSI1SK": f"ARTIFACT#{now}#{artifact_id}",
+                "GSI2PK": pk,
+                "GSI2SK": f"ARTIFACT#{now}#{artifact_id}",
             },
             ConditionExpression="attribute_not_exists(SK)",
         )
@@ -414,6 +437,8 @@ def update_artifact_record(
                 "updated_at": now,
                 "GSI1PK": f"SESSION#{head.get('session_id', '')}",
                 "GSI1SK": f"ARTIFACT#{now}#{artifact_id}",
+                "GSI2PK": pk,
+                "GSI2SK": f"ARTIFACT#{now}#{artifact_id}",
             },
             ConditionExpression="version = :cur",
             ExpressionAttributeValues={":cur": current},

--- a/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
+++ b/backend/tests/agents/builtin_tools/artifacts/test_artifact_tools.py
@@ -123,6 +123,38 @@ def test_update_increments_and_preserves_old(aws) -> None:
     assert head["title"] == "T"  # carried forward
 
 
+def test_head_rows_carry_user_index_keys_on_both_write_paths(aws) -> None:
+    """GSI2PK/GSI2SK are stamped ahead of the index that will consume them.
+
+    No index exists yet (the fixture table declares only SessionIndex), so
+    nothing queries these — but a sparse GSI only ever contains rows that
+    already carry its key attributes. A write path that stops stamping them
+    produces rows permanently invisible to the future UserArtifactsIndex,
+    and does so silently. Both paths are asserted because `update` re-puts
+    HEAD wholesale: dropping the attributes there would strip them from
+    every artifact that is ever edited.
+    """
+    ddb, _ = aws
+    aid, _ = service.create_artifact_record(USER, SESSION, "T", DOC, "")
+
+    head = _item(ddb, aid, "HEAD")
+    assert head["GSI2PK"] == f"USER#{USER}"
+    # Sorts newest-first within the user's partition, so it must track
+    # updated_at rather than creation time.
+    assert head["GSI2SK"] == f"ARTIFACT#{head['updated_at']}#{aid}"
+
+    # Sparse by design: one indexed row per artifact, not one per version.
+    assert "GSI2PK" not in _item(ddb, aid, "V#00001")
+
+    service.update_artifact_record(USER, aid, "<p>v2</p>", None, None)
+
+    updated = _item(ddb, aid, "HEAD")
+    assert updated["GSI2PK"] == f"USER#{USER}"
+    assert updated["GSI2SK"] == f"ARTIFACT#{updated['updated_at']}#{aid}"
+    assert updated["GSI2SK"] > head["GSI2SK"]
+    assert "GSI2PK" not in _item(ddb, aid, "V#00002")
+
+
 def test_update_unknown_artifact_raises(aws) -> None:
     with pytest.raises(service.ArtifactNotFoundError):
         service.update_artifact_record(USER, "nope", DOC, None, None)


### PR DESCRIPTION
## What

HEAD rows in `user-artifacts` now carry `GSI2PK = USER#{user_id}` and `GSI2SK = ARTIFACT#{updated_at}#{aid}`, stamped on both write paths in the artifact writer.

**No index is created here.** No infra change, no CDK, no deploy ordering to manage — this ships on `backend.yml` alone.

## Why now, if nothing queries them

Groundwork for a user-wide "my artifacts" list/grid view. That page doesn't need an index yet: a base-table `Query` on `PK=USER#{uid}` already serves it, because the artifacts table is *already* partitioned by user. Measured against prod (`boisestateai-v2-user-artifacts`): 1,494 artifacts across 340 users, heaviest single user at 64 artifacts / 188 partition rows / ~110KB — roughly an order of magnitude under the 1MB `Query` page limit.

The attributes ship ahead of the index because **a sparse GSI only ever contains rows that already carry its key attributes.** Rows written before the attributes exist stay invisible to it forever unless a migration script backfills them — and that omission fails *silently*: a library page that lists only artifacts created after the deploy, with no error anywhere.

Stamping from now on means the eventual `UserArtifactsIndex` backfills every row written since this commit, shrinking the manual backfill to the rows that predate it (and shrinking further as those artifacts get edited).

Until the index exists these are inert ordinary attributes — DynamoDB charges no index write when no index consumes them, and item growth is ~60 bytes on HEAD rows only.

## Design notes

- **HEAD rows only.** Sparse by design: one indexed row per artifact, not one per version.
- **Both write paths.** `update_artifact_record` re-puts HEAD wholesale, so stamping only on create would strip the keys from every artifact anyone ever edits. The test covers exactly that regression — verified by mutation (removing the update-path stamping fails with `KeyError: 'GSI2PK'`).
- **`GSI2SK` tracks `updated_at`, not `created_at`**, so the future index sorts by recency with `ScanIndexForward=False`. Mirrors the existing `GSI1SK` shape.
- The module's frozen cross-PR contract docstring records the key shape, the intended index, and the reasoning — so a future reader doesn't remove the attributes as dead weight.

## When the index actually lands

Deliberately deferred. Trigger: a single user's partition approaching a 1MB `Query` page, or ~300 artifacts. At that point it's a CDK change + wait for `IndexStatus: ACTIVE` + backfill the pre-this-commit rows, sequenced per the known GSI deploy-ordering hazards (one GSI per `UpdateTable`; a green CFN run only means DynamoDB accepted the update).

Also worth naming as an open product gap for the list page, unaffected by this PR: **there is no artifact delete or rename.** `delete_for_session` only revokes shares. A library view would surface every scratch artifact a user has ever generated with no way to clean up.

## Testing

`test_head_rows_carry_user_index_keys_on_both_write_paths` — asserts the keys on create and update, that version rows stay unstamped, and that `GSI2SK` equals `updated_at` and advances on update. The moto fixture still declares only `SessionIndex`, keeping it honest that these are ordinary attributes today.

123 passed across `tests/agents/builtin_tools/artifacts/` + `tests/apis/app_api/artifacts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)