### PR TITLE
feat(models): add the bedrock-runtime OpenAI Responses transport

### DIFF
--- a/backend/src/agents/main_agent/core/agent_factory.py
+++ b/backend/src/agents/main_agent/core/agent_factory.py
@@ -12,6 +12,7 @@ from strands.tools.executors import SequentialToolExecutor
 from agents.main_agent.core.bedrock_count_tokens import CountTokensBedrockModel
 from agents.main_agent.core.model_config import ModelConfig, ModelProvider
 from agents.main_agent.config.constants import EnvVars
+from apis.shared.models.bedrock_responses import build_bedrock_responses_model
 from apis.shared.models.mantle import build_mantle_model
 from apis.shared.models.usage_normalization import usage_normalized
 
@@ -113,6 +114,43 @@ class AgentFactory:
         )
 
     @staticmethod
+    def _create_bedrock_responses_model(model_config: ModelConfig):
+        """
+        Create an OpenAI Responses model on the bedrock-runtime endpoint
+
+        The only Bedrock path that serves prompt caching for GPT-5.6. Same
+        OpenAI wire protocol as Mantle, different host and model-id shape
+        (cross-Region inference profiles).
+
+        Args:
+            model_config: Model configuration
+
+        Returns:
+            OpenAIResponsesModel: Configured model targeting bedrock-runtime
+
+        Raises:
+            ValueError: If no AWS region can be resolved for the endpoint
+        """
+        # Same precedence as the Mantle path: model override, then AWS_REGION.
+        # Unlike Mantle, an unresolvable region raises rather than defaulting —
+        # the builder owns that, so both the URL and the token signature stay
+        # on one value.
+        region = model_config.mantle_region or os.getenv(EnvVars.AWS_REGION)
+        responses_config = model_config.to_bedrock_responses_config()
+        logger.info(
+            f"Creating bedrock-runtime Responses model "
+            f"with model_id={model_config.model_id} "
+            f"region={region or '<agent default>'}"
+        )
+        # Shared builder — also used by the API-key /chat/api-converse handler
+        # (apis/app_api) so the transport construction is never forked.
+        return build_bedrock_responses_model(
+            model_id=responses_config["model_id"],
+            region=region,
+            params=responses_config.get("params"),
+        )
+
+    @staticmethod
     def _create_gemini_model(model_config: ModelConfig) -> GeminiModel:
         """
         Create a GeminiModel instance
@@ -178,6 +216,8 @@ class AgentFactory:
             model = AgentFactory._create_openai_model(model_config)
         elif provider == ModelProvider.MANTLE:
             model = AgentFactory._create_mantle_model(model_config)
+        elif provider == ModelProvider.BEDROCK_RESPONSES:
+            model = AgentFactory._create_bedrock_responses_model(model_config)
         elif provider == ModelProvider.GEMINI:
             model = AgentFactory._create_gemini_model(model_config)
         else:

--- a/backend/src/agents/main_agent/core/model_config.py
+++ b/backend/src/agents/main_agent/core/model_config.py
@@ -38,6 +38,17 @@ class ModelProvider(str, Enum):
     # bearer token, not the Converse API with SigV4. Never auto-detected from
     # model_id — admins set it explicitly on the managed model.
     MANTLE = "mantle"
+    # The OpenAI **Responses** API on `bedrock-runtime.<region>.amazonaws.com`
+    # — the second OpenAI-compatible Bedrock surface. Same wire protocol and
+    # bearer-token auth as MANTLE, different host, IAM and model-id shape
+    # (cross-Region inference profiles: `us.` / `global.`).
+    #
+    # It exists for one reason: GPT-5.6 serves prompt caching ONLY over the
+    # Responses API. Routing the same model over Converse (which
+    # `bedrock-runtime` also supports) would drop into the BEDROCK path with
+    # no caching at all — ~10x the input cost on a long stable prefix.
+    # Never auto-detected from model_id; admins set it on the managed model.
+    BEDROCK_RESPONSES = "bedrock-responses"
 
 
 # Canonical param name -> provider-native key path (dot-separated for nested SDK fields).
@@ -293,11 +304,16 @@ class ModelConfig:
     # Completions vs Responses). Only consulted on the MANTLE provider path,
     # where the factory uses it to pick OpenAIModel vs OpenAIResponsesModel.
     mantle_api_mode: MantleApiMode = MantleApiMode.CHAT_COMPLETIONS
-    # Bedrock Mantle: optional AWS region override for the inference endpoint.
+    # Optional AWS region override for an OpenAI-compatible Bedrock endpoint.
     # ``None`` -> the agent's AWS_REGION. Lets a model pin inference to the
     # region where it's hosted (e.g. openai.gpt-5.x in us-east-1) independent
-    # of where the app runs. Drives both the Mantle base URL and the region
-    # the bearer token is signed for (via bedrock_mantle_config).
+    # of where the app runs. Drives both the base URL and the region the
+    # bearer token is signed for, on BOTH OpenAI-compatible surfaces — Mantle
+    # (via bedrock_mantle_config) and bedrock-runtime Responses.
+    #
+    # The attribute name is historical: Mantle was the only such surface when
+    # it was added. The wire/persisted field is already the transport-neutral
+    # `region`, so only this Python name lags.
     mantle_region: Optional[str] = None
 
     def get_provider(self) -> ModelProvider:
@@ -480,6 +496,27 @@ class ModelConfig:
             config["params"] = params
         return config
 
+    def to_bedrock_responses_config(self) -> Dict[str, Any]:
+        """Convert to OpenAI Responses kwargs for the bedrock-runtime surface.
+
+        The Responses API's native param names are the same ones Mantle-Responses
+        uses — they belong to the API, not the transport — so the map is shared.
+        The builder supplies the client (base_url + per-request bearer token)
+        via ``client_args``; see ``apis.shared.models.bedrock_responses``.
+        """
+        params: Dict[str, Any] = {}
+        _apply_canonical_params(
+            params,
+            self.inference_params,
+            _MANTLE_RESPONSES_PARAM_MAP,
+            "bedrock-responses",
+            self.model_id,
+        )
+        config: Dict[str, Any] = {"model_id": self.model_id}
+        if params:
+            config["params"] = params
+        return config
+
     def to_gemini_config(self) -> Dict[str, Any]:
         """Convert to GeminiModel kwargs, translating canonical inference params."""
         params: Dict[str, Any] = {}
@@ -517,7 +554,8 @@ class ModelConfig:
         Args:
             model_id: Model ID (provider-specific format)
             caching_enabled: Whether to enable prompt caching (Bedrock only)
-            provider: Provider name ("bedrock", "openai", "gemini", or "mantle")
+            provider: Provider name ("bedrock", "openai", "gemini", "mantle",
+                or "bedrock-responses")
             inference_params: Canonical-name -> value map (temperature, top_p,
                 max_tokens, thinking, ...). Each provider's translation table
                 drops unsupported keys silently.

--- a/backend/src/apis/app_api/chat/converse_routes.py
+++ b/backend/src/apis/app_api/chat/converse_routes.py
@@ -51,6 +51,7 @@ from apis.shared.sessions.models import (
     Attribution,
 )
 
+from apis.shared.models.bedrock_responses import build_bedrock_responses_model
 from apis.shared.models.mantle import (
     MantleApiMode,
     build_mantle_model,
@@ -355,17 +356,29 @@ async def _stream_converse(request: ConverseRequest, user_id: str, key_id: str) 
 
 
 # ---------------------------------------------------------------------------
-# Bedrock Mantle path (OpenAI-compatible surface; provider="mantle")
+# OpenAI-compatible Bedrock surfaces (provider="mantle" / "bedrock-responses")
 #
-# Mantle models don't speak Bedrock Converse — they ride the OpenAI wire
-# protocol. We reuse the SHARED Strands builder (apis.shared.models.mantle,
-# same one the agent factory uses) and invoke the bare model's `.stream()`,
-# which yields the same Converse-shaped events the Bedrock path emits — so the
-# SSE translation and usage/cost accounting are identical.
+# Neither speaks Bedrock Converse — both ride the OpenAI wire protocol. We
+# reuse the SHARED Strands builders (apis.shared.models.mantle and
+# apis.shared.models.bedrock_responses, the same ones the agent factory uses)
+# and invoke the bare model's `.stream()`, which yields the same
+# Converse-shaped events the Bedrock path emits — so one set of SSE
+# translation and usage/cost accounting serves both.
+#
+# The two surfaces differ only in construction: host, auth scope and model-id
+# shape. Everything downstream of `_build_request_openai_model` is shared.
 # ---------------------------------------------------------------------------
 
-def _build_mantle_params(request: ConverseRequest, api_mode: MantleApiMode) -> dict:
-    """Translate the request's canonical inference params to Mantle-native names."""
+# Providers that ride the OpenAI wire protocol rather than Bedrock Converse.
+OPENAI_SURFACE_PROVIDERS = ("mantle", "bedrock-responses")
+
+
+def _build_openai_params(request: ConverseRequest, api_mode: MantleApiMode) -> dict:
+    """Translate the request's canonical inference params to OpenAI-native names.
+
+    Keyed off the API surface, not the transport: Mantle-Responses and
+    bedrock-runtime Responses share one native param vocabulary.
+    """
     pmap = param_map_for(api_mode)
     canonical = {
         "temperature": request.temperature,
@@ -381,35 +394,56 @@ def _build_mantle_params(request: ConverseRequest, api_mode: MantleApiMode) -> d
     return params
 
 
-def _build_request_mantle_model(request: ConverseRequest, api_mode: MantleApiMode, region: Optional[str]):
-    """Construct the shared Strands Mantle model for this request."""
+def _build_request_openai_model(
+    request: ConverseRequest,
+    provider: str,
+    api_mode: MantleApiMode,
+    region: Optional[str],
+):
+    """Construct the shared Strands model for this request's OpenAI surface.
+
+    Args:
+        request: The converse request.
+        provider: ``"mantle"`` or ``"bedrock-responses"``.
+        api_mode: Chat Completions vs Responses. Always Responses on the
+            bedrock-runtime transport, which serves no other surface here.
+        region: Optional region override for the endpoint and token signature.
+    """
+    params = _build_openai_params(request, api_mode) or None
+    if provider == "bedrock-responses":
+        return build_bedrock_responses_model(
+            model_id=request.model_id,
+            region=region or None,
+            params=params,
+        )
     return build_mantle_model(
         model_id=request.model_id,
         api_mode=api_mode,
         region=region or None,
-        params=_build_mantle_params(request, api_mode) or None,
+        params=params,
     )
 
 
-def _mantle_messages(request: ConverseRequest) -> list[dict]:
+def _openai_surface_messages(request: ConverseRequest) -> list[dict]:
     """Convert request messages to the Converse content-block format."""
     return [{"role": m.role, "content": [{"text": m.content}]} for m in request.messages]
 
 
-async def _stream_mantle(
+async def _stream_openai_surface(
     request: ConverseRequest,
     user_id: str,
     key_id: str,
+    provider: str,
     api_mode: MantleApiMode,
     region: Optional[str],
 ) -> AsyncGenerator[str, None]:
-    """Invoke a Mantle model via Strands and yield the same SSE shape as Bedrock."""
+    """Invoke an OpenAI-surface model via Strands, in the Bedrock SSE shape."""
     try:
-        model = _build_request_mantle_model(request, api_mode, region)
-        messages = _mantle_messages(request)
+        model = _build_request_openai_model(request, provider, api_mode, region)
+        messages = _openai_surface_messages(request)
         system_prompt = request.system_prompt or None
     except Exception:
-        logger.error("Failed to build Mantle model", exc_info=True)
+        logger.error("Failed to build %s model", provider, exc_info=True)
         yield _sse("error", {"error": "Model invocation failed due to an internal error."})
         yield _sse("done", {})
         return
@@ -420,7 +454,7 @@ async def _stream_mantle(
             for frame in _converse_event_to_sse(event, state):
                 yield frame
     except Exception:
-        logger.error("Bedrock Mantle stream error", exc_info=True)
+        logger.error("%s stream error", provider, exc_info=True)
         yield _sse("error", {"error": "Model invocation failed due to a service error."})
         yield _sse("done", {})
         return
@@ -430,24 +464,25 @@ async def _stream_mantle(
     if state["usage"]:
         await _record_cost(
             user_id=user_id, model_id=request.model_id, usage=state["usage"],
-            key_id=key_id, provider="mantle",
+            key_id=key_id, provider=provider,
         )
 
 
-async def _mantle_converse(
+async def _openai_surface_converse(
     request: ConverseRequest,
     user_id: str,
     key_id: str,
+    provider: str,
     api_mode: MantleApiMode,
     region: Optional[str],
 ) -> ConverseResponse:
-    """Non-streaming Mantle converse: consume the model stream and aggregate."""
+    """Non-streaming OpenAI-surface converse: consume the stream and aggregate."""
     try:
-        model = _build_request_mantle_model(request, api_mode, region)
-        messages = _mantle_messages(request)
+        model = _build_request_openai_model(request, provider, api_mode, region)
+        messages = _openai_surface_messages(request)
         system_prompt = request.system_prompt or None
     except Exception:
-        logger.error("Failed to build Mantle model", exc_info=True)
+        logger.error("Failed to build %s model", provider, exc_info=True)
         raise HTTPException(status_code=502, detail="Model invocation failed due to an internal error.")
 
     text_parts: list[str] = []
@@ -469,13 +504,13 @@ async def _mantle_converse(
             elif "metadata" in event:
                 usage = event["metadata"].get("usage", {})
     except Exception:
-        logger.error("Bedrock Mantle converse error", exc_info=True)
+        logger.error("%s converse error", provider, exc_info=True)
         raise HTTPException(status_code=502, detail="Model invocation failed due to a service error.")
 
     if usage:
         await _record_cost(
             user_id=user_id, model_id=request.model_id, usage=usage,
-            key_id=key_id, provider="mantle",
+            key_id=key_id, provider=provider,
         )
 
     return ConverseResponse(
@@ -600,22 +635,31 @@ async def api_converse(
             detail=f"Access denied to model: {request.model_id}",
         )
 
-    # 2.8 Provider routing — Bedrock Converse vs Bedrock Mantle (OpenAI wire).
+    # 2.8 Provider routing — Bedrock Converse vs an OpenAI-compatible Bedrock
+    # surface (Mantle, or the Responses API on bedrock-runtime).
     provider, mantle_api_mode, mantle_region = await _resolve_model_routing(request.model_id)
-    is_mantle = (provider or "").lower() == "mantle"
+    normalized_provider = (provider or "").lower()
+    is_openai_surface = normalized_provider in OPENAI_SURFACE_PROVIDERS
     try:
         api_mode = (
             MantleApiMode(mantle_api_mode) if mantle_api_mode else MantleApiMode.CHAT_COMPLETIONS
         )
     except ValueError:
         api_mode = MantleApiMode.CHAT_COMPLETIONS
+    if normalized_provider == "bedrock-responses":
+        # Not admin-selectable: that transport exists because GPT-5.6 caches
+        # only over the Responses API. Mirrors the same normalization applied
+        # when the model record is written (apis/shared/models/managed_models.py),
+        # so a legacy row that predates it can't silently downgrade the model
+        # to an uncached Chat Completions call.
+        api_mode = MantleApiMode.RESPONSES
 
     # 3. Streaming path
     if request.stream:
-        if is_mantle:
-            generator = _stream_mantle(
+        if is_openai_surface:
+            generator = _stream_openai_surface(
                 request, user_id=validated_key.user_id, key_id=validated_key.key_id,
-                api_mode=api_mode, region=mantle_region,
+                provider=normalized_provider, api_mode=api_mode, region=mantle_region,
             )
         else:
             generator = _stream_converse(
@@ -630,11 +674,11 @@ async def api_converse(
             },
         )
 
-    # 4. Non-streaming path — Mantle (Strands) vs Bedrock Converse (boto3).
-    if is_mantle:
-        return await _mantle_converse(
+    # 4. Non-streaming path — OpenAI surface (Strands) vs Bedrock Converse (boto3).
+    if is_openai_surface:
+        return await _openai_surface_converse(
             request, user_id=validated_key.user_id, key_id=validated_key.key_id,
-            api_mode=api_mode, region=mantle_region,
+            provider=normalized_provider, api_mode=api_mode, region=mantle_region,
         )
 
     client = _get_bedrock_client()

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -431,15 +431,16 @@ async def _resolve_model_settings(
 
     Returns ``(caching_enabled, inference_params, mantle_api_mode,
     mantle_region, provider)``. A single registry lookup drives all of them.
-    The Mantle fields are server-authoritative (recorded on the model):
+    The API-surface fields are server-authoritative (recorded on the model):
     ``mantle_api_mode`` selects Chat Completions vs the Responses API and
-    ``mantle_region`` optionally pins inference to a specific region; both
-    ``None`` for non-Mantle models. ``provider`` is the model's registered
-    provider (e.g. ``"mantle"``), returned so callers can recover it when the
-    request/binding didn't carry one — without it a Mantle model like
-    ``openai.gpt-5.4`` misroutes to Bedrock ConverseStream and fails with an
-    invalid-model-identifier error. Resolving these here keeps them off the
-    client request — the SPA can't override.
+    ``mantle_region`` optionally pins inference to a specific region. Both are
+    meaningful on either OpenAI-compatible Bedrock surface — ``"mantle"`` and
+    ``"bedrock-responses"`` — and ``None`` for every other provider.
+    ``provider`` is the model's registered provider, returned so callers can
+    recover it when the request/binding didn't carry one — without it a Mantle
+    model like ``openai.gpt-5.4`` misroutes to Bedrock ConverseStream and fails
+    with an invalid-model-identifier error. Resolving these here keeps them off
+    the client request — the SPA can't override.
     """
     request_params = dict(request_inference_params or {})
 

--- a/backend/src/apis/shared/models/bedrock_responses.py
+++ b/backend/src/apis/shared/models/bedrock_responses.py
@@ -1,0 +1,213 @@
+"""Shared ``bedrock-runtime`` OpenAI Responses model construction.
+
+The second OpenAI-compatible Bedrock surface, alongside Bedrock Mantle
+(:mod:`apis.shared.models.mantle`). Both speak the OpenAI wire protocol with a
+short-term bearer token; they differ in host, IAM, model-id shape and — the
+reason this module exists — **prompt caching**.
+
+Why this transport at all
+-------------------------
+
+GPT-5.6 supports prompt caching only on the **Responses API**, on either
+endpoint. Converse is the tempting path — it drops into the existing
+``BedrockModel`` plumbing with SigV4 and no new auth — and it is the one path
+with *zero* caching. At Sol's published rates a ~30k stable prefix costs
+~$0.13/turn on Converse against ~$0.013 on a Responses cache hit.
+
+``bedrock-runtime`` over Mantle-Responses because it adds CRIS, invocation
+logging, CloudWatch metrics and Cost Explorer itemization, and Global CRIS is
+cheaper for this family. We give up server-side tool use (unused) and In-Region
+inference (not offered here for this model anyway).
+
+How it differs from the Mantle builder
+--------------------------------------
+
+Strands' ``bedrock_mantle_config`` hardcodes the Mantle host
+(``models/_openai_bedrock.py``) and *rejects* a caller-supplied ``base_url`` /
+``api_key`` when set, so pointing at ``bedrock-runtime`` means not using that
+config at all — plain ``client_args`` instead.
+
+That trade has one consequence worth naming: ``bedrock_mantle_config`` re-mints
+its bearer token per request, while a static ``api_key`` in ``client_args``
+freezes at construction. Our microVMs live 18-50 minutes against a 12-hour
+token cap, so a frozen token would work *by luck*. :func:`build_bedrock_responses_model`
+instead returns a subclass overriding ``_resolve_client_args()`` — which Strands
+calls per request — to mint fresh. A handful of lines that removes a class of
+"worked in dev, expired in prod" failure.
+
+Usage semantics are normalized here as they are on the Mantle path: OpenAI's
+``input_tokens`` is inclusive of both cache buckets, which every cost path we
+own treats as disjoint. See :mod:`apis.shared.models.usage_normalization`.
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+# The OpenAI Responses API's native param names are a property of the *API*,
+# not of the transport, so this is the Mantle map aliased rather than copied —
+# the two surfaces can never drift apart.
+from .mantle import MANTLE_RESPONSES_PARAM_MAP as BEDROCK_RESPONSES_PARAM_MAP
+from .usage_normalization import usage_normalized
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BEDROCK_RESPONSES_PARAM_MAP",
+    "BEDROCK_RUNTIME_OPENAI_PATH",
+    "build_bedrock_responses_model",
+    "get_bedrock_runtime_openai_base_url",
+]
+
+# bedrock-runtime is a regional endpoint on amazonaws.com (Mantle is api.aws).
+_BEDROCK_RUNTIME_HOST_TEMPLATE = "https://bedrock-runtime.{region}.amazonaws.com"
+
+# The OpenAI-compatible base path. Unlike Mantle — where the path varies by
+# model family and the SDK derives it from the model id — bedrock-runtime
+# serves every OpenAI-compatible model from this one path.
+BEDROCK_RUNTIME_OPENAI_PATH = "/openai/v1"
+
+# Cross-Region inference profile prefixes. GPT-5.6 is not offered as an
+# in-Region model on this endpoint, so a bare `openai.` id is a
+# misconfiguration — but this is a warning, not a gate: a future model may
+# well be served in-Region and should not need a code change to run.
+_INFERENCE_PROFILE_PREFIXES = ("us.", "global.", "eu.", "apac.")
+
+
+def get_bedrock_runtime_openai_base_url(region: Optional[str] = None) -> str:
+    """OpenAI-compatible base URL for ``bedrock-runtime`` in ``region``.
+
+    Args:
+        region: AWS region. ``None`` -> ``AWS_REGION``.
+
+    Returns:
+        e.g. ``https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1``.
+
+    Raises:
+        ValueError: When no region can be resolved. Deliberately loud: this
+            endpoint is regional and silently defaulting to some other region
+            produces an opaque auth failure at the first turn, not a clear one.
+    """
+    resolved = _resolve_region(region)
+    return _BEDROCK_RUNTIME_HOST_TEMPLATE.format(region=resolved) + BEDROCK_RUNTIME_OPENAI_PATH
+
+
+def _resolve_region(region: Optional[str]) -> str:
+    """Resolve the region for both the base URL and the token signature."""
+    resolved = region or os.environ.get("AWS_REGION")
+    if not resolved:
+        raise ValueError(
+            "No AWS region available for the bedrock-runtime OpenAI endpoint. "
+            "Set AWS_REGION, or pin a region on the managed model."
+        )
+    return resolved
+
+
+def _warn_on_missing_inference_profile(model_id: str) -> None:
+    """Log when a model id names no cross-Region inference profile."""
+    if not model_id.startswith(_INFERENCE_PROFILE_PREFIXES):
+        logger.warning(
+            "Model id %r names no inference profile (expected one of %s). "
+            "bedrock-runtime does not offer in-Region inference for the "
+            "GPT-5.6 family, so this will likely be rejected — record the "
+            "profile-prefixed id on the managed model.",
+            model_id,
+            ", ".join(_INFERENCE_PROFILE_PREFIXES),
+        )
+
+
+_model_cls: Optional[type] = None
+
+
+def _bedrock_responses_model_cls() -> type:
+    """Build (once) the model class used for this transport.
+
+    Two layers over Strands' ``OpenAIResponsesModel``:
+
+    1. a per-request bearer-token mint, because ``client_args`` is resolved
+       once at construction and our token is short-term;
+    2. the OpenAI usage normalization every OpenAI-family model needs.
+
+    Memoized so repeated agent builds reuse one type — keeps ``isinstance``
+    stable and avoids leaking a class per turn.
+    """
+    global _model_cls
+    if _model_cls is not None:
+        return _model_cls
+
+    # Lazy import: strands is heavy, and apis.shared is imported broadly.
+    from strands.models import OpenAIResponsesModel
+
+    class BedrockRuntimeResponsesModel(OpenAIResponsesModel):
+        """``OpenAIResponsesModel`` that re-mints its Bedrock bearer token per request."""
+
+        def __init__(self, bedrock_region: str, **kwargs: Any) -> None:
+            # Set before super().__init__ so a base-class call into
+            # _resolve_client_args() during construction still resolves.
+            self._bedrock_region = bedrock_region
+            super().__init__(**kwargs)
+
+        def _resolve_client_args(self) -> Dict[str, Any]:
+            """Return client kwargs with a freshly minted bearer token.
+
+            Strands calls this per request. The token is a presigned SigV4
+            request that expires with the signing credentials (12h cap), so
+            minting here rather than at construction is what keeps a
+            long-lived model instance working.
+            """
+            # Lazy import keeps boto3 off this module's import path.
+            from apis.shared.bedrock.bearer_token import generate_bedrock_bearer_token
+
+            args = dict(super()._resolve_client_args())
+            args["api_key"] = generate_bedrock_bearer_token(self._bedrock_region)
+            return args
+
+    _model_cls = usage_normalized(BedrockRuntimeResponsesModel)
+    return _model_cls
+
+
+def build_bedrock_responses_model(
+    model_id: str,
+    region: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+):
+    """Build a Strands Responses model targeting ``bedrock-runtime``.
+
+    Args:
+        model_id: A cross-Region inference profile id, e.g.
+            ``us.openai.gpt-5.6-sol`` or ``global.openai.gpt-5.6-sol``.
+        region: AWS region for the endpoint and the token signature. ``None``
+            -> ``AWS_REGION``. One resolved value drives both, so the URL and
+            the signature can never disagree.
+        params: Already-native Responses params (canonical names must be
+            pre-translated via :data:`BEDROCK_RESPONSES_PARAM_MAP`). Spread
+            verbatim into ``responses.create()`` by the SDK.
+
+    Returns:
+        A configured Responses model reporting disjoint token usage.
+
+    Raises:
+        ValueError: When no region can be resolved.
+    """
+    resolved_region = _resolve_region(region)
+    _warn_on_missing_inference_profile(model_id)
+
+    # base_url is fixed for the life of the model; only api_key is re-minted
+    # per request (see BedrockRuntimeResponsesModel._resolve_client_args).
+    # A placeholder api_key is supplied because the OpenAI client requires one
+    # at construction; it is replaced before any request goes out.
+    client_args: Dict[str, Any] = {
+        "base_url": _BEDROCK_RUNTIME_HOST_TEMPLATE.format(region=resolved_region)
+        + BEDROCK_RUNTIME_OPENAI_PATH,
+        "api_key": "placeholder-replaced-per-request",
+    }
+
+    config: Dict[str, Any] = {"model_id": model_id}
+    if params:
+        config["params"] = params
+
+    return _bedrock_responses_model_cls()(
+        bedrock_region=resolved_region,
+        client_args=client_args,
+        **config,
+    )

--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -25,7 +25,8 @@ def _resolve_supports_caching(supports_caching: Optional[bool], provider: str) -
 
     Args:
         supports_caching: Explicit value from model data (None if not set)
-        provider: The model provider (bedrock, openai, gemini)
+        provider: The model provider (bedrock, openai, gemini, mantle,
+            bedrock-responses)
 
     Returns:
         bool: Whether the model supports caching
@@ -33,33 +34,59 @@ def _resolve_supports_caching(supports_caching: Optional[bool], provider: str) -
     if supports_caching is not None:
         return supports_caching
 
-    # Default behavior: Only Bedrock models support caching by default
-    # Admins can explicitly set this to False for Bedrock models that don't support it
-    return provider.lower() == 'bedrock'
+    # Default behavior: Bedrock Converse models, and the bedrock-runtime
+    # Responses transport (implicit prompt caching is ON by default there —
+    # it is the reason that transport exists). Admins can explicitly set this
+    # to False for models in either family that don't support it.
+    #
+    # Deliberately NOT 'mantle': Mantle hosts open-weight models that mostly
+    # don't cache, and openai.gpt-5.4 there is implicit-only with no write fee.
+    return provider.lower() in ('bedrock', 'bedrock-responses')
+
+
+# The two OpenAI-compatible Bedrock surfaces. Both ride the OpenAI wire
+# protocol with a short-term bearer token; they differ in host, IAM and
+# model-id shape. The `apiMode` / `region` fields are meaningful on both,
+# which is why they are wire-named generically even though the Python
+# attributes still carry the historical `mantle_` prefix.
+_OPENAI_SURFACE_PROVIDERS = ('mantle', 'bedrock-responses')
 
 
 def _resolve_mantle_api_mode(api_mode: Optional[str], provider: str) -> Optional[str]:
-    """Resolve the Bedrock Mantle API surface for a model.
+    """Resolve the OpenAI-compatible API surface for a model.
 
-    Only meaningful for ``provider == 'mantle'`` — it selects Chat Completions
-    vs the Responses API, a per-model fact Mantle exposes no API to discover.
-    Defaults to ``'chat'`` for Mantle models when unset; ``None`` for every
-    other provider (the field is inert there).
+    On ``provider == 'mantle'`` this selects Chat Completions vs the Responses
+    API — a per-model fact Mantle exposes no API to discover. Defaults to
+    ``'chat'`` when unset.
+
+    On ``provider == 'bedrock-responses'`` the answer is fixed: that transport
+    exists precisely because GPT-5.6 serves prompt caching only over the
+    Responses API, so an admin cannot select Chat Completions there. Anything
+    stored is normalized to ``'responses'`` rather than honored — a model
+    silently downgraded to Chat Completions would lose caching, which is the
+    whole point of the transport, and would fail quietly rather than loudly.
+
+    ``None`` for every other provider (the field is inert there).
     """
-    if provider.lower() != 'mantle':
+    normalized_provider = provider.lower()
+    if normalized_provider == 'bedrock-responses':
+        return 'responses'
+    if normalized_provider != 'mantle':
         return None
     mode = (api_mode or '').lower()
     return mode if mode in ('chat', 'responses') else 'chat'
 
 
 def _resolve_mantle_region(region: Optional[str], provider: str) -> Optional[str]:
-    """Resolve the Bedrock Mantle region override for a model.
+    """Resolve the region override for an OpenAI-compatible Bedrock surface.
 
-    Only meaningful for ``provider == 'mantle'`` — pins inference to the region
-    hosting the model, independent of the app's region. ``None`` (fall back to
-    the app's region at agent-build time) when unset or for other providers.
+    Meaningful on both ``'mantle'`` and ``'bedrock-responses'`` — pins
+    inference to a specific region independent of the app's region, and drives
+    both the endpoint host and the region the bearer token is signed for.
+    ``None`` (fall back to the app's region at agent-build time) when unset or
+    for other providers.
     """
-    if provider.lower() != 'mantle':
+    if provider.lower() not in _OPENAI_SURFACE_PROVIDERS:
         return None
     return region or None
 

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -204,18 +204,22 @@ class ManagedModelCreate(BaseModel):
     mantle_api_mode: Optional[str] = Field(
         None,
         alias="apiMode",
-        description="Bedrock Mantle API surface (provider='mantle' only): 'chat' "
-                    "(OpenAI Chat Completions, the default) or 'responses' (OpenAI "
-                    "Responses API — required by models that don't serve Chat "
-                    "Completions, e.g. openai.gpt-5.x). Ignored for other providers."
+        description="OpenAI-compatible API surface: 'chat' (OpenAI Chat "
+                    "Completions, the default) or 'responses' (OpenAI Responses "
+                    "API — required by models that don't serve Chat Completions, "
+                    "e.g. openai.gpt-5.x). Selectable for provider='mantle'; "
+                    "forced to 'responses' for provider='bedrock-responses', "
+                    "which exists because GPT-5.6 caches only over that API. "
+                    "Ignored for other providers."
     )
     mantle_region: Optional[str] = Field(
         None,
         alias="region",
-        description="Bedrock Mantle region override (provider='mantle' only): pins "
-                    "inference to the region hosting the model (e.g. 'us-east-1'), "
-                    "independent of where the app runs. Empty -> the app's region. "
-                    "Ignored for other providers."
+        description="Region override for an OpenAI-compatible Bedrock surface "
+                    "(provider='mantle' or 'bedrock-responses'): pins inference to "
+                    "the region hosting the model (e.g. 'us-east-1'), independent "
+                    "of where the app runs, and signs the bearer token for it. "
+                    "Empty -> the app's region. Ignored for other providers."
     )
     mantle_endpoint_path: Optional[str] = Field(
         None,
@@ -292,14 +296,16 @@ class ManagedModelUpdate(BaseModel):
     mantle_api_mode: Optional[str] = Field(
         None,
         alias="apiMode",
-        description="Bedrock Mantle API surface (provider='mantle' only): 'chat' "
-                    "or 'responses'. Ignored for other providers."
+        description="OpenAI-compatible API surface: 'chat' or 'responses'. "
+                    "Selectable for provider='mantle'; forced to 'responses' for "
+                    "provider='bedrock-responses'. Ignored for other providers."
     )
     mantle_region: Optional[str] = Field(
         None,
         alias="region",
-        description="Bedrock Mantle region override (provider='mantle' only). "
-                    "Empty -> the app's region. Ignored for other providers."
+        description="Region override for an OpenAI-compatible Bedrock surface "
+                    "(provider='mantle' or 'bedrock-responses'). Empty -> the "
+                    "app's region. Ignored for other providers."
     )
     mantle_endpoint_path: Optional[str] = Field(
         None,
@@ -382,14 +388,17 @@ class ManagedModel(BaseModel):
     mantle_api_mode: Optional[str] = Field(
         None,
         alias="apiMode",
-        description="Bedrock Mantle API surface (provider='mantle' only): 'chat' "
-                    "(default) or 'responses'. Ignored for other providers."
+        description="OpenAI-compatible API surface: 'chat' (default) or "
+                    "'responses'. Selectable for provider='mantle'; forced to "
+                    "'responses' for provider='bedrock-responses'. Ignored for "
+                    "other providers."
     )
     mantle_region: Optional[str] = Field(
         None,
         alias="region",
-        description="Bedrock Mantle region override (provider='mantle' only). "
-                    "Empty -> the app's region. Ignored for other providers."
+        description="Region override for an OpenAI-compatible Bedrock surface "
+                    "(provider='mantle' or 'bedrock-responses'). Empty -> the "
+                    "app's region. Ignored for other providers."
     )
     mantle_endpoint_path: Optional[str] = Field(
         None,

--- a/backend/tests/agents/main_agent/core/test_agent_factory.py
+++ b/backend/tests/agents/main_agent/core/test_agent_factory.py
@@ -166,6 +166,95 @@ class TestCreateAgentMantle:
 
 
 # ---------------------------------------------------------------------------
+# bedrock-responses provider creates an Agent with an OpenAI Responses model on
+# the bedrock-runtime endpoint — the only Bedrock path that caches for GPT-5.6.
+# ---------------------------------------------------------------------------
+class TestCreateAgentBedrockResponses:
+    """Delegation contract for the second OpenAI-compatible Bedrock surface.
+
+    Construction behavior (base URL, per-request token mint, usage
+    normalization) is covered directly on the builder in
+    ``tests/shared/test_bedrock_responses.py``.
+    """
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.build_bedrock_responses_model")
+    def test_delegates_to_the_shared_builder(self, mock_build, mock_agent_cls, monkeypatch):
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        mock_model_instance = MagicMock()
+        mock_build.return_value = mock_model_instance
+
+        config = ModelConfig(
+            model_id="us.openai.gpt-5.6-sol",
+            provider=ModelProvider.BEDROCK_RESPONSES,
+        )
+        AgentFactory.create_agent(model_config=config, **_COMMON_KWARGS)
+
+        mock_build.assert_called_once()
+        call_kwargs = mock_build.call_args.kwargs
+        assert call_kwargs["model_id"] == "us.openai.gpt-5.6-sol"
+        assert call_kwargs["region"] == "us-west-2"
+        assert mock_agent_cls.call_args.kwargs["model"] is mock_model_instance
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.build_bedrock_responses_model")
+    def test_region_override_pins_the_endpoint(self, mock_build, mock_agent_cls, monkeypatch):
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        config = ModelConfig(
+            model_id="global.openai.gpt-5.6-sol",
+            provider=ModelProvider.BEDROCK_RESPONSES,
+            mantle_region="us-east-1",
+        )
+        AgentFactory.create_agent(model_config=config, **_COMMON_KWARGS)
+
+        assert mock_build.call_args.kwargs["region"] == "us-east-1"
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.build_bedrock_responses_model")
+    def test_never_routes_through_the_mantle_builder(
+        self, mock_build, mock_agent_cls, monkeypatch
+    ):
+        """The two surfaces must not cross: Mantle's config hardcodes its host."""
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        config = ModelConfig(
+            model_id="us.openai.gpt-5.6-sol",
+            provider=ModelProvider.BEDROCK_RESPONSES,
+        )
+        with patch("agents.main_agent.core.agent_factory.build_mantle_model") as mantle:
+            AgentFactory.create_agent(model_config=config, **_COMMON_KWARGS)
+
+        mantle.assert_not_called()
+        mock_build.assert_called_once()
+
+    @patch("agents.main_agent.core.agent_factory.Agent")
+    @patch("agents.main_agent.core.agent_factory.build_bedrock_responses_model")
+    def test_inference_params_translate_to_responses_native_names(
+        self, mock_build, mock_agent_cls, monkeypatch
+    ):
+        """`max_tokens` is `max_output_tokens` on the Responses API."""
+        from agents.main_agent.core.agent_factory import AgentFactory
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        config = ModelConfig(
+            model_id="us.openai.gpt-5.6-sol",
+            provider=ModelProvider.BEDROCK_RESPONSES,
+            inference_params={"max_tokens": 2048, "temperature": 0.3},
+        )
+        AgentFactory.create_agent(model_config=config, **_COMMON_KWARGS)
+
+        params = mock_build.call_args.kwargs["params"]
+        assert params["max_output_tokens"] == 2048
+        assert params["temperature"] == 0.3
+        assert "max_tokens" not in params
+
+
+# ---------------------------------------------------------------------------
 # Req 4.3 — Gemini provider with API key creates Agent with GeminiModel
 # ---------------------------------------------------------------------------
 class TestCreateAgentGemini:

--- a/backend/tests/routes/test_api_converse_mantle.py
+++ b/backend/tests/routes/test_api_converse_mantle.py
@@ -191,3 +191,138 @@ class TestResolveModelRouting:
         with patch("apis.shared.models.managed_models.list_managed_models",
                    AsyncMock(side_effect=RuntimeError("boom"))):
             assert await _resolve_model_routing("openai.gpt-5.4") == ("bedrock", None, None)
+
+
+class TestBedrockRuntimeResponsesRouting:
+    """provider="bedrock-responses" rides the same handler, different builder.
+
+    Everything downstream of model construction — SSE translation, usage and
+    cost accounting — is shared with the Mantle path; only the transport
+    differs. These pin that the two never cross.
+    """
+
+    def _patches(self, routing, build_runtime, build_mantle, record_cost):
+        return [
+            patch("apis.app_api.chat.converse_routes._validate_api_key", AsyncMock(return_value=MOCK_KEY)),
+            patch("apis.app_api.chat.converse_routes.shared_quota.is_quota_enforcement_enabled", return_value=False),
+            patch("apis.app_api.chat.converse_routes.get_app_role_service", return_value=_role_service()),
+            patch("apis.app_api.chat.converse_routes._resolve_model_routing", AsyncMock(return_value=routing)),
+            patch("apis.app_api.chat.converse_routes.build_bedrock_responses_model", build_runtime),
+            patch("apis.app_api.chat.converse_routes.build_mantle_model", build_mantle),
+            patch("apis.app_api.chat.converse_routes._record_cost", record_cost),
+        ]
+
+    def _post(self, patches, payload):
+        for p in patches:
+            p.start()
+        try:
+            return _client().post(
+                "/chat/api-converse",
+                headers={"X-API-Key": VALID_KEY},
+                json=payload,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_builds_via_the_runtime_transport_not_mantle(self):
+        build_runtime = MagicMock(return_value=_FakeMantleModel(MANTLE_EVENTS))
+        build_mantle = MagicMock()
+        record_cost = AsyncMock()
+        resp = self._post(
+            self._patches(
+                ("bedrock-responses", "responses", "us-west-2"),
+                build_runtime, build_mantle, record_cost,
+            ),
+            {"model_id": "us.openai.gpt-5.6-sol", "max_tokens": 256,
+             "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "hello mantle"
+        build_mantle.assert_not_called()
+        kwargs = build_runtime.call_args.kwargs
+        assert kwargs["model_id"] == "us.openai.gpt-5.6-sol"
+        assert kwargs["region"] == "us-west-2"
+        # Responses API renames the output cap; no api_mode on this transport.
+        assert kwargs["params"] == {"max_output_tokens": 256}
+        assert "api_mode" not in kwargs
+
+    def test_records_cost_against_the_right_provider(self):
+        record_cost = AsyncMock()
+        resp = self._post(
+            self._patches(
+                ("bedrock-responses", "responses", None),
+                MagicMock(return_value=_FakeMantleModel(MANTLE_EVENTS)),
+                MagicMock(), record_cost,
+            ),
+            {"model_id": "us.openai.gpt-5.6-sol",
+             "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        record_cost.assert_awaited_once()
+        assert record_cost.await_args.kwargs["provider"] == "bedrock-responses"
+
+    def test_a_stored_chat_api_mode_cannot_downgrade_the_surface(self):
+        """A legacy row saying 'chat' must not cost us prompt caching."""
+        build_runtime = MagicMock(return_value=_FakeMantleModel(MANTLE_EVENTS))
+        resp = self._post(
+            self._patches(
+                ("bedrock-responses", "chat", "us-west-2"),
+                build_runtime, MagicMock(), AsyncMock(),
+            ),
+            {"model_id": "us.openai.gpt-5.6-sol", "max_tokens": 256,
+             "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        # Responses-native name proves the surface stayed on Responses.
+        assert build_runtime.call_args.kwargs["params"] == {"max_output_tokens": 256}
+
+    def test_streams_sse_like_the_mantle_path(self):
+        record_cost = AsyncMock()
+        resp = self._post(
+            self._patches(
+                ("bedrock-responses", "responses", "us-west-2"),
+                MagicMock(return_value=_FakeMantleModel(MANTLE_EVENTS)),
+                MagicMock(), record_cost,
+            ),
+            {"model_id": "us.openai.gpt-5.6-sol", "stream": True,
+             "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert "event: message_start" in resp.text
+        assert "event: done" in resp.text
+        assert record_cost.await_args.kwargs["provider"] == "bedrock-responses"
+
+    def test_bedrock_models_still_take_the_converse_path(self):
+        """Regression guard: the new branch must not capture plain Bedrock."""
+        build_runtime = MagicMock()
+        build_mantle = MagicMock()
+        boto_client = MagicMock()
+        boto_client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "hello bedrock"}]}},
+            "usage": {"inputTokens": 10, "outputTokens": 3},
+            "stopReason": "end_turn",
+        }
+        patches = self._patches(
+            ("bedrock", None, None), build_runtime, build_mantle, AsyncMock()
+        )
+        patches.append(
+            patch("apis.app_api.chat.converse_routes._get_bedrock_client",
+                  return_value=boto_client)
+        )
+        resp = self._post(
+            patches,
+            {"model_id": "us.anthropic.claude-haiku-4-5",
+             "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "hello bedrock"
+        boto_client.converse.assert_called_once()
+        build_runtime.assert_not_called()
+        build_mantle.assert_not_called()

--- a/backend/tests/shared/test_bedrock_responses.py
+++ b/backend/tests/shared/test_bedrock_responses.py
@@ -1,0 +1,255 @@
+"""Unit tests for the shared bedrock-runtime OpenAI Responses builder.
+
+Covers the construction contract both consumers depend on — the agent factory
+and the API-key converse handler — plus the two things that distinguish this
+transport from the Mantle one:
+
+- the bearer token is minted **per request**, not frozen at construction;
+- usage still arrives in disjoint Bedrock-Converse buckets, because the
+  Responses API reports an inclusive ``input_tokens``.
+
+The token test is the load-bearing one. Our microVMs live 18-50 minutes
+against a 12-hour token cap, so a token frozen at construction would work by
+luck in dev and expire in prod under any longer-lived process.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from apis.shared.models.bedrock_responses import (
+    BEDROCK_RESPONSES_PARAM_MAP,
+    BEDROCK_RUNTIME_OPENAI_PATH,
+    build_bedrock_responses_model,
+    get_bedrock_runtime_openai_base_url,
+)
+from apis.shared.models.usage_normalization import usage_normalized
+
+_TOKEN_FN = "apis.shared.bedrock.bearer_token.generate_bedrock_bearer_token"
+
+
+class TestBaseUrl:
+    def test_regional_openai_path(self):
+        assert (
+            get_bedrock_runtime_openai_base_url("us-west-2")
+            == "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+        )
+
+    def test_path_is_fixed_not_model_derived(self):
+        """Unlike Mantle, bedrock-runtime serves every OpenAI model from one path."""
+        assert BEDROCK_RUNTIME_OPENAI_PATH == "/openai/v1"
+
+    def test_falls_back_to_ambient_region(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        assert "bedrock-runtime.us-east-1." in get_bedrock_runtime_openai_base_url()
+
+    def test_raises_without_a_region(self, monkeypatch):
+        # Loud rather than defaulting to some other region: a wrong-region
+        # endpoint fails as an opaque auth error at the first turn.
+        monkeypatch.delenv("AWS_REGION", raising=False)
+
+        with pytest.raises(ValueError, match="No AWS region"):
+            get_bedrock_runtime_openai_base_url()
+
+
+class TestBuildBedrockResponsesModel:
+    def test_builds_a_responses_model_on_the_runtime_endpoint(self):
+        from strands.models import OpenAIResponsesModel
+
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        assert isinstance(model, OpenAIResponsesModel)
+        assert model.client_args["base_url"] == (
+            "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+        )
+        assert model.get_config()["model_id"] == "us.openai.gpt-5.6-sol"
+
+    def test_does_not_use_bedrock_mantle_config(self):
+        """The Mantle config hardcodes the Mantle host and rejects our base_url."""
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        assert getattr(model, "_bedrock_mantle_config", None) is None
+
+    def test_params_are_forwarded(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol",
+            region="us-west-2",
+            params={"max_output_tokens": 512, "temperature": 0.4},
+        )
+
+        assert model.get_config()["params"] == {
+            "max_output_tokens": 512,
+            "temperature": 0.4,
+        }
+
+    def test_no_params_key_when_none_given(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        assert "params" not in model.get_config()
+
+    def test_region_pins_both_url_and_token_signature(self):
+        """One resolved value drives both, so they cannot disagree."""
+        model = build_bedrock_responses_model(
+            model_id="global.openai.gpt-5.6-sol", region="us-east-1"
+        )
+
+        assert "bedrock-runtime.us-east-1." in model.client_args["base_url"]
+        with patch(_TOKEN_FN, return_value="bedrock-api-key-x") as mint:
+            model._resolve_client_args()
+        mint.assert_called_once_with("us-east-1")
+
+    def test_raises_without_a_region(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+
+        with pytest.raises(ValueError, match="No AWS region"):
+            build_bedrock_responses_model(model_id="us.openai.gpt-5.6-sol")
+
+    def test_model_class_is_memoized(self):
+        first = build_bedrock_responses_model("us.openai.gpt-5.6-sol", region="us-west-2")
+        second = build_bedrock_responses_model("global.openai.gpt-5.6-sol", region="us-east-1")
+
+        assert type(first) is type(second)
+
+    def test_param_map_is_the_responses_vocabulary(self):
+        """Native names belong to the API, not the transport — shared, not copied."""
+        from apis.shared.models.mantle import MANTLE_RESPONSES_PARAM_MAP
+
+        assert BEDROCK_RESPONSES_PARAM_MAP is MANTLE_RESPONSES_PARAM_MAP
+        assert BEDROCK_RESPONSES_PARAM_MAP["max_tokens"] == "max_output_tokens"
+
+
+class TestInferenceProfileWarning:
+    def test_warns_when_the_id_names_no_inference_profile(self, caplog):
+        # bedrock-runtime does not offer in-Region inference for GPT-5.6, so a
+        # bare `openai.` id is a misconfiguration worth surfacing.
+        with caplog.at_level("WARNING"):
+            build_bedrock_responses_model("openai.gpt-5.6-sol", region="us-west-2")
+
+        assert "names no inference profile" in caplog.text
+
+    @pytest.mark.parametrize(
+        "model_id",
+        ["us.openai.gpt-5.6-sol", "global.openai.gpt-5.6-sol", "eu.openai.gpt-5.6-luna"],
+    )
+    def test_silent_for_profile_prefixed_ids(self, model_id, caplog):
+        with caplog.at_level("WARNING"):
+            build_bedrock_responses_model(model_id, region="us-west-2")
+
+        assert "names no inference profile" not in caplog.text
+
+    def test_warning_does_not_block_construction(self, caplog):
+        """A future in-Region model must not need a code change to run."""
+        with caplog.at_level("WARNING"):
+            model = build_bedrock_responses_model("openai.some-future-model", region="us-west-2")
+
+        assert model.get_config()["model_id"] == "openai.some-future-model"
+
+
+class TestPerRequestTokenMint:
+    """The reason this transport gets its own model class."""
+
+    def test_token_is_minted_on_every_resolve(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        with patch(_TOKEN_FN, side_effect=["token-1", "token-2"]) as mint:
+            first = model._resolve_client_args()
+            second = model._resolve_client_args()
+
+        assert mint.call_count == 2
+        assert first["api_key"] == "token-1"
+        assert second["api_key"] == "token-2"
+
+    def test_construction_does_not_mint(self):
+        """Nothing is signed until a request actually needs a credential."""
+        with patch(_TOKEN_FN) as mint:
+            build_bedrock_responses_model(
+                model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+            )
+
+        mint.assert_not_called()
+
+    def test_placeholder_key_never_survives_to_a_request(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+        placeholder = model.client_args["api_key"]
+
+        with patch(_TOKEN_FN, return_value="bedrock-api-key-real"):
+            resolved = model._resolve_client_args()
+
+        assert resolved["api_key"] == "bedrock-api-key-real"
+        assert resolved["api_key"] != placeholder
+
+    def test_base_url_survives_the_token_swap(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        with patch(_TOKEN_FN, return_value="bedrock-api-key-x"):
+            resolved = model._resolve_client_args()
+
+        assert resolved["base_url"] == (
+            "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+        )
+
+    def test_resolve_does_not_mutate_the_stored_client_args(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+        before = dict(model.client_args)
+
+        with patch(_TOKEN_FN, return_value="bedrock-api-key-x"):
+            model._resolve_client_args()
+
+        assert model.client_args == before
+
+
+class TestUsageNormalizationApplies:
+    """This transport is an OpenAI surface, so its usage needs normalizing too."""
+
+    def test_model_class_is_usage_normalized(self):
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+
+        assert type(model).__name__.startswith("UsageNormalized")
+        # The wrapper sits directly over our token-refreshing subclass.
+        assert type(model) is usage_normalized(type(model).__mro__[1])
+
+    def test_metadata_chunk_reports_disjoint_buckets(self):
+        from openai.types.responses.response_usage import ResponseUsage
+
+        model = build_bedrock_responses_model(
+            model_id="us.openai.gpt-5.6-sol", region="us-west-2"
+        )
+        usage_obj = ResponseUsage.model_validate(
+            {
+                "input_tokens": 30_500,
+                "input_tokens_details": {"cached_tokens": 30_000, "cache_write_tokens": 400},
+                "output_tokens": 120,
+                "output_tokens_details": {"reasoning_tokens": 64},
+                "total_tokens": 30_620,
+            }
+        )
+
+        usage = model._format_chunk({"chunk_type": "metadata", "data": usage_obj})[
+            "metadata"
+        ]["usage"]
+
+        assert usage["inputTokens"] == 100
+        assert usage["cacheReadInputTokens"] == 30_000
+        assert usage["cacheWriteInputTokens"] == 400
+        assert (
+            usage["inputTokens"]
+            + usage["cacheReadInputTokens"]
+            + usage["cacheWriteInputTokens"]
+        ) == usage["totalTokens"] - usage["outputTokens"]

--- a/backend/tests/shared/test_openai_surface_model_records.py
+++ b/backend/tests/shared/test_openai_surface_model_records.py
@@ -1,0 +1,75 @@
+"""Managed-model field resolution for the OpenAI-compatible Bedrock surfaces.
+
+``apiMode`` and ``region`` are wire-generic fields that mean something on two
+providers — ``mantle`` and ``bedrock-responses`` — and nothing on the rest.
+These pin how a record is normalized on write, which is the only place that
+decision is made.
+"""
+
+import pytest
+
+from apis.shared.models.managed_models import (
+    _resolve_supports_caching,
+    _resolve_mantle_api_mode,
+    _resolve_mantle_region,
+)
+
+
+class TestApiModeResolution:
+    @pytest.mark.parametrize(
+        "stored,expected",
+        [("chat", "chat"), ("responses", "responses"), (None, "chat"), ("bogus", "chat")],
+    )
+    def test_mantle_is_admin_selectable(self, stored, expected):
+        assert _resolve_mantle_api_mode(stored, "mantle") == expected
+
+    @pytest.mark.parametrize("stored", ["chat", "responses", None, "", "bogus"])
+    def test_bedrock_responses_is_always_responses(self, stored):
+        """Not a choice: that transport exists because 5.6 caches only there.
+
+        A stored 'chat' — from a hand-edited record, or a provider switch that
+        left the old value behind — would silently downgrade the model to an
+        uncached Chat Completions call. Normalize, don't honor.
+        """
+        assert _resolve_mantle_api_mode(stored, "bedrock-responses") == "responses"
+
+    @pytest.mark.parametrize("provider", ["bedrock", "openai", "gemini"])
+    def test_inert_for_other_providers(self, provider):
+        assert _resolve_mantle_api_mode("responses", provider) is None
+
+    def test_provider_matching_is_case_insensitive(self):
+        assert _resolve_mantle_api_mode("chat", "Bedrock-Responses") == "responses"
+
+
+class TestRegionResolution:
+    @pytest.mark.parametrize("provider", ["mantle", "bedrock-responses"])
+    def test_kept_on_both_openai_surfaces(self, provider):
+        assert _resolve_mantle_region("us-east-1", provider) == "us-east-1"
+
+    @pytest.mark.parametrize("provider", ["mantle", "bedrock-responses"])
+    def test_empty_means_the_apps_region(self, provider):
+        assert _resolve_mantle_region("", provider) is None
+        assert _resolve_mantle_region(None, provider) is None
+
+    @pytest.mark.parametrize("provider", ["bedrock", "openai", "gemini"])
+    def test_dropped_for_other_providers(self, provider):
+        assert _resolve_mantle_region("us-east-1", provider) is None
+
+
+class TestCachingDefault:
+    @pytest.mark.parametrize("provider", ["bedrock", "bedrock-responses"])
+    def test_defaults_on_for_caching_families(self, provider):
+        assert _resolve_supports_caching(None, provider) is True
+
+    def test_mantle_defaults_off(self):
+        """Mantle hosts open-weight models that mostly don't cache."""
+        assert _resolve_supports_caching(None, "mantle") is False
+
+    @pytest.mark.parametrize("provider", ["openai", "gemini"])
+    def test_other_providers_default_off(self, provider):
+        assert _resolve_supports_caching(None, provider) is False
+
+    @pytest.mark.parametrize("provider", ["bedrock", "bedrock-responses", "mantle"])
+    def test_explicit_value_always_wins(self, provider):
+        assert _resolve_supports_caching(False, provider) is False
+        assert _resolve_supports_caching(True, provider) is True

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -95,7 +95,7 @@
                 [class.border-state-danger-500]="modelForm.controls.provider.invalid && modelForm.controls.provider.touched"
               >
                 @for (provider of availableProviders; track provider) {
-                  <option [value]="provider">{{ provider }}</option>
+                  <option [value]="provider">{{ providerLabels[provider] }}</option>
                 }
               </select>
               @if (modelForm.controls.provider.invalid && modelForm.controls.provider.touched) {
@@ -121,7 +121,21 @@
             </div>
           </div>
 
-          <!-- Bedrock Mantle API surface + region (Mantle provider only) -->
+          <!-- OpenAI-compatible Bedrock surfaces: API surface + region -->
+          @if (isBedrockResponses()) {
+            <div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+              <p class="text-sm/6 text-gray-700 dark:text-gray-300">
+                This transport always uses the <strong>Responses API</strong> on
+                <code>bedrock-runtime</code> — it exists because GPT-5.6 serves prompt caching
+                only over that API. The same model routed over Converse gets no caching at all.
+              </p>
+              <p class="mt-2 text-xs/5 text-gray-500 dark:text-gray-400">
+                Use a cross-Region inference profile id (<code>us.</code> or <code>global.</code>
+                prefixed, e.g. <code>us.openai.gpt-5.6-sol</code>). In-Region ids are not offered
+                on this endpoint for the GPT-5.6 family.
+              </p>
+            </div>
+          }
           @if (isMantle()) {
             <div>
               <label for="mantleApiMode" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
@@ -143,9 +157,11 @@
                 API" error at chat time.
               </p>
             </div>
+          }
+          @if (isOpenAiSurface()) {
             <div>
               <label for="mantleRegion" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                Mantle region
+                Endpoint region
               </label>
               <input
                 type="text"
@@ -156,7 +172,8 @@
               />
               <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
                 Optional. Pins inference to the region hosting the model (e.g. <code>us-east-1</code>),
-                independent of where the app runs. Leave blank to use the app's region.
+                independent of where the app runs, and signs the bearer token for it. Leave blank to
+                use the app's region.
               </p>
             </div>
           }
@@ -438,11 +455,11 @@
             </div>
           </div>
 
-          <!-- Prompt Caching (Bedrock Only) -->
-          @if (modelForm.value.provider === 'bedrock') {
+          <!-- Prompt Caching (Bedrock Converse + bedrock-runtime Responses) -->
+          @if (supportsCachingControls()) {
             <div class="space-y-4">
               <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
-                Prompt caching (Bedrock only)
+                Prompt caching
               </h3>
 
               <!-- Supports Caching Toggle -->

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -14,6 +14,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft, heroChevronDown, heroChevronRight } from '@ng-icons/heroicons/outline';
 import {
   AVAILABLE_PROVIDERS,
+  OPENAI_SURFACE_PROVIDERS,
+  PROVIDER_LABELS,
   KNOWN_PARAMS,
   KnownParamMeta,
   MANTLE_API_MODES,
@@ -263,12 +265,25 @@ export class ModelFormPage implements OnInit {
 
   /**
    * Tracks the selected provider as a signal so the template can show/hide
-   * the Mantle-only API-mode/region fields and suppress the caching controls
-   * (Mantle open-weight models never cache). Kept in sync with the form
-   * control in ngOnInit + its valueChanges subscription.
+   * the API-mode/region fields and the caching controls. Kept in sync with the
+   * form control in ngOnInit + its valueChanges subscription.
    */
   readonly selectedProvider = signal<ModelProvider>('bedrock');
   readonly isMantle = computed(() => this.selectedProvider() === 'mantle');
+  readonly isBedrockResponses = computed(() => this.selectedProvider() === 'bedrock-responses');
+  /**
+   * Either OpenAI-compatible Bedrock surface. Both carry a region override and
+   * a bearer-token transport; only the API surface differs, and only Mantle
+   * lets an admin choose it.
+   */
+  readonly isOpenAiSurface = computed(() =>
+    OPENAI_SURFACE_PROVIDERS.includes(this.selectedProvider()),
+  );
+  readonly providerLabels = PROVIDER_LABELS;
+  /** Providers whose models can prompt-cache — drives the caching form block. */
+  readonly supportsCachingControls = computed(
+    () => this.selectedProvider() === 'bedrock' || this.isBedrockResponses(),
+  );
 
   /**
    * Model-id suggestions for the Mantle escape-hatch form, sourced from the
@@ -444,6 +459,11 @@ export class ModelFormPage implements OnInit {
       this.selectedProvider.set(provider);
       if (provider === 'mantle') {
         this.loadMantleModelIdOptions();
+      }
+      if (provider === 'bedrock-responses') {
+        // Not admin-selectable on this transport; keep the control's value
+        // truthful so a later provider switch doesn't carry 'chat' back in.
+        this.modelForm.controls.mantleApiMode.setValue('responses');
       }
     });
 
@@ -989,10 +1009,15 @@ export class ModelFormPage implements OnInit {
         cacheReadPricePerMillionTokens: v.cacheReadPricePerMillionTokens,
         knowledgeCutoffDate: v.knowledgeCutoffDate,
         supportsCaching: v.supportsCaching,
-        // Only meaningful for Mantle; null elsewhere so the backend stores
-        // nothing for other providers. An empty region means "app's region".
-        apiMode: v.provider === 'mantle' ? v.mantleApiMode : null,
-        region: v.provider === 'mantle' ? (v.mantleRegion?.trim() || null) : null,
+        // Only meaningful on an OpenAI-compatible Bedrock surface; null
+        // elsewhere so the backend stores nothing for other providers. An
+        // empty region means "app's region". The bedrock-runtime transport
+        // has no API-surface choice — it exists because GPT-5.6 caches only
+        // over Responses — so it is pinned rather than read from the form.
+        apiMode: this.apiModeForProvider(v.provider),
+        region: OPENAI_SURFACE_PROVIDERS.includes(v.provider)
+          ? (v.mantleRegion?.trim() || null)
+          : null,
         supportedParams: this.collectSupportedParams(),
       };
 
@@ -1015,6 +1040,21 @@ export class ModelFormPage implements OnInit {
     } finally {
       this.isSubmitting.set(false);
     }
+  }
+
+  /**
+   * The API surface to persist for a provider.
+   *
+   * Mantle is the only provider where this is a real choice. The
+   * bedrock-runtime transport is pinned to `responses` — the same
+   * normalization the backend applies when the record is written — because a
+   * model silently downgraded to Chat Completions there would lose prompt
+   * caching, which is the only reason to use that transport.
+   */
+  private apiModeForProvider(provider: ModelProvider): MantleApiMode | null {
+    if (provider === 'bedrock-responses') return 'responses';
+    if (provider === 'mantle') return this.modelForm.value.mantleApiMode ?? 'chat';
+    return null;
   }
 
   /**

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -297,10 +297,18 @@ export const CURATED_MANTLE_MODELS: CuratedModel[] = [
  * Provider-keyed lookup for the catalog tabs. Bedrock + Mantle are populated;
  * OpenAI/Gemini are intentional empty arrays — the page renders a
  * 'Coming soon' empty state when the active tab has no entries.
+ *
+ * `bedrock-responses` is empty for now: the transport landed ahead of its
+ * catalog rows, whose rates have to be verified against the Price List API
+ * first. Adding a model there today means the escape-hatch form, which works.
+ * NOTE for whoever curates it: `mantleDefaults()` hardcodes
+ * `supportsCaching: false` — a GPT-5.6 row must not inherit that, since
+ * caching is the entire reason this transport exists.
  */
 export const CURATED_MODELS_BY_PROVIDER: Record<ModelProvider, CuratedModel[]> = {
   bedrock: CURATED_BEDROCK_MODELS,
   openai: [],
   gemini: [],
   mantle: CURATED_MANTLE_MODELS,
+  'bedrock-responses': [],
 };

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -1,17 +1,51 @@
 /**
  * Available model providers.
  *
- * `mantle` is Amazon Bedrock Mantle — AWS's OpenAI-compatible inference
- * surface for Bedrock-hosted open-weight models. It is a distinct provider
- * from `bedrock` because the backend reaches it over the OpenAI wire
- * protocol with a bearer token rather than the Converse API.
+ * Two of them are OpenAI-compatible Bedrock surfaces — the backend reaches
+ * both over the OpenAI wire protocol with a bearer token rather than the
+ * Converse API, which is why neither is just `bedrock`:
+ *
+ * - `mantle` — Amazon Bedrock Mantle, AWS's OpenAI-compatible surface for
+ *   Bedrock-hosted open-weight models.
+ * - `bedrock-responses` — the OpenAI **Responses** API on `bedrock-runtime`.
+ *   Exists because GPT-5.6 serves prompt caching only over the Responses API;
+ *   the same model routed over Converse gets no caching at all.
  */
-export type ModelProvider = 'bedrock' | 'openai' | 'gemini' | 'mantle';
+export type ModelProvider = 'bedrock' | 'openai' | 'gemini' | 'mantle' | 'bedrock-responses';
 
 /**
  * Available model providers as a constant array.
  */
-export const AVAILABLE_PROVIDERS: ModelProvider[] = ['bedrock', 'openai', 'gemini', 'mantle'];
+export const AVAILABLE_PROVIDERS: ModelProvider[] = [
+  'bedrock',
+  'openai',
+  'gemini',
+  'mantle',
+  'bedrock-responses',
+];
+
+/**
+ * Providers that ride the OpenAI wire protocol against a Bedrock endpoint.
+ *
+ * These share the `apiMode` / `region` fields and the bearer-token transport.
+ * Kept as one list so the form doesn't accumulate `=== 'mantle' || === ...`
+ * checks that drift apart.
+ */
+export const OPENAI_SURFACE_PROVIDERS: readonly ModelProvider[] = ['mantle', 'bedrock-responses'];
+
+/**
+ * Human-readable labels for the provider picker.
+ *
+ * The raw values are wire identifiers; `bedrock-responses` in particular says
+ * nothing useful to an admin choosing a transport.
+ */
+export const PROVIDER_LABELS: Record<ModelProvider, string> = {
+  bedrock: 'Bedrock (Converse)',
+  openai: 'OpenAI',
+  gemini: 'Google Gemini',
+  mantle: 'Bedrock Mantle',
+  'bedrock-responses': 'Bedrock Runtime (Responses API)',
+};
 
 /**
  * Capability + bounds for a single inference parameter.
@@ -112,16 +146,20 @@ export interface ManagedModel {
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
   /**
-   * Bedrock Mantle API surface (`provider === 'mantle'` only): `chat` (OpenAI
-   * Chat Completions, the default) or `responses` (OpenAI Responses API —
-   * required by models that don't serve Chat Completions, e.g. openai.gpt-5.x).
-   * Null/absent for every other provider.
+   * OpenAI-compatible API surface: `chat` (OpenAI Chat Completions, the
+   * default) or `responses` (OpenAI Responses API — required by models that
+   * don't serve Chat Completions, e.g. openai.gpt-5.x).
+   *
+   * Selectable for `provider === 'mantle'`. Forced to `responses` for
+   * `provider === 'bedrock-responses'`, whose whole reason to exist is that
+   * GPT-5.6 caches only over that API. Null/absent for every other provider.
    */
   apiMode?: MantleApiMode | null;
   /**
-   * Bedrock Mantle region override (`provider === 'mantle'` only): pins
-   * inference to the region hosting the model (e.g. `us-east-1`), independent
-   * of where the app runs. Null/absent -> the app's region and for other providers.
+   * Region override for an OpenAI-compatible Bedrock surface (`mantle` or
+   * `bedrock-responses`): pins inference to the region hosting the model
+   * (e.g. `us-east-1`), independent of where the app runs, and signs the
+   * bearer token for it. Null/absent -> the app's region and for other providers.
    */
   region?: string | null;
   /** @deprecated No longer used — the SDK derives the base path from the model id. */
@@ -183,24 +221,25 @@ export interface ManagedModelFormData {
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
   /**
-   * Bedrock Mantle API surface (`provider === 'mantle'` only): `chat` or
-   * `responses`. Inert for other providers.
+   * OpenAI-compatible API surface: `chat` or `responses`. Selectable for
+   * `mantle`; forced to `responses` for `bedrock-responses`. Inert for other
+   * providers.
    */
   apiMode?: MantleApiMode | null;
   /**
-   * Bedrock Mantle region override (`provider === 'mantle'` only). Empty ->
-   * the app's region. Inert for other providers.
+   * Region override for an OpenAI-compatible Bedrock surface (`mantle` or
+   * `bedrock-responses`). Empty -> the app's region. Inert for other providers.
    */
   region?: string | null;
   /** Per-model inference parameter capabilities */
   supportedParams?: SupportedParams | null;
 }
 
-/** Selectable Bedrock Mantle API surfaces for the model form. */
+/** Selectable OpenAI-compatible API surfaces for the model form. */
 export const MANTLE_API_MODES = ['chat', 'responses'] as const;
 export type MantleApiMode = (typeof MANTLE_API_MODES)[number];
 
-/** Human-readable labels for the Mantle API surface options. */
+/** Human-readable labels for the OpenAI API surface options. */
 export const MANTLE_API_MODE_LABELS: Record<MantleApiMode, string> = {
   chat: 'Chat Completions',
   responses: 'Responses API',
@@ -268,8 +307,9 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
       openai: { min: 0, max: 2 },    // OpenAI accepts 0–2
       gemini: { min: 0, max: 1 },
       mantle: { min: 0, max: 2 },    // OpenAI wire protocol range
+      'bedrock-responses': { min: 0, max: 2 },
     },
-    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle', 'bedrock-responses'],
   },
   {
     key: 'top_p',
@@ -278,7 +318,7 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     kind: 'number',
     defaultMin: 0,
     defaultMax: 1,
-    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle', 'bedrock-responses'],
   },
   {
     key: 'top_k',
@@ -294,7 +334,7 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     description: 'Maximum tokens in the model response.',
     kind: 'integer',
     defaultMin: 1,
-    providers: ['bedrock', 'openai', 'gemini', 'mantle'],
+    providers: ['bedrock', 'openai', 'gemini', 'mantle', 'bedrock-responses'],
   },
   {
     key: 'thinking',
@@ -321,9 +361,11 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
   {
     key: 'reasoning_effort',
     label: 'Reasoning Effort',
-    description: 'Reasoning depth (OpenAI o-series and reasoning models on Bedrock Mantle).',
+    description:
+      'Reasoning depth (OpenAI o-series and reasoning models on the ' +
+      'OpenAI-compatible Bedrock surfaces).',
     kind: 'number',
-    providers: ['openai', 'mantle'],
+    providers: ['openai', 'mantle', 'bedrock-responses'],
   },
 ];
 

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -485,6 +485,13 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
   //     across regions, so foundation-model must be granted on ALL regions
   //     (`bedrock:*::`), and the inference-profile resource itself is the
   //     account-level ARN in this region.
+  //
+  // ⚠️ The account-scoped resource is also what authorizes the
+  // `bedrock-runtime` OpenAI-compatible endpoint (provider="bedrock-responses",
+  // reached from api-converse), which additionally requires
+  // `bedrock:InvokeModel` on the account's DEFAULT PROJECT —
+  // `arn:aws:bedrock:<region>:<account>:project/default`, already matched by
+  // the `:*` suffix. Do not narrow this to `inference-profile/*`.
   taskRole.addToPrincipalPolicy(
     new iam.PolicyStatement({
       sid: 'BedrockInvokeModel',

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -79,6 +79,16 @@ export function createRuntimeExecutionRole(
   // resource, already covered below. Without this action a flipped native
   // flag AccessDenies and caches the model into the no-count skip list for
   // the process lifetime.
+  //
+  // ⚠️ The account-scoped resource below is LOAD-BEARING for two things
+  // beyond the inference profile, so do not narrow it to
+  // `inference-profile/*` without re-checking:
+  //   - OpenAI models on the `bedrock-runtime` OpenAI-compatible endpoint
+  //     (provider="bedrock-responses") additionally require
+  //     `bedrock:InvokeModel` on the account's DEFAULT PROJECT,
+  //     `arn:aws:bedrock:<region>:<account>:project/default`, which the
+  //     `:*` suffix already matches. There is no separate statement for it.
+  //   - CountTokens on the inference-profile ARN.
   role.addToPolicy(new iam.PolicyStatement({
     sid: 'BedrockModelInvocation',
     effect: iam.Effect.ALLOW,


### PR DESCRIPTION
## PR-2 of [`docs/specs/gpt-5-6-prompt-caching.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/gpt-5-6-prompt-caching.md)

Adds the `bedrock-runtime` OpenAI **Responses** transport as a second OpenAI-compatible Bedrock surface alongside Mantle. Follows PR-1 (#945) and the spec correction (#947).

## Why a new transport rather than Converse

GPT-5.6 serves prompt caching **only over the Responses API**, on either endpoint. Converse is the tempting path — it drops straight into the existing `BedrockModel` plumbing with SigV4 and no new auth — and it is the one path with *zero* caching. At Sol's published rates a ~30k stable prefix costs ~$0.13/turn on Converse against ~$0.013 on a Responses cache hit.

`bedrock-runtime` over Mantle-Responses because it adds CRIS, invocation logging, CloudWatch metrics and Cost Explorer itemization, and Global CRIS is cheaper for this family. We give up server-side tool use (unused) and In-Region inference (not offered here for this model anyway). The Mantle path is untouched, so nothing already shipped moves.

## The transport

New `backend/src/apis/shared/models/bedrock_responses.py`, next to `mantle.py` per the import boundary, consumed by both `agents/` and `app_api`. `tests/architecture/test_import_boundaries.py` passes.

Strands' `bedrock_mantle_config` hardcodes the Mantle host and *rejects* a caller-supplied `base_url`/`api_key` when set, so this path uses plain `client_args` instead.

**The token refresh is the load-bearing part.** `bedrock_mantle_config` re-mints per request; a static `api_key` in `client_args` freezes at construction. Our microVMs live 18–50 min against a 12-hour token cap, so a frozen token would work *by luck* — right up until any longer-lived process. `build_bedrock_responses_model` returns a subclass overriding `_resolve_client_args()`, which Strands calls per request, to mint fresh. Tests pin that construction mints nothing and that two resolves produce two tokens.

Also here: a warning (not a gate) when a model id names no `us.`/`global.` inference profile — `bedrock-runtime` doesn't offer in-Region inference for the GPT-5.6 family, but a future model might, and shouldn't need a code change to run.

Usage normalization from #945 applies automatically — this is an OpenAI surface, so `input_tokens` is inclusive and gets normalized to disjoint buckets at the model seam.

## Wiring

- `ModelProvider.BEDROCK_RESPONSES = "bedrock-responses"`, `ModelConfig.to_bedrock_responses_config()`, and `AgentFactory._create_bedrock_responses_model`.
- `converse_routes`: `_build_request_mantle_model` becomes provider-aware `_build_request_openai_model`; `_stream_mantle`/`_mantle_converse` become `_stream_openai_surface`/`_openai_surface_converse`. Everything downstream of model construction — SSE translation, usage, cost — was already transport-agnostic and is unchanged; cost is now recorded against the actual provider.
- **`apiMode` is forced to `responses`** for this provider, on write (`managed_models.py`) *and* at request time (`converse_routes`). It is not an admin choice: a stored `chat` — from a hand-edited record or a provider switch that left the old value behind — would silently downgrade the model to an uncached Chat Completions call, losing the only reason to use this transport. Normalize, don't honor.
- `supportsCaching` now defaults **on** for `bedrock-responses` (implicit caching is on by default there). Deliberately still off for `mantle`, which hosts open-weight models that mostly don't cache.

The persisted/wire fields needed no migration — they were already the transport-neutral `apiMode` / `region`. Only the Python/TS attribute names still carry the historical `mantle_` prefix; noted in-code as a rename candidate rather than churned here.

## Frontend

Provider enum values are a cross-package contract, so the SPA moves in the same PR: `ModelProvider` union, `AVAILABLE_PROVIDERS`, an `OPENAI_SURFACE_PROVIDERS` list so the form stops accumulating `=== 'mantle' ||` checks that drift, and `PROVIDER_LABELS` (the raw `bedrock-responses` says nothing useful to an admin picking a transport).

In the form: the region field now shows for both OpenAI surfaces; the API-surface **select** stays Mantle-only, replaced on this transport by a note explaining why it's fixed and which model-id shape to use; the prompt-caching block is no longer gated to `provider === 'bedrock'`, since without it an admin can't record the cache rates PR-3 needs.

`CURATED_MODELS_BY_PROVIDER` gets an empty `bedrock-responses` bucket — the transport landed ahead of its catalog rows, whose rates have to be verified against the Price List API first. There's a note there for whoever curates it: `mantleDefaults()` hardcodes `supportsCaching: false` and a GPT-5.6 row must not inherit it.

## ⚠️ The spec's IAM step was wrong — no policy change needed

The spec says `bedrock:InvokeModel` on the account's default project ARN is "not present in `inference-api-iam-roles.ts` today", and sequences a `platform.yml` deploy ahead of the backend change.

It's already granted. Both roles' Bedrock statements use `arn:aws:bedrock:${region}:${account}:*`, which matches `arn:aws:bedrock:${region}:${account}:project/default`:

- `inference-api-iam-roles.ts` → `BedrockModelInvocation`
- `app-api-iam-grants.ts` → `BedrockInvokeModel`

So **no `platform.yml` deploy is required before this merges.** What I did instead is document the dependency at both statements, because that wildcard is now load-bearing for something non-obvious and a future "let's narrow this to `inference-profile/*`" hardening would break the OpenAI path with an opaque auth error. Comments only — the synthesized policy is byte-identical.

## Testing

- `backend/tests/shared/test_bedrock_responses.py` (24) — base URL and region resolution, construction contract, the per-request token mint, the inference-profile warning, and disjoint usage end-to-end through a real `ResponseUsage`.
- `backend/tests/shared/test_openai_surface_model_records.py` (28) — record normalization: `apiMode` forced on this provider and selectable on Mantle, `region` kept on both and dropped elsewhere, caching defaults.
- `test_agent_factory.py` (+4) — delegation, region override, param translation, and that it **never** routes through the Mantle builder.
- `test_api_converse_mantle.py` (+5) — builds via the runtime transport not Mantle, cost against the right provider, a stored `chat` can't downgrade the surface, streaming, and a regression guard that plain Bedrock still takes the Converse path.

- `cd frontend/ai.client && npm test` → **2234 passed**; `npx tsc --noEmit` clean
- `cd infrastructure && npx jest` → **783 passed**; `npx tsc --noEmit` clean
- Backend, targeted (new + every affected suite, incl. `tests/architecture`) → **113 passed**

Full backend suite, after the venv fix below: **7379 passed, 3 skipped, 0 failed** (11:59).

One thing worth flagging from the run before it: 8 failures in `tests/fine_tuning/test_train_script.py`, all `ModuleNotFoundError: No module named 'pandas'`. Not a regression and nothing to do with this change — `pandas==2.3.3` was added to the `dev` extra on `develop` after my worktree's venv was synced, and `dfba6f3f` made those tests non-optional so they now fail rather than skip. After `uv sync --extra agentcore --extra dev` that file passes 55/55. Noting it because anyone with a venv older than `dfba6f3f` will hit the same thing.

## What this PR does not prove

No live turn. Verifying the cache economics needs a catalog row with real rates, which is PR-3 — so the spec's Verification section (drive real turns, read the `C#` rows, expect turn 1 `first_write` and turns 2+ `hit`) runs after PR-3, not here. This PR is unit-tested plumbing.

## Not in this PR

PR-3 (catalog + verified pricing), PR-4 (explicit `prompt_cache_breakpoint` + `prompt_cache_key`), PR-5 (`CACHE_TTL_SECONDS` is wrong by 6× for OpenAI's 30-minute TTL).

Also still open from the spec's own "known non-blocking issues": `use_native_token_count` is set unconditionally on the Bedrock path and CountTokens is unsupported for GPT-5.6 — that path isn't reached by this transport, but the code comment asserting "every catalog model is Claude family" is now stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

