### PR TITLE
fix(observability): derive the prompt-cache TTL from the serving model

### DIFF
--- a/backend/src/apis/shared/observability/__init__.py
+++ b/backend/src/apis/shared/observability/__init__.py
@@ -2,6 +2,9 @@
 
 from apis.shared.observability.prompt_cache import (
     CACHE_TTL_SECONDS,
+    DEFAULT_CACHE_TTL_SECONDS,
+    OPENAI_RESPONSES_CACHE_TTL_SECONDS,
+    cache_ttl_seconds_for,
     PARTIAL_MISS_WRITE_READ_RATIO,
     PROMPT_CACHE_OBSERVABILITY_ENABLED_ENV,
     prompt_cache_observability_enabled,
@@ -18,6 +21,9 @@ from apis.shared.observability.emf import (
 
 __all__ = [
     "CACHE_TTL_SECONDS",
+    "DEFAULT_CACHE_TTL_SECONDS",
+    "OPENAI_RESPONSES_CACHE_TTL_SECONDS",
+    "cache_ttl_seconds_for",
     "PARTIAL_MISS_WRITE_READ_RATIO",
     "PROMPT_CACHE_OBSERVABILITY_ENABLED_ENV",
     "prompt_cache_observability_enabled",

--- a/backend/src/apis/shared/observability/prompt_cache.py
+++ b/backend/src/apis/shared/observability/prompt_cache.py
@@ -50,10 +50,66 @@ def prompt_cache_observability_enabled() -> bool:
     """
     return os.environ.get(PROMPT_CACHE_OBSERVABILITY_ENABLED_ENV, "").lower() != "false"
 
-# Bedrock prompt-cache TTL (sliding, seconds). A gap between consecutive
-# model calls larger than this means the cache entry legitimately expired —
-# the re-write was unavoidable.
+# Prompt-cache TTL (sliding, seconds). A gap between consecutive model calls
+# larger than this means the cache entry legitimately expired — the re-write
+# was unavoidable.
+#
+# The TTL is a property of the MODEL, not of this module. Bedrock/Anthropic
+# prompt caching is a ~5-minute sliding window; the OpenAI Responses API on
+# `bedrock-runtime` holds entries for 30 minutes. Treating every model as
+# 5 minutes is wrong by 6x for GPT-5.6, and wrong in the direction that
+# HIDES waste: a gap inside the real TTL gets called `miss_ttl_expired`
+# (unavoidable) instead of `miss_avoidable`, and `partial_miss` — whose gate
+# is `gap <= ttl` — silently degrades to `hit`. Both suppress `wastedUsd`,
+# which is the metric that exists to catch exactly this.
+#
+# `CACHE_TTL_SECONDS` is retained as the default (and for importers) but
+# callers that know the model should pass `ttl_seconds` from
+# :func:`cache_ttl_seconds_for` instead.
 CACHE_TTL_SECONDS = 300
+DEFAULT_CACHE_TTL_SECONDS = CACHE_TTL_SECONDS
+
+# OpenAI Responses API on bedrock-runtime: entries live 30 minutes.
+# Corroborated by the Price List API's own SKU naming for these models —
+# the cache-write usage types are `...-cache-write-tokens-30m-...`.
+OPENAI_RESPONSES_CACHE_TTL_SECONDS = 1800
+
+# Providers whose models use the OpenAI Responses 30-minute TTL.
+#
+# Deliberately NOT the whole OpenAI family. `mantle` serves `openai.gpt-5.4`
+# with implicit-only caching whose retention AWS does not document as 30m,
+# and guessing there would re-introduce the same class of error in the other
+# direction (over-reporting waste). Only the model whose TTL is documented
+# gets the longer window.
+_OPENAI_RESPONSES_TTL_PROVIDERS = frozenset({"bedrock-responses"})
+
+
+def cache_ttl_seconds_for(
+    provider: Optional[str] = None,
+    model_id: Optional[str] = None,
+) -> int:
+    """Prompt-cache TTL in seconds for the model that served a call.
+
+    Args:
+        provider: The model's registered provider (``bedrock``, ``mantle``,
+            ``bedrock-responses``, ...). The authoritative signal.
+        model_id: Model id, used only as a fallback when the provider is
+            absent on older metadata rows written before the field existed.
+
+    Returns:
+        The TTL to measure this call's gap against. Falls back to
+        :data:`DEFAULT_CACHE_TTL_SECONDS` for anything unrecognized —
+        under-reporting waste rather than inventing it.
+    """
+    if provider and provider.lower() in _OPENAI_RESPONSES_TTL_PROVIDERS:
+        return OPENAI_RESPONSES_CACHE_TTL_SECONDS
+    if not provider and model_id:
+        # Historical rows: infer from the inference-profile-prefixed id the
+        # bedrock-runtime transport requires (us./global. + openai.gpt-5.6).
+        normalized = model_id.lower()
+        if "openai.gpt-5.6" in normalized:
+            return OPENAI_RESPONSES_CACHE_TTL_SECONDS
+    return DEFAULT_CACHE_TTL_SECONDS
 
 # How many times larger than the cache *read* a cache *write* has to be before
 # a nonzero read stops meaning "the prefix was cached" and starts meaning "a
@@ -125,6 +181,7 @@ def classify_cache_status(
     previous_call_exists: bool,
     gap_seconds: Optional[float],
     previous_cached_prefix_tokens: Optional[int] = None,
+    ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
 ) -> CacheStatus:
     """Classify one model call's cache outcome.
 
@@ -138,6 +195,11 @@ def classify_cache_status(
             token total, or None when unknown. Zero means the previous call
             was uncached (e.g. prompt below the model's minimum cacheable
             prefix), so no cache entry existed for this call to read.
+        ttl_seconds: The serving model's prompt-cache TTL. Defaults to the
+            Bedrock/Anthropic 5-minute window; callers that know the model
+            should pass :func:`cache_ttl_seconds_for`. A TTL shorter than the
+            model's real one silently suppresses both ``partial_miss`` and
+            ``miss_avoidable``, and with them ``wastedUsd``.
     """
     if cache_read_tokens > 0:
         # A read proves *something* was cached — but not that the prefix was.
@@ -155,7 +217,7 @@ def classify_cache_status(
             previous_call_exists
             and cache_write_tokens > PARTIAL_MISS_WRITE_READ_RATIO * cache_read_tokens
             and gap_seconds is not None
-            and gap_seconds <= CACHE_TTL_SECONDS
+            and gap_seconds <= ttl_seconds
         ):
             return CacheStatus.PARTIAL_MISS
         return CacheStatus.HIT
@@ -169,7 +231,7 @@ def classify_cache_status(
         # (typically the first prompt to cross the minimum cacheable length),
         # not a miss of any kind.
         return CacheStatus.FIRST_WRITE
-    if gap_seconds is None or gap_seconds > CACHE_TTL_SECONDS:
+    if gap_seconds is None or gap_seconds > ttl_seconds:
         return CacheStatus.MISS_TTL_EXPIRED
     return CacheStatus.MISS_AVOIDABLE
 

--- a/backend/src/apis/shared/sessions/metadata.py
+++ b/backend/src/apis/shared/sessions/metadata.py
@@ -405,6 +405,7 @@ def _derive_cache_observability(
 
         from apis.shared.observability import (
             CacheStatus,
+            cache_ttl_seconds_for,
             classify_cache_status,
             compute_wasted_usd,
             prompt_cache_observability_enabled,
@@ -497,12 +498,24 @@ def _derive_cache_observability(
             classify_gap = None
             prev_cached_prefix = _cached_prefix_of(prev_row)
 
+        # The TTL is the serving model's, not a module constant: Bedrock is a
+        # ~5-minute sliding window, the OpenAI Responses API on bedrock-runtime
+        # holds entries for 30 minutes. Using 5 minutes for the latter calls a
+        # live entry expired, which downgrades `partial_miss` to `hit` and
+        # `miss_avoidable` to `miss_ttl_expired` — both zeroing `wastedUsd`.
+        model_info = message_metadata.model_info
+        ttl_seconds = cache_ttl_seconds_for(
+            provider=getattr(model_info, "provider", None),
+            model_id=getattr(model_info, "model_id", None),
+        )
+
         status = classify_cache_status(
             cache_read_tokens=cache_read,
             cache_write_tokens=cache_write,
             previous_call_exists=prev_row is not None,
             gap_seconds=classify_gap,
             previous_cached_prefix_tokens=prev_cached_prefix,
+            ttl_seconds=ttl_seconds,
         )
         wasted_usd = compute_wasted_usd(
             cache_status=status,

--- a/backend/tests/shared/test_prompt_cache_observability.py
+++ b/backend/tests/shared/test_prompt_cache_observability.py
@@ -7,8 +7,11 @@ import logging
 
 from apis.shared.observability import (
     CACHE_TTL_SECONDS,
+    DEFAULT_CACHE_TTL_SECONDS,
+    OPENAI_RESPONSES_CACHE_TTL_SECONDS,
     PARTIAL_MISS_WRITE_READ_RATIO,
     CacheStatus,
+    cache_ttl_seconds_for,
     classify_cache_status,
     compute_wasted_usd,
     emit_prompt_cache_metrics,
@@ -513,3 +516,142 @@ class TestIncidentReplay:
             if status is CacheStatus.HIT:
                 assert wasted == 0.0
         assert any(status is CacheStatus.PARTIAL_MISS for status, _ in self._replay())
+
+
+class TestCacheTtlResolution:
+    """The TTL is a property of the model, not of the module.
+
+    Bedrock/Anthropic prompt caching is a ~5-minute sliding window; the OpenAI
+    Responses API on bedrock-runtime holds entries for 30 minutes. A single
+    hardcoded 300s was wrong by 6x for GPT-5.6 — and wrong in the direction
+    that hides waste.
+    """
+
+    def test_bedrock_responses_gets_the_thirty_minute_window(self):
+        assert (
+            cache_ttl_seconds_for(provider="bedrock-responses")
+            == OPENAI_RESPONSES_CACHE_TTL_SECONDS
+            == 1800
+        )
+
+    def test_provider_match_is_case_insensitive(self):
+        assert cache_ttl_seconds_for(provider="Bedrock-Responses") == 1800
+
+    def test_bedrock_keeps_the_five_minute_window(self):
+        assert cache_ttl_seconds_for(provider="bedrock") == DEFAULT_CACHE_TTL_SECONDS == 300
+
+    def test_mantle_is_deliberately_not_widened(self):
+        """openai.gpt-5.4 on Mantle is implicit-only; AWS documents no 30m TTL.
+
+        Guessing here would over-report waste — the opposite error, but the
+        same class of mistake.
+        """
+        assert cache_ttl_seconds_for(provider="mantle") == DEFAULT_CACHE_TTL_SECONDS
+
+    def test_unknown_provider_falls_back_to_the_default(self):
+        assert cache_ttl_seconds_for(provider="something-new") == DEFAULT_CACHE_TTL_SECONDS
+        assert cache_ttl_seconds_for() == DEFAULT_CACHE_TTL_SECONDS
+
+    def test_model_id_fallback_for_rows_written_before_provider_existed(self):
+        assert cache_ttl_seconds_for(model_id="us.openai.gpt-5.6-sol") == 1800
+        assert cache_ttl_seconds_for(model_id="global.openai.gpt-5.6-luna") == 1800
+        assert (
+            cache_ttl_seconds_for(model_id="us.anthropic.claude-haiku-4-5")
+            == DEFAULT_CACHE_TTL_SECONDS
+        )
+
+    def test_provider_wins_over_the_model_id_fallback(self):
+        # An explicit provider is authoritative; the id sniff is only for rows
+        # that predate the field.
+        assert (
+            cache_ttl_seconds_for(provider="bedrock", model_id="us.openai.gpt-5.6-sol")
+            == DEFAULT_CACHE_TTL_SECONDS
+        )
+
+
+class TestTtlAwareClassification:
+    """The dollars-visible consequence of the TTL being right."""
+
+    GAP = 900  # 15 min: past the Bedrock window, inside the OpenAI one.
+
+    def test_gap_inside_the_openai_ttl_is_avoidable_waste(self):
+        assert (
+            classify_cache_status(
+                0,
+                30_000,
+                previous_call_exists=True,
+                gap_seconds=self.GAP,
+                previous_cached_prefix_tokens=30_000,
+                ttl_seconds=OPENAI_RESPONSES_CACHE_TTL_SECONDS,
+            )
+            is CacheStatus.MISS_AVOIDABLE
+        )
+
+    def test_the_same_gap_under_the_old_constant_looked_unavoidable(self):
+        """This is the bug: a live entry reported as a legitimate expiry."""
+        assert (
+            classify_cache_status(
+                0,
+                30_000,
+                previous_call_exists=True,
+                gap_seconds=self.GAP,
+                previous_cached_prefix_tokens=30_000,
+                ttl_seconds=DEFAULT_CACHE_TTL_SECONDS,
+            )
+            is CacheStatus.MISS_TTL_EXPIRED
+        )
+
+    def test_partial_miss_survives_a_gap_inside_the_openai_ttl(self):
+        assert (
+            classify_cache_status(
+                11_000,
+                190_000,
+                previous_call_exists=True,
+                gap_seconds=self.GAP,
+                ttl_seconds=OPENAI_RESPONSES_CACHE_TTL_SECONDS,
+            )
+            is CacheStatus.PARTIAL_MISS
+        )
+
+    def test_partial_miss_degrades_to_hit_under_the_wrong_ttl(self):
+        """The compaction-spiral shape, mislabelled — wastedUsd goes to $0."""
+        assert (
+            classify_cache_status(
+                11_000,
+                190_000,
+                previous_call_exists=True,
+                gap_seconds=self.GAP,
+                ttl_seconds=DEFAULT_CACHE_TTL_SECONDS,
+            )
+            is CacheStatus.HIT
+        )
+
+    def test_beyond_the_openai_ttl_is_still_a_real_expiry(self):
+        assert (
+            classify_cache_status(
+                0,
+                30_000,
+                previous_call_exists=True,
+                gap_seconds=OPENAI_RESPONSES_CACHE_TTL_SECONDS + 1,
+                previous_cached_prefix_tokens=30_000,
+                ttl_seconds=OPENAI_RESPONSES_CACHE_TTL_SECONDS,
+            )
+            is CacheStatus.MISS_TTL_EXPIRED
+        )
+
+    def test_default_is_unchanged_for_every_existing_caller(self):
+        """Omitting ttl_seconds must behave exactly as before this change."""
+        for gap, expected in (
+            (CACHE_TTL_SECONDS, CacheStatus.MISS_AVOIDABLE),
+            (CACHE_TTL_SECONDS + 1, CacheStatus.MISS_TTL_EXPIRED),
+        ):
+            assert (
+                classify_cache_status(
+                    0,
+                    5_000,
+                    previous_call_exists=True,
+                    gap_seconds=gap,
+                    previous_cached_prefix_tokens=5_000,
+                )
+                is expected
+            )

--- a/docs/specs/gpt-5-6-prompt-caching.md
+++ b/docs/specs/gpt-5-6-prompt-caching.md
@@ -1,6 +1,6 @@
 # Plan: prompt caching for OpenAI GPT-5.6 on Bedrock
 
-**Status:** In progress — PR-1 shipped (#945), PR-2..PR-5 outstanding
+**Status:** In progress — PR-1 (#945), PR-2 (#949) and PR-5 shipped; PR-3 BLOCKED (no commercial rates in the Price List API), PR-4 outstanding
 **Author:** (drafted with Claude)
 **Date:** 2026-09-04
 **Related:** `agents/main_agent/core/model_config.py`, `agents/main_agent/core/agent_factory.py`,
@@ -207,6 +207,59 @@ API-key `/chat/api-converse` handler. Don't fork the build logic.
   $0 rather than inventing waste.
 - Re-verify every rate against the Price List API, per the ⚠️ above.
 
+#### ⛔ BLOCKED — the Price List API does not publish these rates
+
+Checked 2026-09-05 against dev-ai (490617140655) with SSO credentials, across
+every Bedrock service code:
+
+| Service code | GPT-5.6 coverage |
+|---|---|
+| `AmazonBedrock` | `openai.gpt-5.6-terra` + `-luna` only, **`us-gov-west-1` only**, and only `-mantle-` usage types. **`sol` absent entirely.** |
+| `AmazonBedrockService` | `provider` attribute values are `Anthropic` and `Luma AI` only — no OpenAI |
+| `AmazonBedrockFoundationModels` | no GPT entries in `servicename` |
+| `AmazonBedrockAgentCore` | AgentCore consumption SKUs, not foundation-model pricing |
+
+**Commercial-region rates for the GPT-5.6 family are not in the Price List API
+at all.** Neither are commercial `openai.gpt-5.4` rates — so the shipped
+`$2.75 / $16.50` row on that model was never Price-List-verified either; it
+came from the model card. This PR's own gate therefore cannot be satisfied
+today, and PR-3 is deferred rather than shipped on transcribed numbers.
+
+Options when it is picked back up, in preference order:
+
+1. Wait for AWS to publish commercial rates and verify as specced.
+2. Derive them empirically — add the model through the admin escape-hatch
+   form (the PR-2 transport already supports it), drive real turns via the
+   dev-ai experiment harness, and reconcile against Cost Explorer to back out
+   per-token rates. Stronger evidence than a published table, but Cost
+   Explorer lags ~24h.
+3. Ship model-card rates explicitly labelled unverified, in code and in the
+   PR. Last resort: these rows price real spend against faculty quotas.
+
+What the GovCloud rows *do* establish, and can be relied on:
+
+- The **ratios are exact**. Terra standard: input `2.64`, cache read `0.264`
+  (0.1x), cache write `3.30` (1.25x). The cache economics this whole plan
+  rests on are confirmed.
+- The **30-minute TTL is confirmed** by the SKU naming itself — the write
+  usage types are `...-cache-write-tokens-30m-...`. That is the corroboration
+  PR-5 needed.
+
+#### ⚠️ Modeling gap PR-3 must resolve before it ships
+
+The Price List rows carry two pricing dimensions `CuratedModel` cannot
+represent:
+
+- **Service tiers.** Every model is priced at `flex` / `standard` / `priority`
+  = 0.5x / 1x / 2x.
+- **Long context.** Every rate has a `-long-ctx` twin at **2x** the base.
+
+Our catalog holds one flat rate per bucket, so a GPT-5.6 row would mis-price
+any long-context turn by 2x — silently, as a plausible-looking number rather
+than an error, which is exactly the failure the Verification section exists to
+catch. Decide before curating: either model the dimensions, or scope the row
+to standard-tier short-context and gate on staying inside it.
+
 ### PR-4 — Explicit cache breakpoints + `prompt_cache_key`
 
 Only worth building for 5.6, where the 1.25× write premium makes placement matter.
@@ -228,10 +281,22 @@ Only worth building for 5.6, where the 1.25× write premium makes placement matt
 
 ### PR-5 — Observability
 
-- `CACHE_TTL_SECONDS = 300` (`observability/prompt_cache.py:56`) is wrong by 6× for
-  OpenAI's 30-minute TTL, so `classify_cache_status` will call
-  `miss_ttl_expired` on entries that are still live. Make the TTL model-derived
-  rather than a module constant.
+- ✅ **DONE.** `CACHE_TTL_SECONDS = 300` was wrong by 6× for OpenAI's
+  30-minute TTL, so `classify_cache_status` called `miss_ttl_expired` on
+  entries that were still live. The TTL is now model-derived via
+  `cache_ttl_seconds_for(provider, model_id)`, threaded through
+  `classify_cache_status(ttl_seconds=...)` from the serving model's
+  `ModelInfo`. Only `bedrock-responses` gets the 30-minute window —
+  deliberately **not** the whole OpenAI family, since `mantle`'s
+  implicit-only caching has no documented 30m retention and guessing there
+  would over-report waste. `CACHE_TTL_SECONDS` stays as the default for
+  existing importers.
+
+  Note the error direction, which is why this mattered: a TTL shorter than
+  the model's real one *hides* waste. `partial_miss` is gated on
+  `gap <= ttl`, so it degraded to `hit`; `miss_avoidable` degraded to
+  `miss_ttl_expired`. Both zero `wastedUsd` — the metric that exists to
+  catch this exact class of bug.
 - Now that PR-1 has landed `cacheWriteInputTokens`, `partial_miss` / `miss_avoidable` /
   `wastedUsd` start working for GPT-5.6 as they do for Claude. Until it lands,
   every call classifies as `hit` or `uncached` and `wastedUsd` is structurally


### PR DESCRIPTION
## PR-5 of [`docs/specs/gpt-5-6-prompt-caching.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/gpt-5-6-prompt-caching.md)

Follows PR-1 (#945) and PR-2 (#949). **Taken out of order on purpose: PR-3 is blocked** (see below), and this one was fully unblocked.

## The bug

`CACHE_TTL_SECONDS` was a module constant at 300s — the Bedrock/Anthropic sliding window. The OpenAI Responses API on `bedrock-runtime` holds entries for **30 minutes**, so the constant was wrong by 6× for GPT-5.6.

**The error direction is the reason this matters.** A TTL *shorter* than the model's real one doesn't over-report waste — it **hides** it:

| Real outcome | Gate | Reported as | `wastedUsd` |
|---|---|---|---|
| `partial_miss` | `gap <= ttl` | `hit` | **$0.00** |
| `miss_avoidable` | `gap <= ttl` | `miss_ttl_expired` | **$0.00** |

Both collapse to zero on the one metric that exists to catch nondeterministic prefix assembly — the same reading that held at `$0.00` through the entire compaction spiral while $27 of a $30 faculty quota went to cache re-writes.

## The fix

`cache_ttl_seconds_for(provider, model_id)`, threaded into `classify_cache_status(ttl_seconds=...)` from the serving model's `ModelInfo`, at the single derivation site in `sessions/metadata.py`. `CACHE_TTL_SECONDS` stays as the default, so every existing caller and importer is byte-for-byte unchanged — there's a test pinning that.

Only `provider="bedrock-responses"` gets the 30-minute window. **Deliberately not the whole OpenAI family:** `mantle` serves `openai.gpt-5.4` with implicit-only caching whose retention AWS does not document as 30m, and widening it there would over-report waste — the same mistake in the other direction. A `model_id` fallback covers rows written before the `provider` field existed.

The 30m figure is corroborated by **AWS's own SKU naming**, not just the model card: the Price List API's cache-write usage types for these models are literally `...-cache-write-tokens-30m-...`.

## ⛔ Why PR-3 is not this PR

I checked PR-3's gate before writing any of it. The spec ⚠️'s twice that every rate must be verified against the Price List API before a catalog row ships. Checked against dev-ai across every Bedrock service code:

| Service code | GPT-5.6 coverage |
|---|---|
| `AmazonBedrock` | `terra` + `luna` only, **`us-gov-west-1` only**, only `-mantle-` usage types. **`sol` absent entirely.** |
| `AmazonBedrockService` | `provider` values are `Anthropic`, `Luma AI` — no OpenAI |
| `AmazonBedrockFoundationModels` | no GPT entries in `servicename` |
| `AmazonBedrockAgentCore` | AgentCore consumption SKUs, not FM pricing |

**Commercial-region GPT-5.6 rates are not published in the Price List API at all.** Neither are commercial `openai.gpt-5.4` rates — so the shipped `$2.75 / $16.50` row on that model was never Price-List-verified either; it came from the model card.

Rather than ship catalog rows on transcribed numbers that price real spend against faculty quotas, PR-3 is deferred and the finding is recorded in the spec with three options in preference order (wait for AWS · derive empirically via the dev-ai harness + Cost Explorer · ship model-card rates explicitly labelled unverified).

Also recorded there: **a modeling gap PR-3 must resolve before it ships.** Every Price List rate carries `flex`/`standard`/`priority` tiers (0.5× / 1× / 2×) *and* a `-long-ctx` twin at **2×** the base. `CuratedModel` holds one flat rate per bucket, so a GPT-5.6 row would mis-price any long-context turn by 2× — silently, as a plausible-looking number rather than an error, which is the exact failure the spec's Verification section exists to catch.

What the GovCloud rows **do** establish, and this PR relies on: the cache economics are exact. Terra standard is input `2.64`, cache read `0.264` (0.1×), cache write `3.30` (1.25×).

## Testing

`tests/shared/test_prompt_cache_observability.py` — 13 new cases across two classes:

- **TTL resolution** — `bedrock-responses` → 1800s, case-insensitive; `bedrock` and `mantle` stay at 300s; unknown providers fall back; `model_id` fallback for legacy rows; provider wins over the id sniff.
- **Classification consequence** — a 15-minute gap (past the Bedrock window, inside the OpenAI one) is `miss_avoidable` under the right TTL and `miss_ttl_expired` under the old constant; the compaction-spiral shape (11k read / 190k write) is `partial_miss` correctly and `hit` under the old constant; beyond 30m is still a real expiry; and omitting `ttl_seconds` reproduces the pre-change behavior exactly.

`cd backend && uv run python -m pytest tests/ -q` → **7402 passed, 3 skipped, 0 failed**

## Not in this PR

PR-3 (blocked, above) and PR-4 (explicit `prompt_cache_breakpoint` + `prompt_cache_key`). PR-4 is unblocked and could go next.

No live verification here either — the spec's Verification section still needs a catalog row, so it waits on PR-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
