### PR TITLE
fix(artifacts): stop reporting "Pop-up blocked" on every artifact open

### DIFF
--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -207,13 +207,69 @@ describe('ArtifactLibraryPage', () => {
   });
 
   describe('open()', () => {
+    /**
+     * Stands in for a real `window.open`, including the rule that bit us:
+     * per spec it returns **null** when `noopener` (or `noreferrer`, which
+     * implies it) is set, because severing the opener leaves no handle to
+     * return. A mock that hands back a tab regardless of the feature
+     * string is how the bug shipped — it agreed with the broken code
+     * instead of with the browser.
+     */
+    function spyOnWindowOpen() {
+      const tab = { location: { href: '' }, opener: {} as unknown, close: vi.fn() };
+      const spy = vi
+        .spyOn(window, 'open')
+        .mockImplementation((_url?: string | URL, _target?: string, features?: string) =>
+          /noopener|noreferrer/.test(features ?? '') ? null : (tab as unknown as Window),
+        );
+      return { tab, spy };
+    }
+
+    it('does not pass noopener, which would make window.open return null', async () => {
+      // Regression: 'noopener,noreferrer' reported "Pop-up blocked" on
+      // every click and left a stray about:blank tab behind.
+      const { tab, spy } = spyOnWindowOpen();
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact());
+
+      const features = spy.mock.calls[0]?.[2] ?? '';
+      expect(features).not.toMatch(/noopener|noreferrer/);
+      expect(mockToast.error).not.toHaveBeenCalled();
+      expect(tab.location.href).toBe('https://artifacts.example/x?t=tok');
+    });
+
+    it('severs the opener itself, since it cannot ask the browser to', async () => {
+      const { tab } = spyOnWindowOpen();
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact());
+
+      // Reverse-tabnabbing guard standing in for the unusable noopener.
+      expect(tab.opener).toBeNull();
+    });
+
+    it('still opens when the webview makes opener read-only', async () => {
+      const tab = { location: { href: '' }, close: vi.fn() };
+      Object.defineProperty(tab, 'opener', {
+        get: () => null,
+        set: () => {
+          throw new TypeError('read only');
+        },
+      });
+      vi.spyOn(window, 'open').mockImplementation(() => tab as unknown as Window);
+
+      const c = api(await createComponent());
+      await c.open(stubArtifact());
+
+      expect(tab.location.href).toBe('https://artifacts.example/x?t=tok');
+      expect(mockToast.error).not.toHaveBeenCalled();
+    });
+
     it('opens the tab before awaiting the mint, then points it at the URL', async () => {
       // The ordering is the whole contract: a window.open() after the await
       // is no longer tied to the click gesture and every browser blocks it.
-      const tab = { location: { href: '' }, close: vi.fn() };
-      const openSpy = vi
-        .spyOn(window, 'open')
-        .mockImplementation(() => tab as unknown as Window);
+      const { tab, spy: openSpy } = spyOnWindowOpen();
 
       let mintStarted = false;
       mockHttp.mintRenderToken.mockImplementation(async () => {
@@ -232,8 +288,7 @@ describe('ArtifactLibraryPage', () => {
     });
 
     it('closes the blank tab and reports the failure when minting fails', async () => {
-      const tab = { location: { href: '' }, close: vi.fn() };
-      vi.spyOn(window, 'open').mockImplementation(() => tab as unknown as Window);
+      const { tab } = spyOnWindowOpen();
       mockHttp.mintRenderToken.mockRejectedValue(new Error('500'));
 
       const c = api(await createComponent());

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -257,15 +257,36 @@ export class ArtifactLibraryPage {
    * render token is a short-lived (~120s) bearer credential in a URL, so
    * pre-minting one per row would both expire before use and mean a
    * round trip per artifact just to draw the page.
+   *
+   * The feature string must NOT contain `noopener` (nor `noreferrer`,
+   * which implies it). `window.open()` returns **null** whenever
+   * `noopener` is set — that is the specified behaviour, not a failure:
+   * severing the opener relationship means there is no handle to hand
+   * back. Passing it here opened a stray blank tab, made the null check
+   * below read as a blocked pop-up, and reported "Pop-up blocked" on
+   * every single click. We need the handle, so the opener is severed
+   * afterwards by assignment instead, which is the pre-`rel=noopener`
+   * mitigation and equally durable across the navigation.
    */
   protected async open(item: LibraryArtifact): Promise<void> {
-    const tab = window.open('', '_blank', 'noopener,noreferrer');
+    const tab = window.open('', '_blank');
     if (!tab) {
       this.toast.error(
         'Pop-up blocked',
         'Allow pop-ups for this site to open artifacts in a new tab.',
       );
       return;
+    }
+
+    // Reverse-tabnabbing guard, standing in for the `noopener` we cannot
+    // pass. Set while the tab is still same-origin about:blank; it
+    // survives the navigation, so the artifact origin never gets a
+    // handle back to this window.
+    try {
+      tab.opener = null;
+    } catch {
+      // Some embedded webviews make `opener` read-only. Not worth
+      // abandoning the open over — the destination is our own origin.
     }
 
     this.opening.set(item.artifactId);


### PR DESCRIPTION
## The bug

Clicking any artifact in the library reported **"Pop-up blocked"** and opened a stray blank tab. The artifact never opened. This affected every click, in every browser — the open path shipped broken in #950.

## Cause

`window.open()` returns **`null` whenever `noopener` is set.** That is [specified behaviour](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open-dev), not a failure: severing the opener relationship means there is no handle to hand back. `noreferrer` implies `noopener` and does the same.

The page passed `'noopener,noreferrer'`:

```ts
const tab = window.open('', '_blank', 'noopener,noreferrer');
if (!tab) { toast.error('Pop-up blocked', …); return; }   // always taken
```

So every click opened a blank tab, read the spec-mandated `null` as a blocked pop-up, returned early without minting a render token, and toasted.

## Fix

The handle is genuinely needed — the tab must be opened *before* the `await` on the mint, because afterwards the click is no longer the active user gesture and the pop-up gets blocked for real. So the flag comes off and the opener is severed by assignment instead:

```ts
const tab = window.open('', '_blank');
if (!tab) { … }            // now a real blocked pop-up
try { tab.opener = null; } catch { /* read-only in some webviews */ }
```

Set while the tab is still same-origin `about:blank`, this is the pre-`rel=noopener` mitigation and survives the navigation, so the artifact origin never gets a handle back to the app window. The reverse-tabnabbing guard is unchanged in substance.

`noreferrer` is also gone, so the artifact origin now receives the SPA origin as `Referer`. That origin is our own CloudFront distribution and the referrer never carries the render token (which travels in the URL being navigated *to*, not the one navigated *from*), so this is not a leak.

The assignment is wrapped in try/catch: some embedded webviews make `opener` read-only, which isn't worth abandoning the open over when the destination is our own origin.

## Why the tests didn't catch it

They mocked `window.open` to return a tab regardless of the feature string — so they agreed with the broken code rather than with the browser, and stayed green through a feature that could never work in production.

The mock now emulates the real rule (null when `noopener`/`noreferrer` is present). Verified by mutation: restoring the old feature string fails **4 tests**, including one asserting directly that the flag is absent, plus new coverage for the opener being severed and for the read-only-`opener` webview case.

`ng test`: 2280 passed across 207 files. `tsc --noEmit` clean.

## Verifying after deploy

On dev, go to Settings → Profile → Artifacts and click any artifact title or its open icon. It should open the rendered artifact in a new tab with no toast, and no leftover blank tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)