### PR TITLE
fix(artifacts): stop the library view toggle stretching on narrow screens

### DIFF
--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -14,11 +14,16 @@
 
       @if (items().length > 0) {
         <!-- One setting with two values, so a radiogroup rather than two
-             independent toggle buttons. Mirrors the Agents page. -->
+             independent toggle buttons. Mirrors the Agents page.
+
+             `self-start` is load-bearing, not tidying: below `sm` the header
+             is a flex column, whose default align-items:stretch pulls this to
+             full width and strands two 32px icons in an empty bar.
+             `inline-flex` sets display, not alignment, so it does not help. -->
         <div
           role="radiogroup"
           aria-label="Layout"
-          class="inline-flex shrink-0 gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
+          class="inline-flex shrink-0 self-start gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
         >
           <button
             type="button"


### PR DESCRIPTION
## What

Below the `sm` breakpoint, the grid/list toggle on `/artifacts` stretched to the full width of the page — two 32px icon buttons marooned at the left of an otherwise empty bar.

Found while validating the artifact library on dev at a 375px viewport. Layout a unit test cannot see.

## Cause

The header is `flex-col` below `sm`, and a flex column's default `align-items: stretch` stretches its children. Neither existing class prevented that:

- `inline-flex` sets **display**, not alignment
- `shrink-0` governs **shrinking**, not stretching

`self-start` is the property that actually applies.

## Measured on the live page

| | Radiogroup width |
|---|---|
| Before | **311px** — exactly its parent's width |
| After | **78px** — hugging its two buttons |

Desktop is unaffected: at `sm` and up the header is already `flex-row` with the toggle right-aligned, where `self-start` is a no-op on the cross axis.

`ng test`: 2280 passed across 207 files.

## Verifying after deploy

Open `/artifacts` on a phone, or at a viewport narrower than 640px. The toggle should sit at the left as a compact pill, not span the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)