### PR TITLE
feat(models): explicit prompt-cache breakpoints for GPT-5.6

### DIFF
--- a/backend/src/apis/shared/models/bedrock_responses.py
+++ b/backend/src/apis/shared/models/bedrock_responses.py
@@ -55,7 +55,13 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "BEDROCK_RESPONSES_PARAM_MAP",
     "BEDROCK_RUNTIME_OPENAI_PATH",
+    "EXPLICIT_CACHE_ENABLED_ENV",
+    "EXPLICIT_CACHE_OPTIONS",
+    "EXPLICIT_CACHE_TTL",
+    "apply_explicit_prompt_cache",
     "build_bedrock_responses_model",
+    "build_prompt_cache_key",
+    "explicit_prompt_cache_enabled",
     "get_bedrock_runtime_openai_base_url",
 ]
 
@@ -116,6 +122,128 @@ def _warn_on_missing_inference_profile(model_id: str) -> None:
         )
 
 
+# ── Explicit prompt caching (GPT-5.6) ────────────────────────────────────────
+#
+# GPT-5.6 caches implicitly by default. Explicit mode instead lets us mark
+# where the reusable prefix ends, which is what buys the resilience the Claude
+# path already has: a change in conversation history costs a *read* of the
+# ~30k static prefix (tools + system prompt) rather than a full re-write at the
+# 1.25x premium.
+#
+# Kill switch, default ON per repo convention. Only the literal string "false"
+# disables it — an empty or unset value stays enabled, because workflow env
+# vars can materialize as "".
+#
+# ⚠️ Deliberately NOT wired into the CDK Runtime construct.
+# `AWS::BedrockAgentCore::Runtime` caps EnvironmentVariables at 50 and
+# `inference-agentcore-construct.ts` is AT that cap — a 51st entry fails
+# CloudFormation *changeset validation*, i.e. after synth, tsc, jest and green
+# CI (it broke the dev Platform Stack deploy on 2026-08-05). A code-level flag
+# that reads os.environ and defaults ON needs no entry, which is exactly this
+# one. Turning it off in a deployed environment takes an out-of-band Runtime
+# update until a slot is freed.
+EXPLICIT_CACHE_ENABLED_ENV = "BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED"
+
+# Request-level cache controls. `ttl` is the string form of the same window
+# the cache-status classifier measures gaps against
+# (``OPENAI_RESPONSES_CACHE_TTL_SECONDS``); a test asserts the two agree so a
+# change to one cannot silently diverge from the other.
+EXPLICIT_CACHE_TTL = "30m"
+EXPLICIT_CACHE_OPTIONS: Dict[str, str] = {"mode": "explicit", "ttl": EXPLICIT_CACHE_TTL}
+
+# Marks the end of the reusable prefix. Goes on a *content block*, not on the
+# request — see the AWS explicit-prompt-caching guidance for GPT-5.6.
+_CACHE_BREAKPOINT = {"mode": "explicit"}
+
+
+def explicit_prompt_cache_enabled() -> bool:
+    """Whether to send explicit cache breakpoints on this transport.
+
+    Read per call (no module-level caching) so tests and live config changes
+    behave predictably; the env read is negligible next to request assembly.
+    """
+    return os.environ.get(EXPLICIT_CACHE_ENABLED_ENV, "").lower() != "false"
+
+
+def build_prompt_cache_key(
+    system_prompt: Optional[str],
+    tool_specs: Optional[Any],
+) -> str:
+    """Cache key for requests that share a prefix.
+
+    Derived from the same fingerprints the prompt-cache observability layer
+    records on each call, so requests with an identical static prefix route to
+    one cache entry and any config change rotates the key *by construction* —
+    there is no separate list to keep in sync.
+
+    Deliberately covers only the static prefix (system prompt + tool
+    definitions). Including conversation history would rotate the key every
+    turn, which is precisely the cache-busting this exists to prevent.
+    """
+    from apis.shared.observability import fingerprint_canonical_json, fingerprint_text
+
+    return f"{fingerprint_text(system_prompt)}:{fingerprint_canonical_json(tool_specs or [])}"
+
+
+def apply_explicit_prompt_cache(
+    request: Dict[str, Any],
+    system_prompt: Optional[str],
+    tool_specs: Optional[Any],
+) -> Dict[str, Any]:
+    """Stamp explicit cache controls onto a formatted Responses request.
+
+    Strands emits the system prompt as the top-level ``instructions`` string,
+    but a breakpoint has to sit on a *content block*. So the instructions are
+    re-expressed as the ``developer`` message the AWS guidance shows, placed at
+    the head of ``input`` and carrying the breakpoint — which puts the cache
+    boundary exactly at the end of the static prefix (tools + system), before
+    any conversation history.
+
+    Args:
+        request: The request dict from ``OpenAIResponsesModel._format_request``.
+            Mutated in place and returned.
+        system_prompt: This turn's system prompt.
+        tool_specs: This turn's tool specifications.
+
+    Returns:
+        ``request``.
+
+    Note:
+        With no system prompt there is no content block marking the end of a
+        static prefix, so this returns the request untouched and the model
+        keeps its default **implicit** caching. Switching to explicit mode with
+        a badly placed boundary would be worse than not switching at all.
+    """
+    instructions = request.get("instructions")
+    if not instructions:
+        return request
+
+    developer_message = {
+        "type": "message",
+        "role": "developer",
+        "content": [
+            {
+                "type": "input_text",
+                "text": instructions,
+                "prompt_cache_breakpoint": dict(_CACHE_BREAKPOINT),
+            }
+        ],
+    }
+    request.pop("instructions", None)
+    existing_input = request.get("input")
+    request["input"] = [developer_message, *(existing_input or [])]
+
+    # `prompt_cache_key` is a first-class SDK parameter; `prompt_cache_options`
+    # is not, so it rides `extra_body`. Merge rather than assign — a caller's
+    # `params` may already carry an extra_body.
+    request.setdefault("prompt_cache_key", build_prompt_cache_key(system_prompt, tool_specs))
+    extra_body = dict(request.get("extra_body") or {})
+    extra_body.setdefault("prompt_cache_options", dict(EXPLICIT_CACHE_OPTIONS))
+    request["extra_body"] = extra_body
+
+    return request
+
+
 _model_cls: Optional[type] = None
 
 
@@ -161,6 +289,29 @@ def _bedrock_responses_model_cls() -> type:
             args = dict(super()._resolve_client_args())
             args["api_key"] = generate_bedrock_bearer_token(self._bedrock_region)
             return args
+
+        def _format_request(
+            self,
+            messages: Any,
+            tool_specs: Optional[Any] = None,
+            system_prompt: Optional[str] = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Dict[str, Any]:
+            """Format the request, then mark where the reusable prefix ends.
+
+            The three leading parameters are named because this override needs
+            two of them; ``tool_choice`` / ``model_state`` (and anything a
+            future SDK adds) ride ``*args`` / ``**kwargs`` untouched. Strands
+            calls this both positionally with five arguments and by keyword,
+            so both forms have to work.
+            """
+            request = super()._format_request(messages, tool_specs, system_prompt, *args, **kwargs)
+            if not explicit_prompt_cache_enabled():
+                return request
+            return apply_explicit_prompt_cache(
+                request, system_prompt=system_prompt, tool_specs=tool_specs
+            )
 
     _model_cls = usage_normalized(BedrockRuntimeResponsesModel)
     return _model_cls

--- a/backend/tests/shared/test_bedrock_responses_explicit_cache.py
+++ b/backend/tests/shared/test_bedrock_responses_explicit_cache.py
@@ -1,0 +1,281 @@
+"""Explicit prompt-cache controls on the bedrock-runtime Responses transport.
+
+GPT-5.6 caches implicitly by default. Explicit mode lets us mark where the
+reusable prefix ends, so a change in conversation history costs a *read* of the
+~30k static prefix instead of a full re-write at the 1.25x premium — the
+resilience the Claude path already has.
+
+The request shape asserted here is AWS's documented one for explicit prompt
+caching: ``prompt_cache_breakpoint`` on a content block of a ``developer``
+message, ``prompt_cache_options`` at request level, ``prompt_cache_key``
+top-level. Strands emits the system prompt as the top-level ``instructions``
+string, which has no content block to mark — so the override re-expresses it
+as that developer message.
+
+These drive the real model class through the real ``_format_request``; nothing
+here stubs the SDK's request assembly.
+"""
+
+import pytest
+
+from apis.shared.models.bedrock_responses import (
+    EXPLICIT_CACHE_ENABLED_ENV,
+    EXPLICIT_CACHE_TTL,
+    apply_explicit_prompt_cache,
+    build_bedrock_responses_model,
+    build_prompt_cache_key,
+    explicit_prompt_cache_enabled,
+)
+
+SYSTEM = "You are a helpful assistant with a long stable preamble."
+TOOLS = [
+    {
+        "name": "search",
+        "description": "search things",
+        "inputSchema": {"json": {"type": "object", "properties": {}}},
+    }
+]
+MESSAGES = [
+    {"role": "user", "content": [{"text": "first"}]},
+    {"role": "assistant", "content": [{"text": "reply"}]},
+    {"role": "user", "content": [{"text": "second"}]},
+]
+
+
+@pytest.fixture
+def model():
+    return build_bedrock_responses_model("us.openai.gpt-5.6-sol", region="us-west-2")
+
+
+def _format(model, *, system_prompt=SYSTEM, tool_specs=TOOLS, messages=MESSAGES):
+    return model._format_request(messages, tool_specs, system_prompt)
+
+
+class TestBreakpointPlacement:
+    def test_instructions_become_a_developer_message_carrying_the_breakpoint(self, model):
+        request = _format(model)
+
+        assert "instructions" not in request, (
+            "the system prompt has to live in `input` to carry a content block"
+        )
+        first = request["input"][0]
+        assert first["type"] == "message"
+        assert first["role"] == "developer"
+        assert first["content"] == [
+            {
+                "type": "input_text",
+                "text": SYSTEM,
+                "prompt_cache_breakpoint": {"mode": "explicit"},
+            }
+        ]
+
+    def test_conversation_history_follows_the_breakpoint_in_order(self, model):
+        request = _format(model)
+
+        # The boundary sits after tools + system and before any history, so
+        # a history change costs a read of the prefix, not a re-write.
+        history = request["input"][1:]
+        assert len(history) == len(MESSAGES)
+        assert [m["role"] for m in history] == ["user", "assistant", "user"]
+
+    def test_only_one_breakpoint_is_emitted(self, model):
+        """The API caps breakpoints at 4; we spend exactly one, on the prefix."""
+        request = _format(model)
+
+        marked = [
+            block
+            for item in request["input"]
+            if isinstance(item.get("content"), list)
+            for block in item["content"]
+            if isinstance(block, dict) and "prompt_cache_breakpoint" in block
+        ]
+        assert len(marked) == 1
+
+    def test_tools_stay_top_level_and_untouched(self, model):
+        request = _format(model)
+
+        assert request["tools"][0]["name"] == "search"
+
+
+class TestCacheOptions:
+    def test_options_ride_extra_body(self, model):
+        # `prompt_cache_options` is not a named parameter on the OpenAI SDK's
+        # responses.create, so it has to travel in extra_body.
+        request = _format(model)
+
+        assert request["extra_body"]["prompt_cache_options"] == {
+            "mode": "explicit",
+            "ttl": EXPLICIT_CACHE_TTL,
+        }
+
+    def test_ttl_agrees_with_the_classifier_window(self):
+        """The string here and the seconds the classifier uses must not drift."""
+        from apis.shared.observability import OPENAI_RESPONSES_CACHE_TTL_SECONDS
+
+        assert EXPLICIT_CACHE_TTL.endswith("m")
+        assert int(EXPLICIT_CACHE_TTL[:-1]) * 60 == OPENAI_RESPONSES_CACHE_TTL_SECONDS
+
+    def test_an_existing_extra_body_is_merged_not_clobbered(self):
+        request = {
+            "instructions": SYSTEM,
+            "input": [],
+            "extra_body": {"something_else": 1},
+        }
+        apply_explicit_prompt_cache(request, system_prompt=SYSTEM, tool_specs=TOOLS)
+
+        assert request["extra_body"]["something_else"] == 1
+        assert "prompt_cache_options" in request["extra_body"]
+
+    def test_a_caller_supplied_option_wins(self):
+        request = {
+            "instructions": SYSTEM,
+            "input": [],
+            "extra_body": {"prompt_cache_options": {"mode": "implicit"}},
+        }
+        apply_explicit_prompt_cache(request, system_prompt=SYSTEM, tool_specs=TOOLS)
+
+        assert request["extra_body"]["prompt_cache_options"] == {"mode": "implicit"}
+
+
+class TestPromptCacheKey:
+    def test_is_a_top_level_request_parameter(self, model):
+        # It IS a named SDK parameter, unlike prompt_cache_options.
+        request = _format(model)
+
+        assert request["prompt_cache_key"] == build_prompt_cache_key(SYSTEM, TOOLS)
+
+    def test_is_stable_across_turns_of_one_conversation(self, model):
+        """Keyed on the static prefix only — history must not rotate it.
+
+        A key that changed every turn would be the exact cache-busting this
+        feature exists to prevent.
+        """
+        turn_one = _format(model, messages=MESSAGES[:1])
+        turn_two = _format(model, messages=MESSAGES)
+
+        assert turn_one["prompt_cache_key"] == turn_two["prompt_cache_key"]
+
+    def test_rotates_when_the_system_prompt_changes(self, model):
+        assert (
+            _format(model)["prompt_cache_key"]
+            != _format(model, system_prompt=SYSTEM + " extra")["prompt_cache_key"]
+        )
+
+    def test_rotates_when_the_tool_set_changes(self, model):
+        other = [dict(TOOLS[0], name="different")]
+
+        assert _format(model)["prompt_cache_key"] != _format(model, tool_specs=other)["prompt_cache_key"]
+
+    def test_rotates_when_only_tool_order_changes(self, model):
+        """Prefix matching is order-sensitive, so the key must be too."""
+        two = TOOLS + [dict(TOOLS[0], name="second")]
+        flipped = list(reversed(two))
+
+        assert (
+            _format(model, tool_specs=two)["prompt_cache_key"]
+            != _format(model, tool_specs=flipped)["prompt_cache_key"]
+        )
+
+    def test_no_tools_is_stable_and_distinct_from_having_tools(self, model):
+        none_key = _format(model, tool_specs=None)["prompt_cache_key"]
+
+        assert none_key == _format(model, tool_specs=[])["prompt_cache_key"]
+        assert none_key != _format(model)["prompt_cache_key"]
+
+    def test_a_caller_supplied_key_wins(self):
+        request = {"instructions": SYSTEM, "input": [], "prompt_cache_key": "mine"}
+        apply_explicit_prompt_cache(request, system_prompt=SYSTEM, tool_specs=TOOLS)
+
+        assert request["prompt_cache_key"] == "mine"
+
+
+class TestNoSystemPrompt:
+    """With no static prefix to bound, stay on implicit caching."""
+
+    def test_request_is_left_untouched(self, model):
+        request = _format(model, system_prompt=None)
+
+        assert "prompt_cache_key" not in request
+        assert "extra_body" not in request
+        assert request["input"][0]["role"] == "user"
+
+    def test_explicit_mode_is_not_forced_on(self, model):
+        # Switching to explicit mode opts OUT of the model's default implicit
+        # caching. With a badly placed boundary that is worse than not
+        # switching at all, so absent a system prompt we do not switch.
+        request = _format(model, system_prompt=None)
+
+        assert "prompt_cache_options" not in (request.get("extra_body") or {})
+
+
+class TestKillSwitch:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv(EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+
+        assert explicit_prompt_cache_enabled() is True
+
+    def test_empty_string_stays_enabled(self, monkeypatch):
+        # Workflow env vars can materialize as "" — that must not disable it.
+        monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, "")
+
+        assert explicit_prompt_cache_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "FALSE", "False"])
+    def test_only_the_literal_false_disables(self, monkeypatch, value):
+        monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, value)
+
+        assert explicit_prompt_cache_enabled() is False
+
+    def test_disabled_leaves_the_stock_request_shape(self, model, monkeypatch):
+        monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, "false")
+
+        request = _format(model)
+
+        assert request["instructions"] == SYSTEM
+        assert "prompt_cache_key" not in request
+        assert "extra_body" not in request
+        assert request["input"][0]["role"] == "user"
+
+
+class TestOtherTransportsUnaffected:
+    def test_mantle_responses_gets_no_explicit_controls(self):
+        """openai.gpt-5.4 on Mantle is implicit-only — it has no breakpoints.
+
+        Sending explicit controls there would at best be ignored and at worst
+        rejected, so the Mantle builder must not inherit any of this.
+        """
+        from apis.shared.models.mantle import MantleApiMode, build_mantle_model
+
+        model = build_mantle_model(
+            model_id="openai.gpt-5.4",
+            api_mode=MantleApiMode.RESPONSES,
+            region="us-east-1",
+        )
+        request = model._format_request(MESSAGES, TOOLS, SYSTEM)
+
+        assert request["instructions"] == SYSTEM
+        assert "prompt_cache_key" not in request
+        assert "extra_body" not in request
+
+
+class TestUsageNormalizationStillApplies:
+    def test_disjoint_buckets_survive_the_format_override(self, model):
+        """PR-1's normalization and this override live on the same class."""
+        from openai.types.responses.response_usage import ResponseUsage
+
+        usage_obj = ResponseUsage.model_validate(
+            {
+                "input_tokens": 30_500,
+                "input_tokens_details": {"cached_tokens": 30_000, "cache_write_tokens": 400},
+                "output_tokens": 120,
+                "output_tokens_details": {"reasoning_tokens": 64},
+                "total_tokens": 30_620,
+            }
+        )
+        usage = model._format_chunk({"chunk_type": "metadata", "data": usage_obj})[
+            "metadata"
+        ]["usage"]
+
+        assert usage["inputTokens"] == 100
+        assert usage["cacheReadInputTokens"] == 30_000
+        assert usage["cacheWriteInputTokens"] == 400

--- a/docs/specs/gpt-5-6-prompt-caching.md
+++ b/docs/specs/gpt-5-6-prompt-caching.md
@@ -1,6 +1,6 @@
 # Plan: prompt caching for OpenAI GPT-5.6 on Bedrock
 
-**Status:** In progress — PR-1 (#945), PR-2 (#949) and PR-5 shipped; PR-3 BLOCKED (no commercial rates in the Price List API), PR-4 outstanding
+**Status:** In progress — PR-1 (#945), PR-2 (#949), PR-5 (#951) and PR-4 shipped; PR-3 BLOCKED (no commercial rates in the Price List API). No step is verified against a live model yet — that waits on PR-3.
 **Author:** (drafted with Claude)
 **Date:** 2026-09-04
 **Related:** `agents/main_agent/core/model_config.py`, `agents/main_agent/core/agent_factory.py`,
@@ -260,7 +260,7 @@ than an error, which is exactly the failure the Verification section exists to
 catch. Decide before curating: either model the dimensions, or scope the row
 to standard-tier short-context and gate on staying inside it.
 
-### PR-4 — Explicit cache breakpoints + `prompt_cache_key`
+### PR-4 — Explicit cache breakpoints + `prompt_cache_key` ✅ SHIPPED
 
 Only worth building for 5.6, where the 1.25× write premium makes placement matter.
 
@@ -278,6 +278,52 @@ Only worth building for 5.6, where the 1.25× write premium makes placement matt
 - The existing prompt-cache contract carries over unchanged — implicit and
   explicit caching are both exact-prefix, so deterministic tool/skill ordering and
   the truncation anchor in `TurnBasedSessionManager` remain load-bearing.
+
+#### Two corrections from building it
+
+**`prompt_cache_key` does not ride `config["params"]`.** It is a first-class
+parameter on the OpenAI SDK's `responses.create`, so it is set directly on the
+formatted request. `prompt_cache_options` is *not* a named parameter and has to
+travel in `extra_body`. Both are set in the `_format_request` override rather
+than at model construction, because that is the only seam where the system
+prompt and tool specs — the inputs the key is derived from — are actually in
+scope.
+
+**There is no "system/developer message" to stamp in Strands' output.** It emits
+the system prompt as the top-level `instructions` *string*, and a breakpoint has
+to sit on a content **block**. So the override re-expresses `instructions` as the
+`developer` message AWS's guidance shows, at the head of `input`, carrying the
+breakpoint:
+
+```python
+{"type": "message", "role": "developer",
+ "content": [{"type": "input_text", "text": ...,
+              "prompt_cache_breakpoint": {"mode": "explicit"}}]}
+```
+
+That places the boundary exactly at the end of the static prefix (tools +
+system), before any history. Stamping `input[0]`'s existing block instead would
+have put the first user message inside the cached segment, so compaction — which
+rewrites history — would invalidate the tools+system segment too.
+
+#### Risk this PR carries
+
+Explicit mode **opts out of** the model's default implicit caching. A badly
+placed boundary is therefore worse than not switching at all. Two mitigations:
+
+- With no system prompt there is no static prefix to bound, so the request is
+  left untouched and implicit caching stays on.
+- Kill switch `BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED` (default ON).
+  ⚠️ Deliberately **not** wired into the CDK Runtime construct: that construct is
+  at the `AWS::BedrockAgentCore::Runtime` 50-variable cap, and a 51st entry fails
+  changeset validation after CI is green. Flipping it in a deployed environment
+  needs an out-of-band Runtime update.
+
+None of this is verified against a live model — no GPT-5.6 catalog row exists
+while PR-3 is blocked. **The Verification section below is the gate before this
+is trusted in prod**, and the specific thing to confirm is that turns 2+ report
+`cacheRead` tracking the whole static prefix. If they do not, the boundary is
+misplaced and the flag is the way out.
 
 ### PR-5 — Observability
 


### PR DESCRIPTION
## PR-4 of [`docs/specs/gpt-5-6-prompt-caching.md`](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/docs/specs/gpt-5-6-prompt-caching.md)

Follows PR-1 (#945), PR-2 (#949) and PR-5 (#951). The first change in this epic that is meant to **reduce** spend rather than measure it correctly.

## What it does

GPT-5.6 caches implicitly by default. Explicit mode lets us mark where the reusable prefix ends, which buys the resilience the Claude path already has: a change in conversation history costs a **read** of the ~30k static prefix (tools + system prompt) instead of a full re-write at the 1.25× premium.

The emitted request is AWS's documented explicit-caching shape:

```jsonc
{
  "model": "us.openai.gpt-5.6-sol",
  "tools": [ ... ],
  "input": [
    {"type": "message", "role": "developer",
     "content": [{"type": "input_text", "text": "<system prompt>",
                  "prompt_cache_breakpoint": {"mode": "explicit"}}]},
    // ...conversation history follows the boundary
  ],
  "prompt_cache_key": "<systemPromptHash>:<toolConfigHash>",
  "extra_body": {"prompt_cache_options": {"mode": "explicit", "ttl": "30m"}}
}
```

## Two things the spec assumed that don't hold

**`prompt_cache_key` does not ride `config["params"]`.** It's a first-class parameter on the OpenAI SDK's `responses.create`. `prompt_cache_options` is *not* a named parameter and has to travel in `extra_body`. Both are set in a `_format_request` override rather than at construction, because that's the only seam where the system prompt and tool specs — the inputs the key derives from — are in scope.

**There is no "system/developer message" to stamp.** Strands emits the system prompt as the top-level `instructions` **string**, and a breakpoint has to sit on a content **block**. So the override re-expresses `instructions` as the developer message AWS documents, at the head of `input`, carrying the breakpoint.

That second one matters beyond shape. Stamping `input[0]`'s existing block instead would have pulled the first user message into the cached segment — so compaction, which rewrites history, would invalidate the tools+system segment too. Exactly the opposite of what this is for.

The key is derived from the same fingerprints the observability layer already records, so a config change rotates it **by construction** and history does not. A key that moved every turn would be the precise cache-busting this exists to prevent — there's a test for it.

## ⚠️ Risk this PR carries

**Explicit mode opts *out* of the model's default implicit caching.** A badly placed boundary is therefore worse than not switching at all. Two mitigations:

- With no system prompt there's no static prefix to bound, so the request is left untouched and implicit caching stays on.
- Kill switch `BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED` (default ON, per repo convention).

**The kill switch is deliberately NOT wired into CDK.** `inference-agentcore-construct.ts` is *at* the `AWS::BedrockAgentCore::Runtime` 50-variable cap. A 51st entry fails CloudFormation changeset validation — after synth, tsc, jest and green CI — which is how the dev Platform Stack deploy broke on 2026-08-05. That construct's own comment states a code-level flag reading `os.environ` and defaulting ON needs no entry; this is one. Flipping it in a deployed environment needs an out-of-band Runtime update until a slot is freed. Documented in the module and the spec.

## Not verified against a live model

No GPT-5.6 catalog row exists while PR-3 is blocked on missing Price List rates, so this — like PR-2 and PR-5 — is unexercised end to end.

**The thing to confirm when a row exists:** turns 2+ should report `cacheRead` tracking the *whole* static prefix. If they don't, the boundary is misplaced and the flag is the way out. That check is now the epic's critical path — four PRs of correctness work rest on it.

## Testing

`backend/tests/shared/test_bedrock_responses_explicit_cache.py` — 25 cases driving the **real** model class through the **real** `_format_request`; nothing stubs the SDK's request assembly.

- **Placement** — instructions become the developer message; history follows the boundary in order; exactly one breakpoint is spent (the API caps at 4); tools stay top-level.
- **Options** — ride `extra_body`; an existing `extra_body` is merged not clobbered; a caller-supplied option wins. Plus a drift guard asserting `"30m"` equals PR-5's `OPENAI_RESPONSES_CACHE_TTL_SECONDS`.
- **Key** — top-level; stable across turns of one conversation; rotates on system-prompt change, tool-set change, and **tool-order** change (prefix matching is order-sensitive, so the key must be too); caller-supplied key wins.
- **No system prompt** — request untouched, explicit mode not forced on.
- **Kill switch** — default on, empty string stays on, only literal `false` disables, and disabled restores the stock request shape exactly.
- **Blast radius** — Mantle-Responses (`openai.gpt-5.4`, implicit-only) gets none of this; PR-1's usage normalization still works on the same class.

`cd backend && uv run python -m pytest tests/ -q` → **7427 passed, 3 skipped, 0 failed**

One interaction I checked and ruled out: Strands' `count_tokens` filters a formatted request to `{model, input, instructions, tools}`, which my override changes. It's unreachable here — `use_native_token_count` is only set on the Converse path, so `count_tokens` short-circuits to the estimator before calling `_format_request`.

## Epic status

PR-1, PR-2, PR-5 and PR-4 shipped. **PR-3 remains blocked** — commercial GPT-5.6 rates aren't published in the Price List API under any Bedrock service code, and it gates all live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
