### PR TITLE
feat(artifacts): delete and rename artifacts

### DIFF
--- a/backend/src/agents/builtin_tools/artifacts/service.py
+++ b/backend/src/agents/builtin_tools/artifacts/service.py
@@ -16,6 +16,17 @@ Frozen cross-PR contract (must stay in sync with the render Lambda
 Versions are immutable (no DeleteObject grant in inference-api) — an
 update writes a new version and re-points HEAD.
 
+Immutable, but not permanent: app-api's `ArtifactLifecycleService`
+deletes whole artifacts (every version row, the HEAD row, and every
+share of them) and retitles them. Two consequences for anything written
+here. Rows can vanish between a read and a write, so every write-back on
+an existing row — `set_produced_by_message_index` is the one today —
+must carry `attribute_exists(SK)` rather than resurrect a deleted
+artifact. And `title` is no longer writer-owned: a rename updates it on
+HEAD and on every version row, deliberately touching neither `version`
+(the optimistic lock below) nor `updated_at` (embedded in the GSI sort
+keys, which only this module maintains).
+
 GSI2PK/GSI2SK are written ahead of the index that will consume them.
 Nothing queries them today — a user-wide artifact list is served by a
 base-table Query on PK=USER#{uid}, which is adequate while the heaviest

--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -15,6 +15,8 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from .service import MAX_ARTIFACT_TITLE_LENGTH
+
 
 class RenderTokenRequest(BaseModel):
     version: int = Field(..., ge=1, description="Artifact version to render")
@@ -83,6 +85,41 @@ class LibraryArtifact(BaseModel):
 
 class ArtifactLibraryResponse(BaseModel):
     artifacts: list[LibraryArtifact] = Field(default_factory=list)
+
+
+class RenameArtifactRequest(BaseModel):
+    """Request body for retitling an artifact.
+
+    A PATCH body with one field rather than a `/title` sub-resource, so
+    a future editable field (a description, say) is an added key rather
+    than another endpoint. The length cap is enforced here *and* in the
+    service — the model guards the HTTP surface, the service guards any
+    other caller, and they read from the same constant.
+    """
+
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_ARTIFACT_TITLE_LENGTH,
+        description="New display title for the artifact",
+    )
+
+
+class RenamedArtifactResponse(BaseModel):
+    """The artifact's HEAD after a rename.
+
+    Returns the whole record rather than an echo of the title so the SPA
+    can reconcile against the server's view — the same shape the library
+    endpoint already hands it, minus nothing it uses.
+    """
+
+    artifact_id: str
+    version: int
+    title: str
+    content_type: str
+    created_at: str
+    updated_at: str
+    session_id: str
 
 
 class ArtifactContentResponse(BaseModel):

--- a/backend/src/apis/app_api/artifacts/routes.py
+++ b/backend/src/apis/app_api/artifacts/routes.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from apis.shared.auth import User, get_current_user_from_session
 
@@ -13,18 +13,23 @@ from .models import (
     ArtifactListResponse,
     ArtifactSummary,
     LibraryArtifact,
+    RenameArtifactRequest,
+    RenamedArtifactResponse,
     RenderTokenRequest,
     RenderTokenResponse,
 )
 from .service import (
     ArtifactContentService,
+    ArtifactLifecycleService,
     ArtifactListService,
     ArtifactNotFoundError,
     ArtifactQueryError,
+    ArtifactTitleError,
     ArtifactTooLargeError,
     RenderTokenConfigError,
     RenderTokenService,
     get_artifact_content_service,
+    get_artifact_lifecycle_service,
     get_artifact_list_service,
     get_render_token_service,
 )
@@ -205,3 +210,101 @@ async def get_artifact_content(
         content_type=content_type,
         version=version,
     )
+
+
+# ---------------------------------------------------------------------
+# Lifecycle
+#
+# Both paths are single-segment under `/artifacts`, so neither collides
+# with the two-segment share routes next door (`/artifacts/shares/{id}`)
+# that `shares.py` mounts on the same prefix.
+# ---------------------------------------------------------------------
+
+
+@router.patch("/{artifact_id}", response_model=RenamedArtifactResponse)
+async def rename_artifact(
+    artifact_id: str,
+    request: RenameArtifactRequest,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactLifecycleService = Depends(get_artifact_lifecycle_service),
+) -> RenamedArtifactResponse:
+    """Retitle an artifact. Owner only.
+
+    Ownership needs no explicit check: the lookup key is built from the
+    authenticated session, so another user's artifact id simply resolves
+    to no row and 404s — the same shape as every other route here.
+
+    The new title applies to the HEAD row and to every version row, so
+    the library and the originating conversation cannot disagree about
+    what the artifact is called.
+    """
+    try:
+        head = service.rename(
+            user_id=user.user_id,
+            artifact_id=artifact_id,
+            title=request.title,
+        )
+    except ArtifactNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Artifact not found")
+    except ArtifactTitleError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc))
+    except RenderTokenConfigError:
+        logger.exception("artifact lifecycle service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifacts are unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact rename failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Renaming is temporarily unavailable",
+        )
+
+    return RenamedArtifactResponse(
+        artifact_id=str(head.get("artifact_id", artifact_id)),
+        version=int(head.get("version", 0)),
+        title=str(head.get("title", "")),
+        content_type=str(
+            head.get("content_type", "text/html; charset=utf-8")
+        ),
+        created_at=str(head.get("created_at") or ""),
+        updated_at=str(head.get("updated_at") or ""),
+        session_id=str(head.get("session_id") or ""),
+    )
+
+
+@router.delete("/{artifact_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_artifact(
+    artifact_id: str,
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactLifecycleService = Depends(get_artifact_lifecycle_service),
+) -> Response:
+    """Delete an artifact, every version of it, and every share of it.
+
+    Owner only, by the same key-scoping as the rest of this router.
+
+    Permanent from the caller's side — there is no trash and no undo.
+    The DynamoDB rows go immediately (which is what stops it rendering
+    everywhere at once) while the S3 objects are tagged for the bucket's
+    retention-window expiry. See the block comment on
+    `ArtifactLifecycleService` for why the two halves differ.
+    """
+    try:
+        service.delete(user_id=user.user_id, artifact_id=artifact_id)
+    except ArtifactNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Artifact not found")
+    except RenderTokenConfigError:
+        logger.exception("artifact lifecycle service misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifacts are unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact delete failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Deleting is temporarily unavailable",
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -85,6 +85,15 @@ class ArtifactQueryError(RenderTokenError):
     feature is set up correctly, the request just couldn't be served."""
 
 
+class ArtifactTitleError(RenderTokenError):
+    """A caller-supplied artifact title is empty or over the length cap.
+
+    A 400, not a 500 — it describes the request, not the service. Kept in
+    this exception family so the routes' existing except-ladder shape
+    still applies.
+    """
+
+
 class ArtifactTooLargeError(RenderTokenError):
     """The artifact body exceeds the inline code-view cap. The caller
     should fall back to the download path rather than streaming a huge
@@ -1049,12 +1058,12 @@ class ArtifactShareService:
             # row can't strand the rest of the cascade.
             revoked = 0
             for share in shares:
-                if self._delete_quietly(
+                if self.delete_quietly(
                     table, _share_lookup_key(str(share["share_id"]))
                 ):
                     revoked += 1
             for share in shares:
-                self._delete_quietly(
+                self.delete_quietly(
                     table,
                     {
                         "PK": f"USER#{owner_id}",
@@ -1081,8 +1090,87 @@ class ArtifactShareService:
             )
             return 0
 
+    def revoke_for_artifact(self, *, owner_id: str, artifact_id: str) -> int:
+        """Revoke every share of one artifact. Returns the count revoked.
+
+        The cascade behind `ArtifactLifecycleService.delete`. Shares are
+        per-version, so deleting an artifact has to sweep the whole
+        `SHARE#{artifact_id}#V#` prefix — otherwise a link handed out for
+        v2 outlives the artifact it points at.
+
+        Ordering matches `delete_for_session` and must not be flipped:
+        the lookup row (`PK=SHARE#{id}`) is what the recipient path
+        resolves, so dropping it is what actually kills the link. If the
+        second pass fails we are left with an unreachable owner row,
+        which is inert; the reverse order would leave a *live* share
+        whose owner can no longer see it to revoke.
+
+        Unlike `delete_for_session`, enumeration failures raise. That
+        call site is a fire-and-forget background task after a 204 has
+        already gone out, so it can only swallow; this one runs inside
+        the request that is about to start deleting rows, and failing
+        before anything has changed is strictly better than proceeding
+        blind. Individual row deletes stay best-effort for the same
+        reason they are there: one bad row must not strand the rest.
+        """
+        table = _table()
+        shares = self._shares_for_artifact(table, owner_id, artifact_id)
+        if not shares:
+            return 0
+
+        revoked = 0
+        for share in shares:
+            if self.delete_quietly(
+                table, _share_lookup_key(str(share["share_id"]))
+            ):
+                revoked += 1
+        for share in shares:
+            self.delete_quietly(
+                table,
+                {
+                    "PK": f"USER#{owner_id}",
+                    "SK": _owner_share_sk(
+                        str(share["artifact_id"]),
+                        int(share["version"]),
+                        str(share["share_id"]),
+                    ),
+                },
+            )
+
+        logger.info(
+            "revoked %s of %s artifact share(s) for deleted artifact %s",
+            revoked,
+            len(shares),
+            scrub_log(artifact_id),
+        )
+        return revoked
+
     @staticmethod
-    def _delete_quietly(table, key: dict) -> bool:
+    def _shares_for_artifact(
+        table, owner_id: str, artifact_id: str
+    ) -> list[dict]:
+        """Every share row the owner holds for one artifact, across all
+        versions. Partition-scoped to the owner, so it can never reach
+        another user's shares."""
+        shares: list[dict] = []
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"USER#{owner_id}")
+            & Key("SK").begins_with(_owner_share_prefix(artifact_id)),
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                shares.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError("share list query failed") from exc
+        return shares
+
+    @staticmethod
+    def delete_quietly(table, key: dict) -> bool:
         """Delete one row, reporting success rather than raising.
 
         A single failed row must not strand the rest of the cascade —
@@ -1134,19 +1222,326 @@ class ArtifactShareService:
 
         shares: list[dict] = []
         for artifact_id in artifact_ids:
-            kwargs: dict = {
-                "KeyConditionExpression": Key("PK").eq(f"USER#{owner_id}")
-                & Key("SK").begins_with(_owner_share_prefix(artifact_id)),
-            }
-            while True:
-                resp = table.query(**kwargs)
-                shares.extend(resp.get("Items", []))
-                last = resp.get("LastEvaluatedKey")
-                if not last:
-                    break
-                kwargs["ExclusiveStartKey"] = last
+            shares.extend(
+                ArtifactShareService._shares_for_artifact(
+                    table, owner_id, artifact_id
+                )
+            )
         return shares
 
 
 def get_artifact_share_service() -> ArtifactShareService:
     return ArtifactShareService()
+
+
+# ---------------------------------------------------------------------
+# Artifact lifecycle — rename + delete
+#
+# The library page lists every artifact a user has ever produced, which
+# made "get rid of this one" the first thing missing from it. Both
+# operations live here rather than in the agent-side writer
+# (`agents/builtin_tools/artifacts/service.py`) because they are
+# user-initiated CRUD on an existing record, not part of the agent's
+# write path — and because the inference-api container cannot serve a
+# custom route at all (see the inference-api boundary note in CLAUDE.md).
+#
+# DELETE SEMANTICS — read this before changing anything below.
+#
+# The DynamoDB rows are hard-deleted; the S3 objects are soft-deleted by
+# tagging them `lifecycle-class=deleted`, which the artifacts bucket's
+# existing `expire-soft-deleted` lifecycle rule reaps after
+# `config.artifacts.retentionDays`.
+#
+# That split is deliberate, and the DynamoDB half is the part worth
+# defending. The rows are the only authority on reachability: the render
+# Lambda resolves a token to content by GetItem-ing the *version* row and
+# following its `content_key`, and every listing, content and share path
+# keys off these rows too. Deleting them makes an artifact unreachable
+# everywhere at once, with no new condition to write and — more to the
+# point — no new condition for a future reader to *forget*. A soft flag
+# on the row would have to be honoured by the render Lambda (a separate
+# deployable, and a frozen cross-PR contract), by both list paths, by the
+# content endpoint, by share creation and by the share-scoped mint; one
+# missed filter is a deleted artifact that still renders, and it fails
+# silently. There is no undo built on top of the flag either, since the
+# S3 bytes are what an undo would need and they are on a retention clock
+# regardless.
+#
+# So: from the user's side delete is immediate and permanent. The
+# retention window is an operational recovery path, not a user-facing
+# trash — restoring an artifact means restoring its rows (the table has
+# point-in-time recovery enabled in production) inside the S3 retention
+# window, not flipping a flag.
+#
+# IAM: this needs nothing new. The app-api task role is already granted
+# `s3:PutObjectTagging` and `dynamodb:DeleteItem`
+# (infrastructure/lib/constructs/app-api/app-api-iam-grants.ts), which is
+# the other reason tagging beats `DeleteObject` here — no bucket-policy
+# widening and no infra deploy has to land before this code ships. Note
+# there is still no `dynamodb:BatchWriteItem`, so deletes below are
+# per-item, exactly as `delete_for_session` documents.
+# ---------------------------------------------------------------------
+
+# The tag the artifacts bucket's `expire-soft-deleted` lifecycle rule
+# filters on. Frozen contract with
+# infrastructure/lib/constructs/artifacts/artifacts-data-construct.ts —
+# a typo here is invisible (the object simply never expires).
+_DELETED_TAG_KEY = "lifecycle-class"
+_DELETED_TAG_VALUE = "deleted"
+
+# Generous ceiling on a user-supplied title. Long enough that no honest
+# title hits it, short enough that the attribute can't be used as free
+# storage on a row every list endpoint reads.
+MAX_ARTIFACT_TITLE_LENGTH = 200
+
+
+class ArtifactLifecycleService:
+    """Rename and delete whole artifacts, owner-scoped.
+
+    Every method builds `PK=USER#{user_id}` from the authenticated
+    session, so ownership is enforced by the key rather than checked
+    after the fact: another user's artifact id resolves to no HEAD row
+    and is an indistinguishable 404.
+    """
+
+    def __init__(self, shares: Optional["ArtifactShareService"] = None) -> None:
+        # Injected so the delete cascade can be asserted in isolation and
+        # so share-row key construction stays owned by the share service.
+        self._shares = shares or ArtifactShareService()
+
+    # -- rename --------------------------------------------------------
+
+    def rename(self, *, user_id: str, artifact_id: str, title: str) -> dict:
+        """Retitle an artifact. Returns the updated HEAD row.
+
+        Writes `title` to the HEAD row *and* to every version row.
+        Renaming HEAD alone would split the display name in two: the
+        library reads HEAD, but the session list reads version rows, so
+        the same artifact would show its new title on `/artifacts` and
+        its old one on the conversation that produced it.
+
+        ############################################################
+        # This is a bare `SET title`. It must never touch `version`.
+        # `update_artifact_record` re-points HEAD under an optimistic
+        # lock (`ConditionExpression="version = :cur"`), so a rename that
+        # wrote `version` would race a concurrent agent update and one of
+        # them would lose. Same reasoning — and the same restraint — as
+        # `set_produced_by_message_index` in the writer.
+        ############################################################
+
+        `updated_at` is deliberately left alone too. It is not just a
+        display field: HEAD's `GSI1SK`/`GSI2SK` embed it, and only the
+        writer keeps those in sync. Bumping the attribute without
+        rewriting the keys would order the library (which sorts on the
+        attribute) differently from the session index (which sorts on the
+        key) for the same artifacts. "Updated" means the content changed;
+        a rename records `renamed_at`, which nothing sorts on.
+        """
+        title = title.strip()
+        if not title:
+            raise ArtifactTitleError("title must not be empty")
+        if len(title) > MAX_ARTIFACT_TITLE_LENGTH:
+            raise ArtifactTitleError(
+                f"title must be {MAX_ARTIFACT_TITLE_LENGTH} characters or fewer"
+            )
+
+        table = _table()
+        head = self._require_head(table, user_id, artifact_id)
+        now = _now_iso()
+
+        # HEAD first: it is what both list surfaces read, so if the
+        # per-version pass fails partway the user still sees the rename
+        # take effect and can retry into a consistent state. The reverse
+        # order would look like the rename silently did nothing.
+        sort_keys = [f"ARTIFACT#{artifact_id}#HEAD"] + [
+            f"ARTIFACT#{artifact_id}#V#{int(item['version']):05d}"
+            for item in self._version_rows(table, user_id, artifact_id)
+            if item.get("version") is not None
+        ]
+        try:
+            for sk in sort_keys:
+                table.update_item(
+                    Key={"PK": f"USER#{user_id}", "SK": sk},
+                    UpdateExpression="SET title = :t, renamed_at = :now",
+                    ExpressionAttributeValues={":t": title, ":now": now},
+                    # Never resurrect a row the delete path just removed.
+                    ConditionExpression="attribute_exists(SK)",
+                )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code == "ConditionalCheckFailedException":
+                # The row went away under us — a concurrent delete.
+                raise ArtifactNotFoundError(artifact_id) from exc
+            raise ArtifactQueryError("artifact rename failed") from exc
+
+        logger.info(
+            "renamed artifact user=%s artifact=%s versions=%s",
+            scrub_log(user_id),
+            scrub_log(artifact_id),
+            len(sort_keys) - 1,
+        )
+        return {**head, "title": title, "renamed_at": now}
+
+    # -- delete --------------------------------------------------------
+
+    def delete(self, *, user_id: str, artifact_id: str) -> int:
+        """Delete an artifact and every version of it. Returns the
+        number of version rows removed.
+
+        All versions, never just the HEAD pointer. Versions are
+        addressable independently — the panel's version picker mints a
+        render token per version, and shares are per-version — so
+        dropping only the pointer would leave every prior version live
+        for anyone holding a link, and unlisted, so the owner could
+        neither see nor clean them up. That is not a delete.
+
+        Ordering is the load-bearing part, and it is the same principle
+        as `delete_for_session`: kill reachability first, kill visibility
+        last, so that every partial-failure state is fail-closed and a
+        retry finishes the job.
+
+          1. Revoke shares (lookup row before owner row, as ever).
+          2. Tag the S3 objects `lifecycle-class=deleted` — this has to
+             happen while the version rows still exist, because those
+             rows hold the only `content_key` pointers to the objects.
+          3. Delete the version rows. This is the moment the artifact
+             stops rendering: the render Lambda's GetItem finds nothing.
+          4. Delete the HEAD row last. It is what the library and the
+             session index list, so an interrupted delete leaves an
+             artifact that is already unreachable but still listed —
+             visibly wrong and self-healing on retry, rather than
+             invisibly still live.
+        """
+        table = _table()
+        self._require_head(table, user_id, artifact_id)
+        versions = self._version_rows(table, user_id, artifact_id)
+
+        # 1 — shares. Enumeration failures raise (nothing has changed
+        # yet, so there is a clean state to fail into); individual row
+        # deletes are best-effort so one bad row can't strand the rest.
+        self._shares.revoke_for_artifact(
+            owner_id=user_id, artifact_id=artifact_id
+        )
+
+        # 2 — soft-delete the bytes.
+        self._tag_objects_deleted(versions)
+
+        # 3 — version rows.
+        deleted = 0
+        for item in versions:
+            version = item.get("version")
+            if version is None:
+                continue
+            if self._shares.delete_quietly(
+                table,
+                {
+                    "PK": f"USER#{user_id}",
+                    "SK": f"ARTIFACT#{artifact_id}#V#{int(version):05d}",
+                },
+            ):
+                deleted += 1
+
+        # 4 — HEAD.
+        try:
+            table.delete_item(
+                Key={
+                    "PK": f"USER#{user_id}",
+                    "SK": f"ARTIFACT#{artifact_id}#HEAD",
+                }
+            )
+        except ClientError as exc:
+            raise ArtifactQueryError("artifact delete failed") from exc
+
+        logger.info(
+            "deleted artifact user=%s artifact=%s versions=%s/%s",
+            scrub_log(user_id),
+            scrub_log(artifact_id),
+            deleted,
+            len(versions),
+        )
+        return deleted
+
+    # -- internals -----------------------------------------------------
+
+    @staticmethod
+    def _require_head(table, user_id: str, artifact_id: str) -> dict:
+        try:
+            result = table.get_item(
+                Key={
+                    "PK": f"USER#{user_id}",
+                    "SK": f"ARTIFACT#{artifact_id}#HEAD",
+                }
+            )
+        except ClientError as exc:
+            raise ArtifactQueryError("artifact lookup failed") from exc
+        head = result.get("Item")
+        if not head:
+            raise ArtifactNotFoundError(artifact_id)
+        return head
+
+    @staticmethod
+    def _version_rows(table, user_id: str, artifact_id: str) -> list[dict]:
+        """Every immutable version row for one artifact. `#HEAD` shares
+        the SK prefix but not the `#V#` infix, so it is excluded."""
+        items: list[dict] = []
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with(f"ARTIFACT#{artifact_id}#V#"),
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError("artifact version query failed") from exc
+        return items
+
+    @staticmethod
+    def _tag_objects_deleted(versions: list[dict]) -> None:
+        """Tag each version's S3 object for lifecycle expiry.
+
+        Best-effort per object, and never fatal. A failed tag leaves an
+        orphaned object that the lifecycle rule will not reap — wasted
+        bytes, logged loudly — whereas aborting the delete over it would
+        leave the artifact *visible*, which is the failure the user
+        actually cares about. The object is already unreachable the
+        moment its row goes, tag or no tag.
+
+        `put_object_tagging` replaces the whole tag set; artifact objects
+        are written untagged, so there is nothing to preserve.
+        """
+        bucket = _bucket_name()
+        client = _s3()
+        for item in versions:
+            key = item.get("content_key")
+            if not isinstance(key, str) or not key:
+                continue
+            try:
+                client.put_object_tagging(
+                    Bucket=bucket,
+                    Key=key,
+                    Tagging={
+                        "TagSet": [
+                            {
+                                "Key": _DELETED_TAG_KEY,
+                                "Value": _DELETED_TAG_VALUE,
+                            }
+                        ]
+                    },
+                )
+            except ClientError:
+                logger.warning(
+                    "artifact delete could not tag object for expiry "
+                    "artifact=%s version=%s",
+                    scrub_log(str(item.get("artifact_id", ""))),
+                    item.get("version"),
+                    exc_info=True,
+                )
+
+
+def get_artifact_lifecycle_service() -> ArtifactLifecycleService:
+    return ArtifactLifecycleService()

--- a/backend/tests/apis/app_api/artifacts/test_artifact_lifecycle.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_lifecycle.py
@@ -1,0 +1,427 @@
+"""Tests for artifact rename and delete (`PATCH`/`DELETE /artifacts/{id}`).
+
+Three things here are worth more than coverage:
+
+* **Rename must not touch `version` or `updated_at`.** `version` carries
+  the writer's optimistic lock and `updated_at` is embedded in the
+  HEAD row's GSI sort keys, which only the writer maintains. Both are
+  asserted explicitly rather than left to a round-trip of the response
+  body, because a regression on either is silent and expensive.
+* **Delete must cascade to shares.** A surviving lookup row is a live
+  link to an artifact that no longer exists.
+* **Ownership is enforced by the partition key**, so the scoping tests
+  assert the other user's rows are untouched, not merely that the call
+  4-0-4s.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as artifact_service
+from apis.app_api.artifacts.routes import router as artifacts_router
+from apis.app_api.artifacts.service import (
+    ArtifactLifecycleService,
+    ArtifactQueryError,
+    get_artifact_lifecycle_service,
+)
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+BUCKET = "test-artifacts-bucket"
+REGION = "us-east-1"
+USER_ID = "user-123"
+OTHER_USER = "user-456"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    artifact_service._reset_caches_for_tests()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+
+        boto3.client("dynamodb", region_name=REGION).create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("S3_ARTIFACTS_BUCKET_NAME", BUCKET)
+
+        app = FastAPI()
+        app.include_router(artifacts_router)
+        app.dependency_overrides[get_current_user_from_session] = (
+            lambda: User(
+                email="u@x.com", user_id=USER_ID, name="U", roles=[]
+            )
+        )
+        yield (
+            TestClient(app),
+            boto3.resource("dynamodb", region_name=REGION),
+            s3,
+        )
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+def _seed_artifact(
+    ddb,
+    s3,
+    *,
+    user_id: str = USER_ID,
+    artifact: str = "art-1",
+    versions: int = 2,
+    title: str = "Original title",
+    session_id: str = "sess-1",
+) -> None:
+    """Write `versions` version rows + a HEAD row, with S3 objects."""
+    table = ddb.Table(TABLE)
+    for version in range(1, versions + 1):
+        key = f"{user_id}/{artifact}/v{version}/index.html"
+        s3.put_object(Bucket=BUCKET, Key=key, Body=b"<h1>hi</h1>")
+        table.put_item(
+            Item={
+                "PK": f"USER#{user_id}",
+                "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+                "storage": "s3",
+                "content_key": key,
+                "content_type": "text/html; charset=utf-8",
+                "version": version,
+                "artifact_id": artifact,
+                "user_id": user_id,
+                "session_id": session_id,
+                "title": title,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": f"2026-01-0{version}T00:00:00+00:00",
+            }
+        )
+    head_updated = f"2026-01-0{versions}T00:00:00+00:00"
+    table.put_item(
+        Item={
+            "PK": f"USER#{user_id}",
+            "SK": f"ARTIFACT#{artifact}#HEAD",
+            "storage": "s3",
+            "content_key": f"{user_id}/{artifact}/v{versions}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "version": versions,
+            "artifact_id": artifact,
+            "user_id": user_id,
+            "session_id": session_id,
+            "title": title,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": head_updated,
+            "GSI1PK": f"SESSION#{session_id}",
+            "GSI1SK": f"ARTIFACT#{head_updated}#{artifact}",
+            "GSI2PK": f"USER#{user_id}",
+            "GSI2SK": f"ARTIFACT#{head_updated}#{artifact}",
+        }
+    )
+
+
+def _seed_share(
+    ddb,
+    *,
+    owner_id: str = USER_ID,
+    artifact: str = "art-1",
+    version: int = 1,
+    share_id: str = "share-1",
+) -> None:
+    """Both rows of one share, exactly as `_write_share_rows` writes them."""
+    table = ddb.Table(TABLE)
+    attrs = {
+        "share_id": share_id,
+        "artifact_id": artifact,
+        "version": version,
+        "owner_id": owner_id,
+        "owner_email": "u@x.com",
+        "access_level": "public",
+        "title": "Original title",
+        "content_type": "text/html; charset=utf-8",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+    table.put_item(
+        Item={
+            **attrs,
+            "PK": f"USER#{owner_id}",
+            "SK": f"SHARE#{artifact}#V#{version:05d}#{share_id}",
+        }
+    )
+    table.put_item(Item={**attrs, "PK": f"SHARE#{share_id}", "SK": "META"})
+
+
+def _row(ddb, pk: str, sk: str) -> dict | None:
+    return ddb.Table(TABLE).get_item(Key={"PK": pk, "SK": sk}).get("Item")
+
+
+def _tags(s3, key: str) -> dict:
+    resp = s3.get_object_tagging(Bucket=BUCKET, Key=key)
+    return {t["Key"]: t["Value"] for t in resp["TagSet"]}
+
+
+# ---------------------------------------------------------------------
+# Rename
+# ---------------------------------------------------------------------
+
+
+def test_rename_updates_head_and_every_version_row(client):
+    """The library reads HEAD, the session list reads version rows. If a
+    rename only reached HEAD, the same artifact would show two different
+    names in two places in the app."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=3)
+
+    resp = api.patch("/artifacts/art-1", json={"title": "Renamed"})
+
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Renamed"
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD")["title"] == (
+        "Renamed"
+    )
+    for version in (1, 2, 3):
+        row = _row(
+            ddb, f"USER#{USER_ID}", f"ARTIFACT#art-1#V#{version:05d}"
+        )
+        assert row["title"] == "Renamed"
+
+
+def test_rename_does_not_touch_version_or_updated_at(client):
+    """`version` is the writer's optimistic-lock attribute and
+    `updated_at` is baked into HEAD's GSI sort keys. A rename that moved
+    either would race concurrent agent updates, or split the library's
+    ordering from the session index's."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=2)
+    before = _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD")
+
+    api.patch("/artifacts/art-1", json={"title": "Renamed"})
+
+    after = _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD")
+    assert after["version"] == before["version"]
+    assert after["updated_at"] == before["updated_at"]
+    assert after["GSI1SK"] == before["GSI1SK"]
+    assert after["GSI2SK"] == before["GSI2SK"]
+    # ...and the rename is still recorded, just on an attribute nothing
+    # sorts on.
+    assert after["renamed_at"]
+
+
+def test_rename_trims_surrounding_whitespace(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+
+    resp = api.patch("/artifacts/art-1", json={"title": "  Spaced  "})
+
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Spaced"
+
+
+def test_rename_rejects_a_whitespace_only_title(client):
+    """Passes the model's `min_length=1` but is empty once trimmed, so
+    the service is the layer that has to catch it."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+
+    resp = api.patch("/artifacts/art-1", json={"title": "   "})
+
+    assert resp.status_code == 400
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD")["title"] == (
+        "Original title"
+    )
+
+
+def test_rename_rejects_an_empty_title(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+
+    assert api.patch("/artifacts/art-1", json={"title": ""}).status_code == 422
+
+
+def test_rename_rejects_an_overlong_title(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+
+    resp = api.patch(
+        "/artifacts/art-1",
+        json={"title": "x" * (artifact_service.MAX_ARTIFACT_TITLE_LENGTH + 1)},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_rename_cannot_reach_another_users_artifact(client):
+    """The lookup key is built from the session, so someone else's id is
+    an indistinguishable 404 — and their row must be untouched."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, user_id=OTHER_USER, artifact="art-9")
+
+    resp = api.patch("/artifacts/art-9", json={"title": "Hijacked"})
+
+    assert resp.status_code == 404
+    assert _row(ddb, f"USER#{OTHER_USER}", "ARTIFACT#art-9#HEAD")["title"] == (
+        "Original title"
+    )
+
+
+def test_rename_of_an_unknown_artifact_is_404(client):
+    api, _ddb, _s3 = client
+    assert api.patch("/artifacts/nope", json={"title": "x"}).status_code == 404
+
+
+# ---------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------
+
+
+def test_delete_removes_head_and_every_version_row(client):
+    """Not just the HEAD pointer: prior versions are independently
+    addressable (the panel's version picker mints a token per version),
+    so leaving them would leave the artifact live and unlistable."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=3)
+
+    resp = api.delete("/artifacts/art-1")
+
+    assert resp.status_code == 204
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD") is None
+    for version in (1, 2, 3):
+        assert (
+            _row(ddb, f"USER#{USER_ID}", f"ARTIFACT#art-1#V#{version:05d}")
+            is None
+        )
+
+
+def test_delete_tags_every_object_for_lifecycle_expiry(client):
+    """The bucket's `expire-soft-deleted` rule filters on this exact tag.
+    It is the only handle left on the object once the row holding its
+    `content_key` is gone."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=2)
+
+    api.delete("/artifacts/art-1")
+
+    for version in (1, 2):
+        key = f"{USER_ID}/art-1/v{version}/index.html"
+        assert _tags(s3, key) == {"lifecycle-class": "deleted"}
+
+
+def test_delete_revokes_every_share_of_the_artifact(client):
+    """Shares are per-version, so the cascade sweeps the whole prefix —
+    otherwise a link handed out for v1 outlives what it points at."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=2)
+    _seed_share(ddb, version=1, share_id="share-1")
+    _seed_share(ddb, version=2, share_id="share-2")
+
+    api.delete("/artifacts/art-1")
+
+    for share_id, version in (("share-1", 1), ("share-2", 2)):
+        assert _row(ddb, f"SHARE#{share_id}", "META") is None
+        assert (
+            _row(
+                ddb,
+                f"USER#{USER_ID}",
+                f"SHARE#art-1#V#{version:05d}#{share_id}",
+            )
+            is None
+        )
+
+
+def test_delete_leaves_shares_of_other_artifacts_alone(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, artifact="art-1", versions=1)
+    _seed_artifact(ddb, s3, artifact="art-2", versions=1)
+    _seed_share(ddb, artifact="art-2", version=1, share_id="keep-me")
+
+    api.delete("/artifacts/art-1")
+
+    assert _row(ddb, "SHARE#keep-me", "META") is not None
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-2#HEAD") is not None
+
+
+def test_delete_cannot_reach_another_users_artifact(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, user_id=OTHER_USER, artifact="art-9")
+
+    resp = api.delete("/artifacts/art-9")
+
+    assert resp.status_code == 404
+    assert _row(ddb, f"USER#{OTHER_USER}", "ARTIFACT#art-9#HEAD") is not None
+    assert (
+        _row(ddb, f"USER#{OTHER_USER}", "ARTIFACT#art-9#V#00001") is not None
+    )
+
+
+def test_delete_of_an_unknown_artifact_is_404(client):
+    api, _ddb, _s3 = client
+    assert api.delete("/artifacts/nope").status_code == 404
+
+
+def test_delete_completes_when_object_tagging_fails(client):
+    """A failed tag costs unreclaimed bytes. Aborting over it would cost
+    the user a delete that visibly did nothing, which is worse — the
+    object is already unreachable once its row is gone."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+
+    failure = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+        "PutObjectTagging",
+    )
+    with patch.object(
+        artifact_service, "_s3"
+    ) as fake_s3:
+        fake_s3.return_value.put_object_tagging.side_effect = failure
+        resp = api.delete("/artifacts/art-1")
+
+    assert resp.status_code == 204
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD") is None
+
+
+def test_delete_stops_before_touching_rows_when_shares_cannot_be_listed(
+    client,
+):
+    """Enumeration runs first precisely so a failure here is a clean
+    no-op — the alternative is deleting an artifact while blind to the
+    live links pointing at it."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=2)
+
+    service = ArtifactLifecycleService()
+    with patch.object(
+        service._shares,
+        "revoke_for_artifact",
+        side_effect=ArtifactQueryError("boom"),
+    ):
+        api.app.dependency_overrides[get_artifact_lifecycle_service] = (
+            lambda: service
+        )
+        resp = api.delete("/artifacts/art-1")
+        api.app.dependency_overrides.pop(get_artifact_lifecycle_service)
+
+    assert resp.status_code == 503
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD") is not None
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#V#00001") is not None

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -238,6 +238,28 @@
                 />
                 <span class="sr-only">Open {{ item.title }} in a new tab</span>
               </button>
+              <button
+                type="button"
+                (click)="rename(item)"
+                [disabled]="busy() === item.artifactId"
+                [appTooltip]="'Rename'"
+                appTooltipPosition="top"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              >
+                <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                <span class="sr-only">Rename {{ item.title }}</span>
+              </button>
+              <button
+                type="button"
+                (click)="confirmDelete(item)"
+                [disabled]="busy() === item.artifactId"
+                [appTooltip]="'Delete'"
+                appTooltipPosition="top"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+              >
+                <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                <span class="sr-only">Delete {{ item.title }}</span>
+              </button>
             </div>
           </li>
         }
@@ -315,6 +337,30 @@
                   Conversation
                 </a>
               }
+              <div class="ml-auto flex items-center gap-1">
+                <button
+                  type="button"
+                  (click)="rename(item)"
+                  [disabled]="busy() === item.artifactId"
+                  [appTooltip]="'Rename'"
+                  appTooltipPosition="top"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                  <span class="sr-only">Rename {{ item.title }}</span>
+                </button>
+                <button
+                  type="button"
+                  (click)="confirmDelete(item)"
+                  [disabled]="busy() === item.artifactId"
+                  [appTooltip]="'Delete'"
+                  appTooltipPosition="top"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                >
+                  <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                  <span class="sr-only">Delete {{ item.title }}</span>
+                </button>
+              </div>
             </div>
           </li>
         }

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { of } from 'rxjs';
 
 import { ArtifactLibraryPage } from './artifact-library.page';
 import {
@@ -28,7 +30,13 @@ describe('ArtifactLibraryPage', () => {
   let mockHttp: {
     listLibrary: ReturnType<typeof vi.fn>;
     mintRenderToken: ReturnType<typeof vi.fn>;
+    renameArtifact: ReturnType<typeof vi.fn>;
+    deleteArtifact: ReturnType<typeof vi.fn>;
   };
+  /** Stands in for the CDK dialog. `closed` is what the page awaits, so
+   *  each test sets the value the user "chose" before acting. */
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let dialogResult: unknown;
   let mockSettings: {
     artifactsViewMode: ReturnType<typeof signal<ViewMode>>;
     setArtifactsViewMode: ReturnType<typeof vi.fn>;
@@ -43,6 +51,12 @@ describe('ArtifactLibraryPage', () => {
       mintRenderToken: vi
         .fn()
         .mockResolvedValue({ url: 'https://artifacts.example/x?t=tok', expiresAt: '' }),
+      renameArtifact: vi.fn(),
+      deleteArtifact: vi.fn().mockResolvedValue(undefined),
+    };
+    dialogResult = undefined;
+    mockDialog = {
+      open: vi.fn(() => ({ closed: of(dialogResult) })),
     };
     mockSettings = {
       artifactsViewMode: signal<ViewMode>('list'),
@@ -61,6 +75,7 @@ describe('ArtifactLibraryPage', () => {
         { provide: ArtifactHttpService, useValue: mockHttp },
         { provide: LocalSettingsService, useValue: mockSettings },
         { provide: ToastService, useValue: mockToast },
+        { provide: Dialog, useValue: mockDialog },
       ],
     });
   });
@@ -96,6 +111,9 @@ describe('ArtifactLibraryPage', () => {
       setViewMode: (m: ViewMode) => void;
       open: (item: LibraryArtifact) => Promise<void>;
       load: () => Promise<void>;
+      rename: (item: LibraryArtifact) => Promise<void>;
+      confirmDelete: (item: LibraryArtifact) => Promise<void>;
+      busy: () => string | null;
     };
   }
 
@@ -276,6 +294,104 @@ describe('ArtifactLibraryPage', () => {
       mockHttp.listLibrary.mockResolvedValue([stubArtifact({ sessionId: '' })]);
       const fixture = await createComponent();
       expect(fixture.nativeElement.querySelector('a[href^="/s/"]')).toBeNull();
+    });
+  });
+
+  describe('rename', () => {
+    it('patches the row from the response, not from what was typed', async () => {
+      // The server trims. Echoing the typed value back would let the page
+      // drift from what is actually stored.
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ artifactId: 'a' })]);
+      mockHttp.renameArtifact.mockResolvedValue(
+        stubArtifact({ artifactId: 'a', title: 'Trimmed' }),
+      );
+      const c = api(await createComponent());
+      dialogResult = '  Trimmed  ';
+
+      await c.rename(c.items()[0]);
+
+      expect(mockHttp.renameArtifact).toHaveBeenCalledWith('a', '  Trimmed  ');
+      expect(c.items()[0].title).toBe('Trimmed');
+    });
+
+    it('does nothing when the dialog is cancelled', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const c = api(await createComponent());
+      dialogResult = undefined;
+
+      await c.rename(c.items()[0]);
+
+      expect(mockHttp.renameArtifact).not.toHaveBeenCalled();
+    });
+
+    it('keeps the old title and warns when the request fails', async () => {
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ title: 'Quarterly plan' }),
+      ]);
+      mockHttp.renameArtifact.mockRejectedValue(new Error('503'));
+      const c = api(await createComponent());
+      dialogResult = 'New name';
+
+      await c.rename(c.items()[0]);
+
+      expect(c.items()[0].title).toBe('Quarterly plan');
+      expect(mockToast.error).toHaveBeenCalled();
+      expect(c.busy()).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the row only after the request succeeds', async () => {
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ artifactId: 'a' }),
+        stubArtifact({ artifactId: 'b' }),
+      ]);
+      const c = api(await createComponent());
+      dialogResult = true;
+
+      await c.confirmDelete(c.items()[0]);
+
+      expect(mockHttp.deleteArtifact).toHaveBeenCalledWith('a');
+      expect(c.items().map((i) => i.artifactId)).toEqual(['b']);
+    });
+
+    it('does nothing when the confirmation is declined', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ artifactId: 'a' })]);
+      const c = api(await createComponent());
+      dialogResult = false;
+
+      await c.confirmDelete(c.items()[0]);
+
+      expect(mockHttp.deleteArtifact).not.toHaveBeenCalled();
+      expect(c.items()).toHaveLength(1);
+    });
+
+    it('confirms destructively, naming versions and shares', async () => {
+      // Neither is visible from this page, so the dialog copy is the only
+      // place a user learns a share link dies with the artifact.
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const c = api(await createComponent());
+      dialogResult = false;
+
+      await c.confirmDelete(c.items()[0]);
+
+      const data = mockDialog.open.mock.calls[0][1].data;
+      expect(data.destructive).toBe(true);
+      expect(data.message).toContain('every version');
+      expect(data.message).toContain('share links');
+    });
+
+    it('keeps the row and warns when the request fails', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ artifactId: 'a' })]);
+      mockHttp.deleteArtifact.mockRejectedValue(new Error('503'));
+      const c = api(await createComponent());
+      dialogResult = true;
+
+      await c.confirmDelete(c.items()[0]);
+
+      expect(c.items()).toHaveLength(1);
+      expect(mockToast.error).toHaveBeenCalled();
+      expect(c.busy()).toBeNull();
     });
   });
 });

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -7,6 +7,8 @@ import {
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroArrowTopRightOnSquare,
@@ -17,9 +19,11 @@ import {
   heroDocument,
   heroDocumentText,
   heroMagnifyingGlass,
+  heroPencilSquare,
   heroPhoto,
   heroSquares2x2,
   heroTableCells,
+  heroTrash,
 } from '@ng-icons/heroicons/outline';
 
 import {
@@ -29,6 +33,15 @@ import {
 import { LocalSettingsService, type ViewMode } from '../services/local-settings.service';
 import { ToastService } from '../services/toast/toast.service';
 import { TooltipDirective } from '../components/tooltip/tooltip.directive';
+import {
+  ConfirmationDialogComponent,
+  type ConfirmationDialogData,
+} from '../components/confirmation-dialog';
+import {
+  RenameArtifactDialogComponent,
+  type RenameArtifactDialogData,
+  type RenameArtifactDialogResult,
+} from './components/rename-artifact-dialog.component';
 
 /**
  * Presentation for one artifact content type.
@@ -126,9 +139,11 @@ const DEFAULT_TYPE_STYLE: TypeStyle = {
       heroDocument,
       heroDocumentText,
       heroMagnifyingGlass,
+      heroPencilSquare,
       heroPhoto,
       heroSquares2x2,
       heroTableCells,
+      heroTrash,
     }),
   ],
 })
@@ -136,6 +151,7 @@ export class ArtifactLibraryPage {
   private readonly artifacts = inject(ArtifactHttpService);
   private readonly localSettings = inject(LocalSettingsService);
   private readonly toast = inject(ToastService);
+  private readonly dialog = inject(Dialog);
 
   protected readonly items = signal<LibraryArtifact[]>([]);
   protected readonly loading = signal(true);
@@ -144,6 +160,8 @@ export class ArtifactLibraryPage {
   protected readonly typeFilter = signal<string>('all');
   /** Artifact id whose render URL is being minted, so its button can wait. */
   protected readonly opening = signal<string | null>(null);
+  /** Artifact id currently being renamed or deleted, so its row can wait. */
+  protected readonly busy = signal<string | null>(null);
 
   protected readonly viewMode = this.localSettings.artifactsViewMode;
 
@@ -266,6 +284,91 @@ export class ArtifactLibraryPage {
       );
     } finally {
       this.opening.set(null);
+    }
+  }
+
+  /**
+   * Rename an artifact.
+   *
+   * The list is patched from the *response*, not from what was typed:
+   * the server trims the title, and reconciling against its answer is
+   * what keeps this page honest if the two ever diverge.
+   */
+  protected async rename(item: LibraryArtifact): Promise<void> {
+    const data: RenameArtifactDialogData = { title: item.title };
+    const dialogRef = this.dialog.open<RenameArtifactDialogResult>(
+      RenameArtifactDialogComponent,
+      { data },
+    );
+    const title = await firstValueFrom(dialogRef.closed);
+    if (!title) {
+      return;
+    }
+
+    this.busy.set(item.artifactId);
+    try {
+      const updated = await this.artifacts.renameArtifact(item.artifactId, title);
+      this.items.update((list) =>
+        list.map((row) =>
+          row.artifactId === updated.artifactId
+            ? { ...row, title: updated.title }
+            : row,
+        ),
+      );
+      this.toast.success('Artifact renamed');
+    } catch {
+      this.toast.error(
+        'Could not rename artifact',
+        'The change was not saved. Try again in a moment.',
+      );
+    } finally {
+      this.busy.set(null);
+    }
+  }
+
+  /**
+   * Delete an artifact after confirmation.
+   *
+   * The dialog copy names what actually goes — every version, and every
+   * share link — because none of that is visible from this page, and a
+   * user who shared v2 with a colleague deserves to know the link dies
+   * with it. There is no undo, so the row is removed only after the
+   * request succeeds.
+   */
+  protected async confirmDelete(item: LibraryArtifact): Promise<void> {
+    const data: ConfirmationDialogData = {
+      title: 'Delete this artifact?',
+      message:
+        `"${item.title || 'Untitled artifact'}" will be deleted permanently, ` +
+        'along with every version of it and any share links you have created. ' +
+        'This cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    };
+
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) {
+      return;
+    }
+
+    this.busy.set(item.artifactId);
+    try {
+      await this.artifacts.deleteArtifact(item.artifactId);
+      this.items.update((list) =>
+        list.filter((row) => row.artifactId !== item.artifactId),
+      );
+      this.toast.success('Artifact deleted');
+    } catch {
+      this.toast.error(
+        'Could not delete artifact',
+        'Nothing was removed. Try again in a moment.',
+      );
+    } finally {
+      this.busy.set(null);
     }
   }
 

--- a/frontend/ai.client/src/app/artifacts/components/rename-artifact-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/components/rename-artifact-dialog.component.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+import {
+  MAX_ARTIFACT_TITLE_LENGTH,
+  RenameArtifactDialogComponent,
+  type RenameArtifactDialogData,
+} from './rename-artifact-dialog.component';
+
+describe('RenameArtifactDialogComponent', () => {
+  let close: ReturnType<typeof vi.fn>;
+
+  function create(data: RenameArtifactDialogData) {
+    TestBed.resetTestingModule();
+    close = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DIALOG_DATA, useValue: data },
+        { provide: DialogRef, useValue: { close } },
+      ],
+    });
+    const fixture = TestBed.createComponent(RenameArtifactDialogComponent);
+    fixture.detectChanges();
+    return {
+      fixture,
+      // Reaching protected members the way the template does.
+      api: fixture.componentInstance as unknown as {
+        draft: { set: (v: string) => void };
+        canConfirm: () => boolean;
+        tooLong: () => boolean;
+        confirm: () => void;
+        onCancel: () => void;
+        onEnter: () => void;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+  });
+
+  it('starts pre-filled with the current title', () => {
+    const { fixture } = create({ title: 'Quarterly plan' });
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('#rename-artifact-input');
+    expect(input.value).toBe('Quarterly plan');
+  });
+
+  it('cannot confirm an unchanged title', () => {
+    // A stray Enter must not fire a write that renames every version row
+    // to exactly what it already says.
+    const { api } = create({ title: 'Quarterly plan' });
+    expect(api.canConfirm()).toBe(false);
+  });
+
+  it('cannot confirm a whitespace-only title', () => {
+    const { api } = create({ title: 'Quarterly plan' });
+    api.draft.set('   ');
+    expect(api.canConfirm()).toBe(false);
+  });
+
+  it('cannot confirm past the length cap, and says why', () => {
+    const { api } = create({ title: 'Quarterly plan' });
+    api.draft.set('x'.repeat(MAX_ARTIFACT_TITLE_LENGTH + 1));
+    expect(api.tooLong()).toBe(true);
+    expect(api.canConfirm()).toBe(false);
+  });
+
+  it('closes with the trimmed title', () => {
+    const { api } = create({ title: 'Old' });
+    api.draft.set('  New name  ');
+    api.confirm();
+    expect(close).toHaveBeenCalledWith('New name');
+  });
+
+  it('closes with undefined on cancel, meaning "cancelled"', () => {
+    const { api } = create({ title: 'Old' });
+    api.onCancel();
+    expect(close).toHaveBeenCalledWith(undefined);
+  });
+
+  it('ignores Enter while the title is not confirmable', () => {
+    const { api } = create({ title: 'Old' });
+    api.onEnter();
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/artifacts/components/rename-artifact-dialog.component.ts
+++ b/frontend/ai.client/src/app/artifacts/components/rename-artifact-dialog.component.ts
@@ -1,0 +1,209 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+import { DialogDismissDirective } from '../../components/dialog/dialog-dismiss.directive';
+
+/** Mirrors the backend's `MAX_ARTIFACT_TITLE_LENGTH`. Enforced there too —
+ *  this copy exists so the user finds out before the round trip, not so
+ *  the server can trust it. */
+export const MAX_ARTIFACT_TITLE_LENGTH = 200;
+
+export interface RenameArtifactDialogData {
+  /** Current title. Pre-filled and pre-selected so the common case —
+   *  replacing the name outright — is a single keystroke. */
+  title: string;
+}
+
+/**
+ * The new title, trimmed. `undefined` means cancelled, per the app's
+ * dialog convention.
+ */
+export type RenameArtifactDialogResult = string | undefined;
+
+/**
+ * Rename dialog for a single artifact, shared by the library page and the
+ * session-side artifact panel.
+ *
+ * Deliberately not the generic confirmation dialog: this collects a
+ * value rather than an approval, and the empty/unchanged/too-long cases
+ * need to disable the confirm button rather than round-trip to a 400.
+ */
+@Component({
+  selector: 'app-rename-artifact-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogDismissDirective, NgIcon],
+  providers: [provideIcons({ heroXMark })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onCancel()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+      appDialogDismiss
+      (dismissed)="onCancel()"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-lg dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rename-artifact-title"
+      >
+        <div class="flex items-start justify-between gap-3 px-6 pt-5">
+          <h2
+            id="rename-artifact-title"
+            class="text-lg/7 font-semibold text-gray-900 dark:text-white"
+          >
+            Rename artifact
+          </h2>
+          <button
+            type="button"
+            (click)="onCancel()"
+            aria-label="Close dialog"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="px-6 py-4">
+          <label
+            for="rename-artifact-input"
+            class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+          >
+            Title
+          </label>
+          <input
+            #input
+            id="rename-artifact-input"
+            type="text"
+            [value]="draft()"
+            (input)="onInput($event)"
+            (keydown.enter)="onEnter()"
+            [attr.maxlength]="maxLength"
+            [attr.aria-describedby]="tooLong() ? 'rename-artifact-hint' : null"
+            [attr.aria-invalid]="tooLong() ? 'true' : null"
+            class="mt-1.5 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+          />
+          @if (tooLong()) {
+            <p
+              id="rename-artifact-hint"
+              class="mt-2 text-xs/5 text-state-danger-600 dark:text-state-danger-400"
+            >
+              Titles are limited to {{ maxLength }} characters.
+            </p>
+          }
+        </div>
+
+        <div
+          class="flex items-center justify-end gap-2 border-t border-gray-200 px-6 py-3 dark:border-gray-700"
+        >
+          <button
+            type="button"
+            (click)="onCancel()"
+            class="rounded-2xl px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            (click)="confirm()"
+            [disabled]="!canConfirm()"
+            class="inline-flex items-center gap-2 rounded-2xl bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:brightness-110"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @reference "../../../styles/theme.css";
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+
+    @keyframes dialog-fade-in-up {
+      from {
+        opacity: 0;
+        transform: translateY(1rem) scale(0.97);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+  `,
+})
+export class RenameArtifactDialogComponent implements AfterViewInit {
+  protected readonly dialogRef = inject(DialogRef<RenameArtifactDialogResult>);
+  protected readonly data = inject<RenameArtifactDialogData>(DIALOG_DATA);
+
+  private readonly input = viewChild<ElementRef<HTMLInputElement>>('input');
+
+  protected readonly maxLength = MAX_ARTIFACT_TITLE_LENGTH;
+  protected readonly draft = signal(this.data.title ?? '');
+
+  protected readonly tooLong = computed(
+    () => this.draft().trim().length > MAX_ARTIFACT_TITLE_LENGTH,
+  );
+
+  /**
+   * Confirm is gated on a title that is non-empty, within the cap, and
+   * actually different. Blocking the no-op case keeps a stray Enter from
+   * firing a write that renames every version row to what they already
+   * say.
+   */
+  protected readonly canConfirm = computed(() => {
+    const next = this.draft().trim();
+    return next.length > 0 && !this.tooLong() && next !== (this.data.title ?? '').trim();
+  });
+
+  ngAfterViewInit(): void {
+    // Select rather than just focus: the field is pre-filled, and
+    // replacing the whole name is far more common than editing a word of
+    // it. The CDK has already trapped focus in the panel by now.
+    this.input()?.nativeElement.select();
+  }
+
+  protected onInput(event: Event): void {
+    this.draft.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onEnter(): void {
+    if (this.canConfirm()) this.confirm();
+  }
+
+  protected confirm(): void {
+    this.dialogRef.close(this.draft().trim());
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.spec.ts
@@ -9,6 +9,8 @@ import { ArtifactHttpService } from '../../../../services/artifacts/artifact-htt
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { SessionService } from '../../../../services/session/session.service';
 import { UserService } from '../../../../../auth/user.service';
+import { ToastService } from '../../../../../services/toast/toast.service';
+import { of } from 'rxjs';
 
 /**
  * Guards the PR-3 extraction: the panel's viewer body moved into
@@ -22,7 +24,16 @@ describe('ArtifactPanelComponent', () => {
   let http: {
     mintRenderToken: ReturnType<typeof vi.fn>;
     getArtifactContent: ReturnType<typeof vi.fn>;
+    renameArtifact: ReturnType<typeof vi.fn>;
+    deleteArtifact: ReturnType<typeof vi.fn>;
   };
+  let state: {
+    remove: ReturnType<typeof vi.fn>;
+    rename: ReturnType<typeof vi.fn>;
+  };
+  let toast: { error: ReturnType<typeof vi.fn> };
+  /** What the stubbed CDK dialog "returns" — the user's choice. */
+  let dialogResult: unknown;
 
   const OPEN = { artifactId: 'art-1', version: 2, title: 'Chart' };
   const openArtifact = signal<typeof OPEN | null>(OPEN);
@@ -51,7 +62,14 @@ describe('ArtifactPanelComponent', () => {
         contentType: 'text/html',
         version: 2,
       }),
+      renameArtifact: vi
+        .fn()
+        .mockResolvedValue({ artifactId: 'art-1', title: 'Renamed' }),
+      deleteArtifact: vi.fn().mockResolvedValue(undefined),
     };
+    state = { remove: vi.fn(), rename: vi.fn() };
+    toast = { error: vi.fn() };
+    dialogResult = undefined;
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
@@ -68,6 +86,8 @@ describe('ArtifactPanelComponent', () => {
             openArtifactPanel: vi.fn(),
             closeArtifactPanel: vi.fn(),
             setPaneWidth: vi.fn(),
+            remove: state.remove,
+            rename: state.rename,
           },
         },
         { provide: ArtifactHttpService, useValue: http },
@@ -80,7 +100,11 @@ describe('ArtifactPanelComponent', () => {
           provide: UserService,
           useValue: { currentUser: signal({ email: 'owner@example.com' }) },
         },
-        { provide: Dialog, useValue: { open: vi.fn() } },
+        { provide: ToastService, useValue: toast },
+        {
+          provide: Dialog,
+          useValue: { open: vi.fn(() => ({ closed: of(dialogResult) })) },
+        },
       ],
     });
 
@@ -151,5 +175,61 @@ describe('ArtifactPanelComponent', () => {
     fixture.detectChanges();
     // The iframe would otherwise swallow the pointer stream mid-drag.
     expect(viewerInstance()!.inert()).toBe(true);
+  });
+
+  describe('rename and delete', () => {
+    const panel = () =>
+      fixture.componentInstance as unknown as Record<string, any>;
+
+    it('applies a rename to the whole artifact in local state', async () => {
+      // The backend retitles every version row, so the registry has to
+      // follow — otherwise the version picker lists one artifact under
+      // two names.
+      dialogResult = 'Renamed';
+      await panel()['rename'](OPEN);
+
+      expect(http.renameArtifact).toHaveBeenCalledWith('art-1', 'Renamed');
+      expect(state.rename).toHaveBeenCalledWith('art-1', 'Renamed');
+    });
+
+    it('leaves state untouched when a rename fails', async () => {
+      dialogResult = 'Renamed';
+      http.renameArtifact.mockRejectedValue(new Error('503'));
+
+      await panel()['rename'](OPEN);
+
+      expect(state.rename).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it('removes the artifact from state once the delete succeeds', async () => {
+      // Removal is what clears the inline cards *and* closes this panel;
+      // both read the same registry.
+      dialogResult = true;
+      await panel()['confirmDelete'](OPEN);
+
+      expect(http.deleteArtifact).toHaveBeenCalledWith('art-1');
+      expect(state.remove).toHaveBeenCalledWith('art-1');
+    });
+
+    it('does not delete when the confirmation is declined', async () => {
+      dialogResult = false;
+      await panel()['confirmDelete'](OPEN);
+
+      expect(http.deleteArtifact).not.toHaveBeenCalled();
+      expect(state.remove).not.toHaveBeenCalled();
+    });
+
+    it('keeps the artifact on screen when the delete fails', async () => {
+      // An optimistic removal would look like success and then reappear
+      // on the next session load.
+      dialogResult = true;
+      http.deleteArtifact.mockRejectedValue(new Error('503'));
+
+      await panel()['confirmDelete'](OPEN);
+
+      expect(state.remove).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-panel.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { Dialog } from '@angular/cdk/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -22,6 +23,8 @@ import {
   heroClipboard,
   heroCheck,
   heroChevronUpDown,
+  heroPencilSquare,
+  heroTrash,
 } from '@ng-icons/heroicons/outline';
 import type {
   Artifact,
@@ -41,6 +44,16 @@ import {
 } from './artifact-share-modal.component';
 import { UserService } from '../../../../../auth/user.service';
 import { TooltipDirective } from '../../../../../components/tooltip/tooltip.directive';
+import { ToastService } from '../../../../../services/toast/toast.service';
+import {
+  ConfirmationDialogComponent,
+  type ConfirmationDialogData,
+} from '../../../../../components/confirmation-dialog';
+import {
+  RenameArtifactDialogComponent,
+  type RenameArtifactDialogData,
+  type RenameArtifactDialogResult,
+} from '../../../../../artifacts/components/rename-artifact-dialog.component';
 
 /**
  * Right-docked pane that renders one artifact version in a sandboxed
@@ -74,6 +87,8 @@ import { TooltipDirective } from '../../../../../components/tooltip/tooltip.dire
       heroClipboard,
       heroCheck,
       heroChevronUpDown,
+      heroPencilSquare,
+      heroTrash,
     }),
   ],
   host: {
@@ -267,6 +282,32 @@ import { TooltipDirective } from '../../../../../components/tooltip/tooltip.dire
           </button>
           <button
             type="button"
+            class="flex size-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+            [attr.aria-label]="'Rename artifact'"
+            [appTooltip]="'Rename'"
+            appTooltipPosition="bottom"
+            [disabled]="mutating()"
+            (click)="rename(ref)"
+          >
+            <ng-icon
+              name="heroPencilSquare"
+              class="text-lg"
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            class="flex size-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-state-danger-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+            [attr.aria-label]="'Delete artifact'"
+            [appTooltip]="'Delete'"
+            appTooltipPosition="bottom"
+            [disabled]="mutating()"
+            (click)="confirmDelete(ref)"
+          >
+            <ng-icon name="heroTrash" class="text-lg" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
             class="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
             [attr.aria-label]="
               downloading() ? 'Downloading artifact…' : 'Download artifact'
@@ -322,12 +363,15 @@ export class ArtifactPanelComponent {
   private artifactDownload = inject(ArtifactDownloadService);
   private dialog = inject(Dialog);
   private userService = inject(UserService);
+  private toast = inject(ToastService);
 
   protected readonly open = this.artifactState.openArtifact;
 
   protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
   protected readonly error = signal<string | null>(null);
   protected readonly downloading = signal(false);
+  /** A rename or delete is in flight, so both buttons wait. */
+  protected readonly mutating = signal(false);
 
   /** Flips when the preview iframe fires `load` — the document has
    *  actually painted, not merely that the render token was minted. */
@@ -678,6 +722,80 @@ export class ArtifactPanelComponent {
         ownerEmail: this.userService.currentUser()?.email ?? '',
       } as ArtifactShareModalData,
     });
+  }
+
+  /**
+   * Rename the open artifact.
+   *
+   * Renames the artifact, not the version on screen: the backend writes
+   * the title to every version row, so the local registry is updated the
+   * same way. Anything less would leave the version picker listing the
+   * same artifact under two names.
+   */
+  protected async rename(ref: OpenArtifactRef): Promise<void> {
+    const data: RenameArtifactDialogData = { title: ref.title };
+    const dialogRef = this.dialog.open<RenameArtifactDialogResult>(
+      RenameArtifactDialogComponent,
+      { data },
+    );
+    const title = await firstValueFrom(dialogRef.closed);
+    if (!title) return;
+
+    this.mutating.set(true);
+    try {
+      const updated = await this.artifactHttp.renameArtifact(
+        ref.artifactId,
+        title,
+      );
+      this.artifactState.rename(ref.artifactId, updated.title);
+    } catch {
+      this.toast.error(
+        'Could not rename artifact',
+        'The change was not saved. Try again in a moment.',
+      );
+    } finally {
+      this.mutating.set(false);
+    }
+  }
+
+  /**
+   * Delete the open artifact after confirmation.
+   *
+   * Removing it from the registry closes this panel *and* clears the
+   * inline cards in the conversation, which read the same registry — a
+   * deleted artifact must not leave a card behind that 404s on click.
+   * That only happens once the request succeeds: an optimistic removal
+   * would silently come back on the next session load.
+   */
+  protected async confirmDelete(ref: OpenArtifactRef): Promise<void> {
+    const data: ConfirmationDialogData = {
+      title: 'Delete this artifact?',
+      message:
+        `"${ref.title || 'Untitled artifact'}" will be deleted permanently, ` +
+        'along with every version of it and any share links you have created. ' +
+        'This cannot be undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    };
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) return;
+
+    this.mutating.set(true);
+    try {
+      await this.artifactHttp.deleteArtifact(ref.artifactId);
+      this.artifactState.remove(ref.artifactId);
+    } catch {
+      this.toast.error(
+        'Could not delete artifact',
+        'Nothing was removed. Try again in a moment.',
+      );
+    } finally {
+      this.mutating.set(false);
+    }
   }
 
   protected async download(): Promise<void> {

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-http.service.ts
@@ -144,6 +144,49 @@ export class ArtifactHttpService {
   }
 
   /**
+   * Retitle an artifact. Returns the server's view of the updated HEAD.
+   *
+   * The backend applies the new title to the HEAD row *and* to every
+   * version row, so the library and the conversation that produced the
+   * artifact cannot end up showing different names for it. Callers
+   * should reconcile against the returned title rather than the one
+   * they sent — it comes back trimmed.
+   */
+  async renameArtifact(artifactId: string, title: string): Promise<LibraryArtifact> {
+    const res = await firstValueFrom(
+      this.http.patch<LibraryArtifactDto>(
+        `${this.config.appApiUrl()}/artifacts/${encodeURIComponent(artifactId)}`,
+        { title },
+      ),
+    );
+    return {
+      artifactId: res.artifact_id,
+      version: res.version,
+      title: res.title,
+      contentType: res.content_type,
+      createdAt: res.created_at,
+      updatedAt: res.updated_at,
+      sessionId: res.session_id,
+    };
+  }
+
+  /**
+   * Delete an artifact, every version of it, and every share of it.
+   *
+   * Permanent — there is no trash and no undo, which is why every call
+   * site is behind a destructive confirmation dialog. The content bytes
+   * sit on a server-side retention clock afterwards, but nothing in the
+   * app can bring the artifact back.
+   */
+  async deleteArtifact(artifactId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.delete<void>(
+        `${this.config.appApiUrl()}/artifacts/${encodeURIComponent(artifactId)}`,
+      ),
+    );
+  }
+
+  /**
    * Every artifact the signed-in user owns, at HEAD, newest-first.
    *
    * Takes no argument on purpose: the endpoint is scoped by the session

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.spec.ts
@@ -230,4 +230,62 @@ describe('ArtifactStateService', () => {
     expect(svc.hasArtifacts()).toBe(false);
     expect(svc.openArtifact()).toBeNull();
   });
+
+  describe('remove', () => {
+    it('drops every version of the artifact', () => {
+      // The conversation renders one card per version, so removing only
+      // the newest would leave older cards pointing at nothing.
+      svc.recordLive(ev({ version: 1 }));
+      svc.recordLive(ev({ version: 2 }));
+      svc.remove('art-1');
+      expect(svc.versionsFor('art-1')).toEqual([]);
+      expect(svc.hasArtifacts()).toBe(false);
+    });
+
+    it('leaves other artifacts alone', () => {
+      svc.recordLive(ev({ artifactId: 'art-1' }));
+      svc.recordLive(ev({ artifactId: 'art-2' }));
+      svc.remove('art-1');
+      expect(svc.get('art-2')).toBeDefined();
+    });
+
+    it('closes the panel when it is showing the deleted artifact', () => {
+      svc.recordLive(ev());
+      expect(svc.openArtifact()?.artifactId).toBe('art-1');
+      svc.remove('art-1');
+      expect(svc.openArtifact()).toBeNull();
+    });
+
+    it('leaves a panel open on a different artifact', () => {
+      svc.recordLive(ev({ artifactId: 'art-1' }));
+      svc.recordLive(ev({ artifactId: 'art-2' }));
+      svc.remove('art-1');
+      expect(svc.openArtifact()?.artifactId).toBe('art-2');
+    });
+  });
+
+  describe('rename', () => {
+    it('retitles every version, matching what the backend writes', () => {
+      svc.recordLive(ev({ version: 1 }));
+      svc.recordLive(ev({ version: 2 }));
+      svc.rename('art-1', 'Renamed');
+      expect(svc.versionsFor('art-1').map((a) => a.title)).toEqual([
+        'Renamed',
+        'Renamed',
+      ]);
+    });
+
+    it('retitles the open panel ref, which holds its own copy', () => {
+      svc.recordLive(ev());
+      svc.rename('art-1', 'Renamed');
+      expect(svc.openArtifact()?.title).toBe('Renamed');
+    });
+
+    it('leaves other artifacts alone', () => {
+      svc.recordLive(ev({ artifactId: 'art-1', title: 'One' }));
+      svc.recordLive(ev({ artifactId: 'art-2', title: 'Two' }));
+      svc.rename('art-1', 'Renamed');
+      expect(svc.get('art-2')?.title).toBe('Two');
+    });
+  });
 });

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-state.service.ts
@@ -136,6 +136,55 @@ export class ArtifactStateService {
     for (const a of list) this.upsert(a);
   }
 
+  /**
+   * Drop every version of an artifact from the registry.
+   *
+   * The conversation's inline cards and the docked panel both read this
+   * registry, so one call clears both — a deleted artifact must not
+   * leave a card behind that 404s when clicked. Closes the panel too if
+   * it happens to be showing the artifact that just went.
+   *
+   * Local bookkeeping only: the caller owns the HTTP delete and must
+   * have seen it succeed first. Removing optimistically would put the
+   * card back on the next session load if the request failed.
+   */
+  remove(artifactId: string): void {
+    this.byKey.update((m) => {
+      const next = new Map(m);
+      for (const key of m.keys()) {
+        if (next.get(key)?.artifactId === artifactId) next.delete(key);
+      }
+      return next;
+    });
+    if (this.openRef()?.artifactId === artifactId) {
+      this.closeArtifactPanel();
+    }
+  }
+
+  /**
+   * Apply a new title to every known version of an artifact.
+   *
+   * Every version, not just the open one, because the backend renames
+   * every version row — leaving older cards on the old title would
+   * invent a disagreement that does not exist on the server. The open
+   * panel ref carries its own copy of the title, so it is updated too.
+   */
+  rename(artifactId: string, title: string): void {
+    this.byKey.update((m) => {
+      const next = new Map(m);
+      for (const [key, artifact] of m) {
+        if (artifact.artifactId === artifactId) {
+          next.set(key, { ...artifact, title });
+        }
+      }
+      return next;
+    });
+    const open = this.openRef();
+    if (open?.artifactId === artifactId) {
+      this.openRef.set({ ...open, title });
+    }
+  }
+
   openArtifactPanel(ref: OpenArtifactRef): void {
     // Collapse the side nav to make room for the docked pane. Only capture
     // the prior state on a genuine closed -> open transition: switching


### PR DESCRIPTION
## Why

`/artifacts` (#950) lists every artifact a user has ever produced, across every conversation. There was no way to delete or rename one — `ArtifactShareService.delete_for_session` revokes shares and explicitly documents that deleting artifact content is out of scope. Before the library existed that was theoretical; now every scratch artifact is permanent and visible.

## Design decisions

**Soft delete vs hard delete — the split, and why.** The DynamoDB rows are hard-deleted; the S3 objects are soft-deleted by tagging them `lifecycle-class=deleted`, which the artifacts bucket's existing (until now unused) `expire-soft-deleted` lifecycle rule reaps after `config.artifacts.retentionDays`.

The rows are the only authority on reachability — the render Lambda resolves a token to content by `GetItem`-ing the *version* row and following its `content_key`. Deleting them makes an artifact unreachable everywhere at once, with no new condition to write and, more to the point, no new condition for a future reader to forget. A soft flag on the row would have to be honoured by the render Lambda (a separate deployable, and a frozen cross-PR contract), by both list paths, by the content endpoint, by share creation and by the share-scoped mint. One missed filter is a deleted artifact that still renders, and it fails silently. There is no undo built on the flag either, since the S3 bytes are what an undo would need and they are on a retention clock regardless.

So delete is immediate and permanent from the user's side. The retention window is an operational recovery path (restore the rows from PITR inside it), not a user-facing trash.

**Cascade to shares.** Shares are per-version, so delete sweeps the whole `SHARE#{artifact_id}#V#` prefix. Ordering reuses `delete_for_session`'s rule and must not be flipped: lookup row (`PK=SHARE#{id}`) before owner row, because the lookup row is what the recipient path resolves. Unlike `delete_for_session` — a background task after a 204 has already gone out — enumeration failures here *raise*, because this runs inside the request that is about to start deleting rows and there is still a clean state to fail into.

**IAM — nothing needed.** The app-api task role already carries `s3:PutObjectTagging` and `dynamodb:DeleteItem` (`app-api-iam-grants.ts`). That is the other reason tagging beats `DeleteObject`: no bucket-policy widening, no CDK deploy has to land ahead of this. (Still no `BatchWriteItem`, so deletes are per-item, exactly as `delete_for_session` documents.) inference-api is not involved — user-facing CRUD belongs on app-api regardless.

**All versions, not just the pointer.** Versions are independently addressable (the panel's version picker mints a token per version) and separately shareable, so dropping only HEAD would leave every prior version live for anyone holding a link, and unlisted, so the owner could neither see nor clean them up.

**Rename and the optimistic lock.** Rename is a bare `SET title` on HEAD *and* every version row — renaming HEAD alone would show the artifact under one name in the library (which reads HEAD) and another in the conversation that produced it (which reads version rows). It touches neither `version`, which carries `update_artifact_record`'s optimistic lock (`ConditionExpression="version = :cur"`), nor `updated_at`, which is embedded in HEAD's `GSI1SK`/`GSI2SK` that only the writer maintains — bumping the attribute without rewriting the keys would order the library differently from the session index. Same restraint, and the same reason, as `set_produced_by_message_index`. A rename records `renamed_at`, which nothing sorts on.

## API

- `DELETE /artifacts/{artifact_id}` → 204
- `PATCH /artifacts/{artifact_id}` `{"title": "..."}` → the updated HEAD

Both owner-scoped by the partition key built from the session, so another user's id is an indistinguishable 404. Neither collides with the two-segment share routes on the same prefix.

## Frontend

Rename and delete on the library page (list + grid) and on the docked session panel. Delete uses `ConfirmationDialogComponent` with copy naming what actually goes — every version, and every share link — since neither is visible from the library. Rename gets its own small dialog: it collects a value rather than an approval, and needs to disable confirm on empty/unchanged/too-long rather than round-trip to a 400.

Local state is mutated only after the request succeeds; an optimistic removal would read as success and reappear on the next session load. In the panel, removal goes through `ArtifactStateService`, which clears the conversation's inline cards and closes the panel in one call.

**Also on the inline artifact card.** The card is per *version* while these two actions are per *artifact*, so the difference is carried in the design rather than left implicit: Rename and Delete are icon-only at every width (Share and Download keep their text — four equally weighted labelled buttons would read as four peers); their accessible names name no version, and Delete says "and all versions" outright; and the confirmation copy leads with the version count — "all 3 versions…, not just the version on this card" — since that dialog is the last chance to correct the reading before the sibling cards vanish alongside this one.

The label-collapse container query moves from 26rem to 34rem, because the row now carries four controls and Share/Download have to shed their text sooner or the title clips to nothing on a narrow card. **That threshold is the one thing worth eyeballing in the running app** — the rest is covered by tests.

## Tests

- `backend/tests/apis/app_api/artifacts/test_artifact_lifecycle.py` — 16 tests. Asserts explicitly that rename leaves `version`, `updated_at` and both GSI sort keys untouched; that delete cascades to both share rows; that ownership scoping leaves the other user's rows intact; that a failed S3 tag does not block the delete; and that a share-enumeration failure is a clean no-op.
- Frontend: extended `artifact-library.page.spec.ts`, `artifact-state.service.spec.ts`, `artifact-panel.component.spec.ts` and `artifact-card.component.spec.ts`, plus a new spec for the rename dialog.

Backend: 7405 passed. Frontend: 2285 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
