### PR TITLE
feat(artifacts): add the artifact library page

### DIFF
--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -61,6 +61,30 @@ class ArtifactListResponse(BaseModel):
     artifacts: list[ArtifactSummary] = Field(default_factory=list)
 
 
+class LibraryArtifact(BaseModel):
+    """One artifact at its current HEAD, for the user-wide library page.
+
+    Distinct from `ArtifactSummary` in cardinality, not just fields: the
+    session list returns one row per *version* so the SPA can anchor a
+    card under the turn that produced it, while the library returns one
+    row per *artifact*. Carries `session_id` so the library can link back
+    to the conversation that produced it — the summary has no need for it
+    (the caller already supplied the session id).
+    """
+
+    artifact_id: str
+    version: int
+    title: str
+    content_type: str
+    created_at: str
+    updated_at: str
+    session_id: str
+
+
+class ArtifactLibraryResponse(BaseModel):
+    artifacts: list[LibraryArtifact] = Field(default_factory=list)
+
+
 class ArtifactContentResponse(BaseModel):
     """Raw source of one artifact version, for the panel's code view.
 

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -9,8 +9,10 @@ from apis.shared.auth import User, get_current_user_from_session
 
 from .models import (
     ArtifactContentResponse,
+    ArtifactLibraryResponse,
     ArtifactListResponse,
     ArtifactSummary,
+    LibraryArtifact,
     RenderTokenRequest,
     RenderTokenResponse,
 )
@@ -107,6 +109,48 @@ async def list_session_artifacts(
 
     return ArtifactListResponse(
         artifacts=[ArtifactSummary(**row) for row in rows]
+    )
+
+
+@router.get("/library", response_model=ArtifactLibraryResponse)
+async def list_user_artifacts(
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactListService = Depends(get_artifact_list_service),
+) -> ArtifactLibraryResponse:
+    """Every artifact the caller owns, at HEAD, newest-first.
+
+    Backs the artifact library page. Takes no scoping parameter by
+    design: the only user it can ever describe is the authenticated one,
+    since the underlying Query is keyed on `PK=USER#{uid}`. There is no
+    way to ask this endpoint about somebody else.
+
+    A separate route rather than an optional `session_id` on the list
+    endpoint above, because the two differ in cardinality: that one
+    returns a row per *version* (the SPA anchors each to its turn), this
+    one a row per *artifact*. Overloading one path with both shapes would
+    make the response type depend on which query params were present.
+
+    Unpaginated, matching the shape of the data: the heaviest partition
+    in production holds well under a single 1MB Query page. Pagination
+    lands with the user index when it is needed, not before.
+    """
+    try:
+        rows = service.list_for_user(user_id=user.user_id)
+    except RenderTokenConfigError:
+        logger.exception("artifact library service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact listing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact library query failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact listing is temporarily unavailable",
+        )
+
+    return ArtifactLibraryResponse(
+        artifacts=[LibraryArtifact(**row) for row in rows]
     )
 
 

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -385,6 +385,80 @@ class ArtifactListService:
             )
         return summaries
 
+    def list_for_user(self, *, user_id: str) -> list[dict]:
+        """Every artifact the user owns, at HEAD, newest-first.
+
+        One base-table Query, no index. The table is already partitioned
+        by user (`PK=USER#{uid}`), so ownership is enforced by the key
+        rather than re-checked per row the way `list_for_session` has to
+        be — a user-wide list is the query this schema was already
+        shaped for.
+
+        Deliberately not using a GSI. `SessionIndex` is partitioned by
+        session, not user, so it cannot serve this at all; the sparse
+        user index the writer stamps keys for (`GSI2PK`/`GSI2SK`) does
+        not exist yet, and is not needed while the heaviest partition
+        sits far under a 1MB page. See the writer's module docstring.
+
+        Two consequences of reading the base table, both deliberate:
+
+        * The Query spans version rows as well as HEAD rows, so it reads
+          roughly 3x what it returns. Filtering happens here rather than
+          in a FilterExpression because the obvious server-side
+          discriminator (`attribute_exists(GSI1PK)`) would couple "is
+          HEAD" to "is session-indexed" — two facts that only happen to
+          coincide today — and a FilterExpression saves payload, not
+          read capacity, so it buys nothing worth that coupling.
+        * The base table sorts by artifact id (a random uuid4), not by
+          time, so recency ordering is applied here in memory. This is
+          the part that would move server-side behind the user index.
+        """
+        table = _table()
+        items: list[dict] = []
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("ARTIFACT#"),
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError("artifact library query failed") from exc
+
+        heads = [
+            item for item in items
+            if str(item.get("SK", "")).endswith("#HEAD")
+        ]
+        rows = [
+            {
+                "artifact_id": item.get("artifact_id", ""),
+                "version": int(item.get("version", 0)),
+                "title": item.get("title", ""),
+                "content_type": item.get(
+                    "content_type", "text/html; charset=utf-8"
+                ),
+                # Rows written before these attributes existed degrade to
+                # an empty string rather than dropping out of the library.
+                "created_at": item.get("created_at") or "",
+                "updated_at": item.get("updated_at") or "",
+                "session_id": item.get("session_id") or "",
+            }
+            for item in heads
+            if item.get("artifact_id")
+        ]
+        # Newest-first. Undated legacy rows sort last rather than first,
+        # which an empty-string key would otherwise do.
+        rows.sort(
+            key=lambda row: (bool(row["updated_at"]), row["updated_at"]),
+            reverse=True,
+        )
+        return rows
+
     @staticmethod
     def _versions_for_artifact(
         user_id: str, artifact_id: str

--- a/backend/tests/apis/app_api/artifacts/test_artifact_library.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_library.py
@@ -1,0 +1,288 @@
+"""Tests for the app-api user-wide artifact library endpoint.
+
+`GET /artifacts/library` differs from the session list next door in
+cardinality and in scoping: one row per *artifact* (not per version),
+across *every* session (not one), served by a single base-table Query on
+`PK=USER#{uid}` with no index involved.
+
+Ownership here is enforced by the partition key rather than re-checked
+per row, which is the substantive difference from `list_for_session` —
+that one reads a GSI partitioned by session and so has to filter. The
+scoping test below exists to prove the key is actually doing that job.
+"""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as artifact_service
+from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.app_api.artifacts.service import (
+    ArtifactListService,
+    ArtifactQueryError,
+    RenderTokenConfigError,
+    get_artifact_list_service,
+)
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+REGION = "us-east-1"
+USER_ID = "user-123"
+OTHER_USER = "user-456"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    artifact_service._reset_caches_for_tests()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        boto3.client("dynamodb", region_name=REGION).create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+
+        app = FastAPI()
+        app.include_router(artifacts_router)
+        app.dependency_overrides[get_current_user_from_session] = lambda: User(
+            email="u@x.com", user_id=USER_ID, name="U", roles=[]
+        )
+        yield TestClient(app), boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_artifact(
+    ddb,
+    *,
+    artifact: str,
+    user_id: str = USER_ID,
+    session_id: str = "sess-1",
+    title: str = "Doc",
+    updated_at: str | None = "2026-05-15T10:00:00+00:00",
+    content_type: str = "text/markdown",
+    versions: int = 1,
+) -> None:
+    """A HEAD row plus its version rows, mirroring the writer.
+
+    `updated_at=None` models a row written before the attribute existed.
+    The version rows matter: the library must not return them, and the
+    Query pays to read them, so a fixture without them would not
+    exercise the filter at all.
+    """
+    table = ddb.Table(TABLE)
+    common = {
+        "storage": "s3",
+        "content_type": content_type,
+        "artifact_id": artifact,
+        "user_id": user_id,
+        "session_id": session_id,
+        "title": title,
+        "created_at": "2026-05-01T09:00:00+00:00",
+    }
+    for version in range(1, versions + 1):
+        table.put_item(
+            Item={
+                **common,
+                "PK": f"USER#{user_id}",
+                "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+                "version": version,
+                "content_key": f"{user_id}/{artifact}/v{version}/index.html",
+                "updated_at": "2026-05-01T09:00:00+00:00",
+            }
+        )
+    head = {
+        **common,
+        "PK": f"USER#{user_id}",
+        "SK": f"ARTIFACT#{artifact}#HEAD",
+        "version": versions,
+        "content_key": f"{user_id}/{artifact}/v{versions}/index.html",
+        "GSI1PK": f"SESSION#{session_id}",
+    }
+    if updated_at is not None:
+        head["updated_at"] = updated_at
+        head["GSI1SK"] = f"ARTIFACT#{updated_at}#{artifact}"
+        head["GSI2PK"] = f"USER#{user_id}"
+        head["GSI2SK"] = f"ARTIFACT#{updated_at}#{artifact}"
+    table.put_item(Item=head)
+
+
+def test_returns_one_row_per_artifact_newest_first(client) -> None:
+    c, ddb = client
+    _put_artifact(ddb, artifact="a1", updated_at="2026-05-10T10:00:00+00:00")
+    _put_artifact(
+        ddb, artifact="a2", updated_at="2026-06-01T10:00:00+00:00", versions=4
+    )
+    _put_artifact(ddb, artifact="a3", updated_at="2026-05-20T10:00:00+00:00")
+
+    res = c.get("/artifacts/library")
+    assert res.status_code == 200
+    rows = res.json()["artifacts"]
+
+    # One per artifact — a2 has four versions and still appears once.
+    assert [r["artifact_id"] for r in rows] == ["a2", "a3", "a1"]
+    assert rows[0]["version"] == 4
+
+
+def test_spans_every_session(client) -> None:
+    """The point of the library: artifacts outlive the chat that made
+    them, and the user's whole history is one partition."""
+    c, ddb = client
+    _put_artifact(
+        ddb, artifact="a1", session_id="sess-1",
+        updated_at="2026-05-10T10:00:00+00:00",
+    )
+    _put_artifact(
+        ddb, artifact="a2", session_id="sess-2",
+        updated_at="2026-05-11T10:00:00+00:00",
+    )
+
+    rows = c.get("/artifacts/library").json()["artifacts"]
+    assert {r["session_id"] for r in rows} == {"sess-1", "sess-2"}
+
+
+def test_scopes_to_the_authenticated_user(client) -> None:
+    """Ownership rides the partition key. There is no request parameter
+    that could widen this, which is why the endpoint takes none."""
+    c, ddb = client
+    _put_artifact(ddb, artifact="mine")
+    _put_artifact(ddb, artifact="theirs", user_id=OTHER_USER)
+
+    rows = c.get("/artifacts/library").json()["artifacts"]
+    assert [r["artifact_id"] for r in rows] == ["mine"]
+
+
+def test_undated_legacy_rows_are_returned_and_sort_last(client) -> None:
+    """A row predating `updated_at` must still be listed — dropping a
+    user's oldest artifacts would be worse than showing them undated —
+    but an empty sort key must not float it to the top."""
+    c, ddb = client
+    _put_artifact(ddb, artifact="old", updated_at=None)
+    _put_artifact(ddb, artifact="new", updated_at="2026-05-10T10:00:00+00:00")
+
+    rows = c.get("/artifacts/library").json()["artifacts"]
+    assert [r["artifact_id"] for r in rows] == ["new", "old"]
+    assert rows[1]["updated_at"] == ""
+
+
+def test_carries_the_fields_the_library_renders(client) -> None:
+    c, ddb = client
+    _put_artifact(
+        ddb, artifact="a1", title="Budget model",
+        content_type="text/csv", session_id="sess-7",
+    )
+
+    row = c.get("/artifacts/library").json()["artifacts"][0]
+    assert row == {
+        "artifact_id": "a1",
+        "version": 1,
+        "title": "Budget model",
+        "content_type": "text/csv",
+        "created_at": "2026-05-01T09:00:00+00:00",
+        "updated_at": "2026-05-15T10:00:00+00:00",
+        "session_id": "sess-7",
+    }
+
+
+def test_empty_library_is_an_empty_list(client) -> None:
+    c, _ = client
+    res = c.get("/artifacts/library")
+    assert res.status_code == 200
+    assert res.json()["artifacts"] == []
+
+
+def test_query_failure_is_retryable_503(client) -> None:
+    c, _ = client
+
+    class Failing(ArtifactListService):
+        def list_for_user(self, *, user_id: str):
+            raise ArtifactQueryError("boom")
+
+    c.app.dependency_overrides[get_artifact_list_service] = Failing
+    assert c.get("/artifacts/library").status_code == 503
+
+
+def test_misconfiguration_is_500(client) -> None:
+    c, _ = client
+
+    class Misconfigured(ArtifactListService):
+        def list_for_user(self, *, user_id: str):
+            raise RenderTokenConfigError("no table")
+
+    c.app.dependency_overrides[get_artifact_list_service] = Misconfigured
+    assert c.get("/artifacts/library").status_code == 500
+
+
+def test_library_route_is_not_shadowed_by_the_artifact_id_route(client) -> None:
+    """`/artifacts/library` sits in the same space as
+    `/artifacts/{artifact_id}/content`. The literal must win rather than
+    be read as an artifact id."""
+    c, ddb = client
+    _put_artifact(ddb, artifact="a1")
+
+    res = c.get("/artifacts/library")
+    assert res.status_code == 200
+    assert "artifacts" in res.json()
+
+
+def test_paginates_a_partition_larger_than_one_page(client) -> None:
+    """The Query loop must drain `LastEvaluatedKey`. Asserted with a
+    stub rather than 1MB of fixture rows, since moto pages on real byte
+    size and a realistic partition is far under the limit."""
+    calls: list[dict] = []
+
+    class Paged:
+        def query(self, **kwargs):
+            calls.append(kwargs)
+            if "ExclusiveStartKey" not in kwargs:
+                return {
+                    "Items": [
+                        {
+                            "PK": f"USER#{USER_ID}",
+                            "SK": "ARTIFACT#a1#HEAD",
+                            "artifact_id": "a1",
+                            "version": 1,
+                            "title": "One",
+                            "content_type": "text/markdown",
+                            "created_at": "2026-05-01T09:00:00+00:00",
+                            "updated_at": "2026-05-01T09:00:00+00:00",
+                            "session_id": "s1",
+                        }
+                    ],
+                    "LastEvaluatedKey": {"PK": "x", "SK": "y"},
+                }
+            return {
+                "Items": [
+                    {
+                        "PK": f"USER#{USER_ID}",
+                        "SK": "ARTIFACT#a2#HEAD",
+                        "artifact_id": "a2",
+                        "version": 1,
+                        "title": "Two",
+                        "content_type": "text/markdown",
+                        "created_at": "2026-05-02T09:00:00+00:00",
+                        "updated_at": "2026-05-02T09:00:00+00:00",
+                        "session_id": "s2",
+                    }
+                ]
+            }
+
+    artifact_service._ddb_table = Paged()
+    rows = ArtifactListService().list_for_user(user_id=USER_ID)
+
+    assert len(calls) == 2
+    assert [r["artifact_id"] for r in rows] == ["a2", "a1"]

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -186,6 +186,11 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'artifacts',
+        loadComponent: () => import('./artifacts/artifact-library.page').then(m => m.ArtifactLibraryPage),
+        canActivate: [authGuard],
+    },
+    {
         path: 'oauth-complete',
         loadComponent: () => import('./oauth-complete/oauth-complete.page').then(m => m.OAuthCompletePage),
     },

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -1,0 +1,324 @@
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">
+          Artifacts
+        </h1>
+        <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+          Everything you've made with the assistant — documents, pages, tables — gathered
+          from every conversation.
+        </p>
+      </div>
+
+      @if (items().length > 0) {
+        <!-- One setting with two values, so a radiogroup rather than two
+             independent toggle buttons. Mirrors the Agents page. -->
+        <div
+          role="radiogroup"
+          aria-label="Layout"
+          class="inline-flex shrink-0 gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
+        >
+          <button
+            type="button"
+            role="radio"
+            [attr.aria-checked]="viewMode() === 'list'"
+            (click)="setViewMode('list')"
+            [appTooltip]="'List view'"
+            appTooltipPosition="top"
+            class="grid size-8 place-items-center rounded-xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            [class]="
+              viewMode() === 'list'
+                ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white'
+                : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+            "
+          >
+            <ng-icon name="heroBars3" class="size-4" aria-hidden="true" />
+            <span class="sr-only">List view</span>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            [attr.aria-checked]="viewMode() === 'grid'"
+            (click)="setViewMode('grid')"
+            [appTooltip]="'Grid view'"
+            appTooltipPosition="top"
+            class="grid size-8 place-items-center rounded-xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            [class]="
+              viewMode() === 'grid'
+                ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white'
+                : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+            "
+          >
+            <ng-icon name="heroSquares2x2" class="size-4" aria-hidden="true" />
+            <span class="sr-only">Grid view</span>
+          </button>
+        </div>
+      }
+    </div>
+
+    <!-- Error -->
+    @if (error()) {
+      <div
+        role="alert"
+        class="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:bg-state-danger-900/20 dark:text-state-danger-400"
+      >
+        <span>{{ error() }}</span>
+        <button
+          type="button"
+          (click)="load()"
+          class="rounded-2xl px-2.5 py-1 text-sm/6 font-medium underline underline-offset-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500"
+        >
+          Try again
+        </button>
+      </div>
+    }
+
+    <!-- Filters. Hidden until there is enough to be worth filtering. -->
+    @if (items().length > 0) {
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div class="relative flex-1 sm:max-w-xs">
+          <ng-icon
+            name="heroMagnifyingGlass"
+            class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <label for="artifact-search" class="sr-only">Search artifacts by title</label>
+          <input
+            id="artifact-search"
+            type="search"
+            [value]="search()"
+            (input)="onSearch($event)"
+            placeholder="Search by title"
+            class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+          />
+        </div>
+
+        @if (typeOptions().length > 1) {
+          <!-- appearance-none + overlaid chevron: the native chevron sits at a
+               fixed offset and collides with the rounded-2xl corner. -->
+          <div class="relative inline-flex">
+            <label for="artifact-type" class="sr-only">Filter by type</label>
+            <select
+              id="artifact-type"
+              [value]="typeFilter()"
+              (change)="onTypeFilter($event)"
+              class="appearance-none rounded-2xl border border-gray-300 bg-white py-2 pl-3 pr-9 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+              <option value="all">All types</option>
+              @for (option of typeOptions(); track option.value) {
+                <option [value]="option.value">{{ option.label }}</option>
+              }
+            </select>
+            <ng-icon
+              name="heroChevronDown"
+              class="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+          </div>
+        }
+
+        <p class="text-xs/5 text-gray-500 sm:ml-auto dark:text-gray-400" aria-live="polite">
+          {{ filtered().length }} of {{ items().length }}
+        </p>
+      </div>
+    }
+
+    <!-- Loading -->
+    @if (loading()) {
+      <div class="mt-6 space-y-2" aria-busy="true" aria-label="Loading artifacts">
+        @for (placeholder of [1, 2, 3, 4, 5]; track placeholder) {
+          <div class="h-16 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+        }
+      </div>
+    }
+
+    <!-- Empty: nothing has ever been created -->
+    @if (isEmpty()) {
+      <div
+        class="mt-8 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800"
+      >
+        <ng-icon
+          name="heroDocumentText"
+          class="mx-auto size-8 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        <h2 class="mt-3 text-sm/6 font-medium text-gray-900 dark:text-white">No artifacts yet</h2>
+        <p class="mx-auto mt-1 max-w-md text-sm/6 text-gray-600 dark:text-gray-400">
+          Ask the assistant to write a document, build a page, or draft a table, and it
+          will show up here.
+        </p>
+        <a
+          routerLink="/"
+          class="mt-6 inline-flex items-center gap-2 rounded-2xl bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        >
+          Start a conversation
+        </a>
+      </div>
+    }
+
+    <!-- Empty: the filters excluded everything -->
+    @if (isFilteredEmpty()) {
+      <div
+        class="mt-6 rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800"
+      >
+        <p class="text-sm/6 text-gray-600 dark:text-gray-400">
+          No artifacts match your search.
+        </p>
+      </div>
+    }
+
+    <!-- List view -->
+    @if (!loading() && filtered().length > 0 && viewMode() === 'list') {
+      <ul
+        role="list"
+        class="mt-6 divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+      >
+        @for (item of filtered(); track item.artifactId) {
+          <li class="flex items-center gap-3 px-3 py-3 sm:px-4">
+            <span
+              class="grid size-9 shrink-0 place-items-center rounded-2xl"
+              [class]="styleFor(item.contentType).bg"
+              aria-hidden="true"
+            >
+              <ng-icon
+                [name]="styleFor(item.contentType).icon"
+                class="size-5"
+                [class]="styleFor(item.contentType).text"
+              />
+            </span>
+
+            <div class="min-w-0 flex-1">
+              <button
+                type="button"
+                (click)="open(item)"
+                [disabled]="opening() === item.artifactId"
+                class="block max-w-full truncate text-left text-sm/6 font-semibold text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-white"
+              >
+                {{ item.title || 'Untitled artifact' }}
+              </button>
+              <p class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
+                <span>{{ styleFor(item.contentType).label }}</span>
+                @if (item.version > 1) {
+                  <span aria-hidden="true">·</span>
+                  <span>{{ versionLabel(item.version) }}</span>
+                }
+                <span aria-hidden="true">·</span>
+                @if (item.updatedAt) {
+                  <span>Updated {{ item.updatedAt | date: 'mediumDate' }}</span>
+                } @else {
+                  <span>Date unknown</span>
+                }
+              </p>
+            </div>
+
+            <div class="flex shrink-0 items-center gap-1">
+              @if (item.sessionId) {
+                <a
+                  [routerLink]="['/s', item.sessionId]"
+                  [appTooltip]="'Open the conversation'"
+                  appTooltipPosition="top"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
+                  <span class="sr-only">Open the conversation for {{ item.title }}</span>
+                </a>
+              }
+              <button
+                type="button"
+                (click)="open(item)"
+                [disabled]="opening() === item.artifactId"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              >
+                <ng-icon
+                  name="heroArrowTopRightOnSquare"
+                  class="size-4"
+                  aria-hidden="true"
+                />
+                <span class="sr-only">Open {{ item.title }} in a new tab</span>
+              </button>
+            </div>
+          </li>
+        }
+      </ul>
+    }
+
+    <!-- Grid view -->
+    @if (!loading() && filtered().length > 0 && viewMode() === 'grid') {
+      <ul role="list" class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        @for (item of filtered(); track item.artifactId) {
+          <li
+            class="flex flex-col rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div class="flex items-start gap-3">
+              <span
+                class="grid size-10 shrink-0 place-items-center rounded-2xl"
+                [class]="styleFor(item.contentType).bg"
+                aria-hidden="true"
+              >
+                <ng-icon
+                  [name]="styleFor(item.contentType).icon"
+                  class="size-5"
+                  [class]="styleFor(item.contentType).text"
+                />
+              </span>
+              <div class="min-w-0 flex-1">
+                <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                  <button
+                    type="button"
+                    (click)="open(item)"
+                    [disabled]="opening() === item.artifactId"
+                    class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60"
+                  >
+                    {{ item.title || 'Untitled artifact' }}
+                  </button>
+                </h2>
+                <span
+                  class="mt-1.5 inline-flex items-center rounded-2xl px-2 py-0.5 text-xs/5 font-medium"
+                  [class]="styleFor(item.contentType).bg + ' ' + styleFor(item.contentType).text"
+                >
+                  {{ styleFor(item.contentType).label }}
+                </span>
+              </div>
+            </div>
+
+            <p class="mt-4 grow text-xs/5 text-gray-500 dark:text-gray-400">
+              @if (item.updatedAt) {
+                Updated {{ item.updatedAt | date: 'mediumDate' }}
+              } @else {
+                Date unknown
+              }
+              @if (item.version > 1) {
+                <span aria-hidden="true"> · </span>{{ versionLabel(item.version) }}
+              }
+            </p>
+
+            <div
+              class="mt-4 flex items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700"
+            >
+              <button
+                type="button"
+                (click)="open(item)"
+                [disabled]="opening() === item.artifactId"
+                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
+                {{ opening() === item.artifactId ? 'Opening…' : 'Open' }}
+              </button>
+              @if (item.sessionId) {
+                <a
+                  [routerLink]="['/s', item.sessionId]"
+                  class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
+                  Conversation
+                </a>
+              }
+            </div>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</div>

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+
+import { ArtifactLibraryPage } from './artifact-library.page';
+import {
+  ArtifactHttpService,
+  type LibraryArtifact,
+} from '../session/services/artifacts/artifact-http.service';
+import { LocalSettingsService, type ViewMode } from '../services/local-settings.service';
+import { ToastService } from '../services/toast/toast.service';
+
+function stubArtifact(overrides: Partial<LibraryArtifact> = {}): LibraryArtifact {
+  return {
+    artifactId: 'a1',
+    version: 1,
+    title: 'Quarterly plan',
+    contentType: 'text/markdown',
+    createdAt: '2026-05-01T09:00:00+00:00',
+    updatedAt: '2026-05-15T10:00:00+00:00',
+    sessionId: 'sess-1',
+    ...overrides,
+  };
+}
+
+describe('ArtifactLibraryPage', () => {
+  let mockHttp: {
+    listLibrary: ReturnType<typeof vi.fn>;
+    mintRenderToken: ReturnType<typeof vi.fn>;
+  };
+  let mockSettings: {
+    artifactsViewMode: ReturnType<typeof signal<ViewMode>>;
+    setArtifactsViewMode: ReturnType<typeof vi.fn>;
+  };
+  let mockToast: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    mockHttp = {
+      listLibrary: vi.fn().mockResolvedValue([]),
+      mintRenderToken: vi
+        .fn()
+        .mockResolvedValue({ url: 'https://artifacts.example/x?t=tok', expiresAt: '' }),
+    };
+    mockSettings = {
+      artifactsViewMode: signal<ViewMode>('list'),
+      setArtifactsViewMode: vi.fn(),
+    };
+    mockToast = { success: vi.fn(), error: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        // The rows link to /s/:sessionId; an empty router would make those
+        // links throw NG04002 during template rendering.
+        provideRouter([
+          { path: '', children: [] },
+          { path: 's/:sessionId', children: [] },
+        ]),
+        { provide: ArtifactHttpService, useValue: mockHttp },
+        { provide: LocalSettingsService, useValue: mockSettings },
+        { provide: ToastService, useValue: mockToast },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+  });
+
+  async function createComponent() {
+    const fixture = TestBed.createComponent(ArtifactLibraryPage);
+    fixture.detectChanges();
+    // The constructor's load() is async; flush it before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  // Reaching protected members the way the template does.
+  function api(fixture: Awaited<ReturnType<typeof createComponent>>) {
+    return fixture.componentInstance as unknown as {
+      items: () => LibraryArtifact[];
+      filtered: () => LibraryArtifact[];
+      typeOptions: () => Array<{ value: string; label: string }>;
+      isEmpty: () => boolean;
+      isFilteredEmpty: () => boolean;
+      error: () => string | null;
+      loading: () => boolean;
+      search: { set: (v: string) => void };
+      typeFilter: { set: (v: string) => void };
+      styleFor: (t: string) => { label: string };
+      setViewMode: (m: ViewMode) => void;
+      open: (item: LibraryArtifact) => Promise<void>;
+      load: () => Promise<void>;
+    };
+  }
+
+  it('loads the library on init', async () => {
+    await createComponent();
+    expect(mockHttp.listLibrary).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves server ordering rather than re-sorting', async () => {
+    // Deliberately not in date order: the server sorts, the client must not
+    // second-guess it, or the two will diverge once paging exists.
+    mockHttp.listLibrary.mockResolvedValue([
+      stubArtifact({ artifactId: 'b', updatedAt: '2026-01-01T00:00:00+00:00' }),
+      stubArtifact({ artifactId: 'a', updatedAt: '2026-09-01T00:00:00+00:00' }),
+    ]);
+    const c = api(await createComponent());
+    expect(c.filtered().map((i) => i.artifactId)).toEqual(['b', 'a']);
+  });
+
+  it('surfaces a retryable message when the load fails', async () => {
+    mockHttp.listLibrary.mockRejectedValue(new Error('503'));
+    const c = api(await createComponent());
+    expect(c.error()).toContain("couldn't load");
+    expect(c.loading()).toBe(false);
+  });
+
+  it('filters by title, case-insensitively', async () => {
+    mockHttp.listLibrary.mockResolvedValue([
+      stubArtifact({ artifactId: 'a', title: 'Budget model' }),
+      stubArtifact({ artifactId: 'b', title: 'Reading list' }),
+    ]);
+    const c = api(await createComponent());
+    c.search.set('BUDGET');
+    expect(c.filtered().map((i) => i.artifactId)).toEqual(['a']);
+  });
+
+  it('filters by type with the charset suffix normalized away', async () => {
+    // The writer stores HTML as `text/html; charset=utf-8`. A filter keyed on
+    // the raw string would never match it.
+    mockHttp.listLibrary.mockResolvedValue([
+      stubArtifact({ artifactId: 'a', contentType: 'text/html; charset=utf-8' }),
+      stubArtifact({ artifactId: 'b', contentType: 'text/markdown' }),
+    ]);
+    const c = api(await createComponent());
+    c.typeFilter.set('text/html');
+    expect(c.filtered().map((i) => i.artifactId)).toEqual(['a']);
+  });
+
+  it('offers only the types the user actually has, deduped', async () => {
+    mockHttp.listLibrary.mockResolvedValue([
+      stubArtifact({ artifactId: 'a', contentType: 'text/markdown' }),
+      stubArtifact({ artifactId: 'b', contentType: 'text/markdown' }),
+      stubArtifact({ artifactId: 'c', contentType: 'text/csv' }),
+    ]);
+    const c = api(await createComponent());
+    expect(c.typeOptions().map((o) => o.label)).toEqual(['CSV', 'Markdown']);
+  });
+
+  it('labels an unrecognised content type instead of dropping it', async () => {
+    mockHttp.listLibrary.mockResolvedValue([
+      stubArtifact({ contentType: 'application/x-weird' }),
+    ]);
+    const c = api(await createComponent());
+    expect(c.filtered()).toHaveLength(1);
+    expect(c.styleFor('application/x-weird').label).toBe('Text');
+  });
+
+  it('distinguishes an empty library from an empty filter result', async () => {
+    // Conflating these tells someone with a full library that it is empty.
+    mockHttp.listLibrary.mockResolvedValue([stubArtifact({ title: 'Budget' })]);
+    const c = api(await createComponent());
+
+    expect(c.isEmpty()).toBe(false);
+    expect(c.isFilteredEmpty()).toBe(false);
+
+    c.search.set('nothing matches this');
+    expect(c.isEmpty()).toBe(false);
+    expect(c.isFilteredEmpty()).toBe(true);
+  });
+
+  it('reports an empty library only once loading has resolved', async () => {
+    mockHttp.listLibrary.mockResolvedValue([]);
+    const c = api(await createComponent());
+    expect(c.isEmpty()).toBe(true);
+  });
+
+  it('persists the view mode through local settings', async () => {
+    const c = api(await createComponent());
+    c.setViewMode('grid');
+    expect(mockSettings.setArtifactsViewMode).toHaveBeenCalledWith('grid');
+  });
+
+  describe('open()', () => {
+    it('opens the tab before awaiting the mint, then points it at the URL', async () => {
+      // The ordering is the whole contract: a window.open() after the await
+      // is no longer tied to the click gesture and every browser blocks it.
+      const tab = { location: { href: '' }, close: vi.fn() };
+      const openSpy = vi
+        .spyOn(window, 'open')
+        .mockImplementation(() => tab as unknown as Window);
+
+      let mintStarted = false;
+      mockHttp.mintRenderToken.mockImplementation(async () => {
+        mintStarted = true;
+        expect(openSpy).toHaveBeenCalled();
+        return { url: 'https://artifacts.example/a1', expiresAt: '' };
+      });
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact({ artifactId: 'a1', version: 3, sessionId: 's9' }));
+
+      expect(mintStarted).toBe(true);
+      expect(mockHttp.mintRenderToken).toHaveBeenCalledWith('a1', 3, 's9');
+      expect(tab.location.href).toBe('https://artifacts.example/a1');
+      expect(tab.close).not.toHaveBeenCalled();
+    });
+
+    it('closes the blank tab and reports the failure when minting fails', async () => {
+      const tab = { location: { href: '' }, close: vi.fn() };
+      vi.spyOn(window, 'open').mockImplementation(() => tab as unknown as Window);
+      mockHttp.mintRenderToken.mockRejectedValue(new Error('500'));
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact());
+
+      // Leaving an about:blank tab open would look like a broken app.
+      expect(tab.close).toHaveBeenCalled();
+      expect(mockToast.error).toHaveBeenCalled();
+    });
+
+    it('reports a blocked pop-up without minting a token', async () => {
+      vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact());
+
+      expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
+      expect(mockToast.error).toHaveBeenCalledWith(
+        'Pop-up blocked',
+        expect.stringContaining('Allow pop-ups'),
+      );
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders a row per artifact in list view', async () => {
+      mockSettings.artifactsViewMode.set('list');
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ artifactId: 'a', title: 'Budget model' }),
+        stubArtifact({ artifactId: 'b', title: 'Reading list' }),
+      ]);
+      const fixture = await createComponent();
+      const rows = fixture.nativeElement.querySelectorAll('li');
+      expect(rows).toHaveLength(2);
+      expect(fixture.nativeElement.textContent).toContain('Budget model');
+    });
+
+    it('switches to cards in grid view', async () => {
+      mockSettings.artifactsViewMode.set('grid');
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ title: 'Budget model' })]);
+      const fixture = await createComponent();
+      // The grid card exposes a labelled Open control; the list row uses an
+      // icon button with an sr-only label instead.
+      expect(fixture.nativeElement.textContent).toContain('Open');
+      expect(fixture.nativeElement.textContent).toContain('Conversation');
+    });
+
+    it('falls back to a placeholder title and an undated label', async () => {
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ title: '', updatedAt: '' }),
+      ]);
+      const fixture = await createComponent();
+      expect(fixture.nativeElement.textContent).toContain('Untitled artifact');
+      expect(fixture.nativeElement.textContent).toContain('Date unknown');
+    });
+
+    it('omits the conversation link when the row has no session', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ sessionId: '' })]);
+      const fixture = await createComponent();
+      expect(fixture.nativeElement.querySelector('a[href^="/s/"]')).toBeNull();
+    });
+  });
+});

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -1,0 +1,276 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowTopRightOnSquare,
+  heroBars3,
+  heroChatBubbleLeftRight,
+  heroChevronDown,
+  heroCodeBracket,
+  heroDocument,
+  heroDocumentText,
+  heroMagnifyingGlass,
+  heroPhoto,
+  heroSquares2x2,
+  heroTableCells,
+} from '@ng-icons/heroicons/outline';
+
+import {
+  ArtifactHttpService,
+  type LibraryArtifact,
+} from '../session/services/artifacts/artifact-http.service';
+import { LocalSettingsService, type ViewMode } from '../services/local-settings.service';
+import { ToastService } from '../services/toast/toast.service';
+import { TooltipDirective } from '../components/tooltip/tooltip.directive';
+
+/**
+ * Presentation for one artifact content type.
+ *
+ * Colors are `filetype-*` identity tokens, not brand tokens: a Markdown
+ * badge means "this is Markdown" and must not follow a rebrand, the same
+ * reason `file-card.component.ts` uses them for attachments. Reusing the
+ * same hues keeps one artifact and one uploaded file of the same type
+ * reading as the same kind of thing.
+ */
+interface TypeStyle {
+  readonly label: string;
+  readonly icon: string;
+  readonly bg: string;
+  readonly text: string;
+}
+
+const TYPE_STYLES: Record<string, TypeStyle> = {
+  'text/markdown': {
+    label: 'Markdown',
+    icon: 'heroDocumentText',
+    bg: 'bg-filetype-markdown-100 dark:bg-filetype-markdown-900/60',
+    text: 'text-filetype-markdown-600 dark:text-filetype-markdown-300',
+  },
+  'text/x-markdown': {
+    label: 'Markdown',
+    icon: 'heroDocumentText',
+    bg: 'bg-filetype-markdown-100 dark:bg-filetype-markdown-900/60',
+    text: 'text-filetype-markdown-600 dark:text-filetype-markdown-300',
+  },
+  'text/html': {
+    label: 'Web page',
+    icon: 'heroCodeBracket',
+    bg: 'bg-filetype-code-100 dark:bg-filetype-code-900/60',
+    text: 'text-filetype-code-600 dark:text-filetype-code-300',
+  },
+  'application/xhtml+xml': {
+    label: 'Web page',
+    icon: 'heroCodeBracket',
+    bg: 'bg-filetype-code-100 dark:bg-filetype-code-900/60',
+    text: 'text-filetype-code-600 dark:text-filetype-code-300',
+  },
+  'text/csv': {
+    label: 'CSV',
+    icon: 'heroTableCells',
+    bg: 'bg-filetype-sheet-100 dark:bg-filetype-sheet-900/60',
+    text: 'text-filetype-sheet-600 dark:text-filetype-sheet-300',
+  },
+  'image/svg+xml': {
+    label: 'SVG',
+    icon: 'heroPhoto',
+    bg: 'bg-filetype-image-100 dark:bg-filetype-image-900/60',
+    text: 'text-filetype-image-600 dark:text-filetype-image-300',
+  },
+};
+
+const DEFAULT_TYPE_STYLE: TypeStyle = {
+  label: 'Text',
+  icon: 'heroDocument',
+  bg: 'bg-gray-100 dark:bg-gray-700',
+  text: 'text-gray-600 dark:text-gray-300',
+};
+
+/**
+ * The artifact library at `/artifacts` — every artifact the user has ever
+ * produced, across every conversation.
+ *
+ * Artifacts outlive the chat that made them, but until now the only way
+ * back to one was to remember which conversation produced it and scroll.
+ * This is the index.
+ *
+ * Filtering and sorting are entirely client-side, which is a deliberate
+ * match to the endpoint: it returns the user's whole library in one
+ * unpaginated response, because a single user's artifacts sit far under
+ * one DynamoDB page. If that endpoint ever gains pagination, search and
+ * the type filter have to move to the server with it — a filter that
+ * only sees the loaded page is worse than no filter, because it looks
+ * authoritative.
+ *
+ * Ordering comes from the server and is not re-sorted here, for the same
+ * reason.
+ */
+@Component({
+  selector: 'app-artifact-library',
+  imports: [RouterLink, NgIcon, DatePipe, TooltipDirective],
+  templateUrl: './artifact-library.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [
+    provideIcons({
+      heroArrowTopRightOnSquare,
+      heroBars3,
+      heroChatBubbleLeftRight,
+      heroChevronDown,
+      heroCodeBracket,
+      heroDocument,
+      heroDocumentText,
+      heroMagnifyingGlass,
+      heroPhoto,
+      heroSquares2x2,
+      heroTableCells,
+    }),
+  ],
+})
+export class ArtifactLibraryPage {
+  private readonly artifacts = inject(ArtifactHttpService);
+  private readonly localSettings = inject(LocalSettingsService);
+  private readonly toast = inject(ToastService);
+
+  protected readonly items = signal<LibraryArtifact[]>([]);
+  protected readonly loading = signal(true);
+  protected readonly error = signal<string | null>(null);
+  protected readonly search = signal('');
+  protected readonly typeFilter = signal<string>('all');
+  /** Artifact id whose render URL is being minted, so its button can wait. */
+  protected readonly opening = signal<string | null>(null);
+
+  protected readonly viewMode = this.localSettings.artifactsViewMode;
+
+  /**
+   * Type options built from what the user actually has, not from the full
+   * `TYPE_STYLES` map — offering a "CSV" filter to someone with no CSV
+   * artifacts is a dead end that reads as a broken filter.
+   */
+  protected readonly typeOptions = computed(() => {
+    const seen = new Map<string, string>();
+    for (const item of this.items()) {
+      const key = this.normalizeType(item.contentType);
+      if (!seen.has(key)) {
+        seen.set(key, this.styleFor(item.contentType).label);
+      }
+    }
+    return [...seen.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  });
+
+  protected readonly filtered = computed(() => {
+    const term = this.search().trim().toLowerCase();
+    const type = this.typeFilter();
+    return this.items().filter((item) => {
+      if (type !== 'all' && this.normalizeType(item.contentType) !== type) {
+        return false;
+      }
+      return term === '' || item.title.toLowerCase().includes(term);
+    });
+  });
+
+  /** True only once loading has resolved, so the empty state can't flash. */
+  protected readonly isEmpty = computed(
+    () => !this.loading() && !this.error() && this.items().length === 0,
+  );
+
+  /**
+   * "Nothing matches" is a different message from "you have nothing", and
+   * conflating them tells a user with a full library that it is empty.
+   */
+  protected readonly isFilteredEmpty = computed(
+    () =>
+      !this.loading() &&
+      this.items().length > 0 &&
+      this.filtered().length === 0,
+  );
+
+  constructor() {
+    void this.load();
+  }
+
+  protected async load(): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      this.items.set(await this.artifacts.listLibrary());
+    } catch {
+      this.error.set("We couldn't load your artifacts. Try again in a moment.");
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected setViewMode(mode: ViewMode): void {
+    this.localSettings.setArtifactsViewMode(mode);
+  }
+
+  protected onSearch(event: Event): void {
+    this.search.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onTypeFilter(event: Event): void {
+    this.typeFilter.set((event.target as HTMLSelectElement).value);
+  }
+
+  protected styleFor(contentType: string): TypeStyle {
+    return TYPE_STYLES[this.normalizeType(contentType)] ?? DEFAULT_TYPE_STYLE;
+  }
+
+  protected versionLabel(version: number): string {
+    return `v${version}`;
+  }
+
+  /**
+   * Open the rendered artifact in a new tab.
+   *
+   * The tab is opened *before* the await, then pointed at the minted URL.
+   * Opening it afterwards would be a popup blocked by every browser,
+   * because by then the click is no longer the active user gesture.
+   *
+   * Minting is per-click rather than up front for the whole list: a
+   * render token is a short-lived (~120s) bearer credential in a URL, so
+   * pre-minting one per row would both expire before use and mean a
+   * round trip per artifact just to draw the page.
+   */
+  protected async open(item: LibraryArtifact): Promise<void> {
+    const tab = window.open('', '_blank', 'noopener,noreferrer');
+    if (!tab) {
+      this.toast.error(
+        'Pop-up blocked',
+        'Allow pop-ups for this site to open artifacts in a new tab.',
+      );
+      return;
+    }
+
+    this.opening.set(item.artifactId);
+    try {
+      const token = await this.artifacts.mintRenderToken(
+        item.artifactId,
+        item.version,
+        item.sessionId,
+      );
+      tab.location.href = token.url;
+    } catch {
+      tab.close();
+      this.toast.error(
+        'Could not open artifact',
+        'The preview link could not be created. Try again in a moment.',
+      );
+    } finally {
+      this.opening.set(null);
+    }
+  }
+
+  /** Strips the `; charset=…` the writer stores on HTML content types. */
+  private normalizeType(contentType: string): string {
+    return contentType.split(';')[0].trim().toLowerCase();
+  }
+}

--- a/frontend/ai.client/src/app/services/local-settings.service.ts
+++ b/frontend/ai.client/src/app/services/local-settings.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, signal } from '@angular/core';
 
-/** How My Agents lays its list out. Per-device, not per-account. */
-export type AgentsViewMode = 'grid' | 'list';
+/** How a collection page lays its items out. Per-device, not per-account. */
+export type ViewMode = 'grid' | 'list';
+
+/** @deprecated Use {@link ViewMode} — the type was never agent-specific. */
+export type AgentsViewMode = ViewMode;
 
 @Injectable({
   providedIn: 'root'
@@ -10,6 +13,7 @@ export class LocalSettingsService {
   private readonly SHOW_TOKEN_COUNT_KEY = 'show-token-count';
   private readonly SHOW_DEBUG_OUTPUT_KEY = 'show-debug-output';
   private readonly AGENTS_VIEW_MODE_KEY = 'agents-view-mode';
+  private readonly ARTIFACTS_VIEW_MODE_KEY = 'artifacts-view-mode';
 
   readonly showTokenCount = signal(this.loadBoolean(this.SHOW_TOKEN_COUNT_KEY, false));
   readonly showDebugOutput = signal(this.loadBoolean(this.SHOW_DEBUG_OUTPUT_KEY, false));
@@ -19,8 +23,20 @@ export class LocalSettingsService {
    * recognise, and most people have few enough agents that density is not yet the
    * problem. List becomes the better view somewhere around a screenful.
    */
-  readonly agentsViewMode = signal<AgentsViewMode>(
+  readonly agentsViewMode = signal<ViewMode>(
     this.loadViewMode(this.AGENTS_VIEW_MODE_KEY, 'grid'),
+  );
+
+  /**
+   * List is the default here, unlike Agents. An agent tile earns its size by
+   * showing artwork you recognise; an artifact has no artwork, so a grid card
+   * spends a lot of space to show the same title and date a row does. Most
+   * artifacts are documents — text/markdown outnumbers text/html roughly two
+   * to one in production — and a document library is something you scan, not
+   * something you browse.
+   */
+  readonly artifactsViewMode = signal<ViewMode>(
+    this.loadViewMode(this.ARTIFACTS_VIEW_MODE_KEY, 'list'),
   );
 
   setShowTokenCount(value: boolean): void {
@@ -33,9 +49,14 @@ export class LocalSettingsService {
     localStorage.setItem(this.SHOW_DEBUG_OUTPUT_KEY, JSON.stringify(value));
   }
 
-  setAgentsViewMode(value: AgentsViewMode): void {
+  setAgentsViewMode(value: ViewMode): void {
     this.agentsViewMode.set(value);
     localStorage.setItem(this.AGENTS_VIEW_MODE_KEY, value);
+  }
+
+  setArtifactsViewMode(value: ViewMode): void {
+    this.artifactsViewMode.set(value);
+    localStorage.setItem(this.ARTIFACTS_VIEW_MODE_KEY, value);
   }
 
   private loadBoolean(key: string, defaultValue: boolean): boolean {
@@ -49,7 +70,7 @@ export class LocalSettingsService {
   }
 
   /** Stored raw rather than JSON-encoded, so anything unrecognised falls back. */
-  private loadViewMode(key: string, defaultValue: AgentsViewMode): AgentsViewMode {
+  private loadViewMode(key: string, defaultValue: ViewMode): ViewMode {
     const stored = localStorage.getItem(key);
     return stored === 'grid' || stored === 'list' ? stored : defaultValue;
   }

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
@@ -23,6 +23,20 @@ interface ArtifactListResponseDto {
   artifacts: ArtifactSummaryDto[];
 }
 
+interface LibraryArtifactDto {
+  artifact_id: string;
+  version: number;
+  title: string;
+  content_type: string;
+  created_at: string;
+  updated_at: string;
+  session_id: string;
+}
+
+interface ArtifactLibraryResponseDto {
+  artifacts: LibraryArtifactDto[];
+}
+
 interface ArtifactContentResponseDto {
   content: string;
   content_type: string;
@@ -39,6 +53,24 @@ export interface ArtifactContent {
   content: string;
   contentType: string;
   version: number;
+}
+
+/**
+ * One artifact at its current HEAD, for the library page.
+ *
+ * Not `Artifact`: that model is per-version and carries the message index
+ * the session view anchors a card to, which is meaningless across sessions.
+ * This one carries `sessionId` instead — the library's job is to lead you
+ * back to the conversation an artifact came from.
+ */
+export interface LibraryArtifact {
+  artifactId: string;
+  version: number;
+  title: string;
+  contentType: string;
+  createdAt: string;
+  updatedAt: string;
+  sessionId: string;
 }
 
 /**
@@ -108,6 +140,31 @@ export class ArtifactHttpService {
       updatedAt: a.updated_at,
       createdAt: a.created_at ?? undefined,
       producedByMessageIndex: a.produced_by_message_index ?? null,
+    }));
+  }
+
+  /**
+   * Every artifact the signed-in user owns, at HEAD, newest-first.
+   *
+   * Takes no argument on purpose: the endpoint is scoped by the session
+   * cookie's identity, and there is no parameter that could widen it.
+   * Server-ordered, so callers should not re-sort — a client-side sort
+   * would silently diverge the day the backend gains pagination.
+   */
+  async listLibrary(): Promise<LibraryArtifact[]> {
+    const res = await firstValueFrom(
+      this.http.get<ArtifactLibraryResponseDto>(
+        `${this.config.appApiUrl()}/artifacts/library`,
+      ),
+    );
+    return (res.artifacts ?? []).map((a) => ({
+      artifactId: a.artifact_id,
+      version: a.version,
+      title: a.title,
+      contentType: a.content_type,
+      createdAt: a.created_at,
+      updatedAt: a.updated_at,
+      sessionId: a.session_id,
     }));
   }
 }

--- a/frontend/ai.client/src/app/settings/pages/profile/profile-settings.page.ts
+++ b/frontend/ai.client/src/app/settings/pages/profile/profile-settings.page.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroDocument, heroChevronRight } from '@ng-icons/heroicons/outline';
+import { heroDocument, heroDocumentText, heroChevronRight } from '@ng-icons/heroicons/outline';
 import { UserService } from '../../../auth/user.service';
 
 @Component({
@@ -13,7 +13,7 @@ import { UserService } from '../../../auth/user.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterLink, NgIcon],
   providers: [
-    provideIcons({ heroDocument, heroChevronRight }),
+    provideIcons({ heroDocument, heroDocumentText, heroChevronRight }),
   ],
   host: { class: 'block' },
   template: `
@@ -93,6 +93,29 @@ import { UserService } from '../../../auth/user.service';
               <span class="text-sm/6 font-medium text-gray-900 dark:text-white">My Files</span>
               <p class="text-sm/6 text-gray-500 dark:text-gray-400">
                 Browse and manage your uploaded files.
+              </p>
+            </div>
+          </div>
+          <ng-icon name="heroChevronRight" class="size-5 shrink-0 text-gray-400 dark:text-gray-500" />
+        </a>
+      </div>
+
+      <!-- Artifacts. Alongside My Files deliberately: the two are the same
+           kind of thing from the user's side — one is what they brought in,
+           the other what the assistant made. -->
+      <div class="rounded-lg border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-800">
+        <a
+          routerLink="/artifacts"
+          class="flex items-center justify-between gap-4 p-6 transition-colors hover:bg-gray-50 dark:hover:bg-white/5"
+        >
+          <div class="flex items-start gap-3">
+            <div class="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-gray-100 dark:bg-white/10">
+              <ng-icon name="heroDocumentText" class="size-4 text-gray-500 dark:text-gray-400" />
+            </div>
+            <div>
+              <span class="text-sm/6 font-medium text-gray-900 dark:text-white">Artifacts</span>
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                Everything you've made with the assistant, from every conversation.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What

A user-wide artifact library at `/artifacts` — every artifact you've produced, across every conversation — plus the `GET /artifacts/library` endpoint behind it.

Builds on #940 (merged), which stamps the user-index keys the eventual GSI will consume. **No index is used or created here**; see below.

## Backend

`GET /artifacts/library` returns every artifact the caller owns at HEAD, newest-first, from a single base-table Query on `PK=USER#{uid}`.

- **No index.** The table is already partitioned by user, so ownership rides the key rather than being re-checked per row the way `list_for_session` has to (that one reads a GSI partitioned by *session*). `SessionIndex` cannot serve this at all.
- **Takes no scoping parameter**, because there isn't one that could widen it — the only user it can describe is the authenticated one.
- **A separate route, not an optional `session_id`** on the existing list endpoint. The two differ in cardinality: that one returns a row per *version* so the SPA can anchor each card to the turn that produced it; this one returns a row per *artifact*. Overloading one path would make the response shape depend on which query params were present.
- **Unpaginated**, matching the data. The heaviest partition in production is 64 artifacts / ~110KB — far under a 1MB Query page.

Two consequences of reading the base table, both deliberate and documented at the call site:

1. The Query spans version rows as well as HEAD rows (~3x read amplification). Filtered in Python rather than by a `FilterExpression`, because the obvious server-side discriminator (`attribute_exists(GSI1PK)`) would couple "is HEAD" to "is session-indexed" — two facts that only coincide today — and a FilterExpression saves payload, not read capacity, so it buys nothing worth that coupling.
2. The base table sorts by artifact id (random uuid4), so recency ordering is applied in memory.

Both move server-side if and when the sparse user index lands.

## Frontend

`/artifacts`, reachable from **Settings → Profile** alongside My Files — the established path for user-owned collections (`/files`, `/memories` are surfaced the same way), rather than adding chrome to the global sidenav.

- **List and grid views**, persisted per-device. **List is the default**, unlike Agents: an agent tile earns its size by showing artwork you recognise, an artifact has none, so a card spends a lot of space to show the same title and date a row does. Production is roughly two-thirds `text/markdown` — a document library is something you scan.
- **Title search + a type filter** built only from the types the user actually has, so the filter never offers a dead end.
- **"Nothing matches" is a distinct state from "you have nothing."** Conflating them tells someone with a full library that it's empty.
- **Opening mints a render token per click**, into a tab opened *before* the await. After the await the click is no longer the active user gesture and every browser blocks the pop-up. Pre-minting the list was the alternative and is worse: a token is a ~120s bearer credential, so they'd expire before use and cost a round trip per row just to draw the page. Blocked pop-ups and mint failures both surface as toasts, and a failed mint closes the blank tab rather than leaving it stranded.

### Design tokens

List-page idiom per `.claude/skills/tailwind-ui/references/app-conventions.md`: `rounded-2xl`, `text-sm/6`, `h1` at `text-2xl/8 font-bold`, `<ul>` of `divide-y` rows in one bordered container, dashed empty states. `primary-*` for interactive and focus, `state-*` for the error banner, and `filetype-*` identity tokens for the type badges — matching `file-card.component.ts` so an artifact and an uploaded file of the same type read as the same kind of thing. The view toggle is a `radiogroup` mirroring the Agents page: one setting with two values, and a screen reader should hear it that way.

## Testing

- Backend: 183 passed (artifacts + architecture import boundaries). New `test_artifact_library.py` covers cardinality, cross-session span, user scoping, undated legacy rows sorting last rather than first, the exact response shape, both error paths, route shadowing against `/{artifact_id}/content`, and the pagination drain loop.
- Frontend: 2251 passed across 206 files, including the color-token and surface-literal hygiene guards. New page spec covers filtering, charset-suffix normalization, the two empty states, both render modes, and the pop-up ordering contract.
- `tsc --noEmit` clean.

Not browser-verified: `SKIP_AUTH=false` locally, so per the standing convention a manual test script goes to the reviewer rather than a self-driven clickthrough.

## Known gap

**There is no artifact delete or rename.** `delete_for_session` only revokes shares — artifact content is deliberately never deleted — so this page surfaces every scratch artifact a user has ever generated, permanently, with no way to clean up. That was theoretical before this page existed; it's now the first thing users will ask for. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)