### PR TITLE
fix(fine-tuning): pre-flight and hyperparameter scoping, plus stroke selection styling

### DIFF
--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -39,10 +39,10 @@
             [attr.aria-checked]="selectedTaskType() === task.task_type"
             (click)="selectTaskType(task.task_type)"
             [class]="
-              'rounded-sm border p-4 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 ' +
+              'rounded-sm border bg-white p-4 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-gray-900 ' +
               (selectedTaskType() === task.task_type
-                ? 'border-primary-500 bg-primary-50 dark:border-primary-400 dark:bg-primary-950'
-                : 'border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600')
+                ? 'border-primary-500 ring-1 ring-primary-500 dark:border-primary-400 dark:ring-primary-400'
+                : 'border-gray-200 hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600')
             "
           >
             <div class="flex items-start justify-between gap-2">


### PR DESCRIPTION
Follow-ups from exercising the new fine-tuning flow against deployed dev.

## Two real bugs in the HuggingFace pre-flight

Both found by running the guards against the live Hub rather than a stub, and both let a bad submission through to fail later on a billed GPU — precisely what the pre-flight exists to prevent.

**The Hub answers `401` for a repo that does not exist, not `404`.** It will not confirm existence to an anonymous caller, so a missing repo and a private one are indistinguishable. Only 404 was special-cased, so a 401 fell into the "check unavailable, let it through" branch and the job failed on SageMaker as an opaque **500** instead of a 400 here. All of 401/403/404 are equally unusable — training runs without the user's Hub credentials — so they now share one message.

**Canonical single-segment repos answer `307`.** `bert-base-uncased` and `gpt2` redirect to their namespaced form, and httpx does not follow redirects by default, so every such id silently skipped *all* the checks below it: no weights check, no modality check. Now follows redirects.

## Hyperparameters follow the task

An image job recorded a `context_length`, and a text job would have recorded an `image_size` — the reactive form keeps every control alive regardless of which are visible, and submit sent them all. Harmless at runtime, but the job record then lists a parameter that had no effect, which misleads anyone reading back what a run actually did.

Which knobs a task exposes is now declared once by the task registry, and both the rendered fields and the submitted payload derive from it. The template previously carried its own per-task conditions that duplicated the registry and would drift from it as tasks are added. `TaskTypeResponse` therefore carries `default_hyperparameters`; the SPA treats an unknown task as "show everything" so the form does not collapse while the task list loads.

## Selection cards: stroke, not fill

Selection cards used a light blue fill on top of a primary border, which also washed out their description text (a muted gray chosen for contrast against white). Selection now reads as a primary stroke — border plus a 1px ring, so the outline thickens without the layout shift a border-width change would cause.

Applied to the task cards, the base-model grid, and the custom-HuggingFace card and its detail panel.

The **drag-over highlight** and **upload overlay** keep their blue tint deliberately: those are transient affordances meaning "drop here" and "working", so the fill carries meaning rather than decorating a persistent selection.

## Testing

391 fine-tuning backend tests and 205/205 frontend files pass; both typecheck configs clean. New regression tests cover the 401/403/404 responses, redirect-following, and task-scoped hyperparameter submission.

Verified live against deployed dev through the real SPA: task switching updates the accept list, hint and model list; a real `.zip` uploads via presign to S3; a job is created with `task_type` persisted. The guards reject a GGUF-only repo, a generative VLM, a text model on an image task, and every wrong-format upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)