### PR TITLE
fix(costs): normalize OpenAI-family token usage to disjoint buckets

### DIFF
--- a/backend/src/agents/main_agent/core/agent_factory.py
+++ b/backend/src/agents/main_agent/core/agent_factory.py
@@ -13,6 +13,7 @@ from agents.main_agent.core.bedrock_count_tokens import CountTokensBedrockModel
 from agents.main_agent.core.model_config import ModelConfig, ModelProvider
 from agents.main_agent.config.constants import EnvVars
 from apis.shared.models.mantle import build_mantle_model
+from apis.shared.models.usage_normalization import usage_normalized
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,11 @@ class AgentFactory:
         client_args = {"api_key": api_key}
 
         logger.info(f"Creating OpenAI model with model_id={model_config.model_id}")
-        return OpenAIModel(client_args=client_args, **openai_config)
+        # Wrapped for Bedrock-Converse token-bucket semantics — OpenAI's
+        # `input_tokens` is inclusive of the cache buckets, which our cost and
+        # context-size math treats as disjoint. See
+        # apis/shared/models/usage_normalization.py.
+        return usage_normalized(OpenAIModel)(client_args=client_args, **openai_config)
 
     @staticmethod
     def _create_mantle_model(model_config: ModelConfig):

--- a/backend/src/agents/main_agent/streaming/stream_coordinator.py
+++ b/backend/src/agents/main_agent/streaming/stream_coordinator.py
@@ -719,6 +719,11 @@ class StreamCoordinator:
                     # cacheReadInputTokens. Summing all three buckets
                     # below is the only correct "current context size"
                     # under caching.
+                    #
+                    # The sum is only correct because the buckets are
+                    # disjoint. OpenAI-family models report an inclusive
+                    # inputTokens and are normalized to this convention at
+                    # the model seam — apis/shared/models/usage_normalization.py.
                     if hasattr(session_manager, "update_after_turn"):
                         usage = accumulated_metadata.get("usage", {})
                         total_input_tokens = (

--- a/backend/src/apis/shared/costs/calculator.py
+++ b/backend/src/apis/shared/costs/calculator.py
@@ -69,6 +69,11 @@ class CostCalculator:
         # - cacheReadInputTokens: tokens read from cache
         # - cacheWriteInputTokens: tokens written to cache
         # Total input = inputTokens + cacheReadInputTokens + cacheWriteInputTokens
+        #
+        # That is the Bedrock Converse convention. The OpenAI family reports an
+        # *inclusive* inputTokens instead, so its usage is rewritten to this
+        # shape at the model seam — see apis/shared/models/usage_normalization.py.
+        # Feeding raw OpenAI usage in here bills every cached token twice.
 
         # Calculate costs (per million tokens)
         input_cost = (input_tokens / 1_000_000) * input_price

--- a/backend/src/apis/shared/models/mantle.py
+++ b/backend/src/apis/shared/models/mantle.py
@@ -18,6 +18,8 @@ the declared API mode and forward the region + already-native params.
 from enum import Enum
 from typing import Any, Dict, Optional
 
+from .usage_normalization import usage_normalized
+
 
 class MantleApiMode(str, Enum):
     """OpenAI-compatible API surface a Bedrock Mantle model speaks.
@@ -121,7 +123,12 @@ def build_mantle_model(
     if region:
         bedrock_mantle_config["region"] = region
 
-    model_cls = (
+    # Wrapped so the model reports Bedrock-Converse token-bucket semantics:
+    # OpenAI's `input_tokens` is inclusive of the cache buckets, and Strands
+    # drops `cache_write_tokens` outright. Applied here — the single OpenAI-
+    # family construction seam both consumers share — so no downstream reader
+    # of the usage dict needs to know which provider produced it.
+    model_cls = usage_normalized(
         OpenAIResponsesModel
         if api_mode == MantleApiMode.RESPONSES
         else OpenAIModel

--- a/backend/src/apis/shared/models/usage_normalization.py
+++ b/backend/src/apis/shared/models/usage_normalization.py
@@ -1,0 +1,241 @@
+"""Provider-aware token-usage normalization.
+
+Every cost and context-size path we own assumes the **Bedrock Converse**
+convention: ``inputTokens``, ``cacheReadInputTokens`` and
+``cacheWriteInputTokens`` are three *disjoint* buckets whose sum is the call's
+total input. ``CostCalculator.calculate_message_cost`` documents that contract
+and prices each bucket at its own rate; the context-attribution sum in the
+stream coordinator adds all three to get "current context size".
+
+The OpenAI family reports the opposite convention — ``input_tokens`` is
+**inclusive**. Per AWS's GPT-5.6 prompt-caching guidance the identity is::
+
+    input_tokens = cached_tokens + cache_write_tokens + non-cached remainder
+
+Strands passes ``input_tokens`` straight through as ``inputTokens`` while
+*also* reporting ``cacheReadInputTokens``
+(``strands/models/openai_responses.py`` and ``strands/models/openai.py``), so
+without normalization every cached token is billed twice: once at the full
+input rate and once at the cache-read rate. With cache writes it is worse —
+a written token would be billed at the input rate *plus* the 1.25x write
+premium.
+
+This module fixes both halves, once, at the earliest seam we control:
+
+1. :func:`normalize_usage` restores disjointness for the OpenAI family and
+   leaves Bedrock usage untouched.
+2. :func:`usage_normalized` wraps a Strands OpenAI-family model class so the
+   normalization is applied while the model formats its ``metadata`` chunk —
+   ahead of the cost calculator, the metadata writers, the prompt-cache
+   observability layer and the SSE stream. Downstream consumers keep reading
+   plain Converse-shaped usage dicts and need no provider awareness.
+
+The wrapper is also where ``cache_write_tokens`` re-enters the pipeline.
+Strands never reads it off the Responses usage object, so
+``cacheWriteInputTokens`` is structurally 0 for GPT-5.6 — which pins
+``wastedUsd`` at $0 and makes the 1.25x write premium invisible, the same
+blind spot that let the compaction spiral run unnoticed. An upstream patch is
+in flight; until it lands (and on any older pin) this mapping is the only
+source of the field.
+
+⚠️ :func:`normalize_usage` is **not idempotent** for the OpenAI family — it
+subtracts. Apply it exactly once per usage payload, at the model seam. Do not
+add a second call at a site that reads the usage dict.
+"""
+
+import logging
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class UsageProvider(str, Enum):
+    """Token-accounting convention a model's usage payload follows.
+
+    ``BEDROCK`` — Converse semantics: the three input buckets are already
+    disjoint. Also the correct value for any provider that follows the same
+    convention; normalization is a no-op.
+
+    ``OPENAI`` — Chat Completions *and* the Responses API: ``inputTokens`` is
+    inclusive of the cache buckets and must have them subtracted out.
+    """
+
+    BEDROCK = "bedrock"
+    OPENAI = "openai"
+
+
+def normalize_usage(
+    usage: Mapping[str, Any],
+    provider: UsageProvider,
+) -> Dict[str, Any]:
+    """Return a copy of ``usage`` whose input buckets are disjoint.
+
+    Args:
+        usage: Converse-shaped usage dict (``inputTokens``, ``outputTokens``,
+            ``totalTokens``, and optionally ``cacheReadInputTokens`` /
+            ``cacheWriteInputTokens``).
+        provider: The convention ``usage`` currently follows.
+
+    Returns:
+        A new dict. For :attr:`UsageProvider.BEDROCK` it is an unmodified copy.
+        For :attr:`UsageProvider.OPENAI`, ``inputTokens`` has the cache buckets
+        subtracted out, clamped at 0.
+
+    Note:
+        Not idempotent for the OpenAI family — see the module docstring.
+    """
+    normalized: Dict[str, Any] = dict(usage)
+
+    if provider != UsageProvider.OPENAI:
+        return normalized
+
+    cache_read = normalized.get("cacheReadInputTokens") or 0
+    cache_write = normalized.get("cacheWriteInputTokens") or 0
+    if not cache_read and not cache_write:
+        return normalized
+
+    input_tokens = normalized.get("inputTokens") or 0
+    # Clamp: a provider bug that reports cache buckets larger than the
+    # inclusive total (it has happened upstream) must not produce a negative
+    # bucket that the calculator would silently credit against the bill.
+    normalized["inputTokens"] = max(0, input_tokens - cache_read - cache_write)
+    return normalized
+
+
+def openai_cache_write_tokens(usage_obj: Any) -> Optional[int]:
+    """Read ``cache_write_tokens`` off a raw OpenAI usage object.
+
+    GPT-5.6 reports it at ``usage.input_tokens_details.cache_write_tokens``.
+    The OpenAI SDK's models permit extra fields, so on an SDK pin that predates
+    the field it still arrives as a passthrough attribute. The top level is
+    checked as well because some OpenAI-compatible gateways hoist it there.
+
+    Args:
+        usage_obj: The provider usage object (``ResponseUsage`` or compatible).
+
+    Returns:
+        The token count, or ``None`` when the field is absent or not an int.
+        ``False`` / ``bool`` values are rejected — ``bool`` is an ``int``
+        subclass and would otherwise coerce to 0/1.
+    """
+    if usage_obj is None:
+        return None
+
+    details = getattr(usage_obj, "input_tokens_details", None)
+    for source in (details, usage_obj):
+        if source is None:
+            continue
+        value = getattr(source, "cache_write_tokens", None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+
+    return None
+
+
+# Strands formats every provider chunk through one method per model class, but
+# the two OpenAI-family classes disagree on its name: OpenAIModel exposes a
+# public `format_chunk`, OpenAIResponsesModel a private `_format_chunk`.
+_CHUNK_FORMATTER_NAMES = ("_format_chunk", "format_chunk")
+
+# Subclasses are memoized so repeated model construction reuses one type —
+# keeps `isinstance` stable and avoids leaking a class per agent build.
+_NORMALIZED_CLASSES: Dict[type, type] = {}
+
+
+def _normalize_metadata_chunk(event: Mapping[str, Any], chunk: Any) -> Any:
+    """Rewrite a formatted ``metadata`` chunk into Converse usage semantics.
+
+    Args:
+        event: The raw Strands chunk event; ``event["data"]`` is the provider
+            usage object, the only place ``cache_write_tokens`` survives.
+        chunk: The ``StreamEvent`` the base model produced for that event.
+
+    Returns:
+        ``chunk``, mutated in place when it carried a usage payload.
+    """
+    if not isinstance(chunk, dict):
+        return chunk
+
+    metadata = chunk.get("metadata")
+    if not isinstance(metadata, dict):
+        return chunk
+
+    usage = metadata.get("usage")
+    if not isinstance(usage, dict):
+        return chunk
+
+    # Recover the field Strands drops, before disjointness is computed — the
+    # written tokens are part of the inclusive `input_tokens` and have to come
+    # out of it too, or they are billed at input + 1.25x write.
+    cache_write = openai_cache_write_tokens(event.get("data"))
+    if cache_write:
+        usage["cacheWriteInputTokens"] = cache_write
+
+    usage.update(normalize_usage(usage, UsageProvider.OPENAI))
+    return chunk
+
+
+def usage_normalized(base_cls: Any) -> Any:
+    """Return a subclass of a Strands OpenAI-family model that reports disjoint usage.
+
+    Args:
+        base_cls: ``OpenAIModel`` or ``OpenAIResponsesModel`` (or a subclass).
+
+    Returns:
+        A memoized subclass whose chunk formatter normalizes usage. Anything
+        that is not a class is returned unchanged — ``unittest.mock.patch``
+        replaces a class with a non-type, and production always passes a real
+        class.
+
+    Raises:
+        TypeError: If the class exposes neither chunk-formatter name. Failing
+            loudly is deliberate: a silent fallthrough would double-bill every
+            OpenAI-family token with no symptom other than the bill.
+    """
+    if not isinstance(base_cls, type):
+        return base_cls
+
+    cached = _NORMALIZED_CLASSES.get(base_cls)
+    if cached is not None:
+        return cached
+
+    formatter_name = next(
+        (name for name in _CHUNK_FORMATTER_NAMES if hasattr(base_cls, name)),
+        None,
+    )
+    if formatter_name is None:
+        raise TypeError(
+            f"{base_cls.__name__} exposes neither "
+            f"{' nor '.join(_CHUNK_FORMATTER_NAMES)}; the Strands chunk-"
+            "formatting seam moved. OpenAI token usage cannot be normalized — "
+            "update apis/shared/models/usage_normalization.py."
+        )
+
+    def _formatter(self: Any, event: Dict[str, Any], **kwargs: Any) -> Any:
+        chunk = getattr(super(subclass, self), formatter_name)(event, **kwargs)
+        return _normalize_metadata_chunk(event, chunk)
+
+    _formatter.__name__ = formatter_name
+    _formatter.__qualname__ = f"UsageNormalized{base_cls.__name__}.{formatter_name}"
+    _formatter.__doc__ = (
+        "Format a chunk, then restore Bedrock-Converse token-bucket semantics."
+    )
+
+    subclass = type(
+        f"UsageNormalized{base_cls.__name__}",
+        (base_cls,),
+        {
+            formatter_name: _formatter,
+            "__doc__": (
+                f"{base_cls.__name__} that reports disjoint token buckets.\n\n"
+                "See apis/shared/models/usage_normalization.py — OpenAI's "
+                "inclusive `input_tokens` is double-billed by our cost paths "
+                "otherwise, and Strands drops `cache_write_tokens` entirely."
+            ),
+        },
+    )
+
+    _NORMALIZED_CLASSES[base_cls] = subclass
+    logger.debug("Installed usage normalization on %s", base_cls.__name__)
+    return subclass

--- a/backend/tests/costs/test_calculator.py
+++ b/backend/tests/costs/test_calculator.py
@@ -280,3 +280,111 @@ class TestValidateUsage:
             "inputTokens": None,
             "outputTokens": 50,
         }) is False
+
+
+# GPT-5.6 Sol ($/Mtok), transcribed from the model card. Only the ratios are
+# load-bearing here: cache reads are a 90% discount off input, cache writes a
+# 1.25x premium. The absolute rates are re-verified against the Price List API
+# before any catalog row ships them.
+GPT_56_SOL_PRICING = {
+    "inputPricePerMtok": 4.40,
+    "outputPricePerMtok": 17.60,
+    "cacheReadPricePerMtok": 0.44,
+    "cacheWritePricePerMtok": 5.50,
+}
+
+
+class TestOpenAIFamilyCostAfterUsageNormalization:
+    """GPT-5.6 costs are only right once its usage buckets are disjoint.
+
+    OpenAI reports an *inclusive* ``input_tokens``; Strands forwards it as
+    ``inputTokens`` alongside ``cacheReadInputTokens``. Fed in raw, every
+    cached token is priced at the input rate AND the cache-read rate. The
+    normalization at apis/shared/models/usage_normalization.py is what makes
+    the numbers below correct — these tests pin the dollar consequence.
+    """
+
+    def test_fully_cached_call_costs_only_the_cache_read_rate(self):
+        # 30k-token stable prefix served entirely from cache, no new input.
+        normalized_usage = {
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "cacheReadInputTokens": 30_000,
+        }
+
+        total_cost, breakdown = CostCalculator.calculate_message_cost(
+            normalized_usage, GPT_56_SOL_PRICING
+        )
+
+        assert total_cost == pytest.approx(30_000 / 1_000_000 * 0.44)
+        assert total_cost == pytest.approx(0.0132)
+        assert breakdown.input_cost == 0.0
+
+    def test_raw_openai_usage_would_double_bill_the_same_call(self):
+        """The regression guard: what the un-normalized dict costs."""
+        raw_usage = {
+            "inputTokens": 30_000,  # OpenAI's inclusive total
+            "outputTokens": 0,
+            "cacheReadInputTokens": 30_000,
+        }
+
+        double_billed, _ = CostCalculator.calculate_message_cost(
+            raw_usage, GPT_56_SOL_PRICING
+        )
+        correct, _ = CostCalculator.calculate_message_cost(
+            {**raw_usage, "inputTokens": 0}, GPT_56_SOL_PRICING
+        )
+
+        assert double_billed == pytest.approx(30_000 / 1_000_000 * (4.40 + 0.44))
+        # 11x the real cost — the cache discount is not merely lost, the
+        # cached tokens are charged twice over.
+        assert double_billed == pytest.approx(correct * 11.0)
+
+    def test_cache_write_premium_is_not_stacked_on_the_input_rate(self):
+        # A turn that writes a 30k prefix to cache: those tokens are inside
+        # OpenAI's input_tokens, so normalization subtracts them out and they
+        # are billed once, at 1.25x.
+        normalized_usage = {
+            "inputTokens": 100,
+            "outputTokens": 0,
+            "cacheWriteInputTokens": 30_000,
+        }
+
+        total_cost, breakdown = CostCalculator.calculate_message_cost(
+            normalized_usage, GPT_56_SOL_PRICING
+        )
+
+        assert breakdown.cache_write_cost == pytest.approx(30_000 / 1_000_000 * 5.50)
+        assert breakdown.input_cost == pytest.approx(100 / 1_000_000 * 4.40)
+        assert total_cost == pytest.approx(0.16544)
+
+    def test_mixed_read_write_call_prices_each_bucket_once(self):
+        # The realistic 5.6 turn: most of the prefix read from cache, a small
+        # increment written, a little genuinely new input. Buckets partition
+        # the 30,500 inclusive input tokens OpenAI reported.
+        normalized_usage = {
+            "inputTokens": 100,
+            "outputTokens": 120,
+            "cacheReadInputTokens": 30_000,
+            "cacheWriteInputTokens": 400,
+        }
+
+        total_cost, breakdown = CostCalculator.calculate_message_cost(
+            normalized_usage, GPT_56_SOL_PRICING
+        )
+
+        assert (
+            normalized_usage["inputTokens"]
+            + normalized_usage["cacheReadInputTokens"]
+            + normalized_usage["cacheWriteInputTokens"]
+        ) == 30_500
+        assert breakdown.input_cost == pytest.approx(100 / 1_000_000 * 4.40)
+        assert breakdown.cache_read_cost == pytest.approx(30_000 / 1_000_000 * 0.44)
+        assert breakdown.cache_write_cost == pytest.approx(400 / 1_000_000 * 5.50)
+        assert breakdown.output_cost == pytest.approx(120 / 1_000_000 * 17.60)
+        assert total_cost == pytest.approx(
+            breakdown.input_cost
+            + breakdown.output_cost
+            + breakdown.cache_read_cost
+            + breakdown.cache_write_cost
+        )

--- a/backend/tests/shared/test_usage_normalization.py
+++ b/backend/tests/shared/test_usage_normalization.py
@@ -1,0 +1,339 @@
+"""Unit tests for provider-aware token-usage normalization.
+
+The invariant under test is the one ``CostCalculator`` and the context-size
+sum in the stream coordinator both depend on: ``inputTokens``,
+``cacheReadInputTokens`` and ``cacheWriteInputTokens`` are **disjoint**, and
+their sum is the call's total input.
+
+Bedrock Converse already satisfies it. The OpenAI family does not — per AWS's
+GPT-5.6 prompt-caching guidance ``input_tokens = cached_tokens +
+cache_write_tokens + non-cached remainder`` — so its usage is rewritten at the
+model seam.
+
+The SDK-shape tests below deliberately drive the *real* ``strands`` model
+classes with *real* ``openai`` usage objects rather than hand-rolled stubs. A
+stub that merely matches the broken behavior would hide the bug, and the whole
+mapping hangs off two SDK details (the chunk-formatter method name, and the
+fact that Strands drops ``cache_write_tokens``) that a version bump can move.
+"""
+
+import pytest
+
+from apis.shared.models.usage_normalization import (
+    UsageProvider,
+    normalize_usage,
+    openai_cache_write_tokens,
+    usage_normalized,
+)
+
+
+# Wire-shaped usage payloads, as the provider returns them.
+#
+# GPT-5.6 Responses: a 30k stable prefix served from cache, a 400-token
+# increment written to cache, ~100 tokens of genuinely new input.
+OPENAI_RESPONSES_WIRE_USAGE = {
+    "input_tokens": 30_500,
+    "input_tokens_details": {"cached_tokens": 30_000, "cache_write_tokens": 400},
+    "output_tokens": 120,
+    "output_tokens_details": {"reasoning_tokens": 64},
+    "total_tokens": 30_620,
+}
+
+# GPT-5.4 Chat Completions: implicit caching only, no write bucket exists.
+OPENAI_CHAT_WIRE_USAGE = {
+    "prompt_tokens": 5_000,
+    "completion_tokens": 50,
+    "total_tokens": 5_050,
+    "prompt_tokens_details": {"cached_tokens": 4_096},
+}
+
+
+def _assert_disjoint(usage: dict) -> None:
+    """Assert the three input buckets partition the call's total input."""
+    total_input = (
+        (usage.get("inputTokens") or 0)
+        + (usage.get("cacheReadInputTokens") or 0)
+        + (usage.get("cacheWriteInputTokens") or 0)
+    )
+    assert total_input == (usage["totalTokens"] - usage["outputTokens"]), (
+        "input buckets must partition total input; overlapping buckets are "
+        "double-billed by CostCalculator"
+    )
+
+
+class TestNormalizeUsageDisjointInvariant:
+    """The per-provider contract: what gets rewritten and what must not."""
+
+    def test_bedrock_usage_is_already_disjoint_and_untouched(self):
+        # Converse reports the three buckets pre-partitioned.
+        usage = {
+            "inputTokens": 100,
+            "outputTokens": 120,
+            "totalTokens": 30_620,
+            "cacheReadInputTokens": 30_000,
+            "cacheWriteInputTokens": 400,
+        }
+        _assert_disjoint(usage)
+
+        normalized = normalize_usage(usage, UsageProvider.BEDROCK)
+
+        assert normalized == usage
+        _assert_disjoint(normalized)
+
+    def test_openai_usage_is_normalized_to_disjoint(self):
+        # What Strands hands us for GPT-5.6 once cache_write_tokens is mapped:
+        # inputTokens is the *inclusive* total.
+        usage = {
+            "inputTokens": 30_500,
+            "outputTokens": 120,
+            "totalTokens": 30_620,
+            "cacheReadInputTokens": 30_000,
+            "cacheWriteInputTokens": 400,
+        }
+        with pytest.raises(AssertionError):
+            _assert_disjoint(usage)
+
+        normalized = normalize_usage(usage, UsageProvider.OPENAI)
+
+        assert normalized["inputTokens"] == 100
+        assert normalized["cacheReadInputTokens"] == 30_000
+        assert normalized["cacheWriteInputTokens"] == 400
+        _assert_disjoint(normalized)
+
+    def test_openai_read_only_call_subtracts_only_the_read_bucket(self):
+        usage = {
+            "inputTokens": 5_000,
+            "outputTokens": 50,
+            "totalTokens": 5_050,
+            "cacheReadInputTokens": 4_096,
+        }
+        normalized = normalize_usage(usage, UsageProvider.OPENAI)
+
+        assert normalized["inputTokens"] == 904
+        _assert_disjoint(normalized)
+
+    def test_openai_uncached_call_is_unchanged(self):
+        usage = {"inputTokens": 1_000, "outputTokens": 50, "totalTokens": 1_050}
+
+        assert normalize_usage(usage, UsageProvider.OPENAI) == usage
+
+    def test_negative_result_is_clamped_at_zero(self):
+        # Guards against the upstream reporting bug where the cache buckets
+        # summed to more than the inclusive total: a negative bucket would
+        # credit dollars back against the bill.
+        usage = {
+            "inputTokens": 4_583,
+            "outputTokens": 10,
+            "totalTokens": 4_593,
+            "cacheReadInputTokens": 3_945,
+            "cacheWriteInputTokens": 4_580,
+        }
+        assert normalize_usage(usage, UsageProvider.OPENAI)["inputTokens"] == 0
+
+    def test_none_valued_buckets_are_treated_as_zero(self):
+        usage = {
+            "inputTokens": None,
+            "outputTokens": 10,
+            "totalTokens": 10,
+            "cacheReadInputTokens": None,
+            "cacheWriteInputTokens": None,
+        }
+        assert normalize_usage(usage, UsageProvider.OPENAI) == usage
+
+    def test_returns_a_copy_and_never_mutates_the_input(self):
+        usage = {
+            "inputTokens": 30_500,
+            "outputTokens": 120,
+            "totalTokens": 30_620,
+            "cacheReadInputTokens": 30_000,
+        }
+        normalized = normalize_usage(usage, UsageProvider.OPENAI)
+
+        assert normalized is not usage
+        assert usage["inputTokens"] == 30_500
+
+
+class TestOpenAICacheWriteExtraction:
+    """`cache_write_tokens` recovery, against the real openai usage models."""
+
+    def test_reads_from_input_tokens_details(self):
+        from openai.types.responses.response_usage import ResponseUsage
+
+        usage_obj = ResponseUsage.model_validate(OPENAI_RESPONSES_WIRE_USAGE)
+
+        assert openai_cache_write_tokens(usage_obj) == 400
+
+    def test_reads_from_top_level_when_a_gateway_hoists_it(self):
+        from openai.types.responses.response_usage import ResponseUsage
+
+        payload = dict(OPENAI_RESPONSES_WIRE_USAGE)
+        payload["input_tokens_details"] = {"cached_tokens": 30_000}
+        payload["cache_write_tokens"] = 400
+
+        assert openai_cache_write_tokens(ResponseUsage.model_validate(payload)) == 400
+
+    def test_absent_field_returns_none(self):
+        from openai.types.completion_usage import CompletionUsage
+
+        usage_obj = CompletionUsage.model_validate(OPENAI_CHAT_WIRE_USAGE)
+
+        assert openai_cache_write_tokens(usage_obj) is None
+
+    def test_none_usage_object_returns_none(self):
+        assert openai_cache_write_tokens(None) is None
+
+    def test_bool_is_rejected_rather_than_coerced(self):
+        class _Usage:
+            cache_write_tokens = True
+
+        assert openai_cache_write_tokens(_Usage()) is None
+
+
+class TestStrandsSdkContract:
+    """Pin the two SDK facts the shim is built on.
+
+    If a Strands bump breaks either, these fail loudly here rather than
+    silently double-billing every OpenAI-family token in production.
+    """
+
+    def test_chunk_formatter_seams_still_exist(self):
+        from strands.models import OpenAIResponsesModel
+        from strands.models.openai import OpenAIModel
+
+        # The Responses model formats through a private seam, the Chat
+        # Completions model through a public one. usage_normalized() picks
+        # whichever exists; it raises TypeError if neither does.
+        assert hasattr(OpenAIResponsesModel, "_format_chunk")
+        assert hasattr(OpenAIModel, "format_chunk")
+
+    def test_sdk_still_reports_inclusive_input_and_drops_cache_writes(self):
+        """The bug this module exists to fix, asserted against the real SDK."""
+        from openai.types.responses.response_usage import ResponseUsage
+        from strands.models import OpenAIResponsesModel
+
+        model = OpenAIResponsesModel(
+            bedrock_mantle_config={"region": "us-west-2"},
+            model_id="openai.gpt-5.6-sol",
+        )
+        usage_obj = ResponseUsage.model_validate(OPENAI_RESPONSES_WIRE_USAGE)
+
+        raw = model._format_chunk({"chunk_type": "metadata", "data": usage_obj})
+        usage = raw["metadata"]["usage"]
+
+        # inputTokens is the inclusive total, not the uncached remainder...
+        assert usage["inputTokens"] == 30_500
+        assert usage["cacheReadInputTokens"] == 30_000
+        # ...and the write bucket never makes it out of the SDK.
+        assert "cacheWriteInputTokens" not in usage
+
+        with pytest.raises(AssertionError):
+            _assert_disjoint(usage)
+
+    def test_usage_normalized_raises_when_the_seam_disappears(self):
+        class _Seamless:
+            pass
+
+        with pytest.raises(TypeError, match="chunk-formatting seam moved"):
+            usage_normalized(_Seamless)
+
+
+class TestUsageNormalizedModelClass:
+    """End-to-end through the wrapped model classes."""
+
+    def test_responses_model_emits_disjoint_usage_with_cache_writes(self):
+        from openai.types.responses.response_usage import ResponseUsage
+        from strands.models import OpenAIResponsesModel
+
+        model = usage_normalized(OpenAIResponsesModel)(
+            bedrock_mantle_config={"region": "us-west-2"},
+            model_id="openai.gpt-5.6-sol",
+        )
+        usage_obj = ResponseUsage.model_validate(OPENAI_RESPONSES_WIRE_USAGE)
+
+        chunk = model._format_chunk({"chunk_type": "metadata", "data": usage_obj})
+        usage = chunk["metadata"]["usage"]
+
+        assert usage["inputTokens"] == 100
+        assert usage["cacheReadInputTokens"] == 30_000
+        assert usage["cacheWriteInputTokens"] == 400
+        _assert_disjoint(usage)
+
+    def test_chat_completions_model_emits_disjoint_usage(self):
+        from openai.types.completion_usage import CompletionUsage
+        from strands.models.openai import OpenAIModel
+
+        model = usage_normalized(OpenAIModel)(
+            client_args={"api_key": "test-key"}, model_id="openai.gpt-5.4"
+        )
+        usage_obj = CompletionUsage.model_validate(OPENAI_CHAT_WIRE_USAGE)
+
+        chunk = model.format_chunk({"chunk_type": "metadata", "data": usage_obj})
+        usage = chunk["metadata"]["usage"]
+
+        assert usage["inputTokens"] == 904
+        assert usage["cacheReadInputTokens"] == 4_096
+        # No write bucket exists on Chat Completions — don't invent one.
+        assert "cacheWriteInputTokens" not in usage
+        _assert_disjoint(usage)
+
+    def test_non_metadata_chunks_pass_through_untouched(self):
+        from strands.models import OpenAIResponsesModel
+
+        model = usage_normalized(OpenAIResponsesModel)(
+            bedrock_mantle_config={"region": "us-west-2"},
+            model_id="openai.gpt-5.6-sol",
+        )
+        chunk = model._format_chunk(
+            {"chunk_type": "content_delta", "data_type": "text", "data": "hi"}
+        )
+
+        assert chunk == {"contentBlockDelta": {"delta": {"text": "hi"}}}
+
+    def test_subclass_is_memoized_and_keeps_isinstance(self):
+        from strands.models import OpenAIResponsesModel
+
+        first = usage_normalized(OpenAIResponsesModel)
+        second = usage_normalized(OpenAIResponsesModel)
+
+        assert first is second
+        assert issubclass(first, OpenAIResponsesModel)
+
+    def test_non_class_passes_through(self):
+        """`unittest.mock.patch` swaps a class for a non-type; don't crash."""
+        from unittest.mock import MagicMock
+
+        mock_cls = MagicMock()
+
+        assert usage_normalized(mock_cls) is mock_cls
+
+
+class TestBuildMantleModelInstallsNormalization:
+    """The shared builder is the seam both `agents/` and `app_api` go through."""
+
+    def test_responses_mode_model_is_normalized(self):
+        from strands.models import OpenAIResponsesModel
+
+        from apis.shared.models.mantle import MantleApiMode, build_mantle_model
+
+        model = build_mantle_model(
+            model_id="openai.gpt-5.6-sol",
+            api_mode=MantleApiMode.RESPONSES,
+            region="us-west-2",
+        )
+
+        assert isinstance(model, OpenAIResponsesModel)
+        assert type(model) is usage_normalized(OpenAIResponsesModel)
+
+    def test_chat_mode_model_is_normalized(self):
+        from strands.models.openai import OpenAIModel
+
+        from apis.shared.models.mantle import MantleApiMode, build_mantle_model
+
+        model = build_mantle_model(
+            model_id="openai.gpt-oss-120b",
+            api_mode=MantleApiMode.CHAT_COMPLETIONS,
+            region="us-west-2",
+        )
+
+        assert isinstance(model, OpenAIModel)
+        assert type(model) is usage_normalized(OpenAIModel)


### PR DESCRIPTION
## PR-1 of [`docs/specs/gpt-5-6-prompt-caching.md`](https://github.com/Boise-State-Development/agentcore-public-stack/pull/943)

Normalizes OpenAI-family token-usage semantics so GPT-5 models are costed correctly. Blocks PR-2..PR-5 in that spec.

## The bug

Every cost and context-size path we own assumes the **Bedrock Converse** convention: `inputTokens`, `cacheReadInputTokens` and `cacheWriteInputTokens` are three **disjoint** buckets. `CostCalculator.calculate_message_cost` documents that contract and prices each bucket separately; the context-attribution sum in `stream_coordinator.py` adds all three.

The OpenAI family reports the opposite. Per [AWS's GPT-5.6 prompt-caching guidance](https://aws.amazon.com/blogs/machine-learning/introducing-explicit-prompt-caching-for-openai-gpt-5-6-models-on-amazon-bedrock/):

```
input_tokens = cached_tokens + cache_write_tokens + non-cached remainder
```

Strands forwards `input_tokens` verbatim as `inputTokens` while *also* reporting `cacheReadInputTokens` (`strands/models/openai_responses.py:894`, `strands/models/openai.py:593`). So every cached token was billed twice — once at the full input rate and once at the cache-read rate.

Measured against the real SDK on the pinned `strands-agents==1.51.0`, a 30k-token fully-cached GPT-5.6 Sol prefix:

| | `inputTokens` | `cacheRead` | `cacheWrite` | cost |
|---|---|---|---|---|
| Strands, as-is | 30,500 | 30,000 | *(dropped)* | $0.1452 |
| after this PR | 100 | 30,000 | 400 | $0.0132 |

**11x.** Not "the cache discount is lost" — the cached tokens are charged twice over.

Second half: Strands never reads `cache_write_tokens` off the Responses usage object, so `cacheWriteInputTokens` is structurally 0 for GPT-5.6. That pins `wastedUsd` at $0 and makes the 1.25x write premium invisible — the same blind spot that let the [compaction spiral](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/compaction-over-threshold-cache-spiral.md) burn a faculty quota unnoticed.

**This is live today**, not a GPT-5.6-only concern: `openai.gpt-5.4` on Mantle has the read half of the bug right now.

## The fix

New `backend/src/apis/shared/models/usage_normalization.py` — a provider-aware shim applied **once**, at the model seam, ahead of the calculator, the metadata writers, the prompt-cache observability layer and the SSE stream:

- `normalize_usage(usage, provider)` — Bedrock passes through untouched; OpenAI gets the cache buckets subtracted out of the inclusive `inputTokens`, clamped at 0.
- `openai_cache_write_tokens(usage_obj)` — recovers `input_tokens_details.cache_write_tokens` (also checks the top level, where some gateways hoist it).
- `usage_normalized(model_cls)` — memoized subclass that applies both while the model formats its `metadata` chunk.

Downstream readers keep consuming plain Converse-shaped usage dicts and need no provider awareness. Installed at the two OpenAI-family *construction* sites — `build_mantle_model` (shared by `agents/` and app_api's `/chat/api-converse`) and the direct-OpenAI provider in `AgentFactory`. Bedrock, Gemini and every other path are untouched.

`apis/shared/` per the import boundary; `tests/architecture/test_import_boundaries.py` passes.

## ⚠️ One deviation from the spec

The spec says `inputTokens -= cacheReadInputTokens`. That was written when `cacheWriteInputTokens` was always 0, so it only had to account for reads. Once this PR maps `cache_write_tokens`, the *same* double-count reappears for writes — and worse, at input + 1.25x rather than input + 0.1x. The AWS identity quoted above is explicit that written tokens are inside `input_tokens` too, so the shim subtracts **both** buckets. Worth folding back into #943 before it merges.

## Tests

`backend/tests/shared/test_usage_normalization.py` (22 cases) and a new `TestOpenAIFamilyCostAfterUsageNormalization` class in `backend/tests/costs/test_calculator.py` (4 cases).

- Disjoint invariant per provider — Bedrock buckets stay disjoint and untouched; OpenAI buckets get normalized to disjoint. The invariant is asserted as a partition (`inputTokens + cacheRead + cacheWrite == totalTokens - outputTokens`), not as hardcoded numbers.
- A fully-cached GPT-5.6 call costs `cached x cacheReadRate`, and the un-normalized dict is pinned at exactly 11x it.
- The cache-write premium is billed once at 1.25x, not stacked on the input rate.
- Clamping, covering the [upstream reporting bug](https://community.openai.com/t/question-about-gpt-5-6-api-cache-read-write-token-billing/1386256) where the cache buckets summed to more than the inclusive total. A negative bucket would credit dollars *back* against the bill.

Per the "verify the SDK contract before stubbing" rule, the SDK-shape tests drive the **real** `strands` model classes with **real** `openai` usage objects (`ResponseUsage` / `CompletionUsage` built by `model_validate` from wire-shaped dicts). A stub matching the broken mapping would have hidden the bug. `TestStrandsSdkContract` pins the two SDK facts the shim hangs off — the chunk-formatter seam (`_format_chunk` on Responses, `format_chunk` on Chat Completions) and the dropped `cache_write_tokens` — so a version bump fails loudly here instead of silently double-billing in production. `usage_normalized` raises `TypeError` rather than falling through if the seam disappears.

`cd backend && uv run python -m pytest tests/ -v` -> **7173 passed, 6 skipped**.

## Upstream

[strands-agents/harness-sdk#4193](https://github.com/strands-agents/harness-sdk/pull/4193) — narrow patch mapping `cache_write_tokens` in the Responses adapter, so we don't carry that half forever.

There is substantial prior art there. [strands-agents/harness-sdk#3546](https://github.com/strands-agents/harness-sdk/issues/3546) is an open umbrella bug for exactly the inclusive-vs-disjoint convention problem — it lists "the Responses adapter still drops `cacheWriteInputTokens`" as outstanding work, and reproduces the double-count on `openai.gpt-5.6-luna` via Mantle. The broad fix ([#3561](https://github.com/strands-agents/harness-sdk/pull/3561), 84 files) was closed unmerged; maintainers are taking the remainder as small independently-reviewable PRs, which is why ours is scoped to the dropped field alone rather than the convention.

Two things from that thread worth knowing:

- A maintainer notes AgentCore GenAI Observability currently double-counts these same tokens in its cost display, and suggests pinning `strands-agents==1.53.0` to avoid it. We're on 1.51.0.
- The convention follows the **model family, not the adapter** — GPT-5.6 on `bedrock-runtime` via Converse reports *disjoint* buckets. That matters for PR-2: our shim keys off the model class, which is correct for the Responses transport, but a future Converse-routed OpenAI model must not be wrapped.

Not a blocker — the shim is correct on its own and stays useful for any pin older than the fix.

## Not in this PR

Per the spec: the `bedrock-runtime` Responses transport (PR-2), catalog/pricing rows (PR-3), explicit `prompt_cache_breakpoint` support (PR-4), and the `CACHE_TTL_SECONDS` fix (PR-5). The GPT-5.6 rates in the calculator test are transcribed from the model card and labelled illustrative — only their ratios are load-bearing there. PR-3 verifies them against the Price List API before any catalog row ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
