### PR TITLE
feat(fine-tuning): support image and image+text models via a task-type registry

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -93,6 +93,12 @@ dev = [
     "types-aiofiles==25.1.0.20260409",
     "tiktoken==0.12.0",
     "numpy==2.2.6",
+    # Exercises the fine-tuning dataset contract (manifest reading, label
+    # normalisation, the image-archive path). The SageMaker containers install
+    # their own unpinned pandas; 2.x is what the py3.10 text DLC resolves to,
+    # and it is the only line compatible with the numpy pin above — pandas 3.x
+    # requires numpy>=2.3.3 on py3.14+.
+    "pandas==2.3.3",
 ]
 
 # All dependencies (convenience)

--- a/backend/scripts/refresh_instance_pricing.py
+++ b/backend/scripts/refresh_instance_pricing.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Resync the fine-tuning instance rates in ``fine_tuning/pricing.py``.
+
+Queries the AWS Price List API for the SageMaker ``Training`` and
+``BatchTransform`` components in us-west-2 and prints the two rate maps.  Run
+it when AWS changes prices or when adding an instance family, then paste the
+output into ``pricing.py`` — the maps stay literal so they are reviewable in a
+diff and need no network access at import time.
+
+Usage:
+    python backend/scripts/refresh_instance_pricing.py --profile dev-ai
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+# Instance families we are willing to offer.  Anything not listed here is not
+# priced, and therefore rejected at job creation.
+INSTANCES = [
+    f"ml.{fam}.{size}"
+    for fam in ("g5", "g6", "g6e")
+    for size in ("xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "24xlarge", "48xlarge")
+] + ["ml.g5.16xlarge"]
+
+REGION = "us-west-2"
+
+
+def fetch(instance: str, profile: str) -> dict:
+    """Return {component: usd_per_hour} for one instance type."""
+    result = subprocess.run(
+        [
+            "aws", "pricing", "get-products",
+            "--profile", profile, "--region", "us-east-1",
+            "--service-code", "AmazonSageMaker",
+            "--filters", f"Type=TERM_MATCH,Field=regionCode,Value={REGION}",
+            f"Type=TERM_MATCH,Field=instanceName,Value={instance}",
+            "--max-results", "40", "--output", "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  ! {instance}: {result.stderr.strip()[:120]}", file=sys.stderr)
+        return {}
+
+    rates = {}
+    for entry in json.loads(result.stdout).get("PriceList", []):
+        obj = json.loads(entry)
+        component = obj["product"]["attributes"].get("component")
+        if component not in ("Training", "BatchTransform"):
+            continue
+        for term in obj["terms"].get("OnDemand", {}).values():
+            for dimension in term["priceDimensions"].values():
+                usd = float(dimension["pricePerUnit"]["USD"])
+                if usd > 0:
+                    rates[component] = usd
+    return rates
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", default="dev-ai", help="AWS profile to query with")
+    args = parser.parse_args()
+
+    training, transform = {}, {}
+    for instance in INSTANCES:
+        rates = fetch(instance, args.profile)
+        if "Training" in rates:
+            training[instance] = rates["Training"]
+        if "BatchTransform" in rates:
+            transform[instance] = rates["BatchTransform"]
+
+    for name, rates in (("TRAINING_COST_PER_HOUR", training), ("TRANSFORM_COST_PER_HOUR", transform)):
+        print(f"\n{name}: Dict[str, float] = {{")
+        for instance, usd in rates.items():
+            print(f'    "{instance}": {usd},')
+        print("}")
+
+    missing = [i for i in INSTANCES if i not in training]
+    if missing:
+        print(f"\n# No on-demand training rate (do not offer these): {', '.join(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/apis/app_api/admin/fine_tuning/models.py
+++ b/backend/src/apis/app_api/admin/fine_tuning/models.py
@@ -3,17 +3,18 @@
 from pydantic import BaseModel, Field
 from typing import List
 from apis.app_api.fine_tuning.models import FineTuningAccessGrant
+from apis.app_api.fine_tuning.repository import DEFAULT_QUOTA_USD
 
 
 class GrantAccessRequest(BaseModel):
     """Request body for granting fine-tuning access."""
     email: str
-    monthly_quota_hours: float = Field(default=10.0, gt=0)
+    monthly_quota_usd: float = Field(default=DEFAULT_QUOTA_USD, gt=0)
 
 
 class UpdateQuotaRequest(BaseModel):
-    """Request body for updating a user's GPU-hour quota."""
-    monthly_quota_hours: float = Field(gt=0)
+    """Request body for updating a user's monthly dollar quota."""
+    monthly_quota_usd: float = Field(gt=0)
 
 
 class AccessListResponse(BaseModel):

--- a/backend/src/apis/app_api/admin/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/admin/fine_tuning/routes.py
@@ -91,7 +91,7 @@ async def grant_access(
         grant = repo.grant_access(
             email=request.email,
             granted_by=admin_user.email,
-            monthly_quota_hours=request.monthly_quota_hours,
+            monthly_quota_usd=request.monthly_quota_usd,
         )
         return FineTuningAccessGrant(**grant)
     except ValueError as e:
@@ -126,11 +126,11 @@ async def update_quota(
     admin_user: User = Depends(require_fine_tuning_admin),
     repo: FineTuningAccessRepository = Depends(get_repository),
 ):
-    """Update GPU-hour quota for a user (admin only)."""
+    """Update the monthly dollar quota for a user (admin only)."""
     logger.info("Admin updating fine-tuning quota")
 
     try:
-        result = repo.update_quota(email, request.monthly_quota_hours)
+        result = repo.update_quota(email, request.monthly_quota_usd)
         if result is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/src/apis/app_api/fine_tuning/dependencies.py
+++ b/backend/src/apis/app_api/fine_tuning/dependencies.py
@@ -5,14 +5,25 @@ import logging
 from fastapi import Depends, HTTPException, status
 from apis.shared.auth import User
 from apis.shared.auth.dependencies import get_current_user_from_session
-from .repository import FineTuningAccessRepository, get_fine_tuning_access_repository
+from .repository import (
+    LEGACY_HOURS_TO_USD,
+    FineTuningAccessRepository,
+    get_fine_tuning_access_repository,
+)
 
 logger = logging.getLogger(__name__)
 
-# Default monthly GPU-hour quota for users without an explicit grant.
+# Default monthly dollar quota for users without an explicit grant.
 # Set to 0 to revert to whitelist-only mode (original behaviour).
-DEFAULT_MONTHLY_QUOTA_HOURS = float(
-    os.environ.get("FINE_TUNING_DEFAULT_QUOTA_HOURS", "0")
+#
+# FINE_TUNING_DEFAULT_QUOTA_HOURS is still read as a fallback so an
+# environment configured before the quota moved to dollars keeps working; its
+# value is converted at the ml.g5.xlarge rate those hours were spent at.
+DEFAULT_MONTHLY_QUOTA_USD = float(
+    os.environ.get("FINE_TUNING_DEFAULT_QUOTA_USD", "0")
+) or (
+    float(os.environ.get("FINE_TUNING_DEFAULT_QUOTA_HOURS", "0"))
+    * LEGACY_HOURS_TO_USD
 )
 
 
@@ -22,7 +33,7 @@ async def require_fine_tuning_access(
 ) -> dict:
     """FastAPI dependency that enforces fine-tuning access.
 
-    Behaviour depends on ``FINE_TUNING_DEFAULT_QUOTA_HOURS``:
+    Behaviour depends on ``FINE_TUNING_DEFAULT_QUOTA_USD``:
 
     * **0 (default / whitelist mode):** Only users with an explicit grant
       in the ``fine-tuning-access`` table are allowed.  Anyone else
@@ -41,17 +52,17 @@ async def require_fine_tuning_access(
         return grant
 
     # No explicit grant exists for this user.
-    if DEFAULT_MONTHLY_QUOTA_HOURS > 0:
+    if DEFAULT_MONTHLY_QUOTA_USD > 0:
         # Open-access mode: auto-provision a grant with the default quota.
         logger.info(
             f"Auto-provisioning fine-tuning access for {user.email} "
-            f"with {DEFAULT_MONTHLY_QUOTA_HOURS}h default quota"
+            f"with ${DEFAULT_MONTHLY_QUOTA_USD:.2f} default quota"
         )
         try:
             new_grant = repo.grant_access(
                 email=user.email,
                 granted_by="system-default",
-                monthly_quota_hours=DEFAULT_MONTHLY_QUOTA_HOURS,
+                monthly_quota_usd=DEFAULT_MONTHLY_QUOTA_USD,
             )
             return new_grant
         except ValueError:

--- a/backend/src/apis/app_api/fine_tuning/inference_models.py
+++ b/backend/src/apis/app_api/fine_tuning/inference_models.py
@@ -1,6 +1,8 @@
 """Pydantic models for SageMaker Batch Transform inference jobs."""
 
 from pydantic import BaseModel, Field
+
+from . import task_types
 from typing import List, Optional
 
 
@@ -52,6 +54,9 @@ class TrainedModelResponse(BaseModel):
     training_job_id: str
     model_id: str
     model_name: str
+    #: The task this model was fine-tuned for.  Drives which input formats the
+    #: inference form will accept — an image classifier cannot read a .txt.
+    task_type: str = task_types.DEFAULT_TASK_TYPE
     model_s3_path: str
     instance_type: str
     completed_at: Optional[str] = None

--- a/backend/src/apis/app_api/fine_tuning/job_models.py
+++ b/backend/src/apis/app_api/fine_tuning/job_models.py
@@ -1,7 +1,10 @@
-"""Pydantic models, model catalog, and cost map for fine-tuning training jobs."""
+"""Pydantic models and the base-model catalog for fine-tuning training jobs."""
+
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional
+
+from . import task_types
 
 
 # =========================================================================
@@ -14,226 +17,238 @@ class AvailableModel(BaseModel):
     model_name: str
     huggingface_model_id: str
     description: str
+    #: Which task this checkpoint can be fine-tuned for.  A model is only
+    #: offered for its own task: a ViT cannot classify text and a BERT cannot
+    #: classify images, and letting the two mix produces a job that fails
+    #: several billed minutes into a GPU run.
+    task_type: str
     default_instance_type: str
     default_hyperparameters: Dict[str, str]
 
 
+def _hyperparameters(task_type: str, **overrides: str) -> Dict[str, str]:
+    """Task defaults with per-model overrides applied.
+
+    Keeps the catalog readable: a model entry states only what makes it
+    different, instead of repeating seven identical keys.
+    """
+    spec = task_types.get_task_spec(task_type)
+    return {**spec.default_hyperparameters, **overrides}
+
+
+_TEXT = task_types.TEXT_CLASSIFICATION
+_IMAGE = task_types.IMAGE_CLASSIFICATION
+_IMAGE_TEXT = task_types.IMAGE_TEXT_CLASSIFICATION
+
+
 AVAILABLE_MODELS: List[AvailableModel] = [
+    # ---------------------------------------------------------------
+    # Text classification
+    # ---------------------------------------------------------------
     AvailableModel(
         model_id="bert-base-uncased",
         model_name="BERT Base Uncased",
         huggingface_model_id="bert-base-uncased",
         description="110M parameter masked language model from Google, widely used baseline for NLP tasks",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="roberta-base",
         model_name="RoBERTa Base",
         huggingface_model_id="roberta-base",
         description="125M parameter robustly optimized BERT from Meta, strong on classification and NLU",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="electra-base",
         model_name="ELECTRA",
         huggingface_model_id="google/electra-base-discriminator",
         description="110M parameter discriminative model from Google, efficient pre-training with replaced token detection",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="electra-tiny",
         model_name="ELECTRA Tiny",
         huggingface_model_id="bsu-slim/electra-tiny",
         description="Tiny ELECTRA variant, very fast training for prototyping and experimentation",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "32",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT, per_device_train_batch_size="32"),
     ),
     AvailableModel(
         model_id="electra-tiny-mm",
         model_name="ELECTRA Tiny Multimodal",
         huggingface_model_id="bsu-slim/electra-tiny-mm",
         description="Multimodal tiny ELECTRA variant for cross-modal experimentation",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "32",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT, per_device_train_batch_size="32"),
     ),
     AvailableModel(
         model_id="childes-bert",
         model_name="BERT ChildES",
         huggingface_model_id="smeylan/childes-bert",
         description="BERT model pre-trained on child-directed speech, suited for developmental language research",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="distilgpt2",
         model_name="Distilled GPT2",
         huggingface_model_id="distilbert/distilgpt2",
         description="82M parameter distilled GPT-2, lightweight causal language model for fast iteration",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="childgpt",
         model_name="ChildGPT",
         huggingface_model_id="Aunsiels/ChildGPT",
         description="GPT model trained on child language data for developmental linguistics research",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "16",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT),
     ),
     AvailableModel(
         model_id="gpt2-medium",
         model_name="GPT2 Medium",
         huggingface_model_id="openai-community/gpt2-medium",
         description="355M parameter GPT-2 medium from OpenAI, good balance of capability and efficiency",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "8",
-            "learning_rate": "2e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(
+            _TEXT, per_device_train_batch_size="8", learning_rate="2e-5"
+        ),
     ),
     AvailableModel(
         model_id="eurollm-1.7b-instruct",
         model_name="EuroLLM 1.7B Instruct",
         huggingface_model_id="utter-project/EuroLLM-1.7B-Instruct",
         description="1.7B parameter multilingual European LLM with instruction tuning",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "4",
-            "learning_rate": "2e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(
+            _TEXT, per_device_train_batch_size="4", learning_rate="2e-5"
+        ),
     ),
     AvailableModel(
         model_id="smollm2-135m-instruct",
         model_name="SmolLM2 135M Instruct",
         huggingface_model_id="HuggingFaceTB/SmolLM2-135M-Instruct",
         description="135M parameter instruction-tuned model from HuggingFace, ultra-lightweight for fast experiments",
+        task_type=_TEXT,
         default_instance_type="ml.g5.xlarge",
-        default_hyperparameters={
-            "epochs": "3",
-            "per_device_train_batch_size": "32",
-            "learning_rate": "5e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        },
+        default_hyperparameters=_hyperparameters(_TEXT, per_device_train_batch_size="32"),
+    ),
+    # ---------------------------------------------------------------
+    # Image classification
+    # ---------------------------------------------------------------
+    AvailableModel(
+        model_id="vit-base",
+        model_name="ViT Base",
+        huggingface_model_id="google/vit-base-patch16-224",
+        description="86M parameter Vision Transformer from Google, the standard baseline for image classification",
+        task_type=_IMAGE,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE),
+    ),
+    AvailableModel(
+        model_id="resnet-50",
+        model_name="ResNet-50",
+        huggingface_model_id="microsoft/resnet-50",
+        description="25M parameter convolutional network, fast to train and a strong classical baseline",
+        task_type=_IMAGE,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE, per_device_train_batch_size="32"),
+    ),
+    AvailableModel(
+        model_id="convnext-tiny",
+        model_name="ConvNeXt Tiny",
+        huggingface_model_id="facebook/convnext-tiny-224",
+        description="29M parameter modernised convolutional network from Meta, competitive with transformers at low cost",
+        task_type=_IMAGE,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE, per_device_train_batch_size="32"),
+    ),
+    AvailableModel(
+        model_id="swin-tiny",
+        model_name="Swin Tiny",
+        huggingface_model_id="microsoft/swin-tiny-patch4-window7-224",
+        description="28M parameter hierarchical vision transformer from Microsoft, strong on fine-grained detail",
+        task_type=_IMAGE,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE),
+    ),
+    # ---------------------------------------------------------------
+    # Image + text classification
+    #
+    # These must be dual encoders exposing get_image_features and
+    # get_text_features — the fusion head reads both towers.
+    # ---------------------------------------------------------------
+    AvailableModel(
+        model_id="clip-vit-base",
+        model_name="CLIP ViT-B/32",
+        huggingface_model_id="openai/clip-vit-base-patch32",
+        description="151M parameter image/text dual encoder from OpenAI, the standard baseline for cross-modal tasks",
+        task_type=_IMAGE_TEXT,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE_TEXT),
+    ),
+    AvailableModel(
+        model_id="clip-vit-large",
+        model_name="CLIP ViT-L/14",
+        huggingface_model_id="openai/clip-vit-large-patch14",
+        description="428M parameter CLIP from OpenAI, higher accuracy at meaningfully higher training cost",
+        task_type=_IMAGE_TEXT,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE_TEXT, per_device_train_batch_size="8"),
+    ),
+    AvailableModel(
+        model_id="siglip-base",
+        model_name="SigLIP Base",
+        huggingface_model_id="google/siglip-base-patch16-224",
+        description="203M parameter dual encoder from Google using a sigmoid loss, stronger than CLIP at equal size",
+        task_type=_IMAGE_TEXT,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE_TEXT, context_length="64"),
+    ),
+    AvailableModel(
+        model_id="clip-laion-b32",
+        model_name="CLIP ViT-B/32 (LAION-2B)",
+        huggingface_model_id="laion/CLIP-ViT-B-32-laion2B-s34B-b79K",
+        description="Open-data CLIP trained on LAION-2B, a reproducible alternative to the OpenAI weights",
+        task_type=_IMAGE_TEXT,
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters=_hyperparameters(_IMAGE_TEXT),
     ),
 ]
 
 MODEL_CATALOG: Dict[str, AvailableModel] = {m.model_id: m for m in AVAILABLE_MODELS}
 
 
-# =========================================================================
-# Instance Cost Map (on-demand USD/hour, us-west-2 pricing)
-# =========================================================================
-
-INSTANCE_COST_PER_HOUR: Dict[str, float] = {
-    "ml.g5.xlarge": 1.41,
-    "ml.g5.2xlarge": 1.515,
-    "ml.g5.4xlarge": 2.03,
-    "ml.g5.8xlarge": 3.06,
-    "ml.g5.12xlarge": 7.09,
-    "ml.g5.16xlarge": 6.10,
-    "ml.g5.24xlarge": 10.18,
-    "ml.g5.48xlarge": 20.36,
-    "ml.p3.2xlarge": 3.825,
-    "ml.p3.8xlarge": 14.688,
-    "ml.p3.16xlarge": 28.152,
-}
+def models_for_task(task_type: Optional[str]) -> List[AvailableModel]:
+    """Catalog entries trainable for ``task_type``, in catalog order."""
+    resolved = task_types.get_task_spec(task_type).task_type
+    return [m for m in AVAILABLE_MODELS if m.task_type == resolved]
 
 
 # =========================================================================
 # Request / Response Models
 # =========================================================================
 
-# Dataset formats the SageMaker training script can read — keep in sync with
-# SUPPORTED_DATASET_EXTENSIONS in fine_tuning/sagemaker_scripts/train.py.
-# Enforced here so an unreadable dataset is rejected before a GPU instance is
-# ever provisioned; otherwise the job fails several billed minutes in.
-SUPPORTED_DATASET_EXTENSIONS = (".csv", ".jsonl", ".json")
-
-
 class PresignRequest(BaseModel):
     """Request for a presigned upload URL for a training dataset."""
     filename: str
     content_type: str
+    task_type: str = task_types.DEFAULT_TASK_TYPE
 
 
 class PresignResponse(BaseModel):
@@ -247,6 +262,7 @@ class CreateJobRequest(BaseModel):
     """Request to create a new fine-tuning training job."""
     model_id: str
     dataset_s3_key: str
+    task_type: str = task_types.DEFAULT_TASK_TYPE
     instance_type: Optional[str] = None
     hyperparameters: Optional[Dict[str, str]] = None
     max_runtime_seconds: int = Field(default=86400, le=432000, gt=0)
@@ -260,6 +276,7 @@ class JobResponse(BaseModel):
     email: str
     model_id: str
     model_name: str
+    task_type: str = task_types.DEFAULT_TASK_TYPE
     status: str
     dataset_s3_key: str
     output_s3_prefix: Optional[str] = None
@@ -282,3 +299,15 @@ class JobListResponse(BaseModel):
     """Response for listing training jobs."""
     jobs: List[JobResponse]
     total_count: int
+
+
+class TaskTypeResponse(BaseModel):
+    """A task type offered by the platform, for the create-job UI."""
+    task_type: str
+    display_name: str
+    description: str
+    required_columns: List[str]
+    upload_extensions: List[str]
+    requires_archive: bool
+    inference_upload_extensions: List[str]
+    default_instance_type: str

--- a/backend/src/apis/app_api/fine_tuning/job_repository.py
+++ b/backend/src/apis/app_api/fine_tuning/job_repository.py
@@ -9,6 +9,8 @@ from typing import Optional, List, Dict, Any
 import boto3
 from botocore.exceptions import ClientError
 
+from . import task_types
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,6 +49,9 @@ class FineTuningJobsRepository:
             "email": item["email"],
             "model_id": item["model_id"],
             "model_name": item["model_name"],
+            # Jobs written before task types existed carry no attribute; they
+            # are all text classifiers.
+            "task_type": item.get("task_type", task_types.DEFAULT_TASK_TYPE),
             "status": item["status"],
             "dataset_s3_key": item["dataset_s3_key"],
             "output_s3_prefix": item.get("output_s3_prefix"),
@@ -79,6 +84,7 @@ class FineTuningJobsRepository:
         sagemaker_job_name: str,
         output_s3_prefix: str,
         max_runtime_seconds: int = 86400,
+        task_type: str = task_types.DEFAULT_TASK_TYPE,
     ) -> dict:
         """Create a new training job record."""
         now = datetime.now(timezone.utc).isoformat()
@@ -91,6 +97,7 @@ class FineTuningJobsRepository:
             "email": email,
             "model_id": model_id,
             "model_name": model_name,
+            "task_type": task_type,
             "status": "PENDING",
             "dataset_s3_key": dataset_s3_key,
             "output_s3_prefix": output_s3_prefix,

--- a/backend/src/apis/app_api/fine_tuning/models.py
+++ b/backend/src/apis/app_api/fine_tuning/models.py
@@ -1,7 +1,15 @@
-"""Pydantic models for fine-tuning access control and quota."""
+"""Pydantic models for fine-tuning access control and quota.
+
+The quota is denominated in **US dollars**, not GPU-hours.  Hours were a
+proxy that stopped tracking the thing being budgeted the moment more than one
+instance type was offered: ten hours buys about $14 on an ml.g5.xlarge and
+roughly $450 on an ml.g6e.24xlarge.  Grants written against the old field are
+migrated lazily on read — see ``repository.FineTuningAccessRepository``.
+"""
+
+from typing import Optional
 
 from pydantic import BaseModel, Field
-from typing import Optional
 
 
 class FineTuningAccessGrant(BaseModel):
@@ -9,21 +17,21 @@ class FineTuningAccessGrant(BaseModel):
     email: str
     granted_by: str
     granted_at: str
-    monthly_quota_hours: float = Field(default=10.0)
-    current_month_usage_hours: float = Field(default=0.0)
+    monthly_quota_usd: float = Field(default=15.0)
+    current_month_usage_usd: float = Field(default=0.0)
     quota_period: str = Field(description="YYYY-MM format for lazy reset detection")
 
 
 class FineTuningAccessResponse(BaseModel):
     """User-facing response for access check."""
     has_access: bool
-    monthly_quota_hours: Optional[float] = None
-    current_month_usage_hours: Optional[float] = None
+    monthly_quota_usd: Optional[float] = None
+    current_month_usage_usd: Optional[float] = None
     quota_period: Optional[str] = None
 
 
 class QuotaCheckResult(BaseModel):
     """Internal result of a quota check before job creation."""
     allowed: bool
-    remaining_hours: float
+    remaining_usd: float
     message: str

--- a/backend/src/apis/app_api/fine_tuning/pricing.py
+++ b/backend/src/apis/app_api/fine_tuning/pricing.py
@@ -1,0 +1,164 @@
+"""SageMaker instance pricing and capability map for fine-tuning.
+
+Rates are **us-west-2 on-demand USD/hour**, taken from the AWS Price List API
+(``aws pricing get-products --service-code AmazonSageMaker``), filtered to the
+``Training`` and ``BatchTransform`` components.  They are not from the pricing
+web page, which rounds and lags.
+
+Two things this module gets right that a single flat map could not:
+
+1. **Training and Batch Transform are priced separately.**  They agree across
+   the g5 family but diverge on g6e (e.g. ml.g6e.24xlarge is $18.83/hr to
+   train and $18.8319875/hr to transform), and some instances are offered for
+   one and not the other at all.
+2. **Not every training instance can run Batch Transform.**  ml.p4d.24xlarge
+   and ml.p5.48xlarge publish a Training rate and no BatchTransform rate — an
+   inference job on one is rejected by AWS.  Absence from
+   :data:`TRANSFORM_COST_PER_HOUR` is how we refuse it before billing.
+
+``ml.p3.*`` is deliberately absent: the Price List API returns no on-demand
+SageMaker rate for that family in us-west-2 at all, so the three entries this
+map used to carry priced instances a job could never actually provision.
+``ml.p4d.24xlarge`` and ``ml.p5.48xlarge`` are also left out — they train but
+cannot Batch Transform, so offering them would let a researcher fine-tune a
+model they then have no way to run inference on.  Add them only alongside a
+non-Batch-Transform inference path.
+
+Pricing accuracy is now load-bearing rather than cosmetic: the monthly quota
+is denominated in dollars, so a wrong rate does not just misreport spend, it
+mis-enforces the budget.  Re-run ``backend/scripts/refresh_instance_pricing.py`` to
+resync after an AWS price change.
+"""
+
+from typing import Dict, Optional, Tuple
+
+
+# =========================================================================
+# Training rates (USD/hour, us-west-2 on-demand)
+# =========================================================================
+
+TRAINING_COST_PER_HOUR: Dict[str, float] = {
+    # --- G5 (NVIDIA A10G, 24GB) ---
+    "ml.g5.xlarge": 1.408,
+    "ml.g5.2xlarge": 1.515,
+    "ml.g5.4xlarge": 2.03,
+    "ml.g5.8xlarge": 3.06,
+    "ml.g5.12xlarge": 7.09,
+    "ml.g5.16xlarge": 5.12,
+    "ml.g5.24xlarge": 10.18,
+    "ml.g5.48xlarge": 20.36,
+    # --- G6 (NVIDIA L4, 24GB) — newer and cheaper than G5 at every size ---
+    "ml.g6.xlarge": 1.127,
+    "ml.g6.2xlarge": 1.222,
+    "ml.g6.4xlarge": 1.654,
+    "ml.g6.8xlarge": 2.518,
+    "ml.g6.12xlarge": 5.752,
+    "ml.g6.24xlarge": 8.344,
+    "ml.g6.48xlarge": 16.688,
+    # --- G6e (NVIDIA L40S, 48GB) — the memory headroom vision models want ---
+    "ml.g6e.xlarge": 2.61,
+    "ml.g6e.2xlarge": 2.8,
+    "ml.g6e.4xlarge": 3.76,
+    "ml.g6e.8xlarge": 5.66,
+    "ml.g6e.12xlarge": 13.12,
+    "ml.g6e.24xlarge": 18.83,
+    "ml.g6e.48xlarge": 37.66,
+}
+
+
+# =========================================================================
+# Batch Transform rates (USD/hour, us-west-2 on-demand)
+# =========================================================================
+
+TRANSFORM_COST_PER_HOUR: Dict[str, float] = {
+    "ml.g5.xlarge": 1.408,
+    "ml.g5.2xlarge": 1.515,
+    "ml.g5.4xlarge": 2.03,
+    "ml.g5.8xlarge": 3.06,
+    "ml.g5.12xlarge": 7.09,
+    "ml.g5.16xlarge": 5.12,
+    "ml.g5.24xlarge": 10.18,
+    "ml.g5.48xlarge": 20.36,
+    "ml.g6.xlarge": 1.1267,
+    "ml.g6.2xlarge": 1.222,
+    "ml.g6.4xlarge": 1.654,
+    "ml.g6.8xlarge": 2.518,
+    "ml.g6.12xlarge": 5.752,
+    "ml.g6.24xlarge": 8.344,
+    "ml.g6.48xlarge": 16.688,
+    "ml.g6e.xlarge": 2.6054,
+    "ml.g6e.2xlarge": 2.8026,
+    "ml.g6e.4xlarge": 3.7553,
+    "ml.g6e.8xlarge": 5.6607,
+    "ml.g6e.12xlarge": 13.1158,
+    "ml.g6e.24xlarge": 18.8319875,
+    "ml.g6e.48xlarge": 37.663975,
+}
+
+
+# =========================================================================
+# Accelerator memory (GB of GPU VRAM per instance, summed across GPUs)
+# =========================================================================
+
+# Used to warn a user before they submit a model that cannot fit, rather than
+# letting them discover it as a CUDA OOM several billed minutes in.
+ACCELERATOR_MEMORY_GB: Dict[str, int] = {
+    "ml.g5.xlarge": 24, "ml.g5.2xlarge": 24, "ml.g5.4xlarge": 24,
+    "ml.g5.8xlarge": 24, "ml.g5.16xlarge": 24,
+    "ml.g5.12xlarge": 96, "ml.g5.24xlarge": 96, "ml.g5.48xlarge": 192,
+    "ml.g6.xlarge": 24, "ml.g6.2xlarge": 24, "ml.g6.4xlarge": 24,
+    "ml.g6.8xlarge": 24, "ml.g6.16xlarge": 24,
+    "ml.g6.12xlarge": 96, "ml.g6.24xlarge": 96, "ml.g6.48xlarge": 192,
+    "ml.g6e.xlarge": 48, "ml.g6e.2xlarge": 48, "ml.g6e.4xlarge": 48,
+    "ml.g6e.8xlarge": 48,
+    "ml.g6e.12xlarge": 192, "ml.g6e.24xlarge": 192, "ml.g6e.48xlarge": 384,
+}
+
+
+# =========================================================================
+# Lookups
+# =========================================================================
+
+def training_rate(instance_type: str) -> Optional[float]:
+    """USD/hour to train on ``instance_type``, or None if we have no rate."""
+    return TRAINING_COST_PER_HOUR.get(instance_type)
+
+
+def transform_rate(instance_type: str) -> Optional[float]:
+    """USD/hour to Batch Transform on ``instance_type``, or None if unsupported."""
+    return TRANSFORM_COST_PER_HOUR.get(instance_type)
+
+
+def calculate_cost(
+    instance_type: str, billable_seconds: int, *, transform: bool = False
+) -> float:
+    """Cost in USD for ``billable_seconds`` on ``instance_type``.
+
+    Returns 0.0 for an instance we have no rate for.  Callers must not rely on
+    that to mean "free" — validate the instance up front instead; a silent
+    0.0 is exactly the blind spot that lets unpriced GPU time go unbilled.
+    """
+    rate = transform_rate(instance_type) if transform else training_rate(instance_type)
+    return round((rate or 0.0) * (billable_seconds / 3600), 4)
+
+
+def estimate_max_cost(
+    instance_type: str, max_runtime_seconds: int, *, transform: bool = False
+) -> float:
+    """Worst-case cost if a job runs to its full ``max_runtime_seconds``.
+
+    This is what the dollar quota reserves against at submission time: the
+    actual bill is only known when the job stops, so admitting a job on its
+    *current* spend would let a single long run overshoot the budget.
+    """
+    return calculate_cost(instance_type, max_runtime_seconds, transform=transform)
+
+
+def supported_training_instances() -> Tuple[str, ...]:
+    """Instance types we can price for training, cheapest first."""
+    return tuple(sorted(TRAINING_COST_PER_HOUR, key=lambda i: TRAINING_COST_PER_HOUR[i]))
+
+
+def supported_transform_instances() -> Tuple[str, ...]:
+    """Instance types we can price for Batch Transform, cheapest first."""
+    return tuple(sorted(TRANSFORM_COST_PER_HOUR, key=lambda i: TRANSFORM_COST_PER_HOUR[i]))

--- a/backend/src/apis/app_api/fine_tuning/repository.py
+++ b/backend/src/apis/app_api/fine_tuning/repository.py
@@ -1,4 +1,4 @@
-"""DynamoDB repository for fine-tuning access control table."""
+"""DynamoDB repository for the fine-tuning access control table."""
 
 import os
 import logging
@@ -9,7 +9,18 @@ from typing import Optional, List
 import boto3
 from botocore.exceptions import ClientError
 
+from . import pricing
+
 logger = logging.getLogger(__name__)
+
+#: Default dollar quota for a new grant.  Approximately what the previous
+#: 10 GPU-hour default bought on the ml.g5.xlarge every job actually ran on.
+DEFAULT_QUOTA_USD = 15.0
+
+#: Rate used to convert a legacy hours-denominated grant to dollars.  Every
+#: grant written before the dollar quota existed was spent on ml.g5.xlarge —
+#: it was the only default — so its training rate is the faithful conversion.
+LEGACY_HOURS_TO_USD = pricing.training_rate("ml.g5.xlarge") or 1.408
 
 
 class FineTuningAccessRepository:
@@ -20,8 +31,14 @@ class FineTuningAccessRepository:
         SK: ACCESS          (fixed literal)
 
     Attributes:
-        email, granted_by, granted_at, monthly_quota_hours,
-        current_month_usage_hours, quota_period (YYYY-MM)
+        email, granted_by, granted_at, monthly_quota_usd,
+        current_month_usage_usd, quota_period (YYYY-MM)
+
+    **Legacy grants.**  Records written before the quota moved to dollars
+    carry ``monthly_quota_hours``/``current_month_usage_hours`` instead.  They
+    are converted on read and written back on the next
+    :meth:`check_and_reset_quota`, so the migration is lazy and self-healing
+    rather than a backfill script that has to be run in every environment.
     """
 
     def __init__(self, table_name: Optional[str] = None):
@@ -39,14 +56,30 @@ class FineTuningAccessRepository:
     def _current_period() -> str:
         return datetime.now(timezone.utc).strftime("%Y-%m")
 
+    @staticmethod
+    def _needs_migration(item: dict) -> bool:
+        """True when a record predates the dollar quota."""
+        return "monthly_quota_usd" not in item and "monthly_quota_hours" in item
+
     def _item_to_dict(self, item: dict) -> dict:
-        """Convert DynamoDB item to a plain dict, converting Decimals to float."""
+        """Convert a DynamoDB item to a plain dict, Decimals to float.
+
+        Converts a legacy hours-denominated grant to dollars on the way out so
+        callers only ever see one shape.
+        """
+        if self._needs_migration(item):
+            quota = float(item.get("monthly_quota_hours", 10)) * LEGACY_HOURS_TO_USD
+            usage = float(item.get("current_month_usage_hours", 0)) * LEGACY_HOURS_TO_USD
+        else:
+            quota = float(item.get("monthly_quota_usd", DEFAULT_QUOTA_USD))
+            usage = float(item.get("current_month_usage_usd", 0))
+
         return {
             "email": item["email"],
             "granted_by": item.get("granted_by", ""),
             "granted_at": item.get("granted_at", ""),
-            "monthly_quota_hours": float(item.get("monthly_quota_hours", 10)),
-            "current_month_usage_hours": float(item.get("current_month_usage_hours", 0)),
+            "monthly_quota_usd": round(quota, 4),
+            "current_month_usage_usd": round(usage, 4),
             "quota_period": item.get("quota_period", ""),
         }
 
@@ -90,7 +123,7 @@ class FineTuningAccessRepository:
         self,
         email: str,
         granted_by: str,
-        monthly_quota_hours: float = 10.0,
+        monthly_quota_usd: float = DEFAULT_QUOTA_USD,
     ) -> dict:
         """Grant fine-tuning access to an email.
 
@@ -106,8 +139,8 @@ class FineTuningAccessRepository:
             "email": email.lower(),
             "granted_by": granted_by,
             "granted_at": now,
-            "monthly_quota_hours": Decimal(str(monthly_quota_hours)),
-            "current_month_usage_hours": Decimal("0"),
+            "monthly_quota_usd": Decimal(str(monthly_quota_usd)),
+            "current_month_usage_usd": Decimal("0"),
             "quota_period": period,
         }
 
@@ -123,14 +156,16 @@ class FineTuningAccessRepository:
                 raise ValueError(f"Access already granted to {email.lower()}")
             raise
 
-    def update_quota(self, email: str, monthly_quota_hours: float) -> Optional[dict]:
-        """Update the monthly quota for a user. Returns None if not found."""
+    def update_quota(self, email: str, monthly_quota_usd: float) -> Optional[dict]:
+        """Update the monthly dollar quota for a user. Returns None if not found."""
         try:
             response = self._table.update_item(
                 Key={"PK": self._make_pk(email), "SK": "ACCESS"},
-                UpdateExpression="SET monthly_quota_hours = :mq",
+                UpdateExpression=(
+                    "SET monthly_quota_usd = :mq REMOVE monthly_quota_hours"
+                ),
                 ExpressionAttributeValues={
-                    ":mq": Decimal(str(monthly_quota_hours)),
+                    ":mq": Decimal(str(monthly_quota_usd)),
                 },
                 ConditionExpression="attribute_exists(PK)",
                 ReturnValues="ALL_NEW",
@@ -156,42 +191,78 @@ class FineTuningAccessRepository:
             raise
 
     def check_and_reset_quota(self, email: str) -> Optional[dict]:
-        """Check quota and lazily reset if a new month has started.
+        """Check quota, lazily resetting it when a new month has started.
+
+        Also completes the hours-to-dollars migration for a legacy record, so
+        a grant is rewritten in the new shape the first time its owner is seen
+        rather than by a backfill script run per environment.
 
         Returns the (possibly updated) access grant, or None if not found.
         """
-        item = self.get_access(email)
-        if item is None:
+        try:
+            response = self._table.get_item(
+                Key={"PK": self._make_pk(email), "SK": "ACCESS"}
+            )
+            raw = response.get("Item")
+        except ClientError as e:
+            logger.error(f"Error getting access for {email}: {e}")
+            raise
+
+        if raw is None:
             return None
 
+        item = self._item_to_dict(raw)
         current_period = self._current_period()
-        if item["quota_period"] != current_period:
-            try:
-                response = self._table.update_item(
-                    Key={"PK": self._make_pk(email), "SK": "ACCESS"},
-                    UpdateExpression="SET current_month_usage_hours = :zero, quota_period = :period",
-                    ExpressionAttributeValues={
-                        ":zero": Decimal("0"),
-                        ":period": current_period,
-                    },
-                    ReturnValues="ALL_NEW",
-                )
-                logger.info(f"Reset quota for {email.lower()} to period {current_period}")
-                return self._item_to_dict(response["Attributes"])
-            except ClientError as e:
-                logger.error(f"Error resetting quota for {email}: {e}")
-                raise
+        needs_migration = self._needs_migration(raw)
+        new_period = item["quota_period"] != current_period
 
-        return item
+        if not needs_migration and not new_period:
+            return item
 
-    def increment_usage(self, email: str, hours: float) -> Optional[dict]:
-        """Atomically increment current_month_usage_hours."""
+        # A new month zeroes usage; a migration carries the converted usage
+        # across so a user cannot reset their own spend by being migrated.
+        usage = Decimal("0") if new_period else Decimal(str(item["current_month_usage_usd"]))
+
+        update = (
+            "SET monthly_quota_usd = :quota, "
+            "current_month_usage_usd = :usage, "
+            "quota_period = :period "
+            "REMOVE monthly_quota_hours, current_month_usage_hours"
+        )
+
         try:
             response = self._table.update_item(
                 Key={"PK": self._make_pk(email), "SK": "ACCESS"},
-                UpdateExpression="ADD current_month_usage_hours :hours",
+                UpdateExpression=update,
                 ExpressionAttributeValues={
-                    ":hours": Decimal(str(hours)),
+                    ":quota": Decimal(str(item["monthly_quota_usd"])),
+                    ":usage": usage,
+                    ":period": current_period,
+                },
+                ReturnValues="ALL_NEW",
+            )
+        except ClientError as e:
+            logger.error(f"Error resetting quota for {email}: {e}")
+            raise
+
+        if needs_migration:
+            logger.info(
+                f"Migrated {email.lower()} to a dollar quota: "
+                f"${item['monthly_quota_usd']:.2f}/month"
+            )
+        if new_period:
+            logger.info(f"Reset quota for {email.lower()} to period {current_period}")
+
+        return self._item_to_dict(response["Attributes"])
+
+    def increment_usage(self, email: str, usd: float) -> Optional[dict]:
+        """Atomically add spend to current_month_usage_usd."""
+        try:
+            response = self._table.update_item(
+                Key={"PK": self._make_pk(email), "SK": "ACCESS"},
+                UpdateExpression="ADD current_month_usage_usd :usd",
+                ExpressionAttributeValues={
+                    ":usd": Decimal(str(usd)),
                 },
                 ConditionExpression="attribute_exists(PK)",
                 ReturnValues="ALL_NEW",

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -903,6 +903,7 @@ async def list_trained_models(
                 model_id=job["model_id"],
                 model_name=job["model_name"],
                 model_s3_path=model_s3_path,
+                task_type=job.get("task_type", task_types.DEFAULT_TASK_TYPE),
                 instance_type=job["instance_type"],
                 completed_at=job.get("training_end_time"),
                 estimated_cost_usd=job.get("estimated_cost_usd"),

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -5,7 +5,7 @@ import os
 import uuid
 import logging
 from datetime import datetime, timezone, timedelta
-from typing import Optional
+from typing import List, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -17,16 +17,17 @@ from .repository import (
     FineTuningAccessRepository,
     get_fine_tuning_access_repository,
 )
+from . import pricing, task_types
 from .job_models import (
     AVAILABLE_MODELS,
-    INSTANCE_COST_PER_HOUR,
     MODEL_CATALOG,
-    SUPPORTED_DATASET_EXTENSIONS,
     PresignRequest,
     PresignResponse,
     CreateJobRequest,
     JobResponse,
     JobListResponse,
+    TaskTypeResponse,
+    models_for_task,
 )
 from .job_repository import FineTuningJobsRepository, get_fine_tuning_jobs_repository
 from .s3_service import FineTuningS3Service, get_fine_tuning_s3_service
@@ -60,24 +61,24 @@ async def check_access(
     This endpoint does NOT require fine-tuning access — it is used by
     the frontend to decide whether to show the fine-tuning UI.
     """
-    from .dependencies import DEFAULT_MONTHLY_QUOTA_HOURS
+    from .dependencies import DEFAULT_MONTHLY_QUOTA_USD
 
     grant = repo.check_and_reset_quota(user.email)
 
     if grant is not None:
         return FineTuningAccessResponse(
             has_access=True,
-            monthly_quota_hours=grant["monthly_quota_hours"],
-            current_month_usage_hours=grant["current_month_usage_hours"],
+            monthly_quota_usd=grant["monthly_quota_usd"],
+            current_month_usage_usd=grant["current_month_usage_usd"],
             quota_period=grant["quota_period"],
         )
 
     # No explicit grant — check if open-access mode is enabled.
-    if DEFAULT_MONTHLY_QUOTA_HOURS > 0:
+    if DEFAULT_MONTHLY_QUOTA_USD > 0:
         return FineTuningAccessResponse(
             has_access=True,
-            monthly_quota_hours=DEFAULT_MONTHLY_QUOTA_HOURS,
-            current_month_usage_hours=0.0,
+            monthly_quota_usd=DEFAULT_MONTHLY_QUOTA_USD,
+            current_month_usage_usd=0.0,
             quota_period=None,
         )
 
@@ -90,37 +91,77 @@ async def check_access(
 
 @router.get("/models")
 async def list_models(
+    task_type: Optional[str] = Query(None),
     grant: dict = Depends(require_fine_tuning_access),
 ):
-    """List available base models for fine-tuning."""
-    return [m.model_dump() for m in AVAILABLE_MODELS]
+    """List available base models, optionally narrowed to one task type."""
+    if task_type is None:
+        return [m.model_dump() for m in AVAILABLE_MODELS]
+
+    try:
+        return [m.model_dump() for m in models_for_task(task_type)]
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/task-types", response_model=List[TaskTypeResponse])
+async def list_task_types(
+    grant: dict = Depends(require_fine_tuning_access),
+):
+    """List the fine-tuning task types the platform supports.
+
+    Drives the create-job UI: the dataset contract, the accepted upload
+    formats and the model list all follow from the chosen task.
+    """
+    return [
+        TaskTypeResponse(
+            task_type=spec.task_type,
+            display_name=spec.display_name,
+            description=spec.description,
+            required_columns=list(spec.required_columns),
+            upload_extensions=list(spec.upload_extensions),
+            requires_archive=spec.requires_archive,
+            inference_upload_extensions=list(spec.inference_upload_extensions),
+            default_instance_type=spec.default_instance_type,
+        )
+        for spec in (
+            task_types.get_task_spec(t) for t in task_types.TASK_TYPES
+        )
+    ]
 
 
 # =========================================================================
 # HuggingFace Model Search (proxy)
 # =========================================================================
 
-# Pipeline tags compatible with AutoModelForSequenceClassification
-COMPATIBLE_PIPELINE_TAGS = [
-    "fill-mask",
-    "text-classification",
-    "feature-extraction",
-    "token-classification",
-    "text-generation",
-]
+#: Weight files a task can actually be fine-tuned from.  A repo carrying only
+#: GGUF (llama.cpp) or other quantised artifacts cannot be loaded by
+#: ``from_pretrained`` for training — it will provision a GPU and fail minutes
+#: in, which is exactly the failure this check exists to prevent.
+TRAINABLE_WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".msgpack", ".h5")
 
 
 @router.get("/huggingface-models")
 async def search_huggingface_models(
     search: str = Query(..., min_length=2, max_length=200),
     compatible_only: bool = Query(True),
+    task_type: str = Query(task_types.DEFAULT_TASK_TYPE),
     grant: dict = Depends(require_fine_tuning_access),
 ):
     """Search HuggingFace Hub models. Proxied to avoid CORS issues.
 
     When compatible_only=True (default), makes parallel requests for each
-    compatible pipeline_tag and merges results sorted by downloads.
+    pipeline_tag the *task* can use and merges results sorted by downloads.
+    Searching image models with the text task's tags returns a list of models
+    that all fail on submission, so the tags follow the task.
     """
+    try:
+        spec = task_types.get_task_spec(task_type)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    pipeline_tags = list(spec.hf_pipeline_tags)
+
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             if compatible_only:
@@ -143,7 +184,7 @@ async def search_huggingface_models(
                     return resp.json()
 
                 results = await asyncio.gather(
-                    *[_fetch_tag(tag) for tag in COMPATIBLE_PIPELINE_TAGS],
+                    *[_fetch_tag(tag) for tag in pipeline_tags],
                     return_exceptions=True,
                 )
 
@@ -191,48 +232,201 @@ async def search_huggingface_models(
         raise HTTPException(status_code=502, detail="Failed to search HuggingFace models")
 
 
+async def preflight_huggingface_model(hf_id: str, spec) -> None:
+    """Reject a custom HuggingFace model that cannot serve ``spec``.
+
+    Three failure modes, all of which otherwise provision a GPU and die
+    minutes into a billed run with an opaque traceback:
+
+    1. the repo does not exist (typo, or a gated/private model);
+    2. it carries no loadable weights — a GGUF-only repo is the common case,
+       since llama.cpp quantisations cannot be fine-tuned by transformers;
+    3. its pipeline tag belongs to a different modality than the chosen task.
+
+    Network problems are *not* treated as failures: the Hub being unreachable
+    should not block a submission, so an unavailable check falls through and
+    lets the training job be the judge.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"https://huggingface.co/api/models/{hf_id}")
+    except httpx.HTTPError as e:
+        logger.warning(f"HuggingFace pre-flight unavailable for {hf_id}: {e}")
+        return
+
+    if response.status_code == 404:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"HuggingFace model '{hf_id}' was not found. Check the id, and "
+                f"note that gated or private models cannot be used."
+            ),
+        )
+    if response.status_code >= 400:
+        logger.warning(
+            f"HuggingFace pre-flight returned {response.status_code} for {hf_id}"
+        )
+        return
+
+    payload = response.json()
+
+    filenames = [s.get("rfilename", "") for s in payload.get("siblings", [])]
+    if filenames and not any(
+        name.endswith(TRAINABLE_WEIGHT_SUFFIXES) for name in filenames
+    ):
+        gguf = any(name.lower().endswith(".gguf") for name in filenames)
+        reason = (
+            "it only publishes GGUF (llama.cpp) quantisations, which cannot be "
+            "fine-tuned"
+            if gguf
+            else "it publishes no loadable model weights"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"HuggingFace model '{hf_id}' cannot be fine-tuned because "
+                f"{reason}. Look for the original (unquantised) repository."
+            ),
+        )
+
+    pipeline_tag = payload.get("pipeline_tag")
+    if pipeline_tag and pipeline_tag not in spec.hf_pipeline_tags:
+        supported = ", ".join(spec.hf_pipeline_tags)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"HuggingFace model '{hf_id}' is tagged '{pipeline_tag}', which "
+                f"is not compatible with {spec.display_name.lower()}. "
+                f"Compatible tags: {supported}."
+            ),
+        )
+
+
 # =========================================================================
 # Presigned URL
 # =========================================================================
 
-def _validate_dataset_format(name: str) -> None:
+def _validate_dataset_format(name: str, spec) -> None:
     """Reject a dataset filename the training script could not read.
 
     Checked before upload and again before the job is submitted, so an
     unreadable dataset never reaches a billed GPU instance.
     """
-    if not name.lower().endswith(SUPPORTED_DATASET_EXTENSIONS):
-        supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
+    if not spec.supports_extension(name):
+        supported = ", ".join(spec.upload_extensions)
+        required = ", ".join(f'"{c}"' for c in spec.required_columns)
+        detail = (
+            f"Unsupported dataset format for {spec.display_name.lower()}. "
+            f"Supported formats: {supported}. "
+        )
+        if spec.requires_archive:
+            detail += (
+                f"Upload a .zip containing a manifest (CSV/JSONL/JSON) with "
+                f"{required} fields, plus the image files it references."
+            )
+        else:
+            detail += f"Each record needs {required} fields."
+        raise HTTPException(status_code=400, detail=detail)
+
+
+def _resolve_task_spec(task_type: Optional[str]):
+    """Resolve a task type from a request, as a 400 rather than a 500."""
+    try:
+        return task_types.get_task_spec(task_type)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+#: Shortest run worth starting.  Below this a GPU job cannot even pull its
+#: container image and download the base model, so admitting one would spend
+#: the user's remaining budget on producing nothing.
+MIN_BUDGETED_RUNTIME_SECONDS = 1800
+
+
+def _budgeted_runtime(
+    requested_seconds: int,
+    instance_type: str,
+    remaining_usd: float,
+    *,
+    transform: bool = False,
+) -> int:
+    """Clamp a job's stopping condition to what the remaining budget affords.
+
+    Admitting on worst-case cost alone would reject almost everything: the
+    default stopping condition is 24 hours, which is ~$34 on the cheapest
+    instance, so no ordinary monthly quota could ever admit a job — even
+    though the same job typically finishes in minutes and costs cents.
+
+    Instead the budget *becomes* the stopping condition. SageMaker kills the
+    job when MaxRuntimeInSeconds elapses, so clamping that value to the hours
+    the user can actually afford bounds the spend exactly, with no reservation
+    bookkeeping and no false rejections.
+
+    Raises HTTPException when the affordable runtime is too short to be worth
+    starting.
+    """
+    rate = (
+        pricing.transform_rate(instance_type)
+        if transform
+        else pricing.training_rate(instance_type)
+    )
+    if not rate:  # pragma: no cover - _validate_instance_type runs first
+        raise HTTPException(status_code=400, detail=f"Unpriced instance type '{instance_type}'.")
+
+    affordable_seconds = int((remaining_usd / rate) * 3600)
+
+    if affordable_seconds < MIN_BUDGETED_RUNTIME_SECONDS:
         raise HTTPException(
             status_code=400,
             detail=(
-                f"Unsupported dataset format. Supported formats: {supported}. "
-                'Each record needs a "text" and a "label" field.'
+                f"Insufficient quota. ${remaining_usd:.2f} remaining buys "
+                f"{affordable_seconds // 60} minutes on {instance_type}, below "
+                f"the {MIN_BUDGETED_RUNTIME_SECONDS // 60}-minute minimum. "
+                f"Choose a cheaper instance type, or ask an administrator to "
+                f"raise your quota."
             ),
         )
 
+    effective = min(requested_seconds, affordable_seconds)
+    if effective < requested_seconds:
+        logger.info(
+            f"Clamped max runtime from {requested_seconds}s to {effective}s "
+            f"to fit ${remaining_usd:.2f} remaining on {instance_type}"
+        )
+    return effective
 
-def _validate_instance_type(instance_type: str) -> None:
+
+def _validate_instance_type(instance_type: str, *, transform: bool = False) -> None:
     """Reject an instance type we have no price for.
 
-    ``calculate_cost`` falls back to $0.00/hour for anything absent from
-    INSTANCE_COST_PER_HOUR, so an unlisted type runs real GPUs and records no
-    spend — invisible to the admin cost dashboard, the same blind spot the
-    StatusIndex casing bug produced by a different route.
-
-    The quota does not bound the damage either: it meters GPU-*hours*, not
-    dollars, so the same ten hours buys ~$14 on an ml.g5.xlarge or several
-    hundred on a larger instance. `instance_type` arrives straight off the
+    ``calculate_cost`` falls back to $0.00/hour for anything unpriced, so an
+    unlisted type would run real GPUs and record no spend — invisible to the
+    admin cost dashboard, and now also invisible to the dollar quota, which
+    would let it run unbounded. ``instance_type`` arrives straight off the
     request body, so this is the only thing standing between a caller and an
     unpriced instance.
+
+    Training and Batch Transform have separate rate tables because some
+    instances are offered for one and not the other; ``transform`` says which
+    table to check.
     """
-    if instance_type not in INSTANCE_COST_PER_HOUR:
-        supported = ", ".join(sorted(INSTANCE_COST_PER_HOUR))
+    rate = (
+        pricing.transform_rate(instance_type)
+        if transform
+        else pricing.training_rate(instance_type)
+    )
+    if rate is None:
+        supported = ", ".join(
+            pricing.supported_transform_instances()
+            if transform
+            else pricing.supported_training_instances()
+        )
+        operation = "Batch Transform" if transform else "training"
         raise HTTPException(
             status_code=400,
             detail=(
-                f"Unsupported instance type '{instance_type}'. "
-                f"Supported types: {supported}"
+                f"Instance type '{instance_type}' is not available for "
+                f"{operation}. Supported types: {supported}"
             ),
         )
 
@@ -245,7 +439,8 @@ async def presign_upload(
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
 ):
     """Generate a presigned PUT URL for dataset upload."""
-    _validate_dataset_format(request.filename)
+    spec = _resolve_task_spec(request.task_type)
+    _validate_dataset_format(request.filename, spec)
 
     try:
         presigned_url, s3_key = s3_service.generate_upload_url(
@@ -283,30 +478,38 @@ async def create_job(
     script_service: ScriptPackagingService = Depends(get_script_packaging_service),
 ):
     """Create a new fine-tuning training job."""
+    spec = _resolve_task_spec(request.task_type)
+
     # Validate model — either from catalog or custom HuggingFace model
     model = MODEL_CATALOG.get(request.model_id)
     if not model and not request.custom_huggingface_model_id:
         raise HTTPException(status_code=400, detail=f"Unknown model_id: {request.model_id}")
+
+    if model and model.task_type != spec.task_type:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model '{model.model_name}' is a "
+                f"{task_types.get_task_spec(model.task_type).display_name.lower()} "
+                f"model and cannot be fine-tuned for "
+                f"{spec.display_name.lower()}."
+            ),
+        )
 
     if request.custom_huggingface_model_id:
         # Validate the custom HuggingFace model ID format (org/model or just model)
         hf_id = request.custom_huggingface_model_id.strip()
         if not hf_id or len(hf_id) > 200:
             raise HTTPException(status_code=400, detail="Invalid HuggingFace model ID.")
+        # Ask the Hub whether this model can actually serve the task before a
+        # GPU is provisioned for it.
+        await preflight_huggingface_model(hf_id, spec)
 
     # Verify the dataset is readable by the training script and exists in S3
-    _validate_dataset_format(request.dataset_s3_key)
+    _validate_dataset_format(request.dataset_s3_key, spec)
 
     if not s3_service.check_object_exists(request.dataset_s3_key):
         raise HTTPException(status_code=400, detail="Dataset not found in S3. Upload your dataset first.")
-
-    # Check quota (need at least 1 hour remaining)
-    remaining = grant["monthly_quota_hours"] - grant["current_month_usage_hours"]
-    if remaining < 1.0:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Insufficient quota. You have {remaining:.1f} hours remaining, minimum 1.0 required.",
-        )
 
     # Resolve instance type and hyperparameters
     if model:
@@ -315,25 +518,26 @@ async def create_job(
         model_name = model.model_name
         huggingface_id = model.huggingface_model_id
     else:
-        # Custom HuggingFace model — use sensible defaults
-        instance_type = request.instance_type or "ml.g5.xlarge"
-        hyperparameters = {
-            "epochs": "3",
-            "per_device_train_batch_size": "8",
-            "learning_rate": "2e-5",
-            "weight_decay": "0.01",
-            "split_ratio": "0.8",
-            "seed": "42",
-            "context_length": "512",
-        }
+        # Custom HuggingFace model — fall back to the task's own defaults.
+        instance_type = request.instance_type or spec.default_instance_type
+        hyperparameters = {**spec.default_hyperparameters}
         huggingface_id = request.custom_huggingface_model_id.strip()
         model_name = huggingface_id
 
     _validate_instance_type(instance_type)
 
+    # Bound the job's spend by clamping its stopping condition to what the
+    # remaining budget affords.  The real bill is unknown until the job stops,
+    # so this is what keeps a single long run from overshooting the quota.
+    remaining = grant["monthly_quota_usd"] - grant["current_month_usage_usd"]
+    max_runtime_seconds = _budgeted_runtime(
+        request.max_runtime_seconds, instance_type, remaining
+    )
+
     if request.hyperparameters:
         hyperparameters.update(request.hyperparameters)
     hyperparameters["model_name_or_path"] = huggingface_id
+    hyperparameters["task_type"] = spec.task_type
 
     # Generate identifiers
     job_id = uuid.uuid4().hex
@@ -363,12 +567,13 @@ async def create_job(
         job_id=job_id,
         model_id=request.model_id,
         model_name=model_name,
+        task_type=spec.task_type,
         dataset_s3_key=request.dataset_s3_key,
         instance_type=instance_type,
         hyperparameters=hyperparameters,
         sagemaker_job_name=sagemaker_job_name,
         output_s3_prefix=output_s3_prefix,
-        max_runtime_seconds=request.max_runtime_seconds,
+        max_runtime_seconds=max_runtime_seconds,
     )
 
     # Start SageMaker training job
@@ -379,8 +584,9 @@ async def create_job(
             input_s3_uri=input_s3_uri,
             output_s3_uri=output_s3_uri,
             instance_type=instance_type,
-            max_runtime=request.max_runtime_seconds,
+            max_runtime=max_runtime_seconds,
             source_dir_s3_uri=scripts_s3_uri,
+            task_type=spec.task_type,
         )
         job = jobs_repo.update_job_status(user.user_id, job_id, "TRAINING")
     except Exception as e:
@@ -607,11 +813,14 @@ def _sync_job_status(
         job["user_id"], job["job_id"], new_status, **update_kwargs
     )
 
-    # Increment usage quota on completion/failure/stop (if billable time exists)
+    # Charge the quota on completion/failure/stop (if billable time exists).
+    # Failed and stopped runs are billed by AWS too, so they are charged here.
     if new_status in ("COMPLETED", "FAILED", "STOPPED") and sm_status.get("billable_seconds"):
-        billable_hours = sm_status["billable_seconds"] / 3600
-        access_repo.increment_usage(job["email"], billable_hours)
-        logger.info(f"Incremented usage for {job['email']} by {billable_hours:.2f} hours")
+        spend = sagemaker.calculate_cost(
+            job["instance_type"], sm_status["billable_seconds"]
+        )
+        access_repo.increment_usage(job["email"], spend)
+        logger.info(f"Charged {job['email']} ${spend:.4f} for training {job['job_id']}")
 
     return updated
 
@@ -647,7 +856,9 @@ def _sync_inference_status(
         update_kwargs["transform_end_time"] = sm_status["transform_end_time"]
     if sm_status.get("billable_seconds"):
         update_kwargs["billable_seconds"] = sm_status["billable_seconds"]
-        cost = sagemaker.calculate_cost(job["instance_type"], sm_status["billable_seconds"])
+        cost = sagemaker.calculate_cost(
+            job["instance_type"], sm_status["billable_seconds"], transform=True
+        )
         update_kwargs["estimated_cost_usd"] = cost
     if sm_status.get("failure_reason"):
         update_kwargs["error_message"] = sm_status["failure_reason"]
@@ -656,11 +867,13 @@ def _sync_inference_status(
         job["user_id"], job["job_id"], new_status, **update_kwargs
     )
 
-    # Increment usage quota on terminal status (if billable time exists)
+    # Charge the quota on terminal status (if billable time exists).
     if new_status in ("COMPLETED", "FAILED", "STOPPED") and sm_status.get("billable_seconds"):
-        billable_hours = sm_status["billable_seconds"] / 3600
-        access_repo.increment_usage(job["email"], billable_hours)
-        logger.info(f"Incremented inference usage for {job['email']} by {billable_hours:.2f} hours")
+        spend = sagemaker.calculate_cost(
+            job["instance_type"], sm_status["billable_seconds"], transform=True
+        )
+        access_repo.increment_usage(job["email"], spend)
+        logger.info(f"Charged {job['email']} ${spend:.4f} for inference {job['job_id']}")
 
     return updated
 
@@ -711,6 +924,17 @@ async def inference_presign_upload(
     s3_service: FineTuningS3Service = Depends(get_fine_tuning_s3_service),
 ):
     """Generate a presigned PUT URL for inference input file upload."""
+    spec = _resolve_task_spec(request.task_type)
+    if not spec.supports_inference_extension(request.filename):
+        supported = ", ".join(spec.inference_upload_extensions)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported input format for {spec.display_name.lower()} "
+                f"inference. Supported formats: {supported}."
+            ),
+        )
+
     try:
         presigned_url, s3_key = s3_service.generate_inference_upload_url(
             user_id=user.user_id,
@@ -750,24 +974,38 @@ async def create_inference_job(
     if training_job["status"] != "COMPLETED":
         raise HTTPException(status_code=400, detail="Training job has not completed successfully")
 
+    # The inference task is whatever the model was trained for — never what
+    # the caller claims, since the artifact can only serve its own task.
+    spec = _resolve_task_spec(training_job.get("task_type"))
+
     # Verify input file exists in S3
     if not s3_service.check_object_exists(request.input_s3_key):
         raise HTTPException(status_code=400, detail="Input file not found in S3. Upload your input file first.")
 
-    # Check quota (need at least 0.5 hours remaining for inference)
-    remaining = grant["monthly_quota_hours"] - grant["current_month_usage_hours"]
-    if remaining < 0.5:
+    if not spec.supports_inference_extension(request.input_s3_key):
+        supported = ", ".join(spec.inference_upload_extensions)
         raise HTTPException(
             status_code=400,
-            detail=f"Insufficient quota. You have {remaining:.1f} hours remaining, minimum 0.5 required.",
+            detail=(
+                f"This model was fine-tuned for {spec.display_name.lower()}, "
+                f"so its inference input must be one of: {supported}."
+            ),
         )
 
     # Build model artifact S3 path from training job's output
     model_s3_path = f"s3://{s3_service.bucket_name}/{training_job['output_s3_prefix']}/{training_job['sagemaker_job_name']}/output/model.tar.gz"
 
-    # Resolve instance type (default to training job's instance type)
+    # Resolve instance type (default to training job's instance type).  Not
+    # every training instance can run Batch Transform, so this is checked
+    # against the transform rate table.
     instance_type = request.instance_type or training_job["instance_type"]
-    _validate_instance_type(instance_type)
+    _validate_instance_type(instance_type, transform=True)
+
+    # Bound spend the same way training does.
+    remaining = grant["monthly_quota_usd"] - grant["current_month_usage_usd"]
+    max_runtime_seconds = _budgeted_runtime(
+        request.max_runtime_seconds, instance_type, remaining, transform=True
+    )
 
     # Generate identifiers
     job_id = uuid.uuid4().hex
@@ -792,7 +1030,7 @@ async def create_inference_job(
         instance_type=instance_type,
         transform_job_name=transform_job_name,
         output_s3_prefix=output_s3_prefix,
-        max_runtime_seconds=request.max_runtime_seconds,
+        max_runtime_seconds=max_runtime_seconds,
     )
 
     # Start SageMaker Batch Transform job
@@ -803,7 +1041,8 @@ async def create_inference_job(
             input_s3_uri=input_s3_uri,
             output_s3_uri=output_s3_uri,
             instance_type=instance_type,
-            max_runtime=request.max_runtime_seconds,
+            max_runtime=max_runtime_seconds,
+            task_type=spec.task_type,
         )
         job = inf_repo.update_inference_status(user.user_id, job_id, "TRANSFORMING")
     except Exception as e:

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
@@ -42,6 +42,20 @@ TASK_MODULES = {
     task_types.IMAGE_TEXT_CLASSIFICATION: task_image_text_classification,
 }
 
+#: Task type of the artifact currently loaded, remembered at module scope.
+#:
+#: The SageMaker inference toolkit calls the user's ``input_fn`` as
+#: ``input_fn(input_data, content_type)`` — the loaded model is NOT passed to
+#: it, only to ``predict_fn``.  The single-entry-point ``transform_fn`` does
+#: receive the model, but the toolkit forbids defining it alongside
+#: input_fn/predict_fn/output_fn.  So the one place ``input_fn`` can learn
+#: which task it is parsing for is here, written by ``model_fn``, which the
+#: toolkit always calls first and exactly once.
+#:
+#: Without this an image artifact would parse its .zip payload as newline
+#: delimited text and fail on every record.
+_LOADED_TASK_TYPE = None
+
 
 def read_task_type(model_dir):
     """Read the task type recorded in a model artifact.
@@ -78,8 +92,12 @@ def resolve_task_module(task_type):
 
 def model_fn(model_dir):
     """Load the model for whichever task this artifact was trained for."""
+    global _LOADED_TASK_TYPE
+
     task_type = read_task_type(model_dir)
     module, spec = resolve_task_module(task_type)
+    # Remember the task before loading, so input_fn can dispatch on it.
+    _LOADED_TASK_TYPE = spec.task_type
 
     loaded = module.model_fn(model_dir)
     # Carry the task through to input_fn/predict_fn, which SageMaker calls
@@ -92,15 +110,18 @@ def model_fn(model_dir):
 def input_fn(request_body, content_type="text/plain", model=None):
     """Parse the Batch Transform payload into task-appropriate records.
 
-    ``model`` is supplied by the SageMaker inference toolkit when the handler
-    declares it.  When it is absent the payload is assumed to be text, which
+    The toolkit calls this with only ``(input_data, content_type)``, so the
+    task normally comes from :data:`_LOADED_TASK_TYPE`, set by ``model_fn``.
+    ``model`` is accepted as an optional override for direct callers and
+    tests.  Falls back to the default task when nothing has been loaded, which
     preserves the pre-task-types behaviour.
     """
-    if model is None:
-        module, spec = resolve_task_module(task_types.DEFAULT_TASK_TYPE)
-    else:
-        module, spec = resolve_task_module(model["task_type"])
+    task_type = None
+    if isinstance(model, dict):
+        task_type = model.get("task_type")
+    task_type = task_type or _LOADED_TASK_TYPE or task_types.DEFAULT_TASK_TYPE
 
+    module, spec = resolve_task_module(task_type)
     return module.input_fn(request_body, content_type, spec)
 
 

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
@@ -1,170 +1,164 @@
 """SageMaker Inference Toolkit handler for Batch Transform.
 
-Implements the four handler functions required by the HuggingFace inference DLC:
-  - model_fn(model_dir):  Load model and tokenizer
-  - input_fn(body, type):  Parse input text
-  - predict_fn(data, model):  Run batched inference with softmax
-  - output_fn(prediction, accept):  Format as CSV with probability columns
+A dispatcher, mirroring ``train.py``.  It implements the four handler
+functions the HuggingFace inference DLC calls, resolves the task type recorded
+in the model artifact, and delegates the modality-specific work to the
+matching ``task_*`` module.
 
-SageMaker Batch Transform:
-  - Extracts model.tar.gz to a directory, finds code/inference.py
-  - Calls model_fn once to load the model
-  - For each input record: input_fn -> predict_fn -> output_fn
+  - model_fn(model_dir):            load model + processor for the task
+  - input_fn(body, content_type):   parse the payload into records
+  - predict_fn(records, model):     batched inference with softmax
+  - output_fn(prediction, accept):  format as CSV with probability columns
+
+The output shape is deliberately identical across every task — an identifier
+column followed by one probability column per class — so a new modality never
+breaks the result viewer.
 """
 
 import json
 import logging
+import os
 
-# Heavy ML dependencies are imported lazily inside functions since they are only
-# available in the SageMaker DLC container.  input_fn, output_fn, and
-# _sanitize_label must remain importable without torch/transformers so they
-# can be unit-tested locally.
+try:  # package context: unit tests and the app-api container
+    from .. import task_types
+    from . import task_image_classification
+    from . import task_image_text_classification
+    from . import task_text_classification
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_types  # type: ignore
+    import task_image_classification  # type: ignore
+    import task_image_text_classification  # type: ignore
+    import task_text_classification  # type: ignore
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 64
+#: Written into the model artifact at training time so the handler can tell
+#: which task it is serving without being told by the caller.
+TASK_MARKER_FILENAME = "task_type.json"
 
+TASK_MODULES = {
+    task_types.TEXT_CLASSIFICATION: task_text_classification,
+    task_types.IMAGE_CLASSIFICATION: task_image_classification,
+    task_types.IMAGE_TEXT_CLASSIFICATION: task_image_text_classification,
+}
+
+
+def read_task_type(model_dir):
+    """Read the task type recorded in a model artifact.
+
+    Falls back to the default task for an artifact trained before task types
+    existed — those directories have no marker and are all text classifiers.
+    """
+    marker = os.path.join(model_dir, TASK_MARKER_FILENAME)
+    if not os.path.exists(marker):
+        logger.info(
+            f"No {TASK_MARKER_FILENAME} in artifact; assuming "
+            f"'{task_types.DEFAULT_TASK_TYPE}'"
+        )
+        return task_types.DEFAULT_TASK_TYPE
+
+    with open(marker) as handle:
+        return json.load(handle).get("task_type", task_types.DEFAULT_TASK_TYPE)
+
+
+def resolve_task_module(task_type):
+    """Return the (module, spec) pair serving ``task_type``."""
+    spec = task_types.get_task_spec(task_type)
+    module = TASK_MODULES.get(spec.task_type)
+    if module is None:  # pragma: no cover - registry/module drift
+        raise ValueError(
+            f"Task type '{spec.task_type}' is registered but has no inference module."
+        )
+    return module, spec
+
+
+# =========================================================================
+# SageMaker handler functions
+# =========================================================================
 
 def model_fn(model_dir):
-    """Load model and tokenizer from the model directory.
+    """Load the model for whichever task this artifact was trained for."""
+    task_type = read_task_type(model_dir)
+    module, spec = resolve_task_module(task_type)
 
-    Returns a tuple of (model, tokenizer, device).
+    loaded = module.model_fn(model_dir)
+    # Carry the task through to input_fn/predict_fn, which SageMaker calls
+    # with only the payload and this object.
+    loaded["task_type"] = spec.task_type
+    loaded["spec"] = spec
+    return loaded
+
+
+def input_fn(request_body, content_type="text/plain", model=None):
+    """Parse the Batch Transform payload into task-appropriate records.
+
+    ``model`` is supplied by the SageMaker inference toolkit when the handler
+    declares it.  When it is absent the payload is assumed to be text, which
+    preserves the pre-task-types behaviour.
     """
-    import torch
-    from transformers import AutoTokenizer, AutoModelForSequenceClassification
-
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    tokenizer = AutoTokenizer.from_pretrained(model_dir)
-    model = AutoModelForSequenceClassification.from_pretrained(
-        model_dir,
-        torch_dtype="auto",
-    )
-    model.resize_token_embeddings(len(tokenizer))
-    model.to(device)
-    model.eval()
-
-    logger.info(f"Loaded model from {model_dir} on {device}")
-    return (model, tokenizer, device)
-
-
-def input_fn(request_body, content_type="text/plain"):
-    """Parse input data.
-
-    Supports:
-      - text/plain: one text string per line
-      - application/json: list of strings or {"texts": [...]}
-
-    Returns a list of non-empty text strings.
-    """
-    # SageMaker HuggingFace DLC passes request_body as bytes, not str.
-    if isinstance(request_body, (bytes, bytearray)):
-        request_body = request_body.decode("utf-8")
-
-    if content_type == "text/plain":
-        lines = request_body.strip().split("\n")
-        texts = [line.strip() for line in lines if line.strip()]
-        return texts
-    elif content_type == "application/json":
-        data = json.loads(request_body)
-        if isinstance(data, list):
-            return [str(item) for item in data if str(item).strip()]
-        elif isinstance(data, dict) and "texts" in data:
-            return [str(t) for t in data["texts"] if str(t).strip()]
-        raise ValueError('JSON input must be a list or {"texts": [...]}')
+    if model is None:
+        module, spec = resolve_task_module(task_types.DEFAULT_TASK_TYPE)
     else:
-        raise ValueError(f"Unsupported content type: {content_type}")
+        module, spec = resolve_task_module(model["task_type"])
+
+    return module.input_fn(request_body, content_type, spec)
 
 
-def predict_fn(input_data, model_tuple):
-    """Run batched inference with softmax probabilities.
+def predict_fn(input_data, model):
+    """Run inference for the loaded task.
 
-    Args:
-        input_data: List of text strings from input_fn
-        model_tuple: (model, tokenizer, device) from model_fn
-
-    Returns a dict with 'texts', 'probabilities' (numpy array), and 'labels'.
+    Names the identifier column here rather than in each task module, so every
+    task is guaranteed to produce a labelled first column.
     """
-    import torch
-    import numpy as np
-
-    model, tokenizer, device = model_tuple
-    texts = input_data
-
-    if not texts:
-        return {"texts": [], "probabilities": np.zeros((0, 0)), "labels": []}
-
-    # Batched inference
-    all_probs = []
-    with torch.no_grad():
-        for start in range(0, len(texts), BATCH_SIZE):
-            batch_texts = texts[start : start + BATCH_SIZE]
-            enc = tokenizer(
-                batch_texts,
-                padding=True,
-                truncation=True,
-                return_tensors="pt",
-            )
-            enc = {k: v.to(device) for k, v in enc.items()}
-            outputs = model(**enc)
-            probs = torch.softmax(outputs.logits, dim=-1).cpu().numpy()
-            all_probs.append(probs)
-
-    probabilities = np.vstack(all_probs) if all_probs else np.zeros((0, 0))
-
-    # Build label names from model config
-    num_labels = (
-        probabilities.shape[1] if len(probabilities.shape) > 1 else 0
+    module, spec = resolve_task_module(model["task_type"])
+    prediction = module.predict_fn(input_data, model, spec)
+    prediction.setdefault(
+        "identifier_column", spec.image_column or spec.text_column or "id"
     )
-    id2label = getattr(model.config, "id2label", None)
-    if isinstance(id2label, dict):
-        labels = [
-            id2label.get(i) or id2label.get(str(i)) or f"class_{i}"
-            for i in range(num_labels)
-        ]
-    elif isinstance(id2label, (list, tuple)):
-        labels = list(id2label)[:num_labels]
-    else:
-        labels = [f"class_{i}" for i in range(num_labels)]
-
-    return {"texts": texts, "probabilities": probabilities, "labels": labels}
+    return prediction
 
 
 def _sanitize_label(label):
     """Sanitize a label string for use as a CSV column name."""
     if label is None:
         return "class"
-    return "".join(
-        c if (c.isalnum() or c == "_") else "_" for c in str(label)
-    )
+    return "".join(c if (c.isalnum() or c == "_") else "_" for c in str(label))
+
+
+def _escape_csv(value):
+    """Quote and escape a value for CSV output."""
+    return '"' + str(value).replace('"', '""') + '"'
 
 
 def output_fn(prediction, accept="text/csv"):
-    """Format prediction output as CSV with probability columns.
+    """Format predictions as CSV with one probability column per class.
 
     Output format:
-        text,prob_label1,prob_label2,...
-        "example text",0.850000,0.150000
+        id,prob_label1,prob_label2,...
+        "example.jpg",0.850000,0.150000
+
+    The first column is whatever identifies a record for the task: the input
+    text for text classification, the archive-relative image path for the
+    image tasks.
     """
-    texts = prediction["texts"]
-    probs = prediction["probabilities"]
+    identifiers = prediction["identifiers"]
+    probabilities = prediction["probabilities"]
     labels = prediction["labels"]
+    identifier_column = prediction.get("identifier_column", "id")
 
-    # Build CSV header
-    prob_columns = [f"prob_{_sanitize_label(l)}" for l in labels]
-    header = "text," + ",".join(prob_columns)
+    header = identifier_column + "," + ",".join(
+        f"prob_{_sanitize_label(label)}" for label in labels
+    )
 
-    # Build rows
     rows = [header]
-    for i, text in enumerate(texts):
-        # Escape text for CSV (handle commas and quotes)
-        escaped_text = '"' + text.replace('"', '""') + '"'
-        if probs.shape[0] > i and probs.shape[1] > 0:
-            prob_values = ",".join(
-                f"{probs[i, j]:.6f}" for j in range(probs.shape[1])
+    for index, identifier in enumerate(identifiers):
+        if probabilities.shape[0] > index and probabilities.shape[1] > 0:
+            values = ",".join(
+                f"{probabilities[index, column]:.6f}"
+                for column in range(probabilities.shape[1])
             )
         else:
-            prob_values = ",".join("0.000000" for _ in labels)
-        rows.append(f"{escaped_text},{prob_values}")
+            values = ",".join("0.000000" for _ in labels)
+        rows.append(f"{_escape_csv(identifier)},{values}")
 
     return "\n".join(rows)

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/requirements.txt
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/requirements.txt
@@ -1,2 +1,13 @@
+# Installed by the SageMaker DLC into both the training container and, via
+# code/ inside model.tar.gz, the Batch Transform container.
+#
+# One file serves two containers on different Python versions — the text tasks
+# run py3.10 (PyTorch 2.1 DLC), the vision tasks py3.12 (PyTorch 2.8 DLC) — so
+# anything added here has to install on both. pillow 12.x requires >=3.10 and
+# therefore does.
+#
+# torch, transformers, datasets and evaluate are supplied by the DLC itself
+# and are deliberately not listed: pinning them here would fight the image.
 pandas
 scikit-learn
+pillow==12.3.0

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
@@ -1,0 +1,535 @@
+"""Shared helpers for every fine-tuning task type.
+
+Everything here is task-agnostic: dataset discovery, archive unpacking, label
+normalisation, the train/test split, progress reporting and the bundling of
+the inference handler into the model artifact.  Task-specific behaviour —
+which auto-class loads the model, how a batch is collated — lives in the
+``task_*.py`` sibling modules.
+
+**Import shim.** These modules are consumed two ways: as a package
+(``apis.app_api.fine_tuning.sagemaker_scripts.task_common``) by the unit tests
+and the app-api container, and as flat top-level modules inside the SageMaker
+DLC, where ``script_packaging_service`` tars them at the archive root with no
+package around them.  The try/except below is what lets one file serve both;
+it is not defensive coding, it is the two real layouts.
+
+**Heavy ML dependencies are imported lazily inside functions.**  torch,
+transformers, pandas and PIL exist only in the DLC, and the module has to stay
+importable in the backend venv so the dataset contract can be unit-tested
+without them.
+"""
+
+import logging
+import os
+import shutil
+import zipfile
+
+try:  # package context: unit tests and the app-api container
+    from .. import task_types
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_types  # type: ignore
+
+try:
+    from transformers import TrainerCallback
+except ImportError:  # pragma: no cover - local dev/test without transformers
+    TrainerCallback = object
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# Dataset formats
+# =========================================================================
+
+# Formats the trainer can read, mapped to the pandas reader that loads them.
+# Plain .txt is absent because it has no way to express a label; it stays
+# valid for *inference* input, which is unlabelled.
+#
+# Kept as data rather than an if/elif chain so the supported-format contract
+# can be asserted without importing pandas, which only exists inside the
+# SageMaker container.
+DATASET_READERS = {
+    ".csv": ("read_csv", {}),
+    ".jsonl": ("read_json", {"lines": True}),
+    ".json": ("read_json", {}),
+}
+
+#: Image files an archive-based dataset may reference.
+SUPPORTED_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff")
+
+#: Directory the training script unpacks an uploaded archive into.  Sits
+#: outside the input channel so the extracted tree is never mistaken for
+#: another dataset file on a re-scan.
+EXTRACT_DIR = "/opt/ml/input/extracted"
+
+
+# =========================================================================
+# Dataset discovery
+# =========================================================================
+
+def find_file_in_dir(directory, extensions, description="dataset"):
+    """Return the first file under ``directory`` matching ``extensions``.
+
+    Searches recursively, deepest-last, so a manifest at the archive root wins
+    over one nested inside an image folder.  Raises FileNotFoundError when the
+    directory is missing or holds no match.
+    """
+    if not os.path.isdir(directory):
+        raise FileNotFoundError(f"Directory does not exist: {directory}")
+
+    matches = []
+    for root, _dirs, files in os.walk(directory):
+        relative = os.path.relpath(root, directory)
+        # relpath returns "." for the top level and "images" one level down —
+        # both hold zero separators, so counting them alone ranks a nested
+        # manifest equal to a root one.
+        depth = 0 if relative == os.curdir else relative.count(os.sep) + 1
+        for name in sorted(files):
+            if name.startswith("._") or name.startswith("."):
+                # Skip macOS resource forks, which zip up alongside the real
+                # files and would otherwise be picked as the manifest.
+                continue
+            if name.lower().endswith(tuple(extensions)):
+                matches.append((depth, os.path.join(root, name)))
+
+    if not matches:
+        supported = ", ".join(extensions)
+        raise FileNotFoundError(
+            f"No {description} file found in {directory}. "
+            f"Supported formats: {supported}"
+        )
+
+    matches.sort(key=lambda pair: (pair[0], pair[1]))
+    return matches[0][1]
+
+
+def resolve_dataset_reader(dataset_path):
+    """Return the (pandas reader name, kwargs) pair for a manifest file.
+
+    Raises ValueError for an extension the trainer cannot read.
+    """
+    extension = os.path.splitext(dataset_path)[1].lower()
+
+    if extension not in DATASET_READERS:
+        supported = ", ".join(DATASET_READERS)
+        raise ValueError(
+            f"Unsupported dataset format '{extension}'. Supported formats: {supported}"
+        )
+
+    return DATASET_READERS[extension]
+
+
+def validate_dataset_columns(columns, dataset_path, spec):
+    """Raise ValueError if a column the task requires is absent."""
+    missing = [c for c in spec.required_columns if c not in columns]
+    if missing:
+        required = ", ".join(f'"{c}"' for c in spec.required_columns)
+        raise ValueError(
+            f"Dataset {os.path.basename(dataset_path)} is missing required "
+            f"column(s): {', '.join(missing)}. A {spec.display_name.lower()} "
+            f"record needs {required}."
+        )
+
+
+# =========================================================================
+# Archive handling
+# =========================================================================
+
+def _is_within(directory, target):
+    """True when ``target`` resolves to a path inside ``directory``."""
+    directory = os.path.realpath(directory)
+    target = os.path.realpath(target)
+    return os.path.commonpath([directory, target]) == directory
+
+
+def extract_archive(archive_path, dest_dir):
+    """Safely unpack a user-uploaded .zip into ``dest_dir``.
+
+    Rejects absolute paths, parent-directory traversal and symlinks — the
+    archive is untrusted input uploaded by a user, and a naive ``extractall``
+    would let a crafted entry write anywhere the training container can reach
+    (``Zip-Slip``).  Returns ``dest_dir``.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+
+    with zipfile.ZipFile(archive_path) as archive:
+        for member in archive.infolist():
+            name = member.filename
+            if name.endswith("/"):
+                continue
+            if os.path.isabs(name) or ".." in name.replace("\\", "/").split("/"):
+                raise ValueError(
+                    f"Refusing to extract unsafe archive entry: {name!r}"
+                )
+            target = os.path.join(dest_dir, name)
+            if not _is_within(dest_dir, os.path.dirname(target) or dest_dir):
+                raise ValueError(
+                    f"Refusing to extract archive entry outside the "
+                    f"destination: {name!r}"
+                )
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with archive.open(member) as source, open(target, "wb") as sink:
+                shutil.copyfileobj(source, sink)
+
+    logger.info(f"Extracted {archive_path} to {dest_dir}")
+    return dest_dir
+
+
+def resolve_image_path(image_root, relative_path):
+    """Resolve a manifest image reference against the archive root.
+
+    Raises ValueError if the reference escapes the archive, FileNotFoundError
+    if the file is not there.
+    """
+    candidate = os.path.join(image_root, str(relative_path).strip())
+
+    if not _is_within(image_root, candidate):
+        raise ValueError(
+            f"Image path escapes the dataset archive: {relative_path!r}"
+        )
+    if not os.path.isfile(candidate):
+        raise FileNotFoundError(
+            f"Image referenced by the manifest is missing from the archive: "
+            f"{relative_path!r}"
+        )
+    return candidate
+
+
+# =========================================================================
+# Dataset loading
+# =========================================================================
+
+def load_manifest_frame(manifest_path, spec):
+    """Load a manifest file into a DataFrame and validate its columns."""
+    import pandas as pd
+
+    reader_name, reader_kwargs = resolve_dataset_reader(manifest_path)
+    frame = getattr(pd, reader_name)(manifest_path, **reader_kwargs)
+
+    validate_dataset_columns(frame.columns, manifest_path, spec)
+
+    return frame
+
+
+def prepare_dataset(channel_dir, spec):
+    """Locate, unpack and load the dataset for ``spec``.
+
+    Returns ``(frame, image_root)``.  ``image_root`` is None for text-only
+    tasks; for archive tasks it is the extracted archive root, and the frame's
+    image column has been rewritten to absolute, existence-checked paths.
+    """
+    if spec.requires_archive:
+        archive_path = find_file_in_dir(channel_dir, spec.upload_extensions, "dataset archive")
+        logger.info(f"Unpacking dataset archive {archive_path}")
+        image_root = extract_archive(archive_path, EXTRACT_DIR)
+        manifest_path = find_file_in_dir(image_root, spec.manifest_extensions, "manifest")
+    else:
+        image_root = None
+        manifest_path = find_file_in_dir(channel_dir, spec.manifest_extensions, "dataset")
+
+    logger.info(f"Loading dataset manifest from {manifest_path}")
+    frame = load_manifest_frame(manifest_path, spec)
+
+    if spec.image_column:
+        frame = frame.copy()
+        frame[spec.image_column] = [
+            resolve_image_path(image_root, value)
+            for value in frame[spec.image_column]
+        ]
+        logger.info(f"Resolved {len(frame)} image paths against {image_root}")
+
+    if len(frame) == 0:
+        raise ValueError(
+            f"Dataset {os.path.basename(manifest_path)} contains no records."
+        )
+
+    return frame, image_root
+
+
+def build_label_mapping(frame, spec):
+    """Normalise the label column to contiguous ids.
+
+    Returns ``(frame, label2id, id2label)`` with the label column replaced by
+    integer ids.  Non-numeric class names are supported and preserved in the
+    mapping so the model config can carry them through to inference.
+    """
+    import pandas as pd
+
+    label_column = spec.label_column
+    label_names = sorted(pd.Series(frame[label_column]).astype(str).unique())
+
+    if len(label_names) < 2:
+        raise ValueError(
+            f"Dataset needs at least 2 distinct values in the "
+            f'"{label_column}" column, found {len(label_names)}: {label_names}.'
+        )
+
+    label2id = {name: index for index, name in enumerate(label_names)}
+    id2label = {index: name for name, index in label2id.items()}
+
+    frame = frame.copy()
+    frame[label_column] = frame[label_column].astype(str).map(label2id)
+
+    logger.info(f"Label mapping ({len(label_names)} classes): {label2id}")
+    return frame, label2id, id2label
+
+
+def split_frame(frame, split_ratio, seed):
+    """Split a DataFrame into shuffled train/eval HuggingFace Datasets."""
+    from datasets import Dataset
+
+    dataset = Dataset.from_pandas(frame.reset_index(drop=True))
+    dataset = dataset.train_test_split(test_size=1 - split_ratio, seed=seed)
+
+    logger.info(
+        f"Data split: {len(dataset['train'])} train / {len(dataset['test'])} eval"
+    )
+    return dataset["train"].shuffle(seed=seed), dataset["test"].shuffle(seed=seed)
+
+
+# =========================================================================
+# Model helpers
+# =========================================================================
+
+def resolve_max_context_length(config, tokenizer):
+    """Resolve the effective maximum text context length from a model config.
+
+    Checks the usual config attributes and returns the smallest valid value,
+    or None if none can be determined.  Multimodal configs keep these on a
+    nested ``text_config``, so that is consulted too — reading only the top
+    level silently yields None on every vision-language model.
+    """
+    sources = [config, getattr(config, "text_config", None)]
+
+    candidates = []
+    for source in sources:
+        if source is None:
+            continue
+        candidates.extend(
+            [
+                getattr(source, "max_position_embeddings", None),
+                getattr(source, "n_positions", None),
+                getattr(source, "seq_length", None),
+            ]
+        )
+    candidates.append(getattr(tokenizer, "model_max_length", None))
+
+    def _valid(value):
+        try:
+            return value is not None and 0 < float(value) < 1_000_000
+        except Exception:
+            return False
+
+    valid = [int(v) for v in candidates if _valid(v)]
+    return min(valid) if valid else None
+
+
+def build_training_arguments(**kwargs):
+    """Construct ``TrainingArguments``, tolerating the evaluation-strategy rename.
+
+    Text tasks run on a transformers 4.36 container, where the argument is
+    ``evaluation_strategy``.  Vision tasks run on 4.56, where it is
+    ``eval_strategy`` and the old spelling is deprecated.  Pinning either name
+    breaks the other container, so inspect the signature and pass whichever
+    this transformers actually accepts.
+    """
+    import inspect
+
+    from transformers import TrainingArguments
+
+    strategy = kwargs.pop("eval_strategy", None)
+    if strategy is not None:
+        parameters = inspect.signature(TrainingArguments.__init__).parameters
+        key = "eval_strategy" if "eval_strategy" in parameters else "evaluation_strategy"
+        kwargs[key] = strategy
+
+    return TrainingArguments(**kwargs)
+
+
+def compute_accuracy(eval_pred):
+    """Accuracy metric shared by every classification task."""
+    import numpy as np
+    import evaluate
+
+    metric = evaluate.load("accuracy")
+    logits, labels = eval_pred
+    if isinstance(logits, tuple):
+        logits = logits[0]
+    predictions = np.argmax(logits, axis=-1)
+    return metric.compute(predictions=predictions, references=labels)
+
+
+def label_names(config, probabilities):
+    """Recover ordered class names from a model config.
+
+    Every classification task writes ``id2label`` into the config at training
+    time, so inference can name the probability columns without the dataset.
+    """
+    num_labels = probabilities.shape[1] if len(probabilities.shape) > 1 else 0
+    id2label = getattr(config, "id2label", None)
+
+    if isinstance(id2label, dict):
+        return [
+            id2label.get(i) or id2label.get(str(i)) or f"class_{i}"
+            for i in range(num_labels)
+        ]
+    if isinstance(id2label, (list, tuple)):
+        return list(id2label)[:num_labels]
+    return [f"class_{i}" for i in range(num_labels)]
+
+
+# =========================================================================
+# Callbacks
+# =========================================================================
+
+class DynamoDBProgressCallback(TrainerCallback):
+    """Reports training progress (0.0-1.0) to DynamoDB.
+
+    Throttles writes to every 10 steps to reduce API calls.
+    Fails silently so that DynamoDB issues don't abort training.
+    """
+
+    def __init__(self, table_name, region, pk, sk):
+        super().__init__()
+        self._table_name = table_name
+        self._pk = pk
+        self._sk = sk
+        self._client = None
+        if table_name and pk and sk:
+            try:
+                import boto3
+
+                self._client = boto3.client("dynamodb", region_name=region)
+                logger.info(
+                    f"DynamoDB progress callback initialized: "
+                    f"table={table_name}, region={region}"
+                )
+            except Exception as e:
+                logger.warning(f"Could not create DynamoDB client: {e}")
+        else:
+            logger.warning(
+                f"DynamoDB progress callback disabled — missing config: "
+                f"table_name={'set' if table_name else 'EMPTY'}, "
+                f"pk={'set' if pk else 'EMPTY'}, "
+                f"sk={'set' if sk else 'EMPTY'}"
+            )
+
+    def _update_progress(self, progress):
+        if not self._client:
+            return
+        try:
+            self._client.update_item(
+                TableName=self._table_name,
+                Key={
+                    "PK": {"S": self._pk},
+                    "SK": {"S": self._sk},
+                },
+                UpdateExpression="SET training_progress = :p",
+                ExpressionAttributeValues={
+                    ":p": {"N": str(round(progress, 4))},
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to update progress in DynamoDB: {e}")
+
+    def _from_state(self, state):
+        if getattr(state, "max_steps", 0) and state.max_steps > 0:
+            return min(1.0, max(0.0, state.global_step / state.max_steps))
+        if getattr(state, "num_train_epochs", 0) and getattr(
+            state, "epoch", None
+        ) is not None:
+            total = float(state.num_train_epochs)
+            if total > 0:
+                return min(1.0, max(0.0, float(state.epoch) / total))
+        return None
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        self._update_progress(0.0)
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        progress = self._from_state(state)
+        if progress is not None:
+            self._update_progress(progress)
+
+    def on_step_end(self, args, state, control, **kwargs):
+        if state.global_step % 10 == 0:
+            progress = self._from_state(state)
+            if progress is not None:
+                self._update_progress(progress)
+
+    def on_train_end(self, args, state, control, **kwargs):
+        self._update_progress(1.0)
+
+
+class SageMakerLoggingCallback(TrainerCallback):
+    """Logs epoch accuracy to stdout (captured by CloudWatch)."""
+
+    def on_evaluate(self, args, state, control, metrics=None, **kwargs):
+        if state.epoch is not None and state.epoch < args.num_train_epochs:
+            if metrics is not None:
+                accuracy = metrics.get("eval_accuracy")
+                if accuracy is not None:
+                    logger.info(
+                        f"Epoch {int(state.epoch)} finished with "
+                        f"eval_accuracy={accuracy:.4f}"
+                    )
+            logger.info("Starting next epoch...")
+
+
+def build_callbacks(args):
+    """Assemble the callback list every task uses."""
+    return [
+        SageMakerLoggingCallback(),
+        DynamoDBProgressCallback(
+            table_name=args.dynamodb_table_name,
+            region=args.dynamodb_region,
+            pk=args.job_pk,
+            sk=args.job_sk,
+        ),
+    ]
+
+
+# =========================================================================
+# Inference bundling
+# =========================================================================
+
+# Files copied into model.tar.gz so Batch Transform can serve the model.
+# SageMaker discovers code/inference.py inside the artifact and uses it as the
+# handler; the task modules and the task registry travel with it because the
+# handler dispatches on the task type the same way the trainer does.
+INFERENCE_BUNDLE_FILES = (
+    "inference.py",
+    "requirements.txt",
+    "task_types.py",
+    "task_common.py",
+    "task_text_classification.py",
+    "task_image_classification.py",
+    "task_image_text_classification.py",
+)
+
+
+def copy_inference_bundle(model_output_dir, script_dir=None):
+    """Copy the inference handler and its task modules into ``model_dir/code/``.
+
+    ``script_dir`` defaults to the directory this module lives in and exists so
+    tests can point the copy at a fixture tree instead of monkeypatching
+    ``os.path``.
+    """
+    code_dir = os.path.join(model_output_dir, "code")
+    os.makedirs(code_dir, exist_ok=True)
+
+    script_dir = script_dir or os.path.dirname(os.path.abspath(__file__))
+    copied = []
+    for filename in INFERENCE_BUNDLE_FILES:
+        source = os.path.join(script_dir, filename)
+        if not os.path.exists(source):
+            # task_types.py lives one level up in the package layout; inside
+            # the flat SageMaker sourcedir it sits alongside this file.
+            source = os.path.join(os.path.dirname(script_dir), filename)
+        if os.path.exists(source):
+            shutil.copy2(source, os.path.join(code_dir, filename))
+            copied.append(filename)
+            logger.info(f"Copied {filename} to {code_dir}")
+        else:
+            logger.warning(f"Script file not found, skipping: {filename}")
+    return copied

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_classification.py
@@ -1,0 +1,241 @@
+"""Image classification: image -> label.
+
+Uses ``AutoModelForImageClassification``, so the trained artifact is an
+ordinary HuggingFace model directory that ``from_pretrained`` reloads with no
+custom code — the same round-trip the text task gets.
+
+Images are opened lazily in the collator rather than materialised by a
+``Dataset.map``.  Mapping pixel tensors over the whole dataset up front is
+what turns a modest image corpus into an out-of-memory kill several billed
+minutes into training; the dataset carries file paths and the collator reads
+each batch's images as it needs them.
+"""
+
+import logging
+import os
+
+try:  # package context: unit tests and the app-api container
+    from . import task_common
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_common  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 32
+
+
+def load_image(path):
+    """Open an image and normalise it to RGB.
+
+    Greyscale and palette images (common in scanned research corpora) have to
+    be converted, or the processor emits a tensor with the wrong channel count
+    and the batch fails to stack.
+    """
+    from PIL import Image
+
+    with Image.open(path) as image:
+        return image.convert("RGB")
+
+
+def build_collator(processor, label_column, image_column):
+    """Return a collate_fn that opens each batch's images and stacks them."""
+    import torch
+
+    def collate(features):
+        images = [load_image(feature[image_column]) for feature in features]
+        batch = processor(images=images, return_tensors="pt")
+        if label_column is not None and label_column in features[0]:
+            batch["labels"] = torch.tensor(
+                [feature[label_column] for feature in features], dtype=torch.long
+            )
+        return batch
+
+    return collate
+
+
+# =========================================================================
+# Training
+# =========================================================================
+
+def train(args, spec):
+    """Fine-tune an image classification model."""
+    from transformers import (
+        AutoConfig,
+        AutoImageProcessor,
+        AutoModelForImageClassification,
+        Trainer,
+    )
+
+    train_channel = os.environ.get("SM_CHANNEL_TRAIN", "/opt/ml/input/data/train")
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+
+    frame, _ = task_common.prepare_dataset(train_channel, spec)
+    frame, label2id, id2label = task_common.build_label_mapping(frame, spec)
+    num_labels = len(label2id)
+
+    processor = AutoImageProcessor.from_pretrained(args.model_name_or_path)
+    if args.image_size:
+        # Honour the requested resolution where the processor exposes one.
+        # Some processors key this "shortest_edge" instead of height/width.
+        if isinstance(getattr(processor, "size", None), dict):
+            if "height" in processor.size:
+                processor.size = {"height": args.image_size, "width": args.image_size}
+            elif "shortest_edge" in processor.size:
+                processor.size = {"shortest_edge": args.image_size}
+
+    config = AutoConfig.from_pretrained(
+        args.model_name_or_path,
+        num_labels=num_labels,
+        label2id=label2id,
+        id2label=id2label,
+    )
+
+    model = AutoModelForImageClassification.from_pretrained(
+        args.model_name_or_path,
+        config=config,
+        torch_dtype="auto",
+        # The base checkpoint's head has the wrong class count (or none at
+        # all). Without this, loading raises instead of re-initialising it.
+        ignore_mismatched_sizes=True,
+    )
+
+    train_dataset, eval_dataset = task_common.split_frame(
+        frame, args.split_ratio, args.seed
+    )
+
+    training_args = task_common.build_training_arguments(
+        output_dir="/opt/ml/checkpoints",
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        weight_decay=args.weight_decay,
+        eval_strategy="epoch",
+        save_strategy="no",
+        logging_dir="/opt/ml/output/tensorboard",
+        # The collator returns pixel tensors, not model-signature columns;
+        # Trainer's default column pruning would strip the image paths it
+        # needs before the collator ever sees them.
+        remove_unused_columns=False,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        compute_metrics=task_common.compute_accuracy,
+        callbacks=task_common.build_callbacks(args),
+        data_collator=build_collator(processor, spec.label_column, spec.image_column),
+    )
+
+    logger.info(
+        f"Starting fine-tuning: task={spec.task_type}, "
+        f"model={args.model_name_or_path}, epochs={args.epochs}, "
+        f"batch_size={args.per_device_train_batch_size}, "
+        f"image_size={args.image_size}"
+    )
+    trainer.train()
+
+    metrics = trainer.evaluate()
+    logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")
+
+    trainer.save_model(model_dir)
+    processor.save_pretrained(model_dir)
+    logger.info(f"Saved model to {model_dir}")
+
+    return metrics
+
+
+# =========================================================================
+# Inference
+# =========================================================================
+
+def model_fn(model_dir):
+    """Load the model and image processor for Batch Transform."""
+    import torch
+    from transformers import AutoImageProcessor, AutoModelForImageClassification
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    processor = AutoImageProcessor.from_pretrained(model_dir)
+    model = AutoModelForImageClassification.from_pretrained(
+        model_dir, torch_dtype="auto"
+    )
+    model.to(device)
+    model.eval()
+
+    logger.info(f"Loaded image classification model from {model_dir} on {device}")
+    return {"model": model, "processor": processor, "device": device}
+
+
+def input_fn(request_body, content_type, spec):
+    """Unpack a .zip of images into records.
+
+    Batch Transform hands the archive over as a single payload; unpacking it
+    here is what keeps the one-file-in, one-CSV-out contract identical to the
+    text tasks, and therefore keeps the whole result viewer unchanged.
+    """
+    import io
+    import tempfile
+
+    if not isinstance(request_body, (bytes, bytearray)):
+        raise ValueError(
+            f"Expected archive bytes for {spec.task_type}, got {type(request_body).__name__}"
+        )
+
+    work_dir = tempfile.mkdtemp(prefix="inference-images-")
+    archive_path = os.path.join(work_dir, "input.zip")
+    with open(archive_path, "wb") as handle:
+        handle.write(bytes(request_body))
+
+    root = task_common.extract_archive(archive_path, os.path.join(work_dir, "extracted"))
+
+    records = []
+    for directory, _dirs, files in os.walk(root):
+        for name in sorted(files):
+            if name.startswith("."):
+                continue
+            if not name.lower().endswith(task_common.SUPPORTED_IMAGE_EXTENSIONS):
+                continue
+            path = os.path.join(directory, name)
+            records.append(
+                {
+                    spec.image_column: path,
+                    "identifier": os.path.relpath(path, root),
+                }
+            )
+
+    if not records:
+        raise ValueError("Archive contains no readable image files.")
+
+    logger.info(f"Unpacked {len(records)} images for inference")
+    return records
+
+
+def predict_fn(records, loaded, spec):
+    """Run batched image inference with softmax probabilities."""
+    import numpy as np
+    import torch
+
+    model, processor, device = loaded["model"], loaded["processor"], loaded["device"]
+
+    if not records:
+        return {"identifiers": [], "probabilities": np.zeros((0, 0)), "labels": []}
+
+    collate = build_collator(processor, None, spec.image_column)
+
+    batches = []
+    with torch.no_grad():
+        for start in range(0, len(records), BATCH_SIZE):
+            batch = collate(records[start : start + BATCH_SIZE])
+            batch = {k: v.to(device) for k, v in batch.items()}
+            logits = model(**batch).logits
+            batches.append(torch.softmax(logits, dim=-1).cpu().numpy())
+
+    probabilities = np.vstack(batches) if batches else np.zeros((0, 0))
+
+    return {
+        "identifiers": [record["identifier"] for record in records],
+        "probabilities": probabilities,
+        "labels": task_common.label_names(model.config, probabilities),
+    }

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_classification.py
@@ -1,0 +1,404 @@
+"""Image + text classification: (image, text) -> label.
+
+Transformers has no general auto-class for this shape.  ``AutoModelFor
+SequenceClassification`` is text-only, and ``AutoModelForImageTextToText`` is
+generative — it emits tokens, not a class distribution.  So this task builds
+an explicit small model instead of pretending an auto-class fits:
+
+    frozen-or-tuned dual encoder (CLIP / SigLIP / ALIGN)
+        -> pooled image embedding  ++  pooled text embedding
+        -> dropout -> linear classifier -> logits
+
+That composition works across the whole CLIP-family of checkpoints rather than
+a single architecture, and it keeps the output contract — a softmax over the
+dataset's own classes — byte-identical to the other two tasks, so the Batch
+Transform result CSV and the entire result viewer stay unchanged.
+
+Because the result is not a ``PreTrainedModel``, ``Trainer.save_model`` would
+write a bare state dict and lose the backbone config.  The artifact is
+therefore saved explicitly: the backbone via ``save_pretrained``, the head via
+``torch.save``, and the wiring via ``fusion_head.json``.  :func:`load` is the
+exact inverse and is what ``model_fn`` calls at inference.
+"""
+
+import json
+import logging
+import os
+
+try:  # package context: unit tests and the app-api container
+    from . import task_common
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_common  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 32
+
+#: Written next to the backbone so :func:`load` can rebuild the head without
+#: the training arguments.
+HEAD_CONFIG_FILENAME = "fusion_head.json"
+HEAD_WEIGHTS_FILENAME = "fusion_head.pt"
+
+
+# =========================================================================
+# Model
+# =========================================================================
+
+def build_fusion_model(backbone, image_dim, text_dim, num_labels, dropout=0.1):
+    """Wrap a dual encoder with a concat-and-classify head.
+
+    Defined as a factory rather than a module-level class so this file stays
+    importable without torch — the backend venv and the unit tests have no ML
+    stack, and the dataset/artifact contract has to be testable there.
+    """
+    import torch
+    import torch.nn as nn
+
+    class ImageTextClassifier(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.backbone = backbone
+            self.image_dim = image_dim
+            self.text_dim = text_dim
+            self.num_labels = num_labels
+            self.dropout = nn.Dropout(dropout)
+            self.classifier = nn.Linear(image_dim + text_dim, num_labels)
+
+        def encode(self, pixel_values, input_ids, attention_mask=None):
+            image_features = self.backbone.get_image_features(pixel_values=pixel_values)
+            text_features = self.backbone.get_text_features(
+                input_ids=input_ids, attention_mask=attention_mask
+            )
+            return image_features, text_features
+
+        def forward(self, pixel_values=None, input_ids=None, attention_mask=None, labels=None, **_ignored):
+            image_features, text_features = self.encode(
+                pixel_values, input_ids, attention_mask
+            )
+            fused = torch.cat([image_features, text_features], dim=-1)
+            logits = self.classifier(self.dropout(fused))
+
+            loss = None
+            if labels is not None:
+                loss = nn.functional.cross_entropy(logits, labels)
+
+            # Trainer accepts a dict output as long as "loss" is present when
+            # labels were supplied.
+            return {"loss": loss, "logits": logits} if loss is not None else {"logits": logits}
+
+        def save(self, output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+            self.backbone.save_pretrained(output_dir)
+            torch.save(
+                self.classifier.state_dict(),
+                os.path.join(output_dir, HEAD_WEIGHTS_FILENAME),
+            )
+            with open(os.path.join(output_dir, HEAD_CONFIG_FILENAME), "w") as handle:
+                json.dump(
+                    {
+                        "image_dim": self.image_dim,
+                        "text_dim": self.text_dim,
+                        "num_labels": self.num_labels,
+                        "dropout": dropout,
+                    },
+                    handle,
+                    indent=2,
+                )
+
+    return ImageTextClassifier()
+
+
+def load(model_dir, id2label):
+    """Rebuild a saved fusion model. The exact inverse of ``model.save``."""
+    import torch
+    from transformers import AutoModel
+
+    with open(os.path.join(model_dir, HEAD_CONFIG_FILENAME)) as handle:
+        head_config = json.load(handle)
+
+    backbone = AutoModel.from_pretrained(model_dir)
+    model = build_fusion_model(
+        backbone,
+        image_dim=head_config["image_dim"],
+        text_dim=head_config["text_dim"],
+        num_labels=head_config["num_labels"],
+        dropout=head_config.get("dropout", 0.1),
+    )
+    model.classifier.load_state_dict(
+        torch.load(
+            os.path.join(model_dir, HEAD_WEIGHTS_FILENAME), map_location="cpu"
+        )
+    )
+    model.id2label = id2label
+    return model
+
+
+def resolve_projection_dims(config):
+    """Determine the pooled image and text embedding widths for a dual encoder.
+
+    CLIP-family configs expose a shared ``projection_dim``; others fall back to
+    the per-tower hidden sizes.  Getting this wrong only surfaces as a shape
+    error deep inside the first forward pass, so it is resolved up front.
+    """
+    projection_dim = getattr(config, "projection_dim", None)
+    if projection_dim:
+        return int(projection_dim), int(projection_dim)
+
+    vision_config = getattr(config, "vision_config", None)
+    text_config = getattr(config, "text_config", None)
+    image_dim = getattr(vision_config, "hidden_size", None)
+    text_dim = getattr(text_config, "hidden_size", None)
+
+    if not image_dim or not text_dim:
+        raise ValueError(
+            "Could not determine image/text embedding widths from the model "
+            "config. This task needs a dual-encoder checkpoint that exposes "
+            "get_image_features and get_text_features (CLIP, SigLIP, ALIGN)."
+        )
+    return int(image_dim), int(text_dim)
+
+
+# =========================================================================
+# Collation
+# =========================================================================
+
+def build_collator(processor, spec, context_length, include_labels=True):
+    """Return a collate_fn producing pixel_values, input_ids and labels."""
+    import torch
+
+    try:
+        from . import task_image_classification
+    except ImportError:  # pragma: no cover - flat sourcedir
+        import task_image_classification  # type: ignore
+
+    def collate(features):
+        images = [
+            task_image_classification.load_image(feature[spec.image_column])
+            for feature in features
+        ]
+        texts = [str(feature[spec.text_column]) for feature in features]
+
+        batch = processor(
+            images=images,
+            text=texts,
+            return_tensors="pt",
+            padding="max_length",
+            truncation=True,
+            max_length=context_length,
+        )
+        batch = {
+            key: value
+            for key, value in batch.items()
+            if key in ("pixel_values", "input_ids", "attention_mask")
+        }
+
+        if include_labels and spec.label_column in features[0]:
+            batch["labels"] = torch.tensor(
+                [feature[spec.label_column] for feature in features], dtype=torch.long
+            )
+        return batch
+
+    return collate
+
+
+# =========================================================================
+# Training
+# =========================================================================
+
+def train(args, spec):
+    """Fine-tune a dual encoder plus fusion head on image/text pairs."""
+    from transformers import AutoConfig, AutoModel, AutoProcessor, Trainer
+
+    train_channel = os.environ.get("SM_CHANNEL_TRAIN", "/opt/ml/input/data/train")
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+
+    frame, _ = task_common.prepare_dataset(train_channel, spec)
+    frame, label2id, id2label = task_common.build_label_mapping(frame, spec)
+    num_labels = len(label2id)
+
+    processor = AutoProcessor.from_pretrained(args.model_name_or_path)
+    config = AutoConfig.from_pretrained(args.model_name_or_path)
+    backbone = AutoModel.from_pretrained(args.model_name_or_path, torch_dtype="auto")
+
+    if not (hasattr(backbone, "get_image_features") and hasattr(backbone, "get_text_features")):
+        raise ValueError(
+            f"{args.model_name_or_path} is not a dual-encoder model: it does "
+            f"not expose get_image_features/get_text_features. Choose a "
+            f"CLIP, SigLIP or ALIGN style checkpoint for "
+            f"{spec.display_name.lower()}."
+        )
+
+    image_dim, text_dim = resolve_projection_dims(config)
+    logger.info(f"Fusion head: image_dim={image_dim}, text_dim={text_dim}, classes={num_labels}")
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    max_ctx = task_common.resolve_max_context_length(config, tokenizer)
+    effective_context = (
+        min(args.context_length, max_ctx) if max_ctx else args.context_length
+    )
+    logger.info(
+        f"Context length: requested={args.context_length}, "
+        f"effective={effective_context}"
+        f"{' (capped)' if max_ctx and args.context_length > max_ctx else ''}"
+    )
+
+    model = build_fusion_model(backbone, image_dim, text_dim, num_labels)
+
+    train_dataset, eval_dataset = task_common.split_frame(
+        frame, args.split_ratio, args.seed
+    )
+
+    training_args = task_common.build_training_arguments(
+        output_dir="/opt/ml/checkpoints",
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        weight_decay=args.weight_decay,
+        eval_strategy="epoch",
+        save_strategy="no",
+        logging_dir="/opt/ml/output/tensorboard",
+        remove_unused_columns=False,
+        label_names=["labels"],
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        compute_metrics=task_common.compute_accuracy,
+        callbacks=task_common.build_callbacks(args),
+        data_collator=build_collator(processor, spec, effective_context),
+    )
+
+    logger.info(
+        f"Starting fine-tuning: task={spec.task_type}, "
+        f"model={args.model_name_or_path}, epochs={args.epochs}, "
+        f"batch_size={args.per_device_train_batch_size}"
+    )
+    trainer.train()
+
+    metrics = trainer.evaluate()
+    logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")
+
+    # Trainer.save_model cannot round-trip a plain nn.Module, so save the
+    # backbone, head and wiring explicitly.
+    model.save(model_dir)
+    processor.save_pretrained(model_dir)
+    with open(os.path.join(model_dir, "label_mapping.json"), "w") as handle:
+        json.dump({"label2id": label2id, "id2label": id2label}, handle, indent=2)
+    logger.info(f"Saved model to {model_dir}")
+
+    return metrics
+
+
+# =========================================================================
+# Inference
+# =========================================================================
+
+def model_fn(model_dir):
+    """Load the fusion model, processor and label mapping."""
+    import torch
+    from transformers import AutoProcessor
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    with open(os.path.join(model_dir, "label_mapping.json")) as handle:
+        mapping = json.load(handle)
+    id2label = {int(k): v for k, v in mapping["id2label"].items()}
+
+    processor = AutoProcessor.from_pretrained(model_dir)
+    model = load(model_dir, id2label)
+    model.to(device)
+    model.eval()
+
+    logger.info(f"Loaded image+text classification model from {model_dir} on {device}")
+    return {
+        "model": model,
+        "processor": processor,
+        "device": device,
+        "id2label": id2label,
+    }
+
+
+def input_fn(request_body, content_type, spec):
+    """Unpack a .zip holding a manifest plus images into records.
+
+    The manifest needs the task's ``image`` and ``text`` columns; ``label`` is
+    not required, since inference input is unlabelled.
+    """
+    import tempfile
+
+    if not isinstance(request_body, (bytes, bytearray)):
+        raise ValueError(
+            f"Expected archive bytes for {spec.task_type}, got {type(request_body).__name__}"
+        )
+
+    work_dir = tempfile.mkdtemp(prefix="inference-image-text-")
+    archive_path = os.path.join(work_dir, "input.zip")
+    with open(archive_path, "wb") as handle:
+        handle.write(bytes(request_body))
+
+    root = task_common.extract_archive(archive_path, os.path.join(work_dir, "extracted"))
+    manifest_path = task_common.find_file_in_dir(root, spec.manifest_extensions, "manifest")
+
+    import pandas as pd
+
+    reader_name, reader_kwargs = task_common.resolve_dataset_reader(manifest_path)
+    frame = getattr(pd, reader_name)(manifest_path, **reader_kwargs)
+
+    missing = [c for c in (spec.image_column, spec.text_column) if c not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"Inference manifest is missing required column(s): {', '.join(missing)}."
+        )
+
+    records = []
+    for _index, row in frame.iterrows():
+        relative = str(row[spec.image_column]).strip()
+        records.append(
+            {
+                spec.image_column: task_common.resolve_image_path(root, relative),
+                spec.text_column: str(row[spec.text_column]),
+                "identifier": relative,
+            }
+        )
+
+    if not records:
+        raise ValueError("Inference manifest contains no records.")
+
+    logger.info(f"Unpacked {len(records)} image/text pairs for inference")
+    return records
+
+
+def predict_fn(records, loaded, spec):
+    """Run batched image+text inference with softmax probabilities."""
+    import numpy as np
+    import torch
+
+    model, processor, device = loaded["model"], loaded["processor"], loaded["device"]
+    id2label = loaded["id2label"]
+
+    if not records:
+        return {"identifiers": [], "probabilities": np.zeros((0, 0)), "labels": []}
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    context_length = getattr(tokenizer, "model_max_length", 77) or 77
+    collate = build_collator(processor, spec, context_length, include_labels=False)
+
+    batches = []
+    with torch.no_grad():
+        for start in range(0, len(records), BATCH_SIZE):
+            batch = collate(records[start : start + BATCH_SIZE])
+            batch = {k: v.to(device) for k, v in batch.items()}
+            logits = model(**batch)["logits"]
+            batches.append(torch.softmax(logits, dim=-1).cpu().numpy())
+
+    probabilities = np.vstack(batches) if batches else np.zeros((0, 0))
+    num_labels = probabilities.shape[1] if len(probabilities.shape) > 1 else 0
+
+    return {
+        "identifiers": [record["identifier"] for record in records],
+        "probabilities": probabilities,
+        "labels": [id2label.get(i, f"class_{i}") for i in range(num_labels)],
+    }

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_text_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_text_classification.py
@@ -1,0 +1,213 @@
+"""Text classification: text -> label.
+
+The original fine-tuning path, moved here unchanged in behaviour.  Every model
+trained before task types existed was trained by this code, so its handling of
+the pad token and of ``resize_token_embeddings`` is preserved verbatim: the
+decoder-only models in the catalog (GPT-2, SmolLM2, EuroLLM) ship without a
+pad token and genuinely need one added before they can be batched.
+
+That same manoeuvre is actively harmful on a vision-language model, which is
+one of the reasons the tasks are separate modules rather than branches.
+"""
+
+import logging
+import os
+
+try:  # package context: unit tests and the app-api container
+    from . import task_common
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_common  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 64
+
+
+# =========================================================================
+# Training
+# =========================================================================
+
+def train(args, spec):
+    """Fine-tune a sequence classification model on text records."""
+    from transformers import (
+        AutoTokenizer,
+        AutoConfig,
+        AutoModelForSequenceClassification,
+        Trainer,
+    )
+
+    train_channel = os.environ.get("SM_CHANNEL_TRAIN", "/opt/ml/input/data/train")
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+
+    frame, _ = task_common.prepare_dataset(train_channel, spec)
+    frame, label2id, id2label = task_common.build_label_mapping(frame, spec)
+    num_labels = len(label2id)
+
+    # Load tokenizer and add a PAD token.  Decoder-only checkpoints have none,
+    # and padding is required to batch.
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
+    tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+    pad_token_id = tokenizer(
+        "[PAD]", truncation=True, padding=False, return_tensors="pt"
+    )["input_ids"][0][0].item()
+
+    config = AutoConfig.from_pretrained(
+        args.model_name_or_path,
+        num_labels=num_labels,
+        label2id=label2id,
+        id2label=id2label,
+        pad_token_id=pad_token_id,
+    )
+
+    max_ctx = task_common.resolve_max_context_length(config, tokenizer)
+    effective_context = (
+        min(args.context_length, max_ctx) if max_ctx else args.context_length
+    )
+    logger.info(
+        f"Context length: requested={args.context_length}, "
+        f"effective={effective_context}"
+        f"{' (capped)' if max_ctx and args.context_length > max_ctx else ''}"
+    )
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.model_name_or_path,
+        config=config,
+        torch_dtype="auto",
+    )
+    model.resize_token_embeddings(len(tokenizer))
+
+    text_column = spec.text_column
+
+    def tokenize_function(examples):
+        return tokenizer(
+            examples[text_column],
+            max_length=effective_context,
+            padding="max_length",
+            truncation=True,
+        )
+
+    train_dataset, eval_dataset = task_common.split_frame(
+        frame, args.split_ratio, args.seed
+    )
+    train_dataset = train_dataset.map(tokenize_function, batched=True)
+    eval_dataset = eval_dataset.map(tokenize_function, batched=True)
+
+    training_args = task_common.build_training_arguments(
+        output_dir="/opt/ml/checkpoints",
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        weight_decay=args.weight_decay,
+        eval_strategy="epoch",
+        save_strategy="no",
+        logging_dir="/opt/ml/output/tensorboard",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        compute_metrics=task_common.compute_accuracy,
+        callbacks=task_common.build_callbacks(args),
+    )
+
+    logger.info(
+        f"Starting fine-tuning: task={spec.task_type}, "
+        f"model={args.model_name_or_path}, epochs={args.epochs}, "
+        f"batch_size={args.per_device_train_batch_size}"
+    )
+    trainer.train()
+
+    metrics = trainer.evaluate()
+    logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")
+
+    trainer.save_model(model_dir)
+    tokenizer.save_pretrained(model_dir)
+    logger.info(f"Saved model to {model_dir}")
+
+    return metrics
+
+
+# =========================================================================
+# Inference
+# =========================================================================
+
+def model_fn(model_dir):
+    """Load the model and tokenizer for Batch Transform."""
+    import torch
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        model_dir,
+        torch_dtype="auto",
+    )
+    model.resize_token_embeddings(len(tokenizer))
+    model.to(device)
+    model.eval()
+
+    logger.info(f"Loaded text classification model from {model_dir} on {device}")
+    return {"model": model, "tokenizer": tokenizer, "device": device}
+
+
+def input_fn(request_body, content_type, spec):
+    """Parse Batch Transform input into records.
+
+    Supports text/plain (one text per line) and application/json (a list of
+    strings or ``{"texts": [...]}``).
+    """
+    import json
+
+    if isinstance(request_body, (bytes, bytearray)):
+        request_body = request_body.decode("utf-8")
+
+    if content_type in ("text/plain", "text/csv"):
+        texts = [line.strip() for line in request_body.strip().split("\n") if line.strip()]
+    elif content_type == "application/json":
+        data = json.loads(request_body)
+        if isinstance(data, list):
+            texts = [str(item) for item in data if str(item).strip()]
+        elif isinstance(data, dict) and "texts" in data:
+            texts = [str(t) for t in data["texts"] if str(t).strip()]
+        else:
+            raise ValueError('JSON input must be a list or {"texts": [...]}')
+    else:
+        raise ValueError(f"Unsupported content type: {content_type}")
+
+    return [{"text": text, "identifier": text} for text in texts]
+
+
+def predict_fn(records, loaded, spec):
+    """Run batched inference, returning identifiers, probabilities and labels."""
+    import numpy as np
+    import torch
+
+    model, tokenizer, device = loaded["model"], loaded["tokenizer"], loaded["device"]
+    texts = [record["text"] for record in records]
+
+    if not texts:
+        return {"identifiers": [], "probabilities": np.zeros((0, 0)), "labels": []}
+
+    batches = []
+    with torch.no_grad():
+        for start in range(0, len(texts), BATCH_SIZE):
+            encoded = tokenizer(
+                texts[start : start + BATCH_SIZE],
+                padding=True,
+                truncation=True,
+                return_tensors="pt",
+            )
+            encoded = {k: v.to(device) for k, v in encoded.items()}
+            logits = model(**encoded).logits
+            batches.append(torch.softmax(logits, dim=-1).cpu().numpy())
+
+    probabilities = np.vstack(batches) if batches else np.zeros((0, 0))
+
+    return {
+        "identifiers": [record["identifier"] for record in records],
+        "probabilities": probabilities,
+        "labels": task_common.label_names(model.config, probabilities),
+    }

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
@@ -1,31 +1,38 @@
-"""SageMaker training entry point for fine-tuning text classification models.
+"""SageMaker training entry point.
 
-Adapted from the original Flask fine_tune.py for SageMaker HuggingFace DLC.
+A dispatcher.  It parses the hyperparameters SageMaker passes as CLI args,
+resolves the task type against the registry, and hands off to the matching
+``task_*`` module.  All model-specific behaviour lives in those modules; this
+file deliberately knows nothing about auto-classes or collators.
 
 SageMaker paths:
-  - Input data:   /opt/ml/input/data/train/  (CSV with text,label columns)
-  - Model output: /opt/ml/model/             (auto-uploaded to S3 as model.tar.gz)
-  - Checkpoints:  /opt/ml/checkpoints/       (not used)
+  - Input data:   /opt/ml/input/data/train/   (dataset file, or .zip archive)
+  - Model output: /opt/ml/model/              (auto-uploaded as model.tar.gz)
+  - Checkpoints:  /opt/ml/checkpoints/
 
-Usage:
-  The HuggingFace DLC invokes this script with hyperparameters as CLI args:
-    python train.py --model_name_or_path bert-base-uncased --epochs 3 ...
+The HuggingFace DLC invokes this script with hyperparameters as CLI args:
+    python train.py --model_name_or_path google/vit-base-patch16-224 \
+        --task_type image-classification --epochs 3 ...
 """
 
 import argparse
+import json
+import logging
 import os
 import sys
-import shutil
-import logging
 
-# Heavy ML dependencies are imported lazily inside train() since they are only
-# available in the SageMaker DLC container.  Utility functions and callbacks
-# must remain importable without torch/transformers so they can be unit-tested
-# locally.
-try:
-    from transformers import TrainerCallback
-except ImportError:  # pragma: no cover – local dev/test without transformers
-    TrainerCallback = object
+try:  # package context: unit tests and the app-api container
+    from .. import task_types
+    from . import task_common
+    from . import task_image_classification
+    from . import task_image_text_classification
+    from . import task_text_classification
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_types  # type: ignore
+    import task_common  # type: ignore
+    import task_image_classification  # type: ignore
+    import task_image_text_classification  # type: ignore
+    import task_text_classification  # type: ignore
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -35,399 +42,42 @@ logging.basicConfig(
 )
 
 
-# =========================================================================
-# Callbacks
-# =========================================================================
-
-
-class DynamoDBProgressCallback(TrainerCallback):
-    """Reports training progress (0.0-1.0) to DynamoDB.
-
-    Throttles writes to every 10 steps to reduce API calls.
-    Fails silently so that DynamoDB issues don't abort training.
-    """
-
-    def __init__(self, table_name, region, pk, sk):
-        super().__init__()
-        self._table_name = table_name
-        self._pk = pk
-        self._sk = sk
-        self._client = None
-        if table_name and pk and sk:
-            try:
-                import boto3
-
-                self._client = boto3.client("dynamodb", region_name=region)
-                logger.info(
-                    f"DynamoDB progress callback initialized: "
-                    f"table={table_name}, region={region}"
-                )
-            except Exception as e:
-                logger.warning(f"Could not create DynamoDB client: {e}")
-        else:
-            logger.warning(
-                f"DynamoDB progress callback disabled — missing config: "
-                f"table_name={'set' if table_name else 'EMPTY'}, "
-                f"pk={'set' if pk else 'EMPTY'}, "
-                f"sk={'set' if sk else 'EMPTY'}"
-            )
-
-    def _update_progress(self, progress):
-        if not self._client:
-            return
-        try:
-            self._client.update_item(
-                TableName=self._table_name,
-                Key={
-                    "PK": {"S": self._pk},
-                    "SK": {"S": self._sk},
-                },
-                UpdateExpression="SET training_progress = :p",
-                ExpressionAttributeValues={
-                    ":p": {"N": str(round(progress, 4))},
-                },
-            )
-        except Exception as e:
-            logger.warning(f"Failed to update progress in DynamoDB: {e}")
-
-    def _from_state(self, state):
-        if getattr(state, "max_steps", 0) and state.max_steps > 0:
-            return min(1.0, max(0.0, state.global_step / state.max_steps))
-        if getattr(state, "num_train_epochs", 0) and getattr(
-            state, "epoch", None
-        ) is not None:
-            total = float(state.num_train_epochs)
-            if total > 0:
-                return min(1.0, max(0.0, float(state.epoch) / total))
-        return None
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        self._update_progress(0.0)
-
-    def on_log(self, args, state, control, logs=None, **kwargs):
-        progress = self._from_state(state)
-        if progress is not None:
-            self._update_progress(progress)
-
-    def on_step_end(self, args, state, control, **kwargs):
-        if state.global_step % 10 == 0:
-            progress = self._from_state(state)
-            if progress is not None:
-                self._update_progress(progress)
-
-    def on_train_end(self, args, state, control, **kwargs):
-        self._update_progress(1.0)
-
-
-class SageMakerLoggingCallback(TrainerCallback):
-    """Logs epoch accuracy to stdout (captured by CloudWatch)."""
-
-    def on_evaluate(self, args, state, control, metrics=None, **kwargs):
-        if state.epoch is not None and state.epoch < args.num_train_epochs:
-            if metrics is not None:
-                accuracy = metrics.get("eval_accuracy")
-                if accuracy is not None:
-                    logger.info(
-                        f"Epoch {int(state.epoch)} finished with "
-                        f"eval_accuracy={accuracy:.4f}"
-                    )
-            logger.info("Starting next epoch...")
-
-
-# =========================================================================
-# Helper Functions
-# =========================================================================
-
-
-def resolve_max_context_length(config, tokenizer):
-    """Resolve the effective maximum context length from model config.
-
-    Checks multiple config attributes and returns the smallest valid value.
-    Returns None if no valid context length can be determined.
-    """
-    candidates = [
-        getattr(config, "max_position_embeddings", None),
-        getattr(config, "n_positions", None),
-        getattr(config, "seq_length", None),
-        getattr(tokenizer, "model_max_length", None),
-    ]
-
-    def _valid(v):
-        try:
-            return v is not None and float(v) > 0 and float(v) < 1_000_000
-        except Exception:
-            return False
-
-    valid_vals = [int(v) for v in candidates if _valid(v)]
-    return min(valid_vals) if valid_vals else None
-
-
-# Dataset formats the trainer can read, mapped to the pandas reader that loads
-# them. A training record has to carry both a "text" and a "label" field, which
-# is why plain .txt is absent: it has no way to express the label. (.txt stays
-# valid for *inference* input, which is unlabelled — one record per line.)
-#
-# Kept as data rather than an if/elif chain so the supported-format contract can
-# be asserted without importing pandas, which only exists inside the SageMaker
-# training container and not in the backend venv.
-DATASET_READERS = {
-    ".csv": ("read_csv", {}),
-    ".jsonl": ("read_json", {"lines": True}),
-    ".json": ("read_json", {}),
+# Maps a task type to the module implementing it.  Adding a task means adding
+# a module and one entry here — no branching inside the trainer.
+TASK_MODULES = {
+    task_types.TEXT_CLASSIFICATION: task_text_classification,
+    task_types.IMAGE_CLASSIFICATION: task_image_classification,
+    task_types.IMAGE_TEXT_CLASSIFICATION: task_image_text_classification,
 }
 
-SUPPORTED_DATASET_EXTENSIONS = tuple(DATASET_READERS)
 
-REQUIRED_DATASET_COLUMNS = ("text", "label")
+def resolve_task_module(task_type):
+    """Return the module implementing ``task_type``.
 
-
-def find_dataset_in_channel(channel_dir):
-    """Find the first supported dataset file in a SageMaker input channel.
-
-    Raises FileNotFoundError if the directory is missing, or if it holds no
-    file with a supported extension.
+    Raises ValueError for a task the registry knows but no module implements,
+    which would otherwise surface as a confusing KeyError mid-training.
     """
-    if not os.path.isdir(channel_dir):
-        raise FileNotFoundError(f"Channel directory does not exist: {channel_dir}")
-
-    for f in sorted(os.listdir(channel_dir)):
-        if f.lower().endswith(SUPPORTED_DATASET_EXTENSIONS):
-            return os.path.join(channel_dir, f)
-
-    supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
-    raise FileNotFoundError(
-        f"No dataset file found in {channel_dir}. Supported formats: {supported}"
-    )
-
-
-def resolve_dataset_reader(dataset_path):
-    """Return the (pandas reader name, kwargs) pair for a dataset file.
-
-    Raises ValueError for an extension the trainer cannot read.
-    """
-    extension = os.path.splitext(dataset_path)[1].lower()
-
-    if extension not in DATASET_READERS:
-        supported = ", ".join(SUPPORTED_DATASET_EXTENSIONS)
+    spec = task_types.get_task_spec(task_type)
+    module = TASK_MODULES.get(spec.task_type)
+    if module is None:  # pragma: no cover - registry/module drift
         raise ValueError(
-            f"Unsupported dataset format '{extension}'. Supported formats: {supported}"
+            f"Task type '{spec.task_type}' is registered but has no trainer module."
         )
-
-    return DATASET_READERS[extension]
-
-
-def validate_dataset_columns(columns, dataset_path):
-    """Raise ValueError if a required column is absent from the dataset."""
-    missing = [c for c in REQUIRED_DATASET_COLUMNS if c not in columns]
-    if missing:
-        raise ValueError(
-            f"Dataset {os.path.basename(dataset_path)} is missing required "
-            f"column(s): {', '.join(missing)}. Each record needs a \"text\" "
-            f'and a "label" field.'
-        )
+    return module, spec
 
 
-def load_dataset_frame(dataset_path):
-    """Load a dataset file into a DataFrame with "text" and "label" columns."""
-    import pandas as pd
-
-    reader_name, reader_kwargs = resolve_dataset_reader(dataset_path)
-    df = getattr(pd, reader_name)(dataset_path, **reader_kwargs)
-
-    validate_dataset_columns(df.columns, dataset_path)
-
-    return df
-
-
-def copy_inference_script(model_output_dir):
-    """Copy inference.py and requirements.txt into model_output_dir/code/.
-
-    SageMaker Batch Transform discovers code/inference.py in model.tar.gz
-    and uses it as the custom inference handler.
-    """
-    code_dir = os.path.join(model_output_dir, "code")
-    os.makedirs(code_dir, exist_ok=True)
-
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    for filename in ("inference.py", "requirements.txt"):
-        src = os.path.join(script_dir, filename)
-        if os.path.exists(src):
-            shutil.copy2(src, os.path.join(code_dir, filename))
-            logger.info(f"Copied {filename} to {code_dir}")
-        else:
-            logger.warning(f"Script file not found, skipping: {src}")
-
-
-# =========================================================================
-# Main Training Function
-# =========================================================================
-
-
-def train(args):
-    """Main training logic adapted from the original fine_tune.py."""
-    import numpy as np
-    import pandas as pd
-    from transformers import (
-        AutoTokenizer,
-        AutoConfig,
-        AutoModelForSequenceClassification,
-        Trainer,
-        TrainingArguments,
-    )
-    from datasets import Dataset
-    import evaluate
-
-    # SageMaker paths
-    train_channel = os.environ.get(
-        "SM_CHANNEL_TRAIN", "/opt/ml/input/data/train"
-    )
-    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
-
-    # Find and load the dataset (CSV / JSONL / JSON)
-    dataset_path = find_dataset_in_channel(train_channel)
-    logger.info(f"Loading dataset from {dataset_path}")
-    df = load_dataset_frame(dataset_path)
-
-    # Label normalization — support non-numeric class labels
-    label_names = sorted(list(pd.Series(df["label"]).astype(str).unique()))
-    label2id = {name: i for i, name in enumerate(label_names)}
-    id2label = {i: name for name, i in label2id.items()}
-    df["label"] = df["label"].astype(str).map(label2id)
-    num_labels = len(label_names)
-    logger.info(f"Label mapping ({num_labels} classes): {label2id}")
-
-    # Load tokenizer and add PAD token
-    tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
-    tokenizer.add_special_tokens({"pad_token": "[PAD]"})
-    pad_token_id = tokenizer(
-        "[PAD]", truncation=True, padding=False, return_tensors="pt"
-    )["input_ids"][0][0].item()
-
-    # Load model config with label mappings
-    config = AutoConfig.from_pretrained(
-        args.model_name_or_path,
-        num_labels=num_labels,
-        label2id=label2id,
-        id2label=id2label,
-        pad_token_id=pad_token_id,
-    )
-
-    # Resolve effective context length
-    max_ctx = resolve_max_context_length(config, tokenizer)
-    effective_context = (
-        min(args.context_length, max_ctx) if max_ctx else args.context_length
-    )
-    logger.info(
-        f"Context length: requested={args.context_length}, "
-        f"effective={effective_context}"
-        f"{ ' (capped)' if max_ctx and args.context_length > max_ctx else ''}"
-    )
-
-    # Load model
-    model = AutoModelForSequenceClassification.from_pretrained(
-        args.model_name_or_path,
-        config=config,
-        torch_dtype="auto",
-    )
-    model.resize_token_embeddings(len(tokenizer))
-
-    # Tokenization
-    def tokenize_function(examples):
-        return tokenizer(
-            examples["text"],
-            max_length=effective_context,
-            padding="max_length",
-            truncation=True,
-        )
-
-    # Train/test split
-    dataset = Dataset.from_pandas(df)
-    dataset = dataset.train_test_split(
-        test_size=1 - args.split_ratio, seed=args.seed
-    )
-    logger.info(
-        f"Data split: {len(dataset['train'])} train / "
-        f"{len(dataset['test'])} test"
-    )
-
-    tokenized_datasets = dataset.map(tokenize_function, batched=True)
-    train_dataset = tokenized_datasets["train"].shuffle(seed=args.seed)
-    eval_dataset = tokenized_datasets["test"].shuffle(seed=args.seed)
-
-    # Training arguments
-    training_args = TrainingArguments(
-        output_dir="/opt/ml/checkpoints",
-        learning_rate=args.learning_rate,
-        num_train_epochs=args.epochs,
-        per_device_train_batch_size=args.per_device_train_batch_size,
-        weight_decay=args.weight_decay,
-        evaluation_strategy="epoch",
-        save_strategy="no",
-        logging_dir="/opt/ml/output/tensorboard",
-    )
-
-    # Accuracy metric
-    metric = evaluate.load("accuracy")
-
-    def compute_metrics(eval_pred):
-        logits, labels = eval_pred
-        predictions = np.argmax(logits, axis=-1)
-        return metric.compute(predictions=predictions, references=labels)
-
-    # Callbacks
-    callbacks = [SageMakerLoggingCallback()]
-    progress_cb = DynamoDBProgressCallback(
-        table_name=args.dynamodb_table_name,
-        region=args.dynamodb_region,
-        pk=args.job_pk,
-        sk=args.job_sk,
-    )
-    callbacks.append(progress_cb)
-
-    # Train
-    trainer = Trainer(
-        model=model,
-        args=training_args,
-        train_dataset=train_dataset,
-        eval_dataset=eval_dataset,
-        compute_metrics=compute_metrics,
-        callbacks=callbacks,
-    )
-
-    logger.info(
-        f"Starting fine-tuning: model={args.model_name_or_path}, "
-        f"epochs={args.epochs}, batch_size={args.per_device_train_batch_size}"
-    )
-    trainer.train()
-
-    # Final evaluation
-    metrics = trainer.evaluate()
-    logger.info(
-        f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}"
-    )
-
-    # Save model and tokenizer to /opt/ml/model/
-    trainer.save_model(model_dir)
-    tokenizer.save_pretrained(model_dir)
-    logger.info(f"Saved model to {model_dir}")
-
-    # Copy inference handler into model artifact for Batch Transform
-    copy_inference_script(model_dir)
-
-    logger.info("Training complete.")
-
-
-# =========================================================================
-# Argument Parsing
-# =========================================================================
-
-
-def parse_args():
-    """Parse command-line arguments (passed as hyperparameters by SageMaker)."""
+def parse_args(argv=None):
+    """Parse the hyperparameters SageMaker passes as command-line arguments."""
     parser = argparse.ArgumentParser()
 
-    # Model
+    # Model and task
     parser.add_argument("--model_name_or_path", type=str, required=True)
+    parser.add_argument(
+        "--task_type",
+        type=str,
+        default=task_types.DEFAULT_TASK_TYPE,
+        choices=list(task_types.TASK_TYPES),
+    )
 
     # Training hyperparameters
     parser.add_argument("--epochs", type=int, default=3)
@@ -437,6 +87,7 @@ def parse_args():
     parser.add_argument("--split_ratio", type=float, default=0.8)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--context_length", type=int, default=512)
+    parser.add_argument("--image_size", type=int, default=224)
 
     # DynamoDB progress reporting
     parser.add_argument("--dynamodb_table_name", type=str, default="")
@@ -451,10 +102,37 @@ def parse_args():
         default=os.environ.get("SM_MODEL_DIR", "/opt/ml/model"),
     )
 
-    args, _ = parser.parse_known_args()
+    args, _unknown = parser.parse_known_args(argv)
     return args
 
 
+def write_task_marker(model_dir, task_type):
+    """Record the task type inside the model artifact for the inference handler."""
+    os.makedirs(model_dir, exist_ok=True)
+    marker = os.path.join(model_dir, "task_type.json")
+    with open(marker, "w") as handle:
+        json.dump({"task_type": task_type}, handle, indent=2)
+    logger.info(f"Recorded task type '{task_type}' in {marker}")
+    return marker
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    module, spec = resolve_task_module(args.task_type)
+
+    logger.info(f"Dispatching to task '{spec.task_type}' ({spec.display_name})")
+    module.train(args, spec)
+
+    # Bundle the inference handler into the artifact so Batch Transform can
+    # serve this model, and record which task it serves.  Without the marker
+    # the handler would fall back to text classification and mis-parse an
+    # image payload.
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+    write_task_marker(model_dir, spec.task_type)
+    task_common.copy_inference_bundle(model_dir)
+
+    logger.info("Training complete.")
+
+
 if __name__ == "__main__":
-    args = parse_args()
-    train(args)
+    main()

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
@@ -7,28 +7,63 @@ from typing import Dict, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
-from .job_models import INSTANCE_COST_PER_HOUR
+from . import pricing, task_types
 
 logger = logging.getLogger(__name__)
 
-# HuggingFace Deep Learning Container image URIs by region
-# PyTorch 2.1 + Transformers 4.36 (GPU, Python 3.10)
-_HF_DLC_IMAGES = {
-    "us-east-1": "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
-    "us-east-2": "763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
-    "us-west-2": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
-    "eu-west-1": "763104351884.dkr.ecr.eu-west-1.amazonaws.com/huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
-    "ap-southeast-1": "763104351884.dkr.ecr.ap-southeast-1.amazonaws.com/huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
+# =========================================================================
+# Deep Learning Container images
+# =========================================================================
+
+# Keyed by (task DLC family, region).  The two families move independently on
+# purpose: every text model in the catalog was trained and validated against
+# transformers 4.36, and vision models simply do not load there —
+# AutoModelForImageClassification predates it but the modern vision
+# checkpoints do not, and SigLIP-class dual encoders arrived much later.
+# Bumping one shared image to serve vision would silently re-baseline every
+# existing text job.
+#
+# Tags verified present in us-east-1/us-east-2/us-west-2 via
+# `aws ecr describe-images --registry-id 763104351884`.  eu-west-1 and
+# ap-southeast-1 follow the same AWS publishing convention but could not be
+# confirmed from here (an SCP denies ecr:DescribeImages in those regions);
+# override with the environment variables below if a region lags.
+_TRAINING_IMAGE_TAGS = {
+    task_types.DLC_FAMILY_TEXT: "huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
+    task_types.DLC_FAMILY_VISION: "huggingface-pytorch-training:2.8.0-transformers4.56.2-gpu-py312-cu129-ubuntu22.04",
 }
 
-
-_HF_DLC_INFERENCE_IMAGES = {
-    "us-east-1": "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
-    "us-east-2": "763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
-    "us-west-2": "763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
-    "eu-west-1": "763104351884.dkr.ecr.eu-west-1.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
-    "ap-southeast-1": "763104351884.dkr.ecr.ap-southeast-1.amazonaws.com/huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
+_INFERENCE_IMAGE_TAGS = {
+    task_types.DLC_FAMILY_TEXT: "huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
+    task_types.DLC_FAMILY_VISION: "huggingface-pytorch-inference:2.6.0-transformers4.51.3-gpu-py312-cu124-ubuntu22.04",
 }
+
+# The AWS-owned account that publishes Deep Learning Containers. Same in every
+# region we support.
+_DLC_REGISTRY_ACCOUNT = "763104351884"
+
+_SUPPORTED_DLC_REGIONS = (
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "eu-west-1",
+    "ap-southeast-1",
+)
+
+
+def _image_uri_override(kind: str, family: str) -> str:
+    """Read a per-family image override from the environment.
+
+    A DLC tag can be retired or lag in a region.  This is the escape hatch
+    that fixes it without a code deploy, e.g.
+    ``FINE_TUNING_TRAINING_IMAGE_VISION=<account>.dkr.ecr...``.
+    """
+    return os.environ.get(f"FINE_TUNING_{kind}_IMAGE_{family.upper()}", "").strip()
+
+
+def build_image_uri(region: str, tag: str) -> str:
+    """Compose a full DLC ECR image URI."""
+    return f"{_DLC_REGISTRY_ACCOUNT}.dkr.ecr.{region}.amazonaws.com/{tag}"
 
 
 class SageMakerService:
@@ -50,12 +85,29 @@ class SageMakerService:
         self._security_group_id = security_group_id or os.environ.get("SAGEMAKER_SECURITY_GROUP_ID", "")
         self._subnet_ids = subnet_ids or os.environ.get("SAGEMAKER_SUBNET_IDS", "")
 
-    def get_huggingface_image_uri(self) -> str:
-        """Return the HuggingFace training DLC image URI for the current region."""
-        uri = _HF_DLC_IMAGES.get(self._region)
-        if not uri:
-            raise ValueError(f"No HuggingFace DLC image configured for region {self._region}")
-        return uri
+    def _resolve_image_uri(self, kind: str, task_type: Optional[str]) -> str:
+        """Resolve the DLC image for a task, honouring any environment override."""
+        spec = task_types.get_task_spec(task_type)
+        family = spec.dlc_family
+
+        override = _image_uri_override(kind, family)
+        if override:
+            logger.info(f"Using overridden {kind.lower()} image for {family}: {override}")
+            return override
+
+        tags = _TRAINING_IMAGE_TAGS if kind == "TRAINING" else _INFERENCE_IMAGE_TAGS
+        tag = tags.get(family)
+        if not tag:
+            raise ValueError(f"No {kind.lower()} DLC image configured for task family '{family}'")
+        if self._region not in _SUPPORTED_DLC_REGIONS:
+            raise ValueError(
+                f"No HuggingFace DLC image configured for region {self._region}"
+            )
+        return build_image_uri(self._region, tag)
+
+    def get_huggingface_image_uri(self, task_type: Optional[str] = None) -> str:
+        """Return the training DLC image URI for ``task_type`` in this region."""
+        return self._resolve_image_uri("TRAINING", task_type)
 
     def create_training_job(
         self,
@@ -67,6 +119,8 @@ class SageMakerService:
         instance_count: int = 1,
         max_runtime: int = 86400,
         source_dir_s3_uri: str = "",
+        task_type: Optional[str] = None,
+        volume_size_gb: Optional[int] = None,
     ) -> dict:
         """Create a SageMaker training job.
 
@@ -74,9 +128,13 @@ class SageMakerService:
         sagemaker_submit_directory hyperparameters so the HuggingFace DLC
         uses the custom training script instead of the default.
 
+        ``task_type`` selects the DLC image family; omitting it keeps the
+        historical text-classification container.
+
         Returns the response from create_training_job API call.
         """
-        image_uri = self.get_huggingface_image_uri()
+        image_uri = self.get_huggingface_image_uri(task_type)
+        spec = task_types.get_task_spec(task_type)
 
         # Inject custom script hyperparameters if source_dir provided
         if source_dir_s3_uri:
@@ -112,7 +170,11 @@ class SageMakerService:
             "ResourceConfig": {
                 "InstanceType": instance_type,
                 "InstanceCount": instance_count,
-                "VolumeSizeInGB": 100,
+                # An image dataset holds the archive, the unpacked copy and
+                # the model checkpoint at once, so the text default is not
+                # enough headroom for the archive-based tasks.
+                "VolumeSizeInGB": volume_size_gb
+                or (200 if spec.requires_archive else 100),
             },
             "StoppingCondition": {
                 "MaxRuntimeInSeconds": max_runtime,
@@ -212,21 +274,27 @@ class SageMakerService:
             raise
 
     @staticmethod
-    def calculate_cost(instance_type: str, billable_seconds: int) -> float:
-        """Calculate estimated cost based on instance type and billable time."""
-        cost_per_hour = INSTANCE_COST_PER_HOUR.get(instance_type, 0.0)
-        return round(cost_per_hour * (billable_seconds / 3600), 4)
+    def calculate_cost(
+        instance_type: str, billable_seconds: int, *, transform: bool = False
+    ) -> float:
+        """Estimated cost for billable time on an instance.
+
+        Training and Batch Transform are priced separately — see
+        ``pricing.py`` — so the caller has to say which one it is measuring.
+        """
+        return pricing.calculate_cost(
+            instance_type, billable_seconds, transform=transform
+        )
 
     # =====================================================================
     # Batch Transform (Inference) Methods
     # =====================================================================
 
-    def get_huggingface_inference_image_uri(self) -> str:
-        """Return the HuggingFace inference DLC image URI for the current region."""
-        uri = _HF_DLC_INFERENCE_IMAGES.get(self._region)
-        if not uri:
-            raise ValueError(f"No HuggingFace inference DLC image configured for region {self._region}")
-        return uri
+    def get_huggingface_inference_image_uri(
+        self, task_type: Optional[str] = None
+    ) -> str:
+        """Return the inference DLC image URI for ``task_type`` in this region."""
+        return self._resolve_image_uri("INFERENCE", task_type)
 
     def create_transform_job(
         self,
@@ -237,6 +305,7 @@ class SageMakerService:
         instance_type: str,
         instance_count: int = 1,
         max_runtime: int = 3600,
+        task_type: Optional[str] = None,
     ) -> dict:
         """Create a SageMaker Batch Transform job.
 
@@ -244,9 +313,14 @@ class SageMakerService:
         1. Create a SageMaker Model from the training artifact
         2. Create a Transform Job using that model
 
+        ``task_type`` selects both the DLC image family and the payload
+        contract — the image tasks send a .zip archive rather than newline
+        delimited text, and need a far larger MaxPayloadInMB for it.
+
         Returns the response from create_transform_job API call.
         """
-        image_uri = self.get_huggingface_inference_image_uri()
+        image_uri = self.get_huggingface_inference_image_uri(task_type)
+        spec = task_types.get_task_spec(task_type)
         model_name = f"model-{job_name}"
 
         subnets = [s.strip() for s in self._subnet_ids.split(",") if s.strip()]
@@ -286,7 +360,7 @@ class SageMakerService:
                         "S3Uri": input_s3_uri,
                     }
                 },
-                "ContentType": "text/plain",
+                "ContentType": spec.inference_content_type,
             },
             "TransformOutput": {
                 "S3OutputPath": output_s3_uri,
@@ -295,7 +369,7 @@ class SageMakerService:
                 "InstanceType": instance_type,
                 "InstanceCount": instance_count,
             },
-            "MaxPayloadInMB": 6,
+            "MaxPayloadInMB": spec.inference_max_payload_mb,
         }
 
         if max_runtime:

--- a/backend/src/apis/app_api/fine_tuning/script_packaging_service.py
+++ b/backend/src/apis/app_api/fine_tuning/script_packaging_service.py
@@ -15,8 +15,26 @@ logger = logging.getLogger(__name__)
 # Directory containing the SageMaker scripts (relative to this module)
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "sagemaker_scripts")
 
-# Files to include in the source directory tar.gz
-SCRIPT_FILES = ["train.py", "inference.py", "requirements.txt"]
+# Directory containing modules shared between the app-api and the training
+# container.  task_types.py is the task registry, and both sides have to agree
+# on it, so it is packaged rather than duplicated.
+PACKAGE_DIR = os.path.dirname(__file__)
+
+# Files to include in the source directory tar.gz, flattened to the archive
+# root.  The task modules travel with the dispatcher because train.py resolves
+# the task type at runtime and imports whichever module implements it.
+SCRIPT_FILES = [
+    "train.py",
+    "inference.py",
+    "requirements.txt",
+    "task_common.py",
+    "task_text_classification.py",
+    "task_image_classification.py",
+    "task_image_text_classification.py",
+]
+
+# Files pulled from the package directory rather than sagemaker_scripts/.
+SHARED_FILES = ["task_types.py"]
 
 # S3 key for the packaged scripts
 SCRIPTS_S3_KEY = "scripts/sourcedir.tar.gz"
@@ -38,12 +56,23 @@ class ScriptPackagingService:
         )
         self._cached_s3_uri: Optional[str] = None
 
+    @staticmethod
+    def _source_paths() -> list:
+        """Return (archive name, source path) for every packaged file.
+
+        Ordered deterministically so the content hash is stable across calls —
+        an unstable hash would re-upload the source dir on every job.
+        """
+        paths = [(name, os.path.join(SCRIPTS_DIR, name)) for name in SCRIPT_FILES]
+        paths += [(name, os.path.join(PACKAGE_DIR, name)) for name in SHARED_FILES]
+        return sorted(paths, key=lambda pair: pair[0])
+
     def _compute_content_hash(self) -> str:
         """Compute SHA256 hash of all script file contents."""
         hasher = hashlib.sha256()
-        for filename in sorted(SCRIPT_FILES):
-            filepath = os.path.join(SCRIPTS_DIR, filename)
+        for name, filepath in self._source_paths():
             if os.path.exists(filepath):
+                hasher.update(name.encode("utf-8"))
                 with open(filepath, "rb") as f:
                     hasher.update(f.read())
         return hasher.hexdigest()
@@ -56,10 +85,9 @@ class ScriptPackagingService:
         """
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            for filename in SCRIPT_FILES:
-                filepath = os.path.join(SCRIPTS_DIR, filename)
+            for name, filepath in self._source_paths():
                 if os.path.exists(filepath):
-                    tar.add(filepath, arcname=filename)
+                    tar.add(filepath, arcname=name)
                 else:
                     logger.warning(f"Script file not found: {filepath}")
         buf.seek(0)

--- a/backend/src/apis/app_api/fine_tuning/task_types.py
+++ b/backend/src/apis/app_api/fine_tuning/task_types.py
@@ -220,12 +220,17 @@ TASK_SPECS: Dict[str, TaskSpec] = {
         inference_content_type="application/zip",
         inference_max_payload_mb=100,
         dlc_family=DLC_FAMILY_VISION,
-        hf_pipeline_tags=(
-            "zero-shot-image-classification",
-            "image-text-to-text",
-            "image-feature-extraction",
-            "visual-question-answering",
-        ),
+        # Deliberately narrow. This task needs a *dual encoder* exposing both
+        # get_image_features and get_text_features, which in practice means
+        # the CLIP/SigLIP/ALIGN family — exactly what carries the
+        # zero-shot-image-classification tag.
+        #
+        # "image-text-to-text" (LLaVA, Qwen-VL) and "visual-question-answering"
+        # (ViLT, BLIP) are generative or fusion models with no text tower to
+        # pool, and are excluded on purpose: allowing them would let the
+        # pre-flight pass a model that only fails later, on a billed GPU,
+        # inside the trainer's dual-encoder check.
+        hf_pipeline_tags=("zero-shot-image-classification",),
         default_instance_type="ml.g6.xlarge",
         default_hyperparameters={
             **_COMMON_HYPERPARAMETERS,

--- a/backend/src/apis/app_api/fine_tuning/task_types.py
+++ b/backend/src/apis/app_api/fine_tuning/task_types.py
@@ -1,0 +1,272 @@
+"""Task-type registry for the fine-tuning feature.
+
+A *task type* bundles everything that varies between one kind of fine-tuning
+job and another: what a training record looks like, how the dataset is
+packaged for upload, which HuggingFace auto-class loads the model, which Deep
+Learning Container it runs in, and what the inference output looks like.
+
+Before this module existed those answers were hardcoded inline in ``train.py``
+and ``inference.py``, which is why adding a second modality meant a rewrite
+rather than a registration.
+
+**This module must stay importable without torch, transformers, pandas or
+PIL.**  It is imported three different ways:
+
+* by ``routes.py`` in the app-api container, to validate a job *before* it is
+  submitted and a GPU is billed;
+* by the training and inference scripts running inside the SageMaker DLC;
+* by the unit tests, which run in the backend venv where the ML stack is
+  absent.
+
+Keep it pure data and stdlib.  The same reasoning already governs
+``DATASET_READERS`` in the training script: the supported-format contract has
+to be assertable without importing pandas.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, Tuple
+
+
+# =========================================================================
+# Task type identifiers
+# =========================================================================
+
+TEXT_CLASSIFICATION = "text-classification"
+IMAGE_CLASSIFICATION = "image-classification"
+IMAGE_TEXT_CLASSIFICATION = "image-text-classification"
+
+#: Task assumed for a job record written before task types existed, and for a
+#: request that omits the field.  Must stay ``TEXT_CLASSIFICATION`` — every
+#: historical job in DynamoDB is one of these and has no ``task_type``
+#: attribute to read.
+DEFAULT_TASK_TYPE = TEXT_CLASSIFICATION
+
+
+# =========================================================================
+# Deep Learning Container families
+# =========================================================================
+
+# Which DLC image family a task runs in.  Vision tasks need a far newer
+# transformers than the text tasks were built against, and bumping a single
+# shared image would re-baseline every existing text job.  Keying the image
+# map by family lets the two move independently: text jobs keep running the
+# exact container they were validated on.
+DLC_FAMILY_TEXT = "text"
+DLC_FAMILY_VISION = "vision"
+
+
+# =========================================================================
+# Spec
+# =========================================================================
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """Everything the platform needs to know about one fine-tuning task type."""
+
+    task_type: str
+    display_name: str
+    description: str
+
+    # --- Training record contract -------------------------------------
+    #: Columns every training record must carry.
+    required_columns: Tuple[str, ...]
+    #: Column holding the target class.
+    label_column: str
+    #: Column holding an image path relative to the archive root, or None for
+    #: text-only tasks.
+    image_column: Optional[str]
+    #: Column holding free text, or None for image-only tasks.
+    text_column: Optional[str]
+
+    # --- Upload contract ----------------------------------------------
+    #: Extensions the user may upload for training.
+    upload_extensions: Tuple[str, ...]
+    #: Extensions the manifest itself may use.  For archive-based tasks the
+    #: manifest lives *inside* the archive, so this differs from
+    #: ``upload_extensions``.
+    manifest_extensions: Tuple[str, ...]
+    #: True when the upload is an archive bundling a manifest plus image files.
+    requires_archive: bool
+
+    # --- Inference contract -------------------------------------------
+    #: Extensions the user may upload as Batch Transform input.
+    inference_upload_extensions: Tuple[str, ...]
+    #: ContentType handed to Batch Transform for this task.
+    inference_content_type: str
+    #: MaxPayloadInMB for the transform job.  Batch Transform caps this at 100.
+    inference_max_payload_mb: int
+
+    # --- Runtime -------------------------------------------------------
+    dlc_family: str
+    #: HuggingFace Hub pipeline tags whose models can serve this task.  Drives
+    #: both the model-search filter and the pre-flight check on a custom id.
+    hf_pipeline_tags: Tuple[str, ...]
+    default_instance_type: str
+    default_hyperparameters: Mapping[str, str]
+
+    def supports_extension(self, filename: str) -> bool:
+        """True when ``filename`` is an acceptable training upload."""
+        return filename.lower().endswith(self.upload_extensions)
+
+    def supports_inference_extension(self, filename: str) -> bool:
+        """True when ``filename`` is an acceptable Batch Transform input."""
+        return filename.lower().endswith(self.inference_upload_extensions)
+
+
+# =========================================================================
+# Shared hyperparameter defaults
+# =========================================================================
+
+_COMMON_HYPERPARAMETERS = {
+    "epochs": "3",
+    "learning_rate": "5e-5",
+    "weight_decay": "0.01",
+    "split_ratio": "0.8",
+    "seed": "42",
+}
+
+# Manifest formats a task can read.  Kept identical across tasks so a
+# researcher who already has a CSV workflow keeps it when they add images.
+_MANIFEST_EXTENSIONS = (".csv", ".jsonl", ".json")
+
+
+# =========================================================================
+# Registry
+# =========================================================================
+
+TASK_SPECS: Dict[str, TaskSpec] = {
+    TEXT_CLASSIFICATION: TaskSpec(
+        task_type=TEXT_CLASSIFICATION,
+        display_name="Text classification",
+        description=(
+            "Assign a label to a piece of text. Upload a CSV/JSONL/JSON file "
+            'where each record has a "text" and a "label" field.'
+        ),
+        required_columns=("text", "label"),
+        label_column="label",
+        image_column=None,
+        text_column="text",
+        upload_extensions=_MANIFEST_EXTENSIONS,
+        manifest_extensions=_MANIFEST_EXTENSIONS,
+        requires_archive=False,
+        inference_upload_extensions=(".txt", ".csv", ".jsonl", ".json"),
+        inference_content_type="text/plain",
+        inference_max_payload_mb=6,
+        dlc_family=DLC_FAMILY_TEXT,
+        hf_pipeline_tags=(
+            "fill-mask",
+            "text-classification",
+            "feature-extraction",
+            "token-classification",
+            "text-generation",
+        ),
+        default_instance_type="ml.g5.xlarge",
+        default_hyperparameters={
+            **_COMMON_HYPERPARAMETERS,
+            "per_device_train_batch_size": "16",
+            "context_length": "512",
+        },
+    ),
+    IMAGE_CLASSIFICATION: TaskSpec(
+        task_type=IMAGE_CLASSIFICATION,
+        display_name="Image classification",
+        description=(
+            "Assign a label to an image. Upload a .zip containing a "
+            'manifest (CSV/JSONL/JSON) with "image" and "label" fields, plus '
+            "the image files the manifest points at."
+        ),
+        required_columns=("image", "label"),
+        label_column="label",
+        image_column="image",
+        text_column=None,
+        upload_extensions=(".zip",),
+        manifest_extensions=_MANIFEST_EXTENSIONS,
+        requires_archive=True,
+        inference_upload_extensions=(".zip",),
+        # Batch Transform receives the whole archive as one payload and the
+        # handler unpacks it, which keeps the single-CSV result contract (and
+        # therefore the whole result viewer) identical to the text tasks.
+        inference_content_type="application/zip",
+        inference_max_payload_mb=100,
+        dlc_family=DLC_FAMILY_VISION,
+        hf_pipeline_tags=(
+            "image-classification",
+            "image-feature-extraction",
+            "zero-shot-image-classification",
+        ),
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters={
+            **_COMMON_HYPERPARAMETERS,
+            "per_device_train_batch_size": "16",
+            "image_size": "224",
+        },
+    ),
+    IMAGE_TEXT_CLASSIFICATION: TaskSpec(
+        task_type=IMAGE_TEXT_CLASSIFICATION,
+        display_name="Image + text classification",
+        description=(
+            "Assign a label to an image/text pair. Upload a .zip containing a "
+            'manifest (CSV/JSONL/JSON) with "image", "text" and "label" '
+            "fields, plus the image files the manifest points at."
+        ),
+        required_columns=("image", "text", "label"),
+        label_column="label",
+        image_column="image",
+        text_column="text",
+        upload_extensions=(".zip",),
+        manifest_extensions=_MANIFEST_EXTENSIONS,
+        requires_archive=True,
+        inference_upload_extensions=(".zip",),
+        inference_content_type="application/zip",
+        inference_max_payload_mb=100,
+        dlc_family=DLC_FAMILY_VISION,
+        hf_pipeline_tags=(
+            "zero-shot-image-classification",
+            "image-text-to-text",
+            "image-feature-extraction",
+            "visual-question-answering",
+        ),
+        default_instance_type="ml.g6.xlarge",
+        default_hyperparameters={
+            **_COMMON_HYPERPARAMETERS,
+            "per_device_train_batch_size": "16",
+            "image_size": "224",
+            "context_length": "77",
+        },
+    ),
+}
+
+#: Stable, deterministic ordering for anything user-facing.
+TASK_TYPES: Tuple[str, ...] = (
+    TEXT_CLASSIFICATION,
+    IMAGE_CLASSIFICATION,
+    IMAGE_TEXT_CLASSIFICATION,
+)
+
+#: Task types whose upload is an archive of a manifest plus image files.
+ARCHIVE_TASK_TYPES: Tuple[str, ...] = tuple(
+    t for t in TASK_TYPES if TASK_SPECS[t].requires_archive
+)
+
+
+def get_task_spec(task_type: Optional[str]) -> TaskSpec:
+    """Return the spec for ``task_type``.
+
+    ``None`` and the empty string resolve to :data:`DEFAULT_TASK_TYPE` so that
+    a job record written before task types existed still loads.
+
+    Raises ValueError for an unknown task type.
+    """
+    resolved = task_type or DEFAULT_TASK_TYPE
+    spec = TASK_SPECS.get(resolved)
+    if spec is None:
+        supported = ", ".join(TASK_TYPES)
+        raise ValueError(
+            f"Unknown task type '{task_type}'. Supported task types: {supported}"
+        )
+    return spec
+
+
+def requires_images(task_type: Optional[str]) -> bool:
+    """True when the task's training records reference image files."""
+    return get_task_spec(task_type).image_column is not None

--- a/backend/tests/fine_tuning/test_admin_routes.py
+++ b/backend/tests/fine_tuning/test_admin_routes.py
@@ -51,8 +51,8 @@ SAMPLE_GRANT = {
     "email": "user@example.com",
     "granted_by": "admin@example.com",
     "granted_at": "2026-01-01T00:00:00Z",
-    "monthly_quota_hours": 10.0,
-    "current_month_usage_hours": 2.0,
+    "monthly_quota_usd": 10.0,
+    "current_month_usage_usd": 2.0,
     "quota_period": "2026-03",
 }
 
@@ -102,7 +102,7 @@ class TestGrantAccess:
         client = TestClient(app)
         resp = client.post(
             "/admin/fine-tuning/access",
-            json={"email": "user@example.com", "monthly_quota_hours": 10.0},
+            json={"email": "user@example.com", "monthly_quota_usd": 10.0},
         )
 
         assert resp.status_code == 201
@@ -180,7 +180,7 @@ class TestUpdateQuota:
         admin = make_user(email="admin@example.com", roles=["Admin"])
         _override_auth(app, admin)
 
-        updated = {**SAMPLE_GRANT, "monthly_quota_hours": 50.0}
+        updated = {**SAMPLE_GRANT, "monthly_quota_usd": 50.0}
         mock_repo = MagicMock()
         mock_repo.update_quota.return_value = updated
         _override_repo(app, mock_repo)
@@ -188,11 +188,11 @@ class TestUpdateQuota:
         client = TestClient(app)
         resp = client.put(
             "/admin/fine-tuning/access/user@example.com",
-            json={"monthly_quota_hours": 50.0},
+            json={"monthly_quota_usd": 50.0},
         )
 
         assert resp.status_code == 200
-        assert resp.json()["monthly_quota_hours"] == 50.0
+        assert resp.json()["monthly_quota_usd"] == 50.0
 
     def test_returns_404_for_nonexistent(self, make_user):
         app = _create_app()
@@ -206,7 +206,7 @@ class TestUpdateQuota:
         client = TestClient(app)
         resp = client.put(
             "/admin/fine-tuning/access/nobody@example.com",
-            json={"monthly_quota_hours": 50.0},
+            json={"monthly_quota_usd": 50.0},
         )
 
         assert resp.status_code == 404

--- a/backend/tests/fine_tuning/test_inference_routes.py
+++ b/backend/tests/fine_tuning/test_inference_routes.py
@@ -45,8 +45,8 @@ SAMPLE_GRANT = {
     "email": "user@example.com",
     "granted_by": "admin@example.com",
     "granted_at": "2026-01-01T00:00:00Z",
-    "monthly_quota_hours": 10.0,
-    "current_month_usage_hours": 2.0,
+    "monthly_quota_usd": 10.0,
+    "current_month_usage_usd": 2.0,
     "quota_period": "2026-03",
 }
 
@@ -239,7 +239,7 @@ class TestCreateInferenceJob:
         )
 
         assert resp.status_code == 400
-        assert "Unsupported instance type" in resp.json()["detail"]
+        assert "is not available for" in resp.json()["detail"]
         mock_sm.create_transform_job.assert_not_called()
 
     @patch.dict("os.environ", {"PROJECT_PREFIX": "test-prefix"})
@@ -353,7 +353,7 @@ class TestCreateInferenceJob:
         app = _create_app()
         user = make_user(email="user@example.com")
 
-        low_quota = {**SAMPLE_GRANT, "monthly_quota_hours": 10.0, "current_month_usage_hours": 9.8}
+        low_quota = {**SAMPLE_GRANT, "monthly_quota_usd": 10.0, "current_month_usage_usd": 9.8}
 
         mock_jobs = MagicMock()
         mock_jobs.get_job.return_value = SAMPLE_COMPLETED_TRAINING_JOB

--- a/backend/tests/fine_tuning/test_inference_script.py
+++ b/backend/tests/fine_tuning/test_inference_script.py
@@ -1,45 +1,87 @@
-"""Unit tests for SageMaker inference script handler functions."""
+"""Unit tests for the Batch Transform handler.
+
+``inference.py`` is a dispatcher: it resolves the task recorded in the model
+artifact and delegates to the matching ``task_*`` module. These cover the
+dispatch itself, the shared CSV output contract, and the per-task payload
+parsing — the parts that must hold for every modality.
+"""
 
 import json
-import pytest
-from unittest.mock import MagicMock, patch
+import zipfile
 
 import numpy as np
+import pytest
+from unittest.mock import MagicMock
 
+from apis.app_api.fine_tuning import task_types
+from apis.app_api.fine_tuning.sagemaker_scripts import task_text_classification
 from apis.app_api.fine_tuning.sagemaker_scripts.inference import (
+    _sanitize_label,
     input_fn,
     output_fn,
-    predict_fn,
-    _sanitize_label,
+    read_task_type,
+    resolve_task_module,
 )
+
+TEXT_SPEC = task_types.get_task_spec(task_types.TEXT_CLASSIFICATION)
+
+
+def _texts(records):
+    """Pull the text out of the record dicts input_fn now returns."""
+    return [record["text"] for record in records]
+
+
+class TestTaskDispatch:
+    """The handler must serve whichever task the artifact was trained for."""
+
+    def test_reads_the_recorded_task_type(self, tmp_path):
+        (tmp_path / "task_type.json").write_text(
+            json.dumps({"task_type": task_types.IMAGE_CLASSIFICATION})
+        )
+
+        assert read_task_type(str(tmp_path)) == task_types.IMAGE_CLASSIFICATION
+
+    def test_artifact_without_a_marker_is_text_classification(self, tmp_path):
+        """Artifacts trained before task types existed carry no marker.
+
+        They are all text classifiers, and must keep loading.
+        """
+        assert read_task_type(str(tmp_path)) == task_types.TEXT_CLASSIFICATION
+
+    @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
+    def test_every_registered_task_has_an_inference_module(self, task_type):
+        module, spec = resolve_task_module(task_type)
+
+        assert spec.task_type == task_type
+        for handler in ("model_fn", "input_fn", "predict_fn"):
+            assert hasattr(module, handler), f"{module.__name__} lacks {handler}"
+
+    def test_unknown_task_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown task type"):
+            resolve_task_module("image-to-interpretive-dance")
 
 
 class TestInputFn:
+    """With no model loaded the handler assumes text, preserving old behaviour."""
 
     def test_text_plain_parses_lines(self):
-        body = "Hello world\nFoo bar\nBaz qux\n"
-        result = input_fn(body, "text/plain")
-        assert result == ["Hello world", "Foo bar", "Baz qux"]
+        result = input_fn("Hello world\nFoo bar\nBaz qux\n", "text/plain")
+        assert _texts(result) == ["Hello world", "Foo bar", "Baz qux"]
 
     def test_text_plain_skips_empty_lines(self):
-        body = "Hello\n\n  \nWorld\n"
-        result = input_fn(body, "text/plain")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn("Hello\n\n  \nWorld\n", "text/plain")) == ["Hello", "World"]
 
     def test_json_list_input(self):
         body = json.dumps(["Hello", "World"])
-        result = input_fn(body, "application/json")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn(body, "application/json")) == ["Hello", "World"]
 
     def test_json_dict_with_texts_key(self):
         body = json.dumps({"texts": ["Hello", "World"]})
-        result = input_fn(body, "application/json")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn(body, "application/json")) == ["Hello", "World"]
 
     def test_json_dict_without_texts_key_raises(self):
-        body = json.dumps({"data": ["Hello"]})
         with pytest.raises(ValueError, match="must be a list"):
-            input_fn(body, "application/json")
+            input_fn(json.dumps({"data": ["Hello"]}), "application/json")
 
     def test_unsupported_content_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported content type"):
@@ -47,32 +89,61 @@ class TestInputFn:
 
     def test_json_list_skips_empty_strings(self):
         body = json.dumps(["Hello", "", "  ", "World"])
-        result = input_fn(body, "application/json")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn(body, "application/json")) == ["Hello", "World"]
 
     def test_text_plain_bytes_input(self):
         """SageMaker HuggingFace DLC passes request_body as bytes."""
-        body = b"Hello world\nFoo bar\nBaz qux\n"
-        result = input_fn(body, "text/plain")
-        assert result == ["Hello world", "Foo bar", "Baz qux"]
+        result = input_fn(b"Hello world\nFoo bar\n", "text/plain")
+        assert _texts(result) == ["Hello world", "Foo bar"]
 
     def test_json_bytes_input(self):
-        """JSON body delivered as bytes is decoded correctly."""
         body = json.dumps(["Hello", "World"]).encode("utf-8")
-        result = input_fn(body, "application/json")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn(body, "application/json")) == ["Hello", "World"]
 
     def test_bytes_with_utf8_characters(self):
-        """Non-ASCII text encoded as UTF-8 bytes is handled correctly."""
         body = "café latte\nnaïve résumé\n".encode("utf-8")
-        result = input_fn(body, "text/plain")
-        assert result == ["café latte", "naïve résumé"]
+        assert _texts(input_fn(body, "text/plain")) == ["café latte", "naïve résumé"]
 
     def test_bytearray_input(self):
-        """bytearray input is also decoded correctly."""
-        body = bytearray(b"Hello\nWorld\n")
-        result = input_fn(body, "text/plain")
-        assert result == ["Hello", "World"]
+        assert _texts(input_fn(bytearray(b"Hello\nWorld\n"), "text/plain")) == [
+            "Hello",
+            "World",
+        ]
+
+    def test_text_records_identify_themselves_by_their_text(self):
+        records = input_fn("alpha\nbeta\n", "text/plain")
+        assert [r["identifier"] for r in records] == ["alpha", "beta"]
+
+    def test_dispatches_to_the_loaded_task(self, tmp_path):
+        """A loaded image model must not parse its payload as newline text."""
+        from apis.app_api.fine_tuning.sagemaker_scripts import task_image_classification
+
+        archive = tmp_path / "images.zip"
+        png = bytes.fromhex(
+            "89504e470d0a1a0a0000000d4948445200000001000000010806000000"
+            "1f15c4890000000a49444154789c6360000002000100ffff0300000600"
+            "05570c9d0000000049454e44ae426082"
+        )
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.writestr("a.png", png)
+            handle.writestr("b.png", png)
+
+        records = input_fn(
+            archive.read_bytes(),
+            "application/zip",
+            {"task_type": task_types.IMAGE_CLASSIFICATION},
+        )
+
+        assert sorted(r["identifier"] for r in records) == ["a.png", "b.png"]
+        assert all(task_image_classification is not None for _ in records)
+
+    def test_image_task_rejects_a_non_archive_payload(self):
+        with pytest.raises(ValueError, match="Expected archive bytes"):
+            input_fn(
+                "not an archive",
+                "application/zip",
+                {"task_type": task_types.IMAGE_CLASSIFICATION},
+            )
 
 
 class TestSanitizeLabel:
@@ -94,69 +165,81 @@ class TestSanitizeLabel:
 
 
 class TestOutputFn:
+    """One CSV shape for every task, so a new modality never breaks the viewer."""
 
     def test_csv_header_includes_label_columns(self):
-        prediction = {
-            "texts": ["hello"],
-            "probabilities": np.array([[0.8, 0.2]]),
-            "labels": ["positive", "negative"],
-        }
-        result = output_fn(prediction)
+        result = output_fn(
+            {
+                "identifiers": ["hello"],
+                "probabilities": np.array([[0.8, 0.2]]),
+                "labels": ["positive", "negative"],
+                "identifier_column": "text",
+            }
+        )
+        assert result.split("\n")[0] == "text,prob_positive,prob_negative"
+
+    def test_image_task_names_the_first_column_image(self):
+        result = output_fn(
+            {
+                "identifiers": ["cats/a.png"],
+                "probabilities": np.array([[0.8, 0.2]]),
+                "labels": ["cat", "dog"],
+                "identifier_column": "image",
+            }
+        )
         lines = result.split("\n")
-        assert lines[0] == "text,prob_positive,prob_negative"
+        assert lines[0] == "image,prob_cat,prob_dog"
+        assert lines[1].startswith('"cats/a.png"')
 
     def test_csv_row_has_quoted_text(self):
-        prediction = {
-            "texts": ["hello world"],
-            "probabilities": np.array([[0.85, 0.15]]),
-            "labels": ["pos", "neg"],
-        }
-        result = output_fn(prediction)
-        lines = result.split("\n")
-        assert lines[1].startswith('"hello world"')
+        result = output_fn(
+            {
+                "identifiers": ["hello world"],
+                "probabilities": np.array([[0.85, 0.15]]),
+                "labels": ["pos", "neg"],
+            }
+        )
+        assert result.split("\n")[1].startswith('"hello world"')
 
     def test_escapes_quotes_in_text(self):
-        prediction = {
-            "texts": ['She said "hello"'],
-            "probabilities": np.array([[0.9, 0.1]]),
-            "labels": ["pos", "neg"],
-        }
-        result = output_fn(prediction)
-        lines = result.split("\n")
-        # Quotes in text should be doubled
-        assert '""hello""' in lines[1]
+        result = output_fn(
+            {
+                "identifiers": ['She said "hello"'],
+                "probabilities": np.array([[0.9, 0.1]]),
+                "labels": ["pos", "neg"],
+            }
+        )
+        assert '""hello""' in result.split("\n")[1]
 
     def test_escapes_commas_in_text(self):
-        prediction = {
-            "texts": ["hello, world"],
-            "probabilities": np.array([[0.7, 0.3]]),
-            "labels": ["pos", "neg"],
-        }
-        result = output_fn(prediction)
-        lines = result.split("\n")
-        # Text with commas should be quoted
-        assert lines[1].startswith('"hello, world"')
+        result = output_fn(
+            {
+                "identifiers": ["hello, world"],
+                "probabilities": np.array([[0.7, 0.3]]),
+                "labels": ["pos", "neg"],
+            }
+        )
+        assert result.split("\n")[1].startswith('"hello, world"')
 
     def test_multiple_rows(self):
-        prediction = {
-            "texts": ["a", "b", "c"],
-            "probabilities": np.array([[0.9, 0.1], [0.3, 0.7], [0.5, 0.5]]),
-            "labels": ["pos", "neg"],
-        }
-        result = output_fn(prediction)
-        lines = result.split("\n")
-        assert len(lines) == 4  # header + 3 rows
+        result = output_fn(
+            {
+                "identifiers": ["a", "b", "c"],
+                "probabilities": np.array([[0.9, 0.1], [0.3, 0.7], [0.5, 0.5]]),
+                "labels": ["pos", "neg"],
+            }
+        )
+        assert len(result.split("\n")) == 4  # header + 3 rows
 
     def test_probability_values_six_decimals(self):
-        prediction = {
-            "texts": ["test"],
-            "probabilities": np.array([[0.123456789, 0.876543211]]),
-            "labels": ["a", "b"],
-        }
-        result = output_fn(prediction)
-        lines = result.split("\n")
-        # Should have 6 decimal places
-        assert "0.123457" in lines[1]  # rounded
+        result = output_fn(
+            {
+                "identifiers": ["test"],
+                "probabilities": np.array([[0.123456789, 0.876543211]]),
+                "labels": ["a", "b"],
+            }
+        )
+        assert "0.123457" in result.split("\n")[1]  # rounded
 
 
 _has_torch = True
@@ -167,50 +250,52 @@ except ImportError:
 
 
 @pytest.mark.skipif(not _has_torch, reason="torch not installed (SageMaker DLC only)")
-class TestPredictFn:
+class TestTextPredictFn:
+
+    def _loaded(self, model, tokenizer):
+        return {"model": model, "tokenizer": tokenizer, "device": torch.device("cpu")}
 
     def test_empty_input_returns_empty(self):
-        model_tuple = (MagicMock(), MagicMock(), "cpu")
-        result = predict_fn([], model_tuple)
-        assert result["texts"] == []
+        result = task_text_classification.predict_fn(
+            [], self._loaded(MagicMock(), MagicMock()), TEXT_SPEC
+        )
+        assert result["identifiers"] == []
         assert result["probabilities"].shape == (0, 0)
         assert result["labels"] == []
 
     def test_returns_correct_structure(self):
-        # Create mock model that returns logits
         mock_model = MagicMock()
         mock_model.config.id2label = {0: "positive", 1: "negative"}
+        outputs = MagicMock()
+        outputs.logits = torch.tensor([[2.0, -1.0], [0.5, 1.5]])
+        mock_model.return_value = outputs
 
-        mock_outputs = MagicMock()
-        mock_outputs.logits = torch.tensor([[2.0, -1.0], [0.5, 1.5]])
-
-        mock_model.return_value = mock_outputs
-
-        # Mock tokenizer
         mock_tokenizer = MagicMock()
         mock_tokenizer.return_value = {
             "input_ids": torch.tensor([[1, 2], [3, 4]]),
             "attention_mask": torch.tensor([[1, 1], [1, 1]]),
         }
 
-        device = torch.device("cpu")
-        result = predict_fn(["hello", "world"], (mock_model, mock_tokenizer, device))
+        records = [
+            {"text": "hello", "identifier": "hello"},
+            {"text": "world", "identifier": "world"},
+        ]
+        result = task_text_classification.predict_fn(
+            records, self._loaded(mock_model, mock_tokenizer), TEXT_SPEC
+        )
 
-        assert result["texts"] == ["hello", "world"]
+        assert result["identifiers"] == ["hello", "world"]
         assert result["probabilities"].shape == (2, 2)
         assert result["labels"] == ["positive", "negative"]
-
-        # Probabilities should sum to 1 for each row (softmax)
         for row in result["probabilities"]:
             assert abs(sum(row) - 1.0) < 1e-5
 
     def test_uses_class_prefix_when_no_id2label(self):
         mock_model = MagicMock()
         mock_model.config.id2label = None
-
-        mock_outputs = MagicMock()
-        mock_outputs.logits = torch.tensor([[1.0, 2.0, 3.0]])
-        mock_model.return_value = mock_outputs
+        outputs = MagicMock()
+        outputs.logits = torch.tensor([[1.0, 2.0, 3.0]])
+        mock_model.return_value = outputs
 
         mock_tokenizer = MagicMock()
         mock_tokenizer.return_value = {
@@ -218,7 +303,10 @@ class TestPredictFn:
             "attention_mask": torch.tensor([[1, 1]]),
         }
 
-        device = torch.device("cpu")
-        result = predict_fn(["test"], (mock_model, mock_tokenizer, device))
+        result = task_text_classification.predict_fn(
+            [{"text": "test", "identifier": "test"}],
+            self._loaded(mock_model, mock_tokenizer),
+            TEXT_SPEC,
+        )
 
         assert result["labels"] == ["class_0", "class_1", "class_2"]

--- a/backend/tests/fine_tuning/test_inference_script.py
+++ b/backend/tests/fine_tuning/test_inference_script.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 from apis.app_api.fine_tuning import task_types
 from apis.app_api.fine_tuning.sagemaker_scripts import task_text_classification
+from apis.app_api.fine_tuning.sagemaker_scripts import inference as inference_handler
 from apis.app_api.fine_tuning.sagemaker_scripts.inference import (
     _sanitize_label,
     input_fn,
@@ -22,6 +23,14 @@ from apis.app_api.fine_tuning.sagemaker_scripts.inference import (
     read_task_type,
     resolve_task_module,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_loaded_task():
+    """model_fn writes module state; keep it from leaking between tests."""
+    inference_handler._LOADED_TASK_TYPE = None
+    yield
+    inference_handler._LOADED_TASK_TYPE = None
 
 TEXT_SPEC = task_types.get_task_spec(task_types.TEXT_CLASSIFICATION)
 
@@ -144,6 +153,31 @@ class TestInputFn:
                 "application/zip",
                 {"task_type": task_types.IMAGE_CLASSIFICATION},
             )
+
+    def test_dispatches_on_module_state_when_called_with_two_arguments(self):
+        """The toolkit calls input_fn(input_data, content_type) — no model.
+
+        The loaded task therefore has to come from module state written by
+        model_fn. Without it an image artifact parses its .zip as newline
+        delimited text and fails on every record.
+        """
+        inference_handler._LOADED_TASK_TYPE = task_types.IMAGE_CLASSIFICATION
+
+        with pytest.raises(ValueError, match="Expected archive bytes"):
+            input_fn("alpha\nbeta\n", "application/zip")
+
+    def test_falls_back_to_text_when_nothing_is_loaded(self):
+        assert inference_handler._LOADED_TASK_TYPE is None
+        assert _texts(input_fn("alpha\nbeta\n", "text/plain")) == ["alpha", "beta"]
+
+    def test_an_explicit_model_argument_overrides_module_state(self):
+        inference_handler._LOADED_TASK_TYPE = task_types.IMAGE_CLASSIFICATION
+
+        records = input_fn(
+            "alpha\n", "text/plain", {"task_type": task_types.TEXT_CLASSIFICATION}
+        )
+
+        assert _texts(records) == ["alpha"]
 
 
 class TestSanitizeLabel:

--- a/backend/tests/fine_tuning/test_job_guards.py
+++ b/backend/tests/fine_tuning/test_job_guards.py
@@ -1,0 +1,244 @@
+"""Tests for the guards that stand between a request and a billed GPU.
+
+Each of these prevents a job that would provision hardware and then fail, or
+spend past a user's quota. They are the reason a bad submission returns a 400
+in milliseconds rather than an opaque traceback several billed minutes later.
+"""
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from apis.app_api.fine_tuning import task_types
+from apis.app_api.fine_tuning.routes import (
+    MIN_BUDGETED_RUNTIME_SECONDS,
+    _budgeted_runtime,
+    _validate_dataset_format,
+    _validate_instance_type,
+    preflight_huggingface_model,
+)
+
+TEXT_SPEC = task_types.get_task_spec(task_types.TEXT_CLASSIFICATION)
+IMAGE_SPEC = task_types.get_task_spec(task_types.IMAGE_CLASSIFICATION)
+IMAGE_TEXT_SPEC = task_types.get_task_spec(task_types.IMAGE_TEXT_CLASSIFICATION)
+
+
+class TestDatasetFormatIsTaskAware:
+
+    def test_text_task_accepts_a_manifest(self):
+        _validate_dataset_format("datasets/u/1/train.csv", TEXT_SPEC)
+        _validate_dataset_format("datasets/u/1/train.jsonl", TEXT_SPEC)
+
+    def test_text_task_rejects_an_archive(self):
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_dataset_format("datasets/u/1/train.zip", TEXT_SPEC)
+        assert excinfo.value.status_code == 400
+
+    def test_image_task_requires_an_archive(self):
+        """A bare CSV cannot carry the images it references."""
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_dataset_format("datasets/u/1/train.csv", IMAGE_SPEC)
+        assert "zip" in excinfo.value.detail.lower()
+
+    def test_image_task_accepts_a_zip(self):
+        _validate_dataset_format("datasets/u/1/train.zip", IMAGE_SPEC)
+
+    def test_error_names_the_required_columns(self):
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_dataset_format("bad.csv", IMAGE_TEXT_SPEC)
+        for column in ("image", "text", "label"):
+            assert f'"{column}"' in excinfo.value.detail
+
+
+class TestInstanceValidation:
+
+    def test_accepts_a_priced_training_instance(self):
+        _validate_instance_type("ml.g6.xlarge")
+
+    def test_rejects_an_unpriced_instance(self):
+        """An unpriced instance runs real GPUs and records no spend."""
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_instance_type("ml.p4d.24xlarge")
+        assert excinfo.value.status_code == 400
+
+    def test_transform_uses_its_own_table(self):
+        _validate_instance_type("ml.g6.xlarge", transform=True)
+
+    def test_error_names_the_operation(self):
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_instance_type("ml.p3.2xlarge", transform=True)
+        assert "Batch Transform" in excinfo.value.detail
+
+
+class TestBudgetedRuntime:
+    """The budget becomes the stopping condition, bounding spend exactly."""
+
+    def test_leaves_an_affordable_request_alone(self):
+        # $100 buys ~71h on ml.g5.xlarge, well over the 4h requested.
+        assert _budgeted_runtime(14400, "ml.g5.xlarge", 100.0) == 14400
+
+    def test_clamps_to_what_the_budget_affords(self):
+        # $10 / $1.408 per hour = 7.10h = 25568s, under the 24h requested.
+        effective = _budgeted_runtime(86400, "ml.g5.xlarge", 10.0)
+        assert effective == int((10.0 / 1.408) * 3600)
+        assert effective < 86400
+
+    def test_a_full_day_is_admitted_rather_than_rejected(self):
+        """Worst-case rejection would block every job at the 24h default.
+
+        24h on the cheapest instance is ~$27, more than any ordinary monthly
+        quota, even though such a job typically finishes in minutes.
+        """
+        assert _budgeted_runtime(86400, "ml.g6.xlarge", 15.0) > 0
+
+    def test_rejects_a_budget_too_small_to_be_useful(self):
+        with pytest.raises(HTTPException) as excinfo:
+            _budgeted_runtime(86400, "ml.g5.xlarge", 0.10)
+        assert "Insufficient quota" in excinfo.value.detail
+
+    def test_the_floor_is_exactly_the_minimum_runtime(self):
+        rate = 1.408
+        just_enough = (MIN_BUDGETED_RUNTIME_SECONDS / 3600) * rate
+        assert _budgeted_runtime(86400, "ml.g5.xlarge", just_enough * 1.01) > 0
+        with pytest.raises(HTTPException):
+            _budgeted_runtime(86400, "ml.g5.xlarge", just_enough * 0.5)
+
+    def test_transform_prices_against_the_transform_table(self):
+        assert _budgeted_runtime(3600, "ml.g6.xlarge", 50.0, transform=True) == 3600
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response=None, error=None):
+        self._response = response
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url):
+        if self._error:
+            raise self._error
+        return self._response
+
+
+def _patch_client(monkeypatch, *, response=None, error=None):
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda *a, **k: _FakeClient(response, error)
+    )
+
+
+@pytest.mark.asyncio
+class TestHuggingFacePreflight:
+    """Ask the Hub whether a model can serve the task before billing a GPU."""
+
+    async def test_accepts_a_trainable_model(self, monkeypatch):
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "fill-mask",
+                    "siblings": [{"rfilename": "model.safetensors"}],
+                },
+            ),
+        )
+        await preflight_huggingface_model("bert-base-uncased", TEXT_SPEC)
+
+    async def test_rejects_a_gguf_only_repository(self, monkeypatch):
+        """GGUF is a llama.cpp inference format and cannot be fine-tuned.
+
+        Without this the job provisions a GPU and dies in from_pretrained.
+        """
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "image-text-to-text",
+                    "siblings": [
+                        {"rfilename": "model-Q4_K_M.gguf"},
+                        {"rfilename": "README.md"},
+                    ],
+                },
+            ),
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            await preflight_huggingface_model("someone/model-GGUF", IMAGE_TEXT_SPEC)
+        assert "GGUF" in excinfo.value.detail
+
+    async def test_rejects_a_repository_with_no_weights(self, monkeypatch):
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200, {"pipeline_tag": "fill-mask", "siblings": [{"rfilename": "README.md"}]}
+            ),
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            await preflight_huggingface_model("someone/docs-only", TEXT_SPEC)
+        assert "no loadable model weights" in excinfo.value.detail
+
+    async def test_rejects_a_modality_mismatch(self, monkeypatch):
+        """An image model cannot be fine-tuned for text classification."""
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "image-classification",
+                    "siblings": [{"rfilename": "model.safetensors"}],
+                },
+            ),
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            await preflight_huggingface_model("google/vit-base-patch16-224", TEXT_SPEC)
+        assert "not compatible" in excinfo.value.detail
+
+    async def test_accepts_a_matching_modality(self, monkeypatch):
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "image-classification",
+                    "siblings": [{"rfilename": "model.safetensors"}],
+                },
+            ),
+        )
+        await preflight_huggingface_model("google/vit-base-patch16-224", IMAGE_SPEC)
+
+    async def test_reports_a_missing_model(self, monkeypatch):
+        _patch_client(monkeypatch, response=_FakeResponse(404))
+        with pytest.raises(HTTPException) as excinfo:
+            await preflight_huggingface_model("nobody/nothing", TEXT_SPEC)
+        assert "was not found" in excinfo.value.detail
+
+    async def test_an_unreachable_hub_does_not_block_submission(self, monkeypatch):
+        """The Hub being down is our problem, not the researcher's."""
+        _patch_client(monkeypatch, error=httpx.ConnectError("boom"))
+        await preflight_huggingface_model("bert-base-uncased", TEXT_SPEC)
+
+    async def test_a_hub_error_response_does_not_block_submission(self, monkeypatch):
+        _patch_client(monkeypatch, response=_FakeResponse(503))
+        await preflight_huggingface_model("bert-base-uncased", TEXT_SPEC)
+
+    async def test_an_untagged_model_is_allowed_through(self, monkeypatch):
+        """Many valid checkpoints simply carry no pipeline_tag."""
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200, {"pipeline_tag": None, "siblings": [{"rfilename": "model.safetensors"}]}
+            ),
+        )
+        await preflight_huggingface_model("someone/untagged", TEXT_SPEC)

--- a/backend/tests/fine_tuning/test_job_guards.py
+++ b/backend/tests/fine_tuning/test_job_guards.py
@@ -233,6 +233,41 @@ class TestHuggingFacePreflight:
         _patch_client(monkeypatch, response=_FakeResponse(503))
         await preflight_huggingface_model("bert-base-uncased", TEXT_SPEC)
 
+    async def test_rejects_a_generative_vlm_for_the_dual_encoder_task(self, monkeypatch):
+        """LLaVA-style models are image-text, but not dual encoders.
+
+        They are generative: there is no text tower to pool, so the fusion
+        head has nothing to concatenate. The trainer catches this, but only
+        after a GPU has been provisioned — so the tag filter must exclude
+        them here, before anything is billed.
+        """
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "image-text-to-text",
+                    "siblings": [{"rfilename": "model-00001-of-00003.safetensors"}],
+                },
+            ),
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            await preflight_huggingface_model("llava-hf/llava-1.5-7b-hf", IMAGE_TEXT_SPEC)
+        assert "not compatible" in excinfo.value.detail
+
+    async def test_accepts_a_dual_encoder(self, monkeypatch):
+        _patch_client(
+            monkeypatch,
+            response=_FakeResponse(
+                200,
+                {
+                    "pipeline_tag": "zero-shot-image-classification",
+                    "siblings": [{"rfilename": "model.safetensors"}],
+                },
+            ),
+        )
+        await preflight_huggingface_model("openai/clip-vit-base-patch32", IMAGE_TEXT_SPEC)
+
     async def test_an_untagged_model_is_allowed_through(self, monkeypatch):
         """Many valid checkpoints simply carry no pipeline_tag."""
         _patch_client(

--- a/backend/tests/fine_tuning/test_job_routes.py
+++ b/backend/tests/fine_tuning/test_job_routes.py
@@ -43,8 +43,8 @@ SAMPLE_GRANT = {
     "email": "user@example.com",
     "granted_by": "admin@example.com",
     "granted_at": "2026-01-01T00:00:00Z",
-    "monthly_quota_hours": 10.0,
-    "current_month_usage_hours": 2.0,
+    "monthly_quota_usd": 10.0,
+    "current_month_usage_usd": 2.0,
     "quota_period": "2026-03",
 }
 
@@ -231,7 +231,7 @@ class TestCreateJob:
         )
 
         assert resp.status_code == 400
-        assert "Unsupported instance type" in resp.json()["detail"]
+        assert "is not available for" in resp.json()["detail"]
         mock_sm.create_training_job.assert_not_called()
 
     def test_accepts_a_priced_instance_type(self, make_user):
@@ -351,7 +351,7 @@ class TestCreateJob:
         app = _create_app()
         user = make_user(email="user@example.com")
 
-        low_quota_grant = {**SAMPLE_GRANT, "monthly_quota_hours": 10.0, "current_month_usage_hours": 9.5}
+        low_quota_grant = {**SAMPLE_GRANT, "monthly_quota_usd": 10.0, "current_month_usage_usd": 9.5}
 
         mock_s3 = MagicMock()
         mock_s3.check_object_exists.return_value = True

--- a/backend/tests/fine_tuning/test_repository.py
+++ b/backend/tests/fine_tuning/test_repository.py
@@ -4,6 +4,8 @@ import pytest
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+from apis.app_api.fine_tuning.repository import DEFAULT_QUOTA_USD
+
 
 class TestGrantAccess:
 
@@ -13,21 +15,21 @@ class TestGrantAccess:
         assert result["email"] == "alice@example.com"
         assert result["granted_by"] == "admin@example.com"
         assert result["granted_at"] != ""
-        assert result["monthly_quota_hours"] == 10.0
-        assert result["current_month_usage_hours"] == 0.0
+        assert result["monthly_quota_usd"] == DEFAULT_QUOTA_USD
+        assert result["current_month_usage_usd"] == 0.0
         assert result["quota_period"] != ""
 
     def test_grant_access_normalizes_email_to_lowercase(self, repository):
         result = repository.grant_access("Alice@Example.COM", "admin@example.com")
         assert result["email"] == "alice@example.com"
 
-    def test_grant_access_default_quota_is_10_hours(self, repository):
+    def test_grant_access_default_quota_is_the_dollar_default(self, repository):
         result = repository.grant_access("user@example.com", "admin@example.com")
-        assert result["monthly_quota_hours"] == 10.0
+        assert result["monthly_quota_usd"] == DEFAULT_QUOTA_USD
 
     def test_grant_access_custom_quota(self, repository):
-        result = repository.grant_access("user@example.com", "admin@example.com", monthly_quota_hours=25.0)
-        assert result["monthly_quota_hours"] == 25.0
+        result = repository.grant_access("user@example.com", "admin@example.com", monthly_quota_usd=25.0)
+        assert result["monthly_quota_usd"] == 25.0
 
     def test_grant_access_raises_on_duplicate(self, repository):
         repository.grant_access("dup@example.com", "admin@example.com")
@@ -73,12 +75,12 @@ class TestListAccess:
 
 class TestUpdateQuota:
 
-    def test_update_quota_changes_monthly_hours(self, repository):
-        repository.grant_access("user@example.com", "admin@example.com", monthly_quota_hours=10.0)
+    def test_update_quota_changes_monthly_dollars(self, repository):
+        repository.grant_access("user@example.com", "admin@example.com", monthly_quota_usd=10.0)
 
         result = repository.update_quota("user@example.com", 50.0)
         assert result is not None
-        assert result["monthly_quota_hours"] == 50.0
+        assert result["monthly_quota_usd"] == 50.0
 
     def test_update_quota_returns_none_for_nonexistent(self, repository):
         result = repository.update_quota("nobody@example.com", 50.0)
@@ -107,7 +109,7 @@ class TestCheckAndResetQuota:
 
         result = repository.check_and_reset_quota("user@example.com")
         assert result is not None
-        assert result["current_month_usage_hours"] == 3.5
+        assert result["current_month_usage_usd"] == 3.5
 
     def test_resets_usage_when_new_month(self, repository):
         repository.grant_access("user@example.com", "admin@example.com")
@@ -120,7 +122,7 @@ class TestCheckAndResetQuota:
             result = repository.check_and_reset_quota("user@example.com")
 
         assert result is not None
-        assert result["current_month_usage_hours"] == 0.0
+        assert result["current_month_usage_usd"] == 0.0
         assert result["quota_period"] == "2099-12"
 
     def test_returns_none_for_nonexistent(self, repository):
@@ -130,12 +132,12 @@ class TestCheckAndResetQuota:
 
 class TestIncrementUsage:
 
-    def test_increment_adds_hours_atomically(self, repository):
+    def test_increment_adds_dollars_atomically(self, repository):
         repository.grant_access("user@example.com", "admin@example.com")
 
         result = repository.increment_usage("user@example.com", 2.5)
         assert result is not None
-        assert result["current_month_usage_hours"] == 2.5
+        assert result["current_month_usage_usd"] == 2.5
 
     def test_increment_accumulates_across_calls(self, repository):
         repository.grant_access("user@example.com", "admin@example.com")
@@ -144,8 +146,85 @@ class TestIncrementUsage:
         repository.increment_usage("user@example.com", 2.5)
         result = repository.increment_usage("user@example.com", 0.5)
 
-        assert result["current_month_usage_hours"] == pytest.approx(4.0)
+        assert result["current_month_usage_usd"] == pytest.approx(4.0)
 
     def test_increment_returns_none_for_nonexistent(self, repository):
         result = repository.increment_usage("nobody@example.com", 1.0)
         assert result is None
+
+
+class TestLegacyQuotaMigration:
+    """Grants written before the quota moved to dollars must keep working.
+
+    The conversion is lazy: a record is read in the new shape and rewritten on
+    the next check_and_reset_quota, so no environment needs a backfill run.
+    """
+
+    def _seed_legacy(self, repository, email, hours, used_hours, period):
+        from decimal import Decimal
+
+        repository._table.put_item(
+            Item={
+                "PK": f"EMAIL#{email}",
+                "SK": "ACCESS",
+                "email": email,
+                "granted_by": "admin@example.com",
+                "granted_at": "2026-01-01T00:00:00+00:00",
+                "monthly_quota_hours": Decimal(str(hours)),
+                "current_month_usage_hours": Decimal(str(used_hours)),
+                "quota_period": period,
+            }
+        )
+
+    def _period(self):
+        return datetime.now(timezone.utc).strftime("%Y-%m")
+
+    def test_reads_a_legacy_grant_as_dollars(self, repository):
+        from apis.app_api.fine_tuning.repository import LEGACY_HOURS_TO_USD
+
+        self._seed_legacy(repository, "old@example.com", 10, 2.5, self._period())
+
+        grant = repository.get_access("old@example.com")
+
+        assert grant["monthly_quota_usd"] == round(10 * LEGACY_HOURS_TO_USD, 4)
+        assert grant["current_month_usage_usd"] == round(2.5 * LEGACY_HOURS_TO_USD, 4)
+        assert "monthly_quota_hours" not in grant
+
+    def test_migration_preserves_spend_within_the_period(self, repository):
+        """A user must not be able to zero their own spend by being migrated."""
+        self._seed_legacy(repository, "old@example.com", 10, 2.5, self._period())
+
+        grant = repository.check_and_reset_quota("old@example.com")
+
+        assert grant["current_month_usage_usd"] > 0
+
+    def test_migration_rewrites_the_stored_record(self, repository):
+        self._seed_legacy(repository, "old@example.com", 10, 2.5, self._period())
+
+        repository.check_and_reset_quota("old@example.com")
+
+        item = repository._table.get_item(
+            Key={"PK": "EMAIL#old@example.com", "SK": "ACCESS"}
+        )["Item"]
+        assert "monthly_quota_usd" in item
+        assert "monthly_quota_hours" not in item
+        assert "current_month_usage_hours" not in item
+
+    def test_a_new_month_still_resets_a_legacy_grant(self, repository):
+        self._seed_legacy(repository, "old@example.com", 10, 9.0, "2020-01")
+
+        grant = repository.check_and_reset_quota("old@example.com")
+
+        assert grant["current_month_usage_usd"] == 0.0
+        assert grant["quota_period"] == self._period()
+
+    def test_update_quota_clears_the_legacy_field(self, repository):
+        self._seed_legacy(repository, "old@example.com", 10, 0, self._period())
+
+        repository.update_quota("old@example.com", 42.0)
+
+        item = repository._table.get_item(
+            Key={"PK": "EMAIL#old@example.com", "SK": "ACCESS"}
+        )["Item"]
+        assert float(item["monthly_quota_usd"]) == 42.0
+        assert "monthly_quota_hours" not in item

--- a/backend/tests/fine_tuning/test_task_types.py
+++ b/backend/tests/fine_tuning/test_task_types.py
@@ -1,0 +1,220 @@
+"""Tests for the task-type registry and the invariants that hang off it."""
+
+import pytest
+
+from apis.app_api.fine_tuning import pricing, task_types
+from apis.app_api.fine_tuning.job_models import (
+    AVAILABLE_MODELS,
+    MODEL_CATALOG,
+    models_for_task,
+)
+
+
+class TestRegistry:
+
+    def test_every_listed_task_resolves(self):
+        for task_type in task_types.TASK_TYPES:
+            assert task_types.get_task_spec(task_type).task_type == task_type
+
+    def test_unknown_task_raises(self):
+        with pytest.raises(ValueError, match="Unknown task type"):
+            task_types.get_task_spec("interpretive-dance")
+
+    def test_none_resolves_to_the_legacy_default(self):
+        """Job rows written before task types existed have no attribute.
+
+        They are all text classifiers and must keep resolving.
+        """
+        assert task_types.get_task_spec(None).task_type == task_types.TEXT_CLASSIFICATION
+        assert task_types.get_task_spec("").task_type == task_types.TEXT_CLASSIFICATION
+
+    def test_default_task_is_text_classification(self):
+        assert task_types.DEFAULT_TASK_TYPE == task_types.TEXT_CLASSIFICATION
+
+    def test_task_order_is_deterministic(self):
+        """User-facing lists must not reorder between calls."""
+        assert task_types.TASK_TYPES == tuple(task_types.TASK_TYPES)
+        assert list(task_types.TASK_SPECS) == list(task_types.TASK_SPECS)
+
+    @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
+    def test_label_column_is_required(self, task_type):
+        spec = task_types.get_task_spec(task_type)
+        assert spec.label_column in spec.required_columns
+
+    @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
+    def test_image_tasks_require_an_archive(self, task_type):
+        """A task referencing image files needs them bundled with the manifest."""
+        spec = task_types.get_task_spec(task_type)
+        if spec.image_column is not None:
+            assert spec.requires_archive
+            assert spec.image_column in spec.required_columns
+            assert spec.upload_extensions == (".zip",)
+        else:
+            assert not spec.requires_archive
+
+    def test_requires_images_predicate(self):
+        assert not task_types.requires_images(task_types.TEXT_CLASSIFICATION)
+        assert task_types.requires_images(task_types.IMAGE_CLASSIFICATION)
+        assert task_types.requires_images(task_types.IMAGE_TEXT_CLASSIFICATION)
+
+    def test_archive_task_list_matches_the_specs(self):
+        assert task_types.ARCHIVE_TASK_TYPES == (
+            task_types.IMAGE_CLASSIFICATION,
+            task_types.IMAGE_TEXT_CLASSIFICATION,
+        )
+
+    @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
+    def test_payload_size_is_within_batch_transform_limits(self, task_type):
+        """Batch Transform caps MaxPayloadInMB at 100."""
+        spec = task_types.get_task_spec(task_type)
+        assert 0 < spec.inference_max_payload_mb <= 100
+
+    @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
+    def test_default_instance_is_priced(self, task_type):
+        """A task defaulting to an unpriced instance is unusable on arrival."""
+        spec = task_types.get_task_spec(task_type)
+        assert pricing.training_rate(spec.default_instance_type) is not None
+        assert pricing.transform_rate(spec.default_instance_type) is not None
+
+
+class TestCatalog:
+
+    @pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=lambda m: m.model_id)
+    def test_every_model_declares_a_known_task(self, model):
+        assert model.task_type in task_types.TASK_TYPES
+
+    @pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=lambda m: m.model_id)
+    def test_every_model_default_instance_is_priced(self, model):
+        assert pricing.training_rate(model.default_instance_type) is not None
+
+    def test_model_ids_are_unique(self):
+        ids = [m.model_id for m in AVAILABLE_MODELS]
+        assert len(ids) == len(set(ids))
+
+    def test_every_task_has_at_least_one_model(self):
+        for task_type in task_types.TASK_TYPES:
+            assert models_for_task(task_type), f"no catalog models for {task_type}"
+
+    def test_models_for_task_filters(self):
+        image_models = models_for_task(task_types.IMAGE_CLASSIFICATION)
+        assert all(m.task_type == task_types.IMAGE_CLASSIFICATION for m in image_models)
+        assert "bert-base-uncased" not in {m.model_id for m in image_models}
+
+    def test_text_model_defaults_are_unchanged(self):
+        """The catalog refactor must not silently retune existing models."""
+        assert MODEL_CATALOG["gpt2-medium"].default_hyperparameters == {
+            "epochs": "3",
+            "learning_rate": "2e-5",
+            "weight_decay": "0.01",
+            "split_ratio": "0.8",
+            "seed": "42",
+            "per_device_train_batch_size": "8",
+            "context_length": "512",
+        }
+        assert (
+            MODEL_CATALOG["electra-tiny"].default_hyperparameters[
+                "per_device_train_batch_size"
+            ]
+            == "32"
+        )
+        assert (
+            MODEL_CATALOG["eurollm-1.7b-instruct"].default_hyperparameters[
+                "learning_rate"
+            ]
+            == "2e-5"
+        )
+
+
+class TestPricing:
+
+    def test_training_and_transform_tables_are_populated(self):
+        assert pricing.TRAINING_COST_PER_HOUR
+        assert pricing.TRANSFORM_COST_PER_HOUR
+
+    def test_retired_p3_family_is_absent(self):
+        """The Price List API returns no on-demand SageMaker rate for ml.p3.*.
+
+        Pricing them let a caller pick an instance no job could provision.
+        """
+        assert not [i for i in pricing.TRAINING_COST_PER_HOUR if i.startswith("ml.p3.")]
+
+    def test_g5_16xlarge_uses_the_real_rate(self):
+        """This was 6.10 against an actual 5.12 — a ~19% overcharge."""
+        assert pricing.training_rate("ml.g5.16xlarge") == 5.12
+
+    def test_unpriced_instance_returns_none(self):
+        assert pricing.training_rate("ml.nonexistent.xlarge") is None
+        assert pricing.transform_rate("ml.nonexistent.xlarge") is None
+
+    def test_cost_is_prorated_by_seconds(self):
+        assert pricing.calculate_cost("ml.g6.xlarge", 3600) == pytest.approx(1.127)
+        assert pricing.calculate_cost("ml.g6.xlarge", 1800) == pytest.approx(0.5635)
+
+    def test_cost_of_an_unpriced_instance_is_zero(self):
+        assert pricing.calculate_cost("ml.nope.xlarge", 3600) == 0.0
+
+    def test_transform_rate_can_differ_from_training(self):
+        """One shared map would silently misprice these."""
+        assert pricing.training_rate("ml.g6e.24xlarge") != pricing.transform_rate(
+            "ml.g6e.24xlarge"
+        )
+
+    def test_estimate_max_cost_uses_full_runtime(self):
+        assert pricing.estimate_max_cost("ml.g5.xlarge", 86400) == pytest.approx(33.792)
+
+    def test_supported_lists_are_cheapest_first(self):
+        instances = pricing.supported_training_instances()
+        rates = [pricing.training_rate(i) for i in instances]
+        assert rates == sorted(rates)
+
+
+class TestDlcFamilies:
+    """Text and vision must resolve to different containers."""
+
+    def _service(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        monkeypatch.delenv("FINE_TUNING_TRAINING_IMAGE_VISION", raising=False)
+        monkeypatch.delenv("FINE_TUNING_TRAINING_IMAGE_TEXT", raising=False)
+        from apis.app_api.fine_tuning.sagemaker_service import SageMakerService
+
+        return SageMakerService(sagemaker_client=object(), logs_client=object())
+
+    def test_text_keeps_the_validated_container(self, monkeypatch):
+        """Every existing model was trained on transformers 4.36.
+
+        Bumping this image would re-baseline all of them at once.
+        """
+        service = self._service(monkeypatch)
+        uri = service.get_huggingface_image_uri(task_types.TEXT_CLASSIFICATION)
+        assert "transformers4.36" in uri
+
+    def test_vision_gets_a_modern_container(self, monkeypatch):
+        service = self._service(monkeypatch)
+        for task_type in task_types.ARCHIVE_TASK_TYPES:
+            uri = service.get_huggingface_image_uri(task_type)
+            assert "transformers4.56" in uri
+
+    def test_legacy_call_without_a_task_uses_the_text_image(self, monkeypatch):
+        service = self._service(monkeypatch)
+        assert service.get_huggingface_image_uri() == service.get_huggingface_image_uri(
+            task_types.TEXT_CLASSIFICATION
+        )
+
+    def test_environment_override_wins(self, monkeypatch):
+        """Escape hatch for a retired or region-lagging DLC tag."""
+        service = self._service(monkeypatch)
+        monkeypatch.setenv(
+            "FINE_TUNING_TRAINING_IMAGE_VISION", "1.dkr.ecr.us-west-2.amazonaws.com/x:y"
+        )
+        assert (
+            service.get_huggingface_image_uri(task_types.IMAGE_CLASSIFICATION)
+            == "1.dkr.ecr.us-west-2.amazonaws.com/x:y"
+        )
+
+    def test_unsupported_region_raises(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "ap-south-1")
+        from apis.app_api.fine_tuning.sagemaker_service import SageMakerService
+
+        service = SageMakerService(sagemaker_client=object(), logs_client=object())
+        with pytest.raises(ValueError, match="No HuggingFace DLC image"):
+            service.get_huggingface_image_uri(task_types.TEXT_CLASSIFICATION)

--- a/backend/tests/fine_tuning/test_train_script.py
+++ b/backend/tests/fine_tuning/test_train_script.py
@@ -303,7 +303,7 @@ class TestResolveImagePath:
 
 
 class TestLoadManifestFrame:
-    """End-to-end load, where pandas is available (the training container)."""
+    """End-to-end load through pandas, exercising every accepted format."""
 
     @pytest.mark.parametrize(
         "filename,content",
@@ -322,7 +322,6 @@ class TestLoadManifestFrame:
         ],
     )
     def test_loads_each_supported_format(self, tmp_path, filename, content):
-        pytest.importorskip("pandas")
         path = tmp_path / filename
         path.write_text(content)
 
@@ -335,7 +334,6 @@ class TestLoadManifestFrame:
 class TestPrepareDataset:
 
     def test_text_task_reads_the_channel_directly(self, tmp_path):
-        pytest.importorskip("pandas")
         (tmp_path / "d.csv").write_text("text,label\nhello,a\nbye,b\n")
 
         frame, image_root = prepare_dataset(str(tmp_path), TEXT_SPEC)
@@ -344,7 +342,6 @@ class TestPrepareDataset:
         assert frame["text"].tolist() == ["hello", "bye"]
 
     def test_image_task_unpacks_and_resolves_paths(self, tmp_path, monkeypatch):
-        pytest.importorskip("pandas")
         from apis.app_api.fine_tuning.sagemaker_scripts import task_common
 
         monkeypatch.setattr(task_common, "EXTRACT_DIR", str(tmp_path / "extracted"))
@@ -369,7 +366,6 @@ class TestPrepareDataset:
             assert path.startswith(image_root)
 
     def test_image_task_reports_a_missing_image(self, tmp_path, monkeypatch):
-        pytest.importorskip("pandas")
         from apis.app_api.fine_tuning.sagemaker_scripts import task_common
 
         monkeypatch.setattr(task_common, "EXTRACT_DIR", str(tmp_path / "extracted"))
@@ -388,7 +384,6 @@ class TestPrepareDataset:
 class TestBuildLabelMapping:
 
     def test_maps_string_labels_to_contiguous_ids(self):
-        pytest.importorskip("pandas")
         import pandas as pd
 
         frame = pd.DataFrame({"text": ["a", "b", "c"], "label": ["dog", "cat", "dog"]})
@@ -401,7 +396,6 @@ class TestBuildLabelMapping:
 
     def test_rejects_a_single_class(self):
         """One class cannot be classified, and the GPU error is unreadable."""
-        pytest.importorskip("pandas")
         import pandas as pd
 
         frame = pd.DataFrame({"text": ["a", "b"], "label": ["same", "same"]})

--- a/backend/tests/fine_tuning/test_train_script.py
+++ b/backend/tests/fine_tuning/test_train_script.py
@@ -1,19 +1,58 @@
-"""Unit tests for SageMaker training script core functions."""
+"""Unit tests for the shared training helpers in ``task_common``.
 
-import os
+These deliberately avoid torch/transformers: the dataset, archive and label
+contracts have to be assertable in the backend venv, where the ML stack is
+absent. That constraint is why the helpers live in a module that imports its
+heavy dependencies lazily.
+"""
+
+import io
+import json
+import zipfile
+
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
-from apis.app_api.fine_tuning.sagemaker_scripts.train import (
-    resolve_max_context_length,
-    find_dataset_in_channel,
-    load_dataset_frame,
-    resolve_dataset_reader,
-    validate_dataset_columns,
-    SUPPORTED_DATASET_EXTENSIONS,
-    copy_inference_script,
+from apis.app_api.fine_tuning import task_types
+from apis.app_api.fine_tuning.sagemaker_scripts.task_common import (
+    DATASET_READERS,
     DynamoDBProgressCallback,
     SageMakerLoggingCallback,
+    build_label_mapping,
+    copy_inference_bundle,
+    extract_archive,
+    find_file_in_dir,
+    label_names,
+    load_manifest_frame,
+    prepare_dataset,
+    resolve_dataset_reader,
+    resolve_image_path,
+    resolve_max_context_length,
+    validate_dataset_columns,
+)
+
+TEXT_SPEC = task_types.get_task_spec(task_types.TEXT_CLASSIFICATION)
+IMAGE_SPEC = task_types.get_task_spec(task_types.IMAGE_CLASSIFICATION)
+IMAGE_TEXT_SPEC = task_types.get_task_spec(task_types.IMAGE_TEXT_CLASSIFICATION)
+
+MANIFEST_EXTENSIONS = TEXT_SPEC.manifest_extensions
+
+
+def _write_zip(path, entries):
+    """Write a zip from {archive name: bytes-or-str} and return its path."""
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in entries.items():
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            archive.writestr(name, content)
+    return str(path)
+
+
+# 1x1 PNG — enough for path resolution tests, which never decode the file.
+PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d4948445200000001000000010806000000"
+    "1f15c4890000000a49444154789c6360000002000100ffff0300000600"
+    "05570c9d0000000049454e44ae426082"
 )
 
 
@@ -24,53 +63,72 @@ class TestResolveMaxContextLength:
         config.max_position_embeddings = 512
         config.n_positions = 1024
         config.seq_length = None
+        config.text_config = None
 
         tokenizer = MagicMock()
         tokenizer.model_max_length = 2048
 
-        result = resolve_max_context_length(config, tokenizer)
-        assert result == 512
+        assert resolve_max_context_length(config, tokenizer) == 512
 
     def test_returns_none_when_all_invalid(self):
         config = MagicMock(spec=[])
         tokenizer = MagicMock(spec=[])
 
-        result = resolve_max_context_length(config, tokenizer)
-        assert result is None
+        assert resolve_max_context_length(config, tokenizer) is None
 
     def test_ignores_very_large_values(self):
         config = MagicMock()
         config.max_position_embeddings = 2_000_000
         config.n_positions = None
         config.seq_length = None
+        config.text_config = None
 
         tokenizer = MagicMock()
         tokenizer.model_max_length = 512
 
-        result = resolve_max_context_length(config, tokenizer)
-        assert result == 512
+        assert resolve_max_context_length(config, tokenizer) == 512
 
     def test_uses_model_max_length_as_fallback(self):
         config = MagicMock()
         config.max_position_embeddings = None
         config.n_positions = None
         config.seq_length = None
+        config.text_config = None
 
         tokenizer = MagicMock()
         tokenizer.model_max_length = 768
 
-        result = resolve_max_context_length(config, tokenizer)
-        assert result == 768
+        assert resolve_max_context_length(config, tokenizer) == 768
+
+    def test_reads_nested_text_config(self):
+        """Multimodal configs keep the text limits on config.text_config.
+
+        Reading only the top level yields None on every vision-language model,
+        which silently drops the context cap.
+        """
+        text_config = MagicMock()
+        text_config.max_position_embeddings = 77
+        text_config.n_positions = None
+        text_config.seq_length = None
+
+        config = MagicMock()
+        config.max_position_embeddings = None
+        config.n_positions = None
+        config.seq_length = None
+        config.text_config = text_config
+
+        tokenizer = MagicMock(spec=[])
+
+        assert resolve_max_context_length(config, tokenizer) == 77
 
 
-class TestFindDatasetInChannel:
+class TestFindFileInDir:
 
     def test_finds_csv_file(self, tmp_path):
         csv_file = tmp_path / "dataset.csv"
         csv_file.write_text("text,label\nhello,1\n")
 
-        result = find_dataset_in_channel(str(tmp_path))
-        assert result == str(csv_file)
+        assert find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS) == str(csv_file)
 
     @pytest.mark.parametrize("filename", ["dataset.jsonl", "dataset.json"])
     def test_finds_json_formats(self, tmp_path, filename):
@@ -78,26 +136,40 @@ class TestFindDatasetInChannel:
         dataset = tmp_path / filename
         dataset.write_text('{"text": "hello", "label": "a"}\n')
 
-        result = find_dataset_in_channel(str(tmp_path))
-        assert result == str(dataset)
+        assert find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS) == str(dataset)
 
     def test_raises_when_no_supported_dataset(self, tmp_path):
-        txt_file = tmp_path / "readme.txt"
-        txt_file.write_text("not a dataset")
+        (tmp_path / "readme.txt").write_text("not a dataset")
 
         with pytest.raises(FileNotFoundError, match="No dataset file found"):
-            find_dataset_in_channel(str(tmp_path))
+            find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS)
 
     def test_case_insensitive_extension(self, tmp_path):
         csv_file = tmp_path / "DATA.CSV"
         csv_file.write_text("text,label\nhello,1\n")
 
-        result = find_dataset_in_channel(str(tmp_path))
-        assert result == str(csv_file)
+        assert find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS) == str(csv_file)
 
     def test_raises_when_dir_missing(self):
         with pytest.raises(FileNotFoundError, match="does not exist"):
-            find_dataset_in_channel("/nonexistent/path")
+            find_file_in_dir("/nonexistent/path", MANIFEST_EXTENSIONS)
+
+    def test_prefers_shallowest_match(self, tmp_path):
+        """A manifest at the archive root wins over one inside an image folder."""
+        (tmp_path / "images").mkdir()
+        (tmp_path / "images" / "notes.csv").write_text("a,b\n")
+        root_manifest = tmp_path / "manifest.csv"
+        root_manifest.write_text("image,label\na.png,cat\n")
+
+        assert find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS) == str(root_manifest)
+
+    def test_skips_macos_resource_forks(self, tmp_path):
+        """Zips made on macOS carry ._ shadow files that are not manifests."""
+        (tmp_path / "._manifest.csv").write_text("junk")
+        real = tmp_path / "manifest.csv"
+        real.write_text("image,label\na.png,cat\n")
+
+        assert find_file_in_dir(str(tmp_path), MANIFEST_EXTENSIONS) == str(real)
 
 
 class TestResolveDatasetReader:
@@ -110,7 +182,13 @@ class TestResolveDatasetReader:
     """
 
     def test_supports_the_formats_the_ui_offers(self):
-        assert set(SUPPORTED_DATASET_EXTENSIONS) == {".csv", ".jsonl", ".json"}
+        assert set(DATASET_READERS) == {".csv", ".jsonl", ".json"}
+
+    def test_manifest_extensions_match_the_readers(self):
+        """The registry and the reader table must not drift apart."""
+        for task_type in task_types.TASK_TYPES:
+            spec = task_types.get_task_spec(task_type)
+            assert set(spec.manifest_extensions) == set(DATASET_READERS)
 
     def test_csv_uses_read_csv(self):
         assert resolve_dataset_reader("/data/dataset.csv") == ("read_csv", {})
@@ -135,18 +213,96 @@ class TestResolveDatasetReader:
 class TestValidateDatasetColumns:
 
     def test_accepts_required_columns(self):
-        validate_dataset_columns(["text", "label"], "/data/dataset.csv")
+        validate_dataset_columns(["text", "label"], "/data/dataset.csv", TEXT_SPEC)
 
     def test_raises_when_label_missing(self):
         with pytest.raises(ValueError, match="missing required column"):
-            validate_dataset_columns(["text"], "/data/dataset.csv")
+            validate_dataset_columns(["text"], "/data/dataset.csv", TEXT_SPEC)
 
     def test_raises_when_text_missing(self):
         with pytest.raises(ValueError, match="missing required column"):
-            validate_dataset_columns(["label"], "/data/dataset.csv")
+            validate_dataset_columns(["label"], "/data/dataset.csv", TEXT_SPEC)
+
+    def test_image_task_requires_image_column(self):
+        with pytest.raises(ValueError, match="missing required column"):
+            validate_dataset_columns(["text", "label"], "/m.csv", IMAGE_SPEC)
+
+    def test_image_text_task_requires_all_three(self):
+        validate_dataset_columns(
+            ["image", "text", "label"], "/m.csv", IMAGE_TEXT_SPEC
+        )
+        with pytest.raises(ValueError, match="missing required column"):
+            validate_dataset_columns(["image", "label"], "/m.csv", IMAGE_TEXT_SPEC)
 
 
-class TestLoadDatasetFrame:
+class TestExtractArchive:
+    """A dataset archive is untrusted user input."""
+
+    def test_extracts_flat_entries(self, tmp_path):
+        archive = _write_zip(tmp_path / "d.zip", {"manifest.csv": "image,label\n"})
+        dest = tmp_path / "out"
+
+        extract_archive(archive, str(dest))
+
+        assert (dest / "manifest.csv").read_text() == "image,label\n"
+
+    def test_extracts_nested_entries(self, tmp_path):
+        archive = _write_zip(
+            tmp_path / "d.zip",
+            {"manifest.csv": "image,label\n", "images/a.png": PNG_BYTES},
+        )
+        dest = tmp_path / "out"
+
+        extract_archive(archive, str(dest))
+
+        assert (dest / "images" / "a.png").read_bytes() == PNG_BYTES
+
+    def test_rejects_parent_traversal(self, tmp_path):
+        """Zip-Slip: a crafted entry must not write outside the destination."""
+        archive = _write_zip(tmp_path / "evil.zip", {"../escaped.txt": "pwned"})
+
+        with pytest.raises(ValueError, match="unsafe archive entry"):
+            extract_archive(archive, str(tmp_path / "out"))
+
+        assert not (tmp_path / "escaped.txt").exists()
+
+    def test_rejects_absolute_paths(self, tmp_path):
+        archive = _write_zip(tmp_path / "evil.zip", {"/etc/passwd": "pwned"})
+
+        with pytest.raises(ValueError, match="unsafe archive entry"):
+            extract_archive(archive, str(tmp_path / "out"))
+
+
+class TestResolveImagePath:
+
+    def test_resolves_relative_reference(self, tmp_path):
+        (tmp_path / "images").mkdir()
+        image = tmp_path / "images" / "a.png"
+        image.write_bytes(PNG_BYTES)
+
+        assert resolve_image_path(str(tmp_path), "images/a.png") == str(image)
+
+    def test_strips_surrounding_whitespace(self, tmp_path):
+        image = tmp_path / "a.png"
+        image.write_bytes(PNG_BYTES)
+
+        assert resolve_image_path(str(tmp_path), "  a.png  ") == str(image)
+
+    def test_raises_when_missing(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="missing from the archive"):
+            resolve_image_path(str(tmp_path), "nope.png")
+
+    def test_rejects_escape_from_archive(self, tmp_path):
+        outside = tmp_path.parent / "outside.png"
+        outside.write_bytes(PNG_BYTES)
+        root = tmp_path / "root"
+        root.mkdir()
+
+        with pytest.raises(ValueError, match="escapes the dataset archive"):
+            resolve_image_path(str(root), "../outside.png")
+
+
+class TestLoadManifestFrame:
     """End-to-end load, where pandas is available (the training container)."""
 
     @pytest.mark.parametrize(
@@ -170,41 +326,136 @@ class TestLoadDatasetFrame:
         path = tmp_path / filename
         path.write_text(content)
 
-        df = load_dataset_frame(str(path))
+        frame = load_manifest_frame(str(path), TEXT_SPEC)
 
-        assert df["text"].tolist() == ["hello", "bye"]
-        assert df["label"].tolist() == ["positive", "negative"]
+        assert frame["text"].tolist() == ["hello", "bye"]
+        assert frame["label"].tolist() == ["positive", "negative"]
 
 
-class TestCopyInferenceScript:
+class TestPrepareDataset:
+
+    def test_text_task_reads_the_channel_directly(self, tmp_path):
+        pytest.importorskip("pandas")
+        (tmp_path / "d.csv").write_text("text,label\nhello,a\nbye,b\n")
+
+        frame, image_root = prepare_dataset(str(tmp_path), TEXT_SPEC)
+
+        assert image_root is None
+        assert frame["text"].tolist() == ["hello", "bye"]
+
+    def test_image_task_unpacks_and_resolves_paths(self, tmp_path, monkeypatch):
+        pytest.importorskip("pandas")
+        from apis.app_api.fine_tuning.sagemaker_scripts import task_common
+
+        monkeypatch.setattr(task_common, "EXTRACT_DIR", str(tmp_path / "extracted"))
+
+        channel = tmp_path / "channel"
+        channel.mkdir()
+        _write_zip(
+            channel / "dataset.zip",
+            {
+                "manifest.csv": "image,label\nimages/a.png,cat\nimages/b.png,dog\n",
+                "images/a.png": PNG_BYTES,
+                "images/b.png": PNG_BYTES,
+            },
+        )
+
+        frame, image_root = prepare_dataset(str(channel), IMAGE_SPEC)
+
+        assert image_root == str(tmp_path / "extracted")
+        assert frame["label"].tolist() == ["cat", "dog"]
+        # Image column is rewritten to absolute, existence-checked paths.
+        for path in frame["image"]:
+            assert path.startswith(image_root)
+
+    def test_image_task_reports_a_missing_image(self, tmp_path, monkeypatch):
+        pytest.importorskip("pandas")
+        from apis.app_api.fine_tuning.sagemaker_scripts import task_common
+
+        monkeypatch.setattr(task_common, "EXTRACT_DIR", str(tmp_path / "extracted"))
+
+        channel = tmp_path / "channel"
+        channel.mkdir()
+        _write_zip(
+            channel / "dataset.zip",
+            {"manifest.csv": "image,label\nimages/gone.png,cat\n"},
+        )
+
+        with pytest.raises(FileNotFoundError, match="missing from the archive"):
+            prepare_dataset(str(channel), IMAGE_SPEC)
+
+
+class TestBuildLabelMapping:
+
+    def test_maps_string_labels_to_contiguous_ids(self):
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        frame = pd.DataFrame({"text": ["a", "b", "c"], "label": ["dog", "cat", "dog"]})
+
+        frame, label2id, id2label = build_label_mapping(frame, TEXT_SPEC)
+
+        assert label2id == {"cat": 0, "dog": 1}
+        assert id2label == {0: "cat", 1: "dog"}
+        assert frame["label"].tolist() == [1, 0, 1]
+
+    def test_rejects_a_single_class(self):
+        """One class cannot be classified, and the GPU error is unreadable."""
+        pytest.importorskip("pandas")
+        import pandas as pd
+
+        frame = pd.DataFrame({"text": ["a", "b"], "label": ["same", "same"]})
+
+        with pytest.raises(ValueError, match="at least 2 distinct values"):
+            build_label_mapping(frame, TEXT_SPEC)
+
+
+class TestLabelNames:
+
+    def test_reads_int_keyed_id2label(self):
+        import numpy as np
+
+        config = MagicMock()
+        config.id2label = {0: "cat", 1: "dog"}
+
+        assert label_names(config, np.zeros((2, 2))) == ["cat", "dog"]
+
+    def test_reads_string_keyed_id2label(self):
+        """A config round-tripped through JSON comes back string-keyed."""
+        import numpy as np
+
+        config = MagicMock()
+        config.id2label = {"0": "cat", "1": "dog"}
+
+        assert label_names(config, np.zeros((2, 2))) == ["cat", "dog"]
+
+    def test_falls_back_to_positional_names(self):
+        import numpy as np
+
+        config = MagicMock()
+        config.id2label = None
+
+        assert label_names(config, np.zeros((2, 3))) == ["class_0", "class_1", "class_2"]
+
+
+class TestCopyInferenceBundle:
 
     def test_copies_files_to_code_dir(self, tmp_path):
-        # Create fake script files in a "source" dir
         source_dir = tmp_path / "scripts"
         source_dir.mkdir()
         (source_dir / "inference.py").write_text("# inference handler")
         (source_dir / "requirements.txt").write_text("pandas\n")
 
-        # Create output dir
         model_dir = tmp_path / "model"
         model_dir.mkdir()
 
-        # Patch __file__ so copy_inference_script looks in our source_dir
-        with patch(
-            "apis.app_api.fine_tuning.sagemaker_scripts.train.os.path.dirname",
-            return_value=str(source_dir),
-        ):
-            with patch(
-                "apis.app_api.fine_tuning.sagemaker_scripts.train.os.path.abspath",
-                return_value=str(source_dir / "train.py"),
-            ):
-                copy_inference_script(str(model_dir))
+        copied = copy_inference_bundle(str(model_dir), script_dir=str(source_dir))
 
         code_dir = model_dir / "code"
         assert code_dir.exists()
-        assert (code_dir / "inference.py").exists()
-        assert (code_dir / "requirements.txt").exists()
         assert (code_dir / "inference.py").read_text() == "# inference handler"
+        assert (code_dir / "requirements.txt").exists()
+        assert "inference.py" in copied
 
     def test_creates_code_directory(self, tmp_path):
         source_dir = tmp_path / "scripts"
@@ -214,17 +465,30 @@ class TestCopyInferenceScript:
         model_dir = tmp_path / "model"
         model_dir.mkdir()
 
-        with patch(
-            "apis.app_api.fine_tuning.sagemaker_scripts.train.os.path.dirname",
-            return_value=str(source_dir),
-        ):
-            with patch(
-                "apis.app_api.fine_tuning.sagemaker_scripts.train.os.path.abspath",
-                return_value=str(source_dir / "train.py"),
-            ):
-                copy_inference_script(str(model_dir))
+        copy_inference_bundle(str(model_dir), script_dir=str(source_dir))
 
         assert (model_dir / "code").is_dir()
+
+    def test_bundles_every_task_module_from_the_real_tree(self, tmp_path):
+        """Batch Transform needs the task modules, not just inference.py.
+
+        The handler dispatches on the artifact's task type, so a bundle
+        missing a task module fails at load time on the inference container.
+        """
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        copied = copy_inference_bundle(str(model_dir))
+
+        for expected in (
+            "inference.py",
+            "task_types.py",
+            "task_common.py",
+            "task_text_classification.py",
+            "task_image_classification.py",
+            "task_image_text_classification.py",
+        ):
+            assert expected in copied, f"{expected} missing from the inference bundle"
 
 
 class TestDynamoDBProgressCallback:
@@ -234,8 +498,7 @@ class TestDynamoDBProgressCallback:
         cb = DynamoDBProgressCallback("table", "us-west-2", "PK", "SK")
         cb._client = mock_client
 
-        state = MagicMock()
-        cb.on_train_begin(MagicMock(), state, MagicMock())
+        cb.on_train_begin(MagicMock(), MagicMock(), MagicMock())
 
         mock_client.update_item.assert_called_once()
         call_kwargs = mock_client.update_item.call_args[1]
@@ -246,8 +509,7 @@ class TestDynamoDBProgressCallback:
         cb = DynamoDBProgressCallback("table", "us-west-2", "PK", "SK")
         cb._client = mock_client
 
-        state = MagicMock()
-        cb.on_train_end(MagicMock(), state, MagicMock())
+        cb.on_train_end(MagicMock(), MagicMock(), MagicMock())
 
         call_kwargs = mock_client.update_item.call_args[1]
         assert call_kwargs["ExpressionAttributeValues"][":p"]["N"] == "1.0"
@@ -257,11 +519,9 @@ class TestDynamoDBProgressCallback:
         cb = DynamoDBProgressCallback("", "us-west-2", "", "")
         assert cb._client is None
 
-        # Calling _update_progress should not raise
         cb._update_progress(0.5)
 
     def test_logs_warning_when_params_empty(self, caplog):
-        """Should log a warning when DynamoDB params are missing."""
         import logging
 
         with caplog.at_level(logging.WARNING):
@@ -270,7 +530,6 @@ class TestDynamoDBProgressCallback:
         assert any("disabled" in msg and "EMPTY" in msg for msg in caplog.messages)
 
     def test_logs_info_when_initialized(self, caplog):
-        """Should log an info message when DynamoDB client is created."""
         import logging
 
         mock_client = MagicMock()
@@ -289,12 +548,10 @@ class TestDynamoDBProgressCallback:
         state = MagicMock()
         state.max_steps = 100
 
-        # Step 5 should NOT trigger (5 % 10 != 0)
         state.global_step = 5
         cb.on_step_end(MagicMock(), state, MagicMock())
         mock_client.update_item.assert_not_called()
 
-        # Step 10 SHOULD trigger (10 % 10 == 0)
         state.global_step = 10
         cb.on_step_end(MagicMock(), state, MagicMock())
         mock_client.update_item.assert_called_once()
@@ -304,11 +561,11 @@ class TestSageMakerLoggingCallback:
 
     def test_logs_accuracy_on_evaluate(self, caplog):
         import logging
+
         cb = SageMakerLoggingCallback()
 
         args = MagicMock()
         args.num_train_epochs = 5
-
         state = MagicMock()
         state.epoch = 2
 
@@ -319,16 +576,15 @@ class TestSageMakerLoggingCallback:
 
     def test_skips_final_epoch(self, caplog):
         import logging
+
         cb = SageMakerLoggingCallback()
 
         args = MagicMock()
         args.num_train_epochs = 3
-
         state = MagicMock()
-        state.epoch = 3  # Final epoch
+        state.epoch = 3
 
         with caplog.at_level(logging.INFO):
             cb.on_evaluate(args, state, MagicMock(), metrics={"eval_accuracy": 0.95})
 
-        # Should NOT log accuracy for final epoch (avoids redundancy)
         assert not any("eval_accuracy" in msg for msg in caplog.messages)

--- a/backend/tests/fine_tuning/test_user_routes.py
+++ b/backend/tests/fine_tuning/test_user_routes.py
@@ -37,8 +37,8 @@ class TestCheckAccess:
             "email": "allowed@example.com",
             "granted_by": "admin@example.com",
             "granted_at": "2026-01-01T00:00:00Z",
-            "monthly_quota_hours": 10.0,
-            "current_month_usage_hours": 3.5,
+            "monthly_quota_usd": 10.0,
+            "current_month_usage_usd": 3.5,
             "quota_period": "2026-03",
         }
         _override_repo(app, mock_repo)
@@ -49,8 +49,8 @@ class TestCheckAccess:
         assert resp.status_code == 200
         body = resp.json()
         assert body["has_access"] is True
-        assert body["monthly_quota_hours"] == 10.0
-        assert body["current_month_usage_hours"] == 3.5
+        assert body["monthly_quota_usd"] == 10.0
+        assert body["current_month_usage_usd"] == 3.5
         assert body["quota_period"] == "2026-03"
 
     def test_returns_no_access_for_non_whitelisted_user(self, make_user):
@@ -68,7 +68,7 @@ class TestCheckAccess:
         assert resp.status_code == 200
         body = resp.json()
         assert body["has_access"] is False
-        assert body["monthly_quota_hours"] is None
+        assert body["monthly_quota_usd"] is None
 
     def test_returns_401_when_unauthenticated(self):
         app = _create_app()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -59,6 +59,7 @@ all = [
     { name = "mypy" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -77,6 +78,7 @@ dev = [
     { name = "moto", extra = ["cognitoidp", "dynamodb"] },
     { name = "mypy" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -108,6 +110,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "numpy", marker = "extra == 'dev'", specifier = "==2.2.6" },
     { name = "openai", marker = "extra == 'agentcore'", specifier = "==2.32.0" },
+    { name = "pandas", marker = "extra == 'dev'", specifier = "==2.3.3" },
     { name = "pillow", specifier = "==12.3.0" },
     { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
@@ -3394,6 +3397,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]

--- a/docs-site/src/content/docs/admin/fine-tuning.md
+++ b/docs-site/src/content/docs/admin/fine-tuning.md
@@ -1,12 +1,156 @@
 ---
 title: Fine-Tuning
-description: Fine-tuning access and costs.
+description: Task types, datasets, quota and cost for the fine-tuning feature.
 sidebar:
   order: 4
 ---
 
-:::caution[Draft]
-This page is a scaffolded placeholder — content to be written.
-:::
+Researchers fine-tune a pre-trained model on their own labelled data, then run
+the result over new data as a batch job. Everything executes on SageMaker; the
+platform owns the catalog, the dataset contract, access control and the budget.
 
-Usage & Spend group. Grant fine-tuning access and review its spend; backed by `admin/fine_tuning` and the `/admin/fine-tuning` pages.
+## Task types
+
+A **task type** is the organizing primitive. It determines the dataset
+contract, the accepted upload formats, which base models are offered, and which
+Deep Learning Container the job runs in.
+
+| Task | Input → output | Dataset upload | Manifest columns |
+|---|---|---|---|
+| `text-classification` | text → label | `.csv` / `.jsonl` / `.json` | `text`, `label` |
+| `image-classification` | image → label | `.zip` | `image`, `label` |
+| `image-text-classification` | image + text → label | `.zip` | `image`, `text`, `label` |
+
+All three produce the same output: a softmax over the dataset's own classes,
+written as a CSV with one probability column per class. That shared contract is
+deliberate — it means a new modality never breaks the result viewer.
+
+### Image datasets
+
+An image task takes a single `.zip` containing a manifest plus the image files
+it references:
+
+```
+dataset.zip
+├── manifest.csv        image,label
+│                       images/cat-01.jpg,cat
+│                       images/dog-04.jpg,dog
+└── images/
+    ├── cat-01.jpg
+    └── dog-04.jpg
+```
+
+The `image` column holds each file's path **relative to the archive root**. The
+manifest may be `.csv`, `.jsonl` or `.json`. Archives are treated as untrusted
+input: entries that use absolute paths or `../` traversal are refused, as are
+manifest rows pointing outside the archive.
+
+Batch Transform receives the archive as one payload, so inference input is
+capped at 100 MB per job. Larger inference runs should be split across jobs.
+
+## Adding a task type
+
+The registry lives in `backend/src/apis/app_api/fine_tuning/task_types.py`.
+Adding a task means registering a `TaskSpec` and adding a
+`sagemaker_scripts/task_<name>.py` module implementing `train`, `model_fn`,
+`input_fn` and `predict_fn`. `train.py` and `inference.py` are dispatchers and
+should not need editing.
+
+`task_types.py` must stay importable without torch, transformers, pandas or
+PIL — it is read by the app-api container and the unit tests, neither of which
+has the ML stack.
+
+## Deep Learning Containers
+
+Each task declares a DLC *family*, and the two families move independently:
+
+| Family | Training image | Why |
+|---|---|---|
+| `text` | PyTorch 2.1 / transformers 4.36 | Every existing text model was trained and validated here. Bumping it would re-baseline all of them at once. |
+| `vision` | PyTorch 2.8 / transformers 4.56 | Modern vision checkpoints do not load on 4.36. |
+
+If a tag is retired or lags in a region, override it without a code deploy:
+
+```bash
+FINE_TUNING_TRAINING_IMAGE_VISION=<account>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>
+FINE_TUNING_INFERENCE_IMAGE_VISION=...
+```
+
+## Quota
+
+Quota is denominated in **US dollars per calendar month**, not GPU-hours.
+Hours stopped describing the budget the moment more than one instance type was
+offered: ten hours buys about $14 on an `ml.g5.xlarge` and roughly $450 on an
+`ml.g6e.24xlarge`.
+
+Grants written before this change are migrated lazily — read in the new shape
+and rewritten on the next quota check, converting at the `ml.g5.xlarge` rate
+those hours were actually spent at. No backfill run is needed, and a migrated
+user's existing spend carries across rather than resetting.
+
+### How spend is bounded
+
+A job's real cost is unknown until it stops, so the budget becomes its
+**stopping condition**: `MaxRuntimeInSeconds` is clamped to the hours the
+user's remaining quota affords. SageMaker kills the job at that point, which
+bounds spend exactly with no reservation bookkeeping.
+
+Rejecting on worst-case cost instead would block essentially everything — the
+default 24-hour stopping condition is ~$27 even on the cheapest instance, more
+than an ordinary monthly quota, though such a job usually finishes in minutes.
+A job is refused outright only when the remaining budget buys less than 30
+minutes.
+
+Failed and stopped runs are billed by AWS and are charged against the quota
+accordingly.
+
+### Configuration
+
+| Variable | Meaning |
+|---|---|
+| `FINE_TUNING_DEFAULT_QUOTA_USD` | Monthly quota auto-granted to any authenticated user. `0` (default) means whitelist-only. |
+| `FINE_TUNING_DEFAULT_QUOTA_HOURS` | Legacy fallback, converted to dollars at the `ml.g5.xlarge` rate. |
+
+## Instance pricing
+
+Rates live in `fine_tuning/pricing.py` as literal maps, sourced from the AWS
+Price List API (**not** the pricing web page, which rounds and lags). Resync
+them with:
+
+```bash
+python backend/scripts/refresh_instance_pricing.py --profile dev-ai
+```
+
+Two things the map gets right that a single flat table could not:
+
+- **Training and Batch Transform are priced separately.** They agree across the
+  g5 family but diverge on g6e.
+- **Not every training instance can run Batch Transform.** `ml.p4d.24xlarge`
+  and `ml.p5.48xlarge` publish a training rate and no transform rate, so
+  offering them would let a researcher fine-tune a model they then cannot run
+  inference on. They are deliberately absent, as is `ml.p3.*`, which has no
+  on-demand SageMaker rate at all.
+
+Pricing accuracy is load-bearing: a wrong rate does not just misreport spend,
+it mis-enforces the budget.
+
+## Choosing a base model
+
+The catalog offers vetted models per task. Researchers may also supply any
+HuggingFace model id, which is pre-flighted against the Hub before a GPU is
+provisioned. A custom model is refused when it does not exist, publishes no
+loadable weights, or is tagged for a different modality.
+
+The commonest refusal is a **GGUF-only repository**. GGUF is a llama.cpp
+inference format and cannot be fine-tuned by transformers at all — look for the
+original, unquantised repository instead.
+
+Note that generative vision-language models (`image-text-to-text`, e.g. LLaVA
+or Qwen-VL) are **not** supported. They emit tokens rather than a class
+distribution, and would need a separate generative task type with LoRA/PEFT.
+
+## Admin surface
+
+Grant access and review spend under **Usage & Spend**, backed by
+`admin/fine_tuning` and the `/admin/fine-tuning` pages. A grant is a monthly
+dollar quota against an email address; the `AppRole` record is not involved.

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.html
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.html
@@ -4,7 +4,7 @@
     <div>
       <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Fine-Tuning Access</h1>
       <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-        Manage which users can create fine-tuning and inference jobs. Each user gets a monthly GPU-hour quota.
+        Manage which users can create fine-tuning and inference jobs. Each user gets a monthly spending quota in US dollars.
       </p>
     </div>
     <button
@@ -34,7 +34,7 @@
           />
         </div>
         <div class="w-36">
-          <label for="grant-quota" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Monthly hours</label>
+          <label for="grant-quota" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Monthly quota (USD)</label>
           <input
             id="grant-quota"
             type="number"
@@ -124,9 +124,9 @@
                       [(ngModel)]="editQuota"
                       [ngModelOptions]="{standalone: true}"
                       class="w-20 rounded-sm border border-gray-300 bg-white px-2 py-1 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                      aria-label="Monthly quota hours"
+                      aria-label="Monthly quota in US dollars"
                     />
-                    <span class="text-gray-500 dark:text-gray-400">hrs</span>
+                    <span class="text-gray-500 dark:text-gray-400">USD</span>
                     <button
                       type="submit"
                       class="text-state-success-600 hover:text-state-success-800 dark:text-state-success-400 dark:hover:text-state-success-300"
@@ -148,7 +148,7 @@
                     </button>
                   </form>
                 } @else {
-                  {{ grant.monthly_quota_hours }} hrs
+                  ${{ grant.monthly_quota_usd.toFixed(2) }}
                 }
               </td>
 
@@ -156,15 +156,15 @@
               <td class="px-4 py-3">
                 <div class="flex items-center gap-3">
                   <div class="w-24">
-                    <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" role="progressbar" [attr.aria-valuenow]="usagePercent(grant.current_month_usage_hours, grant.monthly_quota_hours)" aria-valuemin="0" aria-valuemax="100">
+                    <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" role="progressbar" [attr.aria-valuenow]="usagePercent(grant.current_month_usage_usd, grant.monthly_quota_usd)" aria-valuemin="0" aria-valuemax="100">
                       <div
-                        [class]="'h-full rounded-full transition-all ' + usageBarColor(grant.current_month_usage_hours, grant.monthly_quota_hours)"
-                        [style.width.%]="usagePercent(grant.current_month_usage_hours, grant.monthly_quota_hours)"
+                        [class]="'h-full rounded-full transition-all ' + usageBarColor(grant.current_month_usage_usd, grant.monthly_quota_usd)"
+                        [style.width.%]="usagePercent(grant.current_month_usage_usd, grant.monthly_quota_usd)"
                       ></div>
                     </div>
                   </div>
                   <span class="whitespace-nowrap text-sm/6 text-gray-600 dark:text-gray-400">
-                    {{ grant.current_month_usage_hours.toFixed(1) }} / {{ grant.monthly_quota_hours }} hrs
+                    {{ grant.current_month_usage_usd.toFixed(1) }} / ${{ grant.monthly_quota_usd.toFixed(2) }}
                   </span>
                 </div>
               </td>
@@ -195,7 +195,7 @@
                 } @else {
                   <div class="flex items-center justify-end gap-1">
                     <button
-                      (click)="startEdit(grant.email, grant.monthly_quota_hours)"
+                      (click)="startEdit(grant.email, grant.monthly_quota_usd)"
                       class="rounded-sm p-1.5 text-gray-400 hover:text-primary-accessible dark:text-gray-500 dark:hover:text-primary-accessible-dark"
                       [appTooltip]="'Edit Quota'"
                       appTooltipPosition="top"

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/fine-tuning-access.page.spec.ts
@@ -10,8 +10,8 @@ const mockGrant: FineTuningGrant = {
   email: 'user@example.com',
   granted_by: 'admin@example.com',
   granted_at: '2026-03-01T00:00:00Z',
-  monthly_quota_hours: 10,
-  current_month_usage_hours: 3,
+  monthly_quota_usd: 10,
+  current_month_usage_usd: 3,
   quota_period: '2026-03',
 };
 

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/models/fine-tuning-access.models.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/models/fine-tuning-access.models.ts
@@ -3,8 +3,8 @@ export interface FineTuningGrant {
   email: string;
   granted_by: string;
   granted_at: string;
-  monthly_quota_hours: number;
-  current_month_usage_hours: number;
+  monthly_quota_usd: number;
+  current_month_usage_usd: number;
   quota_period: string;
 }
 

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-http.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-http.service.spec.ts
@@ -36,8 +36,8 @@ describe('FineTuningAdminHttpService', () => {
           email: 'user@example.com',
           granted_by: 'admin@example.com',
           granted_at: '2026-03-01T00:00:00Z',
-          monthly_quota_hours: 10,
-          current_month_usage_hours: 3,
+          monthly_quota_usd: 10,
+          current_month_usage_usd: 3,
           quota_period: '2026-03',
         },
       ],
@@ -58,8 +58,8 @@ describe('FineTuningAdminHttpService', () => {
       email: 'new@example.com',
       granted_by: 'admin@example.com',
       granted_at: '2026-03-01T00:00:00Z',
-      monthly_quota_hours: 20,
-      current_month_usage_hours: 0,
+      monthly_quota_usd: 20,
+      current_month_usage_usd: 0,
       quota_period: '2026-03',
     };
 
@@ -69,7 +69,7 @@ describe('FineTuningAdminHttpService', () => {
 
     const req = httpMock.expectOne('http://localhost:8000/admin/fine-tuning/access');
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ email: 'new@example.com', monthly_quota_hours: 20 });
+    expect(req.request.body).toEqual({ email: 'new@example.com', monthly_quota_usd: 20 });
     req.flush(mockGrant);
   });
 
@@ -78,8 +78,8 @@ describe('FineTuningAdminHttpService', () => {
       email: 'user@example.com',
       granted_by: 'admin@example.com',
       granted_at: '2026-03-01T00:00:00Z',
-      monthly_quota_hours: 50,
-      current_month_usage_hours: 3,
+      monthly_quota_usd: 50,
+      current_month_usage_usd: 3,
       quota_period: '2026-03',
     };
 
@@ -89,7 +89,7 @@ describe('FineTuningAdminHttpService', () => {
 
     const req = httpMock.expectOne('http://localhost:8000/admin/fine-tuning/access/user%40example.com');
     expect(req.request.method).toBe('PUT');
-    expect(req.request.body).toEqual({ monthly_quota_hours: 50 });
+    expect(req.request.body).toEqual({ monthly_quota_usd: 50 });
     req.flush(mockGrant);
   });
 

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-http.service.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-http.service.ts
@@ -26,18 +26,18 @@ export class FineTuningAdminHttpService {
   }
 
   /** Grant fine-tuning access to a user by email. */
-  grantAccess(email: string, monthlyQuotaHours: number): Observable<FineTuningGrant> {
+  grantAccess(email: string, monthlyQuotaUsd: number): Observable<FineTuningGrant> {
     return this.http.post<FineTuningGrant>(`${this.baseUrl()}/access`, {
       email,
-      monthly_quota_hours: monthlyQuotaHours,
+      monthly_quota_usd: monthlyQuotaUsd,
     });
   }
 
   /** Update the monthly GPU-hour quota for a user. */
-  updateQuota(email: string, monthlyQuotaHours: number): Observable<FineTuningGrant> {
+  updateQuota(email: string, monthlyQuotaUsd: number): Observable<FineTuningGrant> {
     return this.http.put<FineTuningGrant>(
       `${this.baseUrl()}/access/${encodeURIComponent(email)}`,
-      { monthly_quota_hours: monthlyQuotaHours },
+      { monthly_quota_usd: monthlyQuotaUsd },
     );
   }
 

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-state.service.spec.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-state.service.spec.ts
@@ -9,8 +9,8 @@ const mockGrant: FineTuningGrant = {
   email: 'user@example.com',
   granted_by: 'admin@example.com',
   granted_at: '2026-03-01T00:00:00Z',
-  monthly_quota_hours: 10,
-  current_month_usage_hours: 3,
+  monthly_quota_usd: 10,
+  current_month_usage_usd: 3,
   quota_period: '2026-03',
 };
 

--- a/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-state.service.ts
+++ b/frontend/ai.client/src/app/admin/fine-tuning-access/services/fine-tuning-admin-state.service.ts
@@ -47,11 +47,11 @@ export class FineTuningAdminStateService {
   }
 
   /** Grant fine-tuning access and refresh the list. */
-  async grantAccess(email: string, monthlyQuotaHours: number): Promise<void> {
+  async grantAccess(email: string, monthlyQuotaUsd: number): Promise<void> {
     this.loading.set(true);
     this.error.set(null);
     try {
-      await firstValueFrom(this.http.grantAccess(email, monthlyQuotaHours));
+      await firstValueFrom(this.http.grantAccess(email, monthlyQuotaUsd));
       await this.loadGrants();
       this.showGrantForm.set(false);
     } catch (err: unknown) {
@@ -62,11 +62,11 @@ export class FineTuningAdminStateService {
   }
 
   /** Update the monthly quota for a user and refresh the list. */
-  async updateQuota(email: string, monthlyQuotaHours: number): Promise<void> {
+  async updateQuota(email: string, monthlyQuotaUsd: number): Promise<void> {
     this.loading.set(true);
     this.error.set(null);
     try {
-      await firstValueFrom(this.http.updateQuota(email, monthlyQuotaHours));
+      await firstValueFrom(this.http.updateQuota(email, monthlyQuotaUsd));
       await this.loadGrants();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to update quota';

--- a/frontend/ai.client/src/app/fine-tuning/components/quota-card.component.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/components/quota-card.component.spec.ts
@@ -22,29 +22,29 @@ describe('QuotaCardComponent', () => {
 
   const baseAccess: FineTuningAccessResponse = {
     has_access: true,
-    monthly_quota_hours: 10,
-    current_month_usage_hours: 3,
+    monthly_quota_usd: 10,
+    current_month_usage_usd: 3,
     quota_period: '2026-03',
   };
 
   it('should compute used hours from access signal', () => {
     const component = createComponent(baseAccess);
-    expect(component.usedHours()).toBe(3);
+    expect(component.usedUsd()).toBe(3);
   });
 
   it('should compute total hours from access signal', () => {
     const component = createComponent(baseAccess);
-    expect(component.totalHours()).toBe(10);
+    expect(component.totalUsd()).toBe(10);
   });
 
   it('should compute remaining hours', () => {
     const component = createComponent(baseAccess);
-    expect(component.remainingHours()).toBe(7);
+    expect(component.remainingUsd()).toBe(7);
   });
 
   it('should not return negative remaining hours', () => {
-    const component = createComponent({ ...baseAccess, current_month_usage_hours: 15 });
-    expect(component.remainingHours()).toBe(0);
+    const component = createComponent({ ...baseAccess, current_month_usage_usd: 15 });
+    expect(component.remainingUsd()).toBe(0);
   });
 
   it('should compute used percent correctly', () => {
@@ -53,17 +53,17 @@ describe('QuotaCardComponent', () => {
   });
 
   it('should cap used percent at 100', () => {
-    const component = createComponent({ ...baseAccess, current_month_usage_hours: 15 });
+    const component = createComponent({ ...baseAccess, current_month_usage_usd: 15 });
     expect(component.usedPercent()).toBe(100);
   });
 
   it('should return 0 percent when total is 0', () => {
-    const component = createComponent({ ...baseAccess, monthly_quota_hours: 0 });
+    const component = createComponent({ ...baseAccess, monthly_quota_usd: 0 });
     expect(component.usedPercent()).toBe(0);
   });
 
   it('should return 0 percent when total is null', () => {
-    const component = createComponent({ ...baseAccess, monthly_quota_hours: null });
+    const component = createComponent({ ...baseAccess, monthly_quota_usd: null });
     expect(component.usedPercent()).toBe(0);
   });
 
@@ -73,18 +73,18 @@ describe('QuotaCardComponent', () => {
   });
 
   it('should return warning bar color for moderate usage (70-89%)', () => {
-    const component = createComponent({ ...baseAccess, current_month_usage_hours: 7.5 }); // 75%
+    const component = createComponent({ ...baseAccess, current_month_usage_usd: 7.5 }); // 75%
     expect(component.barColor()).toBe('bg-state-warning-500');
   });
 
   it('should return danger bar color for high usage (>=90%)', () => {
-    const component = createComponent({ ...baseAccess, current_month_usage_hours: 9.5 }); // 95%
+    const component = createComponent({ ...baseAccess, current_month_usage_usd: 9.5 }); // 95%
     expect(component.barColor()).toBe('bg-state-danger-500');
   });
 
   it('should handle null usage hours', () => {
-    const component = createComponent({ ...baseAccess, current_month_usage_hours: null });
-    expect(component.usedHours()).toBe(0);
+    const component = createComponent({ ...baseAccess, current_month_usage_usd: null });
+    expect(component.usedUsd()).toBe(0);
     expect(component.usedPercent()).toBe(0);
     expect(component.barColor()).toBe('bg-state-info-500');
   });

--- a/frontend/ai.client/src/app/fine-tuning/components/quota-card.component.ts
+++ b/frontend/ai.client/src/app/fine-tuning/components/quota-card.component.ts
@@ -2,7 +2,10 @@ import { Component, ChangeDetectionStrategy, input, computed } from '@angular/co
 import { FineTuningAccessResponse } from '../models/fine-tuning.models';
 
 /**
- * Displays the user's monthly fine-tuning quota usage as a card with a progress bar.
+ * Displays the user's monthly fine-tuning spend against their quota.
+ *
+ * The quota is denominated in dollars rather than GPU-hours: hours stopped
+ * describing the budget once more than one instance type was offered.
  */
 @Component({
   selector: 'app-quota-card',
@@ -18,10 +21,10 @@ import { FineTuningAccessResponse } from '../models/fine-tuning.models';
       <div class="mt-3">
         <div class="flex items-baseline justify-between">
           <span class="text-2xl font-bold text-gray-900 dark:text-white">
-            {{ usedHours().toFixed(1) }}
+            \${{ usedUsd().toFixed(2) }}
           </span>
           <span class="text-sm/6 text-gray-500 dark:text-gray-400">
-            / {{ totalHours().toFixed(0) }} hrs
+            / \${{ totalUsd().toFixed(2) }}
           </span>
         </div>
         <div
@@ -38,7 +41,7 @@ import { FineTuningAccessResponse } from '../models/fine-tuning.models';
           ></div>
         </div>
         <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          {{ remainingHours().toFixed(1) }} hours remaining
+          \${{ remainingUsd().toFixed(2) }} remaining
         </p>
       </div>
     </div>
@@ -47,14 +50,14 @@ import { FineTuningAccessResponse } from '../models/fine-tuning.models';
 export class QuotaCardComponent {
   readonly access = input.required<FineTuningAccessResponse>();
 
-  readonly usedHours = computed(() => this.access().current_month_usage_hours ?? 0);
-  readonly totalHours = computed(() => this.access().monthly_quota_hours ?? 0);
-  readonly remainingHours = computed(() => Math.max(0, this.totalHours() - this.usedHours()));
+  readonly usedUsd = computed(() => this.access().current_month_usage_usd ?? 0);
+  readonly totalUsd = computed(() => this.access().monthly_quota_usd ?? 0);
+  readonly remainingUsd = computed(() => Math.max(0, this.totalUsd() - this.usedUsd()));
 
   readonly usedPercent = computed(() => {
-    const total = this.totalHours();
+    const total = this.totalUsd();
     if (total <= 0) return 0;
-    return Math.min(100, (this.usedHours() / total) * 100);
+    return Math.min(100, (this.usedUsd() / total) * 100);
   });
 
   readonly barColor = computed(() => {

--- a/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
+++ b/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
@@ -7,9 +7,34 @@
 
 export interface FineTuningAccessResponse {
   has_access: boolean;
-  monthly_quota_hours: number | null;
-  current_month_usage_hours: number | null;
+  monthly_quota_usd: number | null;
+  current_month_usage_usd: number | null;
   quota_period: string | null;
+}
+
+// ── Task Types ──────────────────────────────────────────────────────────
+
+/**
+ * The kinds of fine-tuning the platform supports. The chosen task determines
+ * the dataset contract, the accepted upload formats and the model list, so it
+ * is the first thing the create-job form asks for.
+ */
+export type FineTuningTaskType =
+  | 'text-classification'
+  | 'image-classification'
+  | 'image-text-classification';
+
+export const DEFAULT_TASK_TYPE: FineTuningTaskType = 'text-classification';
+
+export interface TaskTypeResponse {
+  task_type: FineTuningTaskType;
+  display_name: string;
+  description: string;
+  required_columns: string[];
+  upload_extensions: string[];
+  requires_archive: boolean;
+  inference_upload_extensions: string[];
+  default_instance_type: string;
 }
 
 // ── Model Catalog ───────────────────────────────────────────────────────
@@ -19,6 +44,7 @@ export interface AvailableModel {
   model_name: string;
   huggingface_model_id: string;
   description: string;
+  task_type: FineTuningTaskType;
   default_instance_type: string;
   default_hyperparameters: Record<string, string>;
 }
@@ -28,6 +54,7 @@ export interface AvailableModel {
 export interface PresignRequest {
   filename: string;
   content_type: string;
+  task_type?: FineTuningTaskType;
 }
 
 export interface PresignResponse {
@@ -43,6 +70,7 @@ export type TrainingJobStatus = 'PENDING' | 'TRAINING' | 'COMPLETED' | 'FAILED' 
 export interface CreateJobRequest {
   model_id: string;
   dataset_s3_key: string;
+  task_type?: FineTuningTaskType;
   instance_type?: string;
   hyperparameters?: Record<string, string>;
   max_runtime_seconds?: number;
@@ -55,6 +83,7 @@ export interface JobResponse {
   email: string;
   model_id: string;
   model_name: string;
+  task_type: FineTuningTaskType;
   status: TrainingJobStatus;
   dataset_s3_key: string;
   output_s3_prefix: string | null;
@@ -124,6 +153,7 @@ export interface TrainedModelResponse {
   training_job_id: string;
   model_id: string;
   model_name: string;
+  task_type: FineTuningTaskType;
   model_s3_path: string;
   instance_type: string;
   completed_at: string | null;

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.html
@@ -117,13 +117,19 @@
           <p class="mt-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
             Click to upload your input file
           </p>
-          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Text file with one input per line</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            @if (requiresArchive()) {
+              .zip archive of the images to classify
+            } @else {
+              Text file with one input per line
+            }
+          </p>
         </label>
         <input
           id="inference-upload"
           type="file"
           class="sr-only"
-          accept=".txt,.csv,.jsonl,.json"
+          [accept]="uploadAccept()"
           (change)="onFileSelected($event)"
         />
       }

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.spec.ts
@@ -17,6 +17,7 @@ const mockTrainedModel: TrainedModelResponse = {
   training_job_id: 'tj-1',
   model_id: 'model-1',
   model_name: 'Test Model',
+  task_type: 'text-classification',
   model_s3_path: 's3://bucket/model',
   instance_type: 'ml.g5.xlarge',
   completed_at: '2026-02-28T00:00:00Z',
@@ -129,6 +130,9 @@ describe('CreateInferenceJobPage', () => {
     await component.onFileSelected(input);
 
     expect(mockHttp.presignInferenceUpload).toHaveBeenCalledWith({
+      // The accepted input format follows the task the chosen model was
+      // fine-tuned for, not anything the user picks.
+      task_type: 'text-classification',
       filename: 'input.txt',
       content_type: 'text/plain',
     });

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.ts
@@ -48,6 +48,9 @@ export class CreateInferenceJobPage implements OnInit {
   /** Upload state tracking. */
   readonly uploadState = signal<FileUploadState | null>(null);
 
+  /** The currently chosen training job id, mirrored from the form control. */
+  readonly selectedTrainingJobId = signal<string>('');
+
   /**
    * The task the chosen model was fine-tuned for.
    *
@@ -68,9 +71,6 @@ export class CreateInferenceJobPage implements OnInit {
   readonly uploadAccept = computed(() =>
     this.requiresArchive() ? '.zip' : '.txt,.csv,.jsonl,.json',
   );
-
-  /** The currently chosen training job id, as a signal for the computeds above. */
-  readonly selectedTrainingJobId = signal<string>('');
 
   /** Whether the form is being submitted. */
   readonly submitting = signal(false);

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-inference-job/create-inference-job.page.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, OnInit, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { DatePipe } from '@angular/common';
@@ -14,7 +14,12 @@ import { firstValueFrom } from 'rxjs';
 import { FineTuningStateService } from '../../services/fine-tuning-state.service';
 import { FineTuningHttpService } from '../../services/fine-tuning-http.service';
 import { FineTuningUploadService } from '../../services/fine-tuning-upload.service';
-import { FileUploadState, CreateInferenceJobRequest } from '../../models/fine-tuning.models';
+import {
+  CreateInferenceJobRequest,
+  DEFAULT_TASK_TYPE,
+  FileUploadState,
+  FineTuningTaskType,
+} from '../../models/fine-tuning.models';
 import { SpinnerComponent } from '../../../components/spinner/spinner.component';
 
 @Component({
@@ -43,6 +48,30 @@ export class CreateInferenceJobPage implements OnInit {
   /** Upload state tracking. */
   readonly uploadState = signal<FileUploadState | null>(null);
 
+  /**
+   * The task the chosen model was fine-tuned for.
+   *
+   * The artifact can only serve its own task, so the accepted input format
+   * follows the model rather than anything the user picks — an image
+   * classifier cannot read a .txt of one line per record.
+   */
+  readonly selectedTaskType = computed<FineTuningTaskType>(() => {
+    const jobId = this.selectedTrainingJobId();
+    const model = this.state.trainedModels().find((m) => m.training_job_id === jobId);
+    return model?.task_type ?? DEFAULT_TASK_TYPE;
+  });
+
+  /** Whether the chosen model expects a .zip of images. */
+  readonly requiresArchive = computed(() => this.selectedTaskType() !== 'text-classification');
+
+  /** `accept` attribute for the inference input, per the chosen model's task. */
+  readonly uploadAccept = computed(() =>
+    this.requiresArchive() ? '.zip' : '.txt,.csv,.jsonl,.json',
+  );
+
+  /** The currently chosen training job id, as a signal for the computeds above. */
+  readonly selectedTrainingJobId = signal<string>('');
+
   /** Whether the form is being submitted. */
   readonly submitting = signal(false);
 
@@ -57,6 +86,18 @@ export class CreateInferenceJobPage implements OnInit {
 
   ngOnInit(): void {
     this.state.loadTrainedModels();
+
+    // Mirror the model choice into a signal so the accepted input format can
+    // follow it, and drop any file already staged under the previous model's
+    // contract — a .txt uploaded for a text classifier is not valid input for
+    // an image one.
+    this.form.get('trainingJobId')?.valueChanges.subscribe((jobId) => {
+      const next = jobId ?? '';
+      if (next === this.selectedTrainingJobId()) return;
+      this.selectedTrainingJobId.set(next);
+      this.uploadState.set(null);
+      this.submitError.set(null);
+    });
   }
 
   /** Handle file selection from the file input. */
@@ -72,6 +113,7 @@ export class CreateInferenceJobPage implements OnInit {
       // Step 1: Get presigned URL for inference input
       const presignResponse = await firstValueFrom(
         this.http.presignInferenceUpload({
+          task_type: this.selectedTaskType(),
           filename: file.name,
           content_type: file.type || 'application/octet-stream',
         }),

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -19,12 +19,61 @@
     </div>
   }
 
-  <!-- Section 1: Upload Dataset -->
+  <!-- Section 1: Choose Task -->
   <section class="mb-8">
-    <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">1. Upload Dataset</h2>
+    <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">1. Choose a Task</h2>
     <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
-      Upload your training data as a CSV, JSONL, or JSON file. Each record should include "text" and "label" fields.
+      What should the fine-tuned model predict? This determines the dataset format and which base models are available.
     </p>
+
+    @if (taskTypes().length === 0) {
+      <div class="flex items-center justify-center py-8">
+        <app-spinner size="md" label="Loading task types" />
+      </div>
+    } @else {
+      <div class="grid gap-3 sm:grid-cols-3" role="radiogroup" aria-label="Fine-tuning task">
+        @for (task of taskTypes(); track task.task_type) {
+          <button
+            type="button"
+            role="radio"
+            [attr.aria-checked]="selectedTaskType() === task.task_type"
+            (click)="selectTaskType(task.task_type)"
+            [class]="
+              'rounded-sm border p-4 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 ' +
+              (selectedTaskType() === task.task_type
+                ? 'border-primary-500 bg-primary-50 dark:border-primary-400 dark:bg-primary-950'
+                : 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600')
+            "
+          >
+            <div class="flex items-start justify-between gap-2">
+              <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ task.display_name }}</span>
+              @if (selectedTaskType() === task.task_type) {
+                <ng-icon name="heroCheck" class="size-5 shrink-0 text-primary-600 dark:text-primary-400" />
+              }
+            </div>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ task.description }}</p>
+          </button>
+        }
+      </div>
+    }
+  </section>
+
+  <!-- Section 2: Upload Dataset -->
+  <section class="mb-8">
+    <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">2. Upload Dataset</h2>
+    @if (requiresArchive()) {
+      <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
+        Upload a <strong>.zip</strong> containing a manifest (CSV, JSONL, or JSON) with
+        @for (col of requiredColumns(); track col; let last = $last) {<code class="rounded-sm bg-gray-100 px-1 dark:bg-gray-800">{{ col }}</code>{{ last ? '' : ', ' }}}
+        fields, plus the image files the manifest references.
+      </p>
+    } @else {
+      <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
+        Upload your training data as a CSV, JSONL, or JSON file. Each record should include
+        @for (col of requiredColumns(); track col; let last = $last) {<code class="rounded-sm bg-gray-100 px-1 dark:bg-gray-800">{{ col }}</code>{{ last ? '' : ', ' }}}
+        fields.
+      </p>
+    }
 
     @if (uploadState(); as upload) {
       <div class="rounded-sm border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
@@ -95,13 +144,15 @@
           <p class="mt-2 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
             Click or drag &amp; drop your dataset
           </p>
-          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CSV, JSONL, or JSON file</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            @if (requiresArchive()) { .zip archive (manifest + images) } @else { CSV, JSONL, or JSON file }
+          </p>
         </label>
         <input
           id="dataset-upload"
           type="file"
           class="sr-only"
-          accept=".csv,.jsonl,.json"
+          [accept]="uploadAccept()"
           (change)="onFileSelected($event)"
         />
       </div>
@@ -145,14 +196,14 @@
     </div>
   </section>
 
-  <!-- Section 2: Select Base Model -->
+  <!-- Section 3: Select Base Model -->
   <section class="mb-8">
-    <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">2. Select Base Model</h2>
+    <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">3. Select Base Model</h2>
     <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
       Choose a pre-trained model to fine-tune, or enter any HuggingFace model ID.
     </p>
 
-    @if (state.loading() && state.availableModels().length === 0) {
+    @if (state.loading() && modelsForTask().length === 0) {
       <div class="flex items-center justify-center py-8">
         <app-spinner size="md" label="Loading models" />
       </div>
@@ -326,7 +377,7 @@
       }
 
       <div class="grid gap-4 sm:grid-cols-3">
-        @for (model of state.availableModels(); track model.model_id) {
+        @for (model of modelsForTask(); track model.model_id) {
           <button
             type="button"
             (click)="selectModel(model)"
@@ -349,7 +400,7 @@
   <!-- Section 3: Training Configuration -->
   @if (hasModelSelection()) {
     <section class="mb-8">
-      <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">3. Training Configuration</h2>
+      <h2 class="mb-1 text-base/7 font-semibold text-gray-900 dark:text-white">4. Training Configuration</h2>
       <p class="mb-4 text-sm/6 text-gray-500 dark:text-gray-400">
         Adjust hyperparameters as needed. Defaults are pre-filled from the selected model.
       </p>
@@ -400,16 +451,31 @@
             />
           </div>
 
-          <!-- Context Length -->
-          <div>
-            <label for="hp-ctx" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Context Length</label>
-            <input
-              id="hp-ctx"
-              formControlName="contextLength"
-              type="text"
-              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-            />
-          </div>
+          <!-- Context Length — text-bearing tasks only -->
+          @if (selectedTaskType() !== 'image-classification') {
+            <div>
+              <label for="hp-ctx" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Context Length</label>
+              <input
+                id="hp-ctx"
+                formControlName="contextLength"
+                type="text"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+            </div>
+          }
+
+          <!-- Image Size — image-bearing tasks only -->
+          @if (requiresArchive()) {
+            <div>
+              <label for="hp-img" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Image Size</label>
+              <input
+                id="hp-img"
+                formControlName="imageSize"
+                type="text"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+            </div>
+          }
 
           <!-- Seed -->
           <div>

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
@@ -7,11 +7,17 @@ import { CreateTrainingJobPage } from './create-training-job.page';
 import { FineTuningStateService } from '../../services/fine-tuning-state.service';
 import { FineTuningHttpService } from '../../services/fine-tuning-http.service';
 import { FineTuningUploadService } from '../../services/fine-tuning-upload.service';
-import type { AvailableModel, JobResponse, PresignResponse } from '../../models/fine-tuning.models';
+import type {
+  AvailableModel,
+  JobResponse,
+  PresignResponse,
+  TaskTypeResponse,
+} from '../../models/fine-tuning.models';
 
 const mockModel: AvailableModel = {
   model_id: 'model-1',
   model_name: 'Test Model',
+  task_type: 'text-classification',
   huggingface_model_id: 'test/model',
   description: 'A test model',
   default_instance_type: 'ml.g5.xlarge',
@@ -38,6 +44,7 @@ const mockJobResponse: JobResponse = {
   email: 'test@example.com',
   model_id: 'model-1',
   model_name: 'Test Model',
+  task_type: 'text-classification',
   status: 'PENDING',
   dataset_s3_key: 'uploads/data.jsonl',
   output_s3_prefix: null,
@@ -67,10 +74,34 @@ function createMockState() {
   };
 }
 
+const mockTaskTypes: TaskTypeResponse[] = [
+  {
+    task_type: 'text-classification',
+    display_name: 'Text classification',
+    description: 'Assign a label to a piece of text.',
+    required_columns: ['text', 'label'],
+    upload_extensions: ['.csv', '.jsonl', '.json'],
+    requires_archive: false,
+    inference_upload_extensions: ['.txt', '.csv', '.jsonl', '.json'],
+    default_instance_type: 'ml.g5.xlarge',
+  },
+  {
+    task_type: 'image-classification',
+    display_name: 'Image classification',
+    description: 'Assign a label to an image.',
+    required_columns: ['image', 'label'],
+    upload_extensions: ['.zip'],
+    requires_archive: true,
+    inference_upload_extensions: ['.zip'],
+    default_instance_type: 'ml.g6.xlarge',
+  },
+];
+
 function createMockHttp() {
   return {
     presignDatasetUpload: vi.fn().mockReturnValue(of(mockPresignResponse)),
     searchHuggingFaceModels: vi.fn().mockReturnValue(of([])),
+    listTaskTypes: vi.fn().mockReturnValue(of(mockTaskTypes)),
   };
 }
 
@@ -155,6 +186,9 @@ describe('CreateTrainingJobPage', () => {
     expect(mockHttp.presignDatasetUpload).toHaveBeenCalledWith({
       filename: 'data.jsonl',
       content_type: 'application/jsonl',
+      // The presign is task-scoped: the backend validates the upload format
+      // against the task before minting a URL.
+      task_type: 'text-classification',
     });
     expect(mockUpload.uploadFile).toHaveBeenCalled();
     expect(component.uploadState()?.status).toBe('complete');
@@ -173,6 +207,7 @@ describe('CreateTrainingJobPage', () => {
     expect(mockHttp.presignDatasetUpload).toHaveBeenCalledWith({
       filename: 'data.jsonl',
       content_type: 'application/octet-stream',
+      task_type: 'text-classification',
     });
   });
 
@@ -404,6 +439,10 @@ describe('CreateTrainingJobPage', () => {
     const call = mockState.createTrainingJob.mock.calls[0][0];
     expect(call.model_id).toBe('custom');
     expect(call.custom_huggingface_model_id).toBe('bert-base-multilingual-cased');
-    expect(call.instance_type).toBe('ml.g5.xlarge');
+    // A custom model has no catalog entry to take an instance type from, so
+    // the field is omitted and the backend resolves it from the task
+    // registry rather than the SPA guessing.
+    expect(call.instance_type).toBeUndefined();
+    expect(call.task_type).toBe('text-classification');
   });
 });

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
@@ -20,7 +20,15 @@ import { debounceTime, distinctUntilChanged, switchMap, takeUntil, filter, tap, 
 import { FineTuningStateService } from '../../services/fine-tuning-state.service';
 import { FineTuningHttpService } from '../../services/fine-tuning-http.service';
 import { FineTuningUploadService } from '../../services/fine-tuning-upload.service';
-import { AvailableModel, FileUploadState, CreateJobRequest, HuggingFaceModelResult } from '../../models/fine-tuning.models';
+import {
+  AvailableModel,
+  CreateJobRequest,
+  DEFAULT_TASK_TYPE,
+  FileUploadState,
+  FineTuningTaskType,
+  HuggingFaceModelResult,
+  TaskTypeResponse,
+} from '../../models/fine-tuning.models';
 import { SpinnerComponent } from '../../../components/spinner/spinner.component';
 
 @Component({
@@ -59,6 +67,34 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
 
   /** Track drag enter/leave depth to handle nested elements. */
   private dragCounter = 0;
+
+  /** Task types offered by the platform, loaded from the backend. */
+  readonly taskTypes = signal<TaskTypeResponse[]>([]);
+
+  /** The task being fine-tuned for. Drives the dataset contract, the accepted
+   * upload formats and the model list, so changing it resets all three. */
+  readonly selectedTaskType = signal<FineTuningTaskType>(DEFAULT_TASK_TYPE);
+
+  /** Spec for the selected task, or null before the task list has loaded. */
+  readonly selectedTaskSpec = computed(
+    () => this.taskTypes().find((t) => t.task_type === this.selectedTaskType()) ?? null,
+  );
+
+  /** Catalog models trainable for the selected task. */
+  readonly modelsForTask = computed(() =>
+    this.state.availableModels().filter((m) => m.task_type === this.selectedTaskType()),
+  );
+
+  /** `accept` attribute for the dataset file input, per the selected task. */
+  readonly uploadAccept = computed(
+    () => this.selectedTaskSpec()?.upload_extensions.join(',') ?? '.csv,.jsonl,.json',
+  );
+
+  /** Whether the selected task expects a .zip bundling images with a manifest. */
+  readonly requiresArchive = computed(() => this.selectedTaskSpec()?.requires_archive ?? false);
+
+  /** Columns a record must carry, for the upload hint. */
+  readonly requiredColumns = computed(() => this.selectedTaskSpec()?.required_columns ?? []);
 
   /** Currently selected model (catalog or custom). */
   readonly selectedModel = signal<AvailableModel | null>(null);
@@ -122,11 +158,13 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
     weightDecay: ['0.01'],
     seed: ['42'],
     contextLength: ['512'],
+    imageSize: ['224'],
     maxRuntimeHours: [24, [Validators.required, Validators.min(1), Validators.max(120)]],
   });
 
   ngOnInit(): void {
     this.state.loadAvailableModels();
+    this.loadTaskTypes();
     this.splitSlider.valueChanges.subscribe((v) => this.splitPercent.set(v));
 
     // Set up debounced HuggingFace model search
@@ -136,7 +174,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       filter((query) => query.trim().length >= 2),
       tap(() => this.searchingModels.set(true)),
       switchMap((query) =>
-        this.http.searchHuggingFaceModels(query, this.compatibleOnly()).pipe(
+        this.http.searchHuggingFaceModels(query, this.compatibleOnly(), this.selectedTaskType()).pipe(
           catchError(() => of([])),
         ),
       ),
@@ -150,6 +188,35 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  /** Load the supported task types. */
+  private async loadTaskTypes(): Promise<void> {
+    try {
+      this.taskTypes.set(await firstValueFrom(this.http.listTaskTypes()));
+    } catch {
+      // Leave the list empty; the form falls back to text-classification
+      // defaults so the page stays usable.
+    }
+  }
+
+  /**
+   * Switch the task being fine-tuned for.
+   *
+   * Clears the model and the uploaded dataset: a model trained for one task
+   * cannot serve another, and the dataset contract differs between them, so
+   * carrying either across would submit a job that fails on the backend.
+   */
+  selectTaskType(taskType: FineTuningTaskType): void {
+    if (taskType === this.selectedTaskType()) return;
+
+    this.selectedTaskType.set(taskType);
+    this.selectedModel.set(null);
+    this.selectedHfModel.set(null);
+    this.customHuggingFaceId.set('');
+    this.hfSearchResults.set([]);
+    this.uploadState.set(null);
+    this.submitError.set(null);
   }
 
   /** Handle file selection from the file input. */
@@ -175,6 +242,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
         this.http.presignDatasetUpload({
           filename: file.name,
           content_type: file.type || 'application/octet-stream',
+          task_type: this.selectedTaskType(),
         }),
       );
 
@@ -327,6 +395,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       weightDecay: hp['weight_decay'] ?? '0.01',
       seed: hp['seed'] ?? '42',
       contextLength: hp['context_length'] ?? '512',
+      imageSize: hp['image_size'] ?? '224',
     });
 
     // Sync slider from model defaults (e.g. "0.8" → 80)
@@ -373,6 +442,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       if (formValues.weightDecay) hyperparameters['weight_decay'] = formValues.weightDecay;
       if (formValues.seed) hyperparameters['seed'] = formValues.seed;
       if (formValues.contextLength) hyperparameters['context_length'] = formValues.contextLength;
+      if (formValues.imageSize) hyperparameters['image_size'] = formValues.imageSize;
 
       // Convert slider percentage (e.g. 80) to decimal string (e.g. "0.8")
       hyperparameters['split_ratio'] = (this.splitSlider.value / 100).toString();
@@ -380,7 +450,12 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       const request: CreateJobRequest = {
         model_id: isCustom ? 'custom' : model!.model_id,
         dataset_s3_key: upload.s3Key,
-        instance_type: isCustom ? 'ml.g5.xlarge' : model!.default_instance_type,
+        task_type: this.selectedTaskType(),
+        // A catalog model carries its own instance type. A custom model has
+        // no catalog entry, so the field is omitted and the backend resolves
+        // it from the task registry — the single source of that default,
+        // rather than a copy of it here that can disagree.
+        ...(isCustom ? {} : { instance_type: model!.default_instance_type }),
         hyperparameters,
         max_runtime_seconds: (formValues.maxRuntimeHours ?? 24) * 3600,
         ...(isCustom ? { custom_huggingface_model_id: customHfId } : {}),

--- a/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.html
@@ -45,10 +45,16 @@
     </summary>
     <div class="border-t border-state-info-200 px-4 py-3 text-sm/6 text-gray-700 dark:border-state-info-800/40 dark:text-gray-300">
       <p>
-        If you have a need for a language model to perform automatic coding or classification for your research, and the input is text, then this is a potentially useful option for you. Fine-tuning takes an existing small language model and helps it become better at coding/classification on the data that you provide.
+        If you need a model to perform automatic coding or classification for your research, this is a potentially useful option for you. Fine-tuning takes an existing pre-trained model and helps it become better at coding/classification on the data that you provide. Your input can be text, images, or images paired with text.
       </p>
       <p class="mt-2">
-        To get started, upload a <strong>.csv</strong> file with two columns: <strong>text</strong> (your input data) and <strong>label</strong> (the code/classification you want the model to predict). You can control the train/test split, and once fine-tuning is complete, download the model for your own use. We also provide the ability to run inference on any future data you collect.
+        For <strong>text classification</strong>, upload a <strong>.csv</strong> file with two columns: <strong>text</strong> (your input data) and <strong>label</strong> (the code/classification you want the model to predict).
+      </p>
+      <p class="mt-2">
+        For <strong>image</strong> or <strong>image + text classification</strong>, upload a <strong>.zip</strong> containing a manifest (CSV, JSONL, or JSON) plus the image files it references. The manifest needs an <strong>image</strong> column holding each file's path inside the archive, a <strong>label</strong> column, and — for image + text — a <strong>text</strong> column.
+      </p>
+      <p class="mt-2">
+        You can control the train/test split, and once fine-tuning is complete, download the model for your own use. We also provide the ability to run inference on any future data you collect.
       </p>
     </div>
   </details>

--- a/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.spec.ts
@@ -8,8 +8,8 @@ import type { JobResponse, InferenceJobResponse, FineTuningAccessResponse } from
 
 const mockAccess: FineTuningAccessResponse = {
   has_access: true,
-  monthly_quota_hours: 10,
-  current_month_usage_hours: 3,
+  monthly_quota_usd: 10,
+  current_month_usage_usd: 3,
   quota_period: '2026-03',
 };
 
@@ -19,6 +19,7 @@ const mockTrainingJob: JobResponse = {
   email: 'test@example.com',
   model_id: 'model-1',
   model_name: 'Test Model',
+  task_type: 'text-classification',
   status: 'TRAINING',
   dataset_s3_key: 's3://bucket/data.jsonl',
   output_s3_prefix: null,

--- a/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.spec.ts
@@ -12,6 +12,7 @@ const mockJob: JobResponse = {
   email: 'test@example.com',
   model_id: 'model-1',
   model_name: 'Test Model',
+  task_type: 'text-classification',
   status: 'TRAINING',
   dataset_s3_key: 's3://bucket/data.jsonl',
   output_s3_prefix: null,

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-http.service.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-http.service.spec.ts
@@ -34,7 +34,7 @@ describe('FineTuningHttpService', () => {
   // ── Access ──────────────────────────────────────────────────────────
 
   it('should check access via GET /access', () => {
-    const mockResponse = { has_access: true, monthly_quota_hours: 10, current_month_usage_hours: 2, quota_period: '2026-03' };
+    const mockResponse = { has_access: true, monthly_quota_usd: 10, current_month_usage_usd: 2, quota_period: '2026-03' };
     service.checkAccess().subscribe(result => {
       expect(result).toEqual(mockResponse);
     });

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-http.service.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-http.service.ts
@@ -17,6 +17,9 @@ import {
   LogsResponse,
   DownloadResponse,
   HuggingFaceModelResult,
+  DEFAULT_TASK_TYPE,
+  FineTuningTaskType,
+  TaskTypeResponse,
 } from '../models/fine-tuning.models';
 
 /**
@@ -40,18 +43,34 @@ export class FineTuningHttpService {
 
   // ── Model Catalog ───────────────────────────────────────────────────
 
-  /** List available base models for fine-tuning. */
-  listModels(): Observable<AvailableModel[]> {
-    return this.http.get<AvailableModel[]>(`${this.baseUrl()}/models`);
+  /** List available base models, optionally narrowed to one task type. */
+  listModels(taskType?: FineTuningTaskType): Observable<AvailableModel[]> {
+    const params = taskType ? { params: { task_type: taskType } } : {};
+    return this.http.get<AvailableModel[]>(`${this.baseUrl()}/models`, params);
+  }
+
+  /** List the fine-tuning task types the platform supports. */
+  listTaskTypes(): Observable<TaskTypeResponse[]> {
+    return this.http.get<TaskTypeResponse[]>(`${this.baseUrl()}/task-types`);
   }
 
   // ── HuggingFace Model Search ────────────────────────────────────────
 
   /** Search HuggingFace Hub models via backend proxy. */
-  searchHuggingFaceModels(query: string, compatibleOnly: boolean = true): Observable<HuggingFaceModelResult[]> {
+  searchHuggingFaceModels(
+    query: string,
+    compatibleOnly: boolean = true,
+    taskType: FineTuningTaskType = DEFAULT_TASK_TYPE,
+  ): Observable<HuggingFaceModelResult[]> {
     return this.http.get<HuggingFaceModelResult[]>(
       `${this.baseUrl()}/huggingface-models`,
-      { params: { search: query, compatible_only: compatibleOnly.toString() } },
+      {
+        params: {
+          search: query,
+          compatible_only: compatibleOnly.toString(),
+          task_type: taskType,
+        },
+      },
     );
   }
 

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.spec.ts
@@ -11,14 +11,15 @@ describe('FineTuningStateService', () => {
 
   const mockAccess: FineTuningAccessResponse = {
     has_access: true,
-    monthly_quota_hours: 10,
-    current_month_usage_hours: 3,
+    monthly_quota_usd: 10,
+    current_month_usage_usd: 3,
     quota_period: '2026-03',
   };
 
   const mockTrainingJob: JobResponse = {
     job_id: 'j1', user_id: 'u1', email: 'test@example.com', model_id: 'm1',
     model_name: 'Llama', status: 'TRAINING', dataset_s3_key: 'key', output_s3_prefix: null,
+    task_type: 'text-classification',
     instance_type: 'ml.g5.2xlarge', instance_count: 1, hyperparameters: null,
     sagemaker_job_name: null, training_start_time: null, training_end_time: null,
     billable_seconds: null, estimated_cost_usd: null, created_at: '2026-03-01T00:00:00Z',
@@ -106,7 +107,7 @@ describe('FineTuningStateService', () => {
   });
 
   it('should cap quotaUsedPercent at 100', () => {
-    service.access.set({ ...mockAccess, current_month_usage_hours: 15, monthly_quota_hours: 10 });
+    service.access.set({ ...mockAccess, current_month_usage_usd: 15, monthly_quota_usd: 10 });
     expect(service.quotaUsedPercent()).toBe(100);
   });
 

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.ts
@@ -63,8 +63,8 @@ export class FineTuningStateService {
   /** Quota usage percentage (0-100). */
   readonly quotaUsedPercent = computed(() => {
     const a = this.access();
-    if (!a?.monthly_quota_hours || !a.current_month_usage_hours) return 0;
-    return Math.min(100, (a.current_month_usage_hours / a.monthly_quota_hours) * 100);
+    if (!a?.monthly_quota_usd || !a.current_month_usage_usd) return 0;
+    return Math.min(100, (a.current_month_usage_usd / a.monthly_quota_usd) * 100);
   });
 
   /** Total number of training jobs. */


### PR DESCRIPTION
Extends fine-tuning beyond text to **image classification** and **image + text classification**, and moves the quota from GPU-hours to dollars.

Generative vision-language models (`image-text-to-text`) are deliberately **out of scope** — they emit tokens rather than a class distribution, which would mean a new output contract through Batch Transform and the whole result viewer. Keeping to classification means all three tasks share one output shape.

## Why a re-architecture

Everything task-specific was hardcoded inline in `train.py` and `inference.py`: the `AutoModelForSequenceClassification` call, a `("text","label")` column contract, a `max_length` tokenizer map, accuracy-on-argmax. Adding a modality meant branching inside those functions.

`task_types.py` is now the organizing primitive. A `TaskSpec` declares its dataset contract, upload/inference payload shapes, HF pipeline tags, default instance, and **DLC family**. `train.py` and `inference.py` became dispatchers; the modality-specific work lives in `task_*.py` modules. Adding a task is a registration plus a module.

**Text jobs are untouched at runtime.** Keying the DLC image by task family means text stays on the exact transformers 4.36 container every existing model was validated against, while vision gets 4.56 — instead of one shared bump re-baselining all of them.

## Bugs this fixes along the way

- **`ml.g5.16xlarge` was priced at `6.10` against an actual `5.12`** — ~19% overbilling on every job that used it.
- **The whole `ml.p3.*` family had no on-demand SageMaker rate at all.** Those three entries priced instances a job could never provision; `_validate_instance_type` accepted them, so users could pick one and get a failure at provision time.
- **`p4d`/`p5` publish a training rate but no Batch Transform rate.** One shared cost map can't express that, so training and transform rates are now separate tables and those instances are deliberately not offered — otherwise a researcher could fine-tune a model they then cannot run inference on.

Rates come from the AWS Price List API, not the pricing page; `backend/scripts/refresh_instance_pricing.py` regenerates them.

## Quota: hours → dollars

Hours stopped describing the budget the moment a second instance type existed — ten hours buys ~$14 on `ml.g5.xlarge` and ~$450 on `ml.g6e.24xlarge`.

Grants migrate **lazily**: read in the new shape, rewritten on the next quota check, converting at the `g5.xlarge` rate those hours were actually spent at. No backfill script, and a migrated user's existing spend carries across rather than resetting.

Spend is bounded by **clamping `MaxRuntimeInSeconds`** to what the remaining quota affords, not by rejecting on worst-case cost. Worst-case rejection would block essentially every job: the default 24h stopping condition is ~$27 even on the cheapest instance, more than an ordinary monthly quota, though such a job usually finishes in minutes. A job is refused outright only when the remaining budget buys under 30 minutes.

## Guards before a GPU is billed

Each of these turns a job that would provision hardware and fail into a 400 in milliseconds:

- catalog models are rejected for a task they cannot serve;
- a custom HuggingFace id is pre-flighted against the Hub for existence, loadable weights, and modality. This is what refuses a **GGUF-only repository**, which transformers cannot fine-tune at all. A Hub outage explicitly does *not* block submission;
- generative VLMs (LLaVA, Qwen-VL) are excluded from the image+text task, which needs a dual encoder exposing `get_image_features` **and** `get_text_features`;
- Batch Transform instances validate against the transform rate table;
- inference input format is checked against the task the model was actually trained for, read from the job record rather than trusted from the caller.

## Datasets

Image tasks take a single `.zip` holding a manifest (CSV/JSONL/JSON) plus the image files it references. Archives are untrusted input: extraction refuses absolute paths and `../` traversal (Zip-Slip), and manifest rows pointing outside the archive.

## Notable implementation detail

The SageMaker inference toolkit calls `input_fn(input_data, content_type)` — **the loaded model is passed only to `predict_fn`**, and the single-entry `transform_fn` cannot be mixed with the four-function form. The task is therefore recorded at module scope by `model_fn`. Without this an image artifact parses its `.zip` as newline-delimited text and fails every record.

## Testing

- Backend: **7292 passed, 3 skipped** (the 3 remaining skips need torch, which only exists in the DLC).
- Frontend: **205/205 files passed**; `tsc --noEmit` clean for both app and spec configs.
- Both run against this branch **with `develop` merged in**, not an older base.
- `pandas` added to the dev extra and the `importorskip` guards removed, so the archive→DataFrame path is now genuinely covered in CI rather than silently skipped — skips dropped from 11 to 3.

## Infrastructure

**No CDK changes**, so `platform.yml` does not fire on merge — only `backend.yml` and `frontend-deploy.yml`.

The app-api task still receives `FINE_TUNING_DEFAULT_QUOTA_HOURS` from CDK, which the runtime converts (`10` → `$14.08/month`), so the dollar quota works without an infra deploy. Adding a `CDK_FINE_TUNING_DEFAULT_QUOTA_USD` var to express it in the same unit is a sensible follow-up, not a blocker.

 The new DLC images live in the same registry account and the same two repositories as the existing ones, only at different tags, so the SageMaker execution role needs no new permissions. Tags were verified present in `us-east-1`/`us-east-2`/`us-west-2` via `aws ecr describe-images`; `FINE_TUNING_{TRAINING,INFERENCE}_IMAGE_{TEXT,VISION}` override them without a code deploy if a tag is retired or lags a region.

## What has NOT been verified

**No image job has run on real hardware.** Everything above is unit-verified and the container tags are confirmed to exist, but the first real dev run is where a wrong processor size key, a collator shape, or the fusion-head save/load round-trip would surface. That is the point of merging this to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
