### PR TITLE
fix(models): ship explicit prompt caching OFF — it measured 57% more expensive

### DIFF
--- a/backend/scripts/probe_gpt56_cache_rates.py
+++ b/backend/scripts/probe_gpt56_cache_rates.py
@@ -1,0 +1,433 @@
+"""Empirically derive GPT-5.6 rates, and verify the caching path end to end.
+
+The Price List API publishes no commercial-region rates for the GPT-5.6 family
+(checked 2026-09-05 across every Bedrock service code — only GovCloud Mantle
+rows exist, and `sol` is absent entirely), so
+`docs/specs/gpt-5-6-prompt-caching.md` PR-3 cannot verify catalog rates the way
+it specifies. This drives real turns to produce a known token split, which a
+later Cost Explorer read divides into to recover $/MTok per bucket.
+
+It deliberately does **not** touch the shared dev catalog, RBAC, or the agent
+loop. It calls the model through our own transport
+(`apis.shared.models.bedrock_responses`), which means one run also exercises,
+against a live model for the first time:
+
+- PR-2  the bedrock-runtime base URL, the per-request bearer-token mint, and
+        the inference-profile model id
+- PR-1  usage normalization — whether the reported buckets are disjoint
+- PR-4  explicit cache breakpoints, by comparing `--mode explicit` against
+        `--mode implicit`
+
+**Reads only, apart from the model invocations themselves.** Nothing is written
+to DynamoDB or to the catalog.
+
+⚠️ Real spend. A run is `--turns` calls against a `--prefix-tokens`-sized
+prompt; the script prints an estimate before starting and totals actual tokens
+after. Keep it small.
+
+Usage:
+
+    cd backend
+    AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py \
+        --model-id us.openai.gpt-5.6-sol --turns 4
+
+    # A/B the explicit breakpoint against stock implicit caching
+    AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py \
+        --mode both --turns 3
+
+Then, once Cost Explorer has settled (~24h), recover the rates:
+
+    AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py \
+        --rates-only --since 2026-09-05
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+# A stable, boring preamble. Repeated to reach the requested size so the prefix
+# is deterministic across turns — an unstable prefix would defeat the cache and
+# make the whole measurement meaningless.
+_PREFIX_UNIT = (
+    "You are a careful assistant for a university platform. Answer briefly. "
+    "Follow institutional policy. Do not speculate. Cite sources when asked. "
+)
+
+
+def build_system_prompt(approx_tokens: int) -> str:
+    """Build a deterministic system prompt of roughly ``approx_tokens`` tokens."""
+    # ~4 chars/token is the standard rough conversion; exactness does not
+    # matter because the model reports the true count back.
+    target_chars = approx_tokens * 4
+    repeats = max(1, target_chars // len(_PREFIX_UNIT))
+    return _PREFIX_UNIT * repeats
+
+
+@dataclass
+class TurnObservation:
+    turn: int
+    input_tokens: int
+    cache_read: int
+    cache_write: int
+    output_tokens: int
+    total_tokens: int
+    latency_s: float
+
+    @property
+    def disjoint(self) -> bool:
+        """Do the buckets partition the reported input total?"""
+        return (
+            self.input_tokens + self.cache_read + self.cache_write
+            == self.total_tokens - self.output_tokens
+        )
+
+
+@dataclass
+class ArmResult:
+    mode: str
+    turns: List[TurnObservation] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def totals(self) -> Dict[str, int]:
+        return {
+            "inputTokens": sum(t.input_tokens for t in self.turns),
+            "cacheReadInputTokens": sum(t.cache_read for t in self.turns),
+            "cacheWriteInputTokens": sum(t.cache_write for t in self.turns),
+            "outputTokens": sum(t.output_tokens for t in self.turns),
+        }
+
+
+async def _run_turn(
+    model: Any, system_prompt: str, messages: List[Dict[str, Any]]
+) -> TurnObservation:
+    """One streamed call; returns the normalized usage the model reported."""
+    usage: Dict[str, int] = {}
+    started = time.monotonic()
+    async for event in model.stream(
+        messages,
+        system_prompt=system_prompt,
+    ):
+        if "metadata" in event:
+            usage = event["metadata"].get("usage", {}) or {}
+    elapsed = time.monotonic() - started
+    return TurnObservation(
+        turn=0,
+        input_tokens=usage.get("inputTokens", 0),
+        cache_read=usage.get("cacheReadInputTokens", 0),
+        cache_write=usage.get("cacheWriteInputTokens", 0),
+        output_tokens=usage.get("outputTokens", 0),
+        total_tokens=usage.get("totalTokens", 0),
+        latency_s=elapsed,
+    )
+
+
+async def run_arm(
+    mode: str,
+    *,
+    model_id: str,
+    region: str,
+    turns: int,
+    prefix_tokens: int,
+    gap_seconds: float,
+    grow_history: bool = False,
+    history_chunk_tokens: int = 0,
+    prefix_salt: str = "",
+) -> ArmResult:
+    """Run one arm: N sequential calls sharing one static prefix.
+
+    With ``grow_history`` each turn carries the accumulated conversation, which
+    is the scenario PR-4 exists for: history churn behind a stable prefix. A
+    fixed single-message workload only shows that explicit mode does not *hurt*.
+    """
+    from apis.shared.models.bedrock_responses import (
+        EXPLICIT_CACHE_ENABLED_ENV,
+        build_bedrock_responses_model,
+    )
+
+    # The flag is read per call, so flipping it here is enough — no rebuild.
+    os.environ[EXPLICIT_CACHE_ENABLED_ENV] = "true" if mode == "explicit" else "false"
+
+    result = ArmResult(mode=f"{mode}+churn" if grow_history else mode)
+    system_prompt = build_system_prompt(prefix_tokens)
+    if prefix_salt:
+        # Distinct prefix bytes -> a distinct cache entry, so the arm starts cold.
+        system_prompt = f"[{prefix_salt}] " + system_prompt
+    model = build_bedrock_responses_model(
+        model_id=model_id, region=region, params={"max_output_tokens": 32}
+    )
+
+    label = f"{mode}+churn" if grow_history else mode
+    print(f"\n▸ arm={label}  model={model_id}  region={region}  turns={turns}")
+    history: List[Dict[str, Any]] = []
+    for i in range(1, turns + 1):
+        question = f"Reply with the number {i}."
+        if history_chunk_tokens:
+            question += " Context: " + ("filler context words " * (history_chunk_tokens // 3))
+        if grow_history:
+            history.append({"role": "user", "content": [{"text": question}]})
+            messages = list(history)
+        else:
+            messages = [{"role": "user", "content": [{"text": question}]}]
+        try:
+            obs = await _run_turn(model, system_prompt, messages)
+        except Exception as exc:  # noqa: BLE001 — a probe reports, never raises
+            result.error = f"{type(exc).__name__}: {exc}"
+            print(f"   turn {i}: FAILED — {result.error}")
+            return result
+        obs.turn = i
+        result.turns.append(obs)
+        if grow_history:
+            # Cheap stand-in for the assistant's reply; its exact text does not
+            # matter, only that the history grows deterministically.
+            history.append({"role": "assistant", "content": [{"text": str(i)}]})
+        print(
+            f"   turn {i}: input={obs.input_tokens:>7,} "
+            f"cacheRead={obs.cache_read:>7,} cacheWrite={obs.cache_write:>7,} "
+            f"output={obs.output_tokens:>4,} "
+            f"disjoint={'yes' if obs.disjoint else 'NO'} "
+            f"({obs.latency_s:.1f}s)"
+        )
+        if i < turns and gap_seconds:
+            await asyncio.sleep(gap_seconds)
+    return result
+
+
+def print_verdicts(results: List[ArmResult]) -> None:
+    """Say what each arm proves, or fails to."""
+    print("\n" + "=" * 72)
+    print("VERDICTS")
+    print("=" * 72)
+
+    for r in results:
+        print(f"\n▸ arm={r.mode}")
+        if r.error:
+            print(f"   TRANSPORT: FAILED — {r.error}")
+            continue
+        if not r.turns:
+            print("   no turns recorded")
+            continue
+
+        print("   PR-2 transport: reached the model and streamed usage — OK")
+
+        bad = [t.turn for t in r.turns if not t.disjoint]
+        print(
+            "   PR-1 disjoint buckets: "
+            + ("OK on every turn" if not bad else f"VIOLATED on turns {bad}")
+        )
+
+        first, rest = r.turns[0], r.turns[1:]
+        print(
+            f"   turn 1 (cold): write={first.cache_write:,} read={first.cache_read:,}"
+        )
+        if rest:
+            reads = [t.cache_read for t in rest]
+            writes = [t.cache_write for t in rest]
+            print(f"   turns 2+ read:  min={min(reads):,} max={max(reads):,}")
+            print(f"   turns 2+ write: min={min(writes):,} max={max(writes):,}")
+            # The check the spec names: a warm turn should READ the static
+            # prefix rather than re-write it.
+            if max(reads) == 0:
+                print("   ⚠️  NO cache reads on warm turns — caching is not engaging.")
+            elif min(reads) >= 0.8 * first.total_tokens - first.output_tokens:
+                print("   ✅ warm turns read ~the whole prefix — boundary looks right.")
+            else:
+                print(
+                    "   ⚠️  warm reads are well under the prefix — boundary may be "
+                    "misplaced (PR-4 kill switch is the way out)."
+                )
+        if all(t.cache_write == 0 for t in r.turns):
+            print(
+                "   ⚠️  cacheWrite is 0 on every turn — either the model reports no "
+                "writes, or the cache_write_tokens mapping is not landing."
+            )
+
+    if len(results) == 2:
+        a, b = results
+        print(f"\n▸ {a.mode} vs {b.mode} (totals)")
+        ta, tb = a.totals(), b.totals()
+        for key in ("inputTokens", "cacheReadInputTokens", "cacheWriteInputTokens"):
+            print(f"   {key:<24} {ta.get(key,0):>9,}   {tb.get(key,0):>9,}")
+
+
+def derive_rates(since: str, until: Optional[str], region: str) -> int:
+    """Recover $/MTok per bucket from Cost Explorer usage + cost.
+
+    Rate = unblended cost / usage quantity, per usage type. This is the step the
+    Price List API cannot supply for these models.
+    """
+    import boto3
+
+    from datetime import date, timedelta
+
+    end = until or (date.today() + timedelta(days=1)).isoformat()
+    ce = boto3.client("ce", region_name="us-east-1")
+    resp = ce.get_cost_and_usage(
+        TimePeriod={"Start": since, "End": end},
+        Granularity="MONTHLY",
+        Metrics=["UnblendedCost", "UsageQuantity"],
+        Filter={"Dimensions": {"Key": "SERVICE", "Values": ["Amazon Bedrock"]}},
+        GroupBy=[{"Type": "DIMENSION", "Key": "USAGE_TYPE"}],
+    )
+
+    rows = []
+    for period in resp.get("ResultsByTime", []):
+        for group in period.get("Groups", []):
+            usage_type = group["Keys"][0]
+            if "gpt-5.6" not in usage_type.lower():
+                continue
+            cost = float(group["Metrics"]["UnblendedCost"]["Amount"])
+            qty = float(group["Metrics"]["UsageQuantity"]["Amount"])
+            rows.append((usage_type, qty, cost, (cost / qty) if qty else None))
+
+    if not rows:
+        print(
+            f"No GPT-5.6 usage types in Cost Explorer for {since}..{end}.\n"
+            "Cost Explorer lags ~24h — if the turns ran today, try again tomorrow."
+        )
+        return 1
+
+    print(f"\nGPT-5.6 usage, {since}..{end}")
+    print(f"{'usage type':<62} {'qty':>14} {'cost USD':>10} {'$/MTok':>10}")
+    for usage_type, qty, cost, rate in sorted(rows):
+        # Cost Explorer reports Bedrock token usage in units of 1K tokens.
+        per_mtok = f"{rate * 1000:.4f}" if rate is not None else "n/a"
+        print(f"{usage_type:<62} {qty:>14,.0f} {cost:>10.4f} {per_mtok:>10}")
+    print(
+        "\n⚠️  Confirm the usage UNIT before trusting $/MTok: the column above "
+        "assumes Cost Explorer reports these in 1K-token units. Cross-check one "
+        "row against the token totals this script printed when it ran the turns."
+    )
+    return 0
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default="us.openai.gpt-5.6-sol")
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument(
+        "--prefix-tokens",
+        type=int,
+        default=8000,
+        help="Approximate size of the stable system prompt. Must exceed the "
+        "1024-token minimum cacheable prefix by a wide margin.",
+    )
+    parser.add_argument("--gap-seconds", type=float, default=3.0)
+    parser.add_argument(
+        "--mode",
+        default="explicit",
+        choices=["explicit", "implicit", "both"],
+        help="explicit = PR-4 breakpoints on; implicit = stock caching.",
+    )
+    parser.add_argument("--json-out", default=None)
+    parser.add_argument(
+        "--history-chunk-tokens",
+        type=int,
+        default=0,
+        help="Pad each history message to roughly this size, so the effect of "
+        "history growth on the cache is large enough to read.",
+    )
+    parser.add_argument(
+        "--prefix-salt",
+        default="",
+        help="Change the static prefix so the run starts against a COLD cache.",
+    )
+    parser.add_argument(
+        "--grow-history",
+        action="store_true",
+        help="Accumulate conversation history across turns — the churn "
+        "scenario explicit breakpoints are meant to protect against.",
+    )
+    parser.add_argument(
+        "--rates-only",
+        action="store_true",
+        help="Skip the turns; just read Cost Explorer and derive rates.",
+    )
+    parser.add_argument("--since", default=None, help="YYYY-MM-DD for --rates-only")
+    parser.add_argument("--until", default=None)
+    args = parser.parse_args()
+
+    if args.rates_only:
+        if not args.since:
+            parser.error("--rates-only requires --since YYYY-MM-DD")
+        return derive_rates(args.since, args.until, args.region)
+
+    modes = ["explicit", "implicit"] if args.mode == "both" else [args.mode]
+    approx_calls = args.turns * len(modes)
+    print(
+        f"About to make {approx_calls} real model calls against {args.model_id} "
+        f"with a ~{args.prefix_tokens:,}-token prefix.\n"
+        f"Rough worst case if nothing caches: "
+        f"~{approx_calls * args.prefix_tokens:,} input tokens."
+    )
+
+    results = []
+    for mode in modes:
+        results.append(
+            await run_arm(
+                mode,
+                model_id=args.model_id,
+                region=args.region,
+                turns=args.turns,
+                prefix_tokens=args.prefix_tokens,
+                gap_seconds=args.gap_seconds,
+                grow_history=args.grow_history,
+                history_chunk_tokens=args.history_chunk_tokens,
+                prefix_salt=args.prefix_salt,
+            )
+        )
+
+    print_verdicts(results)
+
+    grand = {
+        "inputTokens": sum(r.totals()["inputTokens"] for r in results),
+        "cacheReadInputTokens": sum(r.totals()["cacheReadInputTokens"] for r in results),
+        "cacheWriteInputTokens": sum(r.totals()["cacheWriteInputTokens"] for r in results),
+        "outputTokens": sum(r.totals()["outputTokens"] for r in results),
+    }
+    print("\n▸ tokens consumed this run (the denominator for rate derivation)")
+    for key, value in grand.items():
+        print(f"   {key:<24} {value:>10,}")
+    print(
+        "\nNext: wait for Cost Explorer to settle (~24h), then\n"
+        f"   AWS_PROFILE=dev-ai uv run python {os.path.basename(__file__)} "
+        f"--rates-only --since {time.strftime('%Y-%m-%d')}"
+    )
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(
+                {
+                    "modelId": args.model_id,
+                    "region": args.region,
+                    "prefixTokens": args.prefix_tokens,
+                    "totals": grand,
+                    "arms": [
+                        {
+                            "mode": r.mode,
+                            "error": r.error,
+                            "turns": [vars(t) for t in r.turns],
+                        }
+                        for r in results
+                    ],
+                },
+                fh,
+                indent=2,
+            )
+        print(f"\nRaw observations -> {args.json_out}")
+
+    return 1 if any(r.error for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/src/apis/shared/models/bedrock_responses.py
+++ b/backend/src/apis/shared/models/bedrock_responses.py
@@ -124,24 +124,40 @@ def _warn_on_missing_inference_profile(model_id: str) -> None:
 
 # ── Explicit prompt caching (GPT-5.6) ────────────────────────────────────────
 #
-# GPT-5.6 caches implicitly by default. Explicit mode instead lets us mark
-# where the reusable prefix ends, which is what buys the resilience the Claude
-# path already has: a change in conversation history costs a *read* of the
-# ~30k static prefix (tools + system prompt) rather than a full re-write at the
-# 1.25x premium.
+# ⛔ OPT-IN, DEFAULT OFF — measured as a pessimization on our workload.
 #
-# Kill switch, default ON per repo convention. Only the literal string "false"
-# disables it — an empty or unset value stays enabled, because workflow env
-# vars can materialize as "".
+# The plan was: mark where the reusable prefix ends, so a change in
+# conversation history costs a *read* of the static prefix rather than a full
+# re-write at the 1.25x premium. That reasoning had the counterfactual wrong.
+# GPT-5.6's default **implicit** caching does not re-write history when it
+# grows — it appends the delta — so a single breakpoint after the static
+# prefix does not save a re-write. It stops the history being cached at all.
+#
+# Measured live on `us.openai.gpt-5.6-sol` (dev-ai, us-west-2, 8k static
+# prefix, 5 turns, ~1.5k tokens of history growth per turn), priced at the
+# Price List ratios (input 1x, cache read 0.1x, cache write 1.25x):
+#
+#                uncached input   cacheRead   cacheWrite   input-equivalents
+#   explicit            22,790      23,228        5,807              32,372
+#   implicit                10      38,410       13,405              20,607
+#
+# Explicit cost ~57% MORE. Under explicit the uncached input grew every turn
+# (1,516 -> 7,600) while cacheRead stayed flat at 5,807; under implicit the
+# whole growing conversation stayed cached.
+#
+# The code is kept because the placement, not the mechanism, is what failed —
+# the API allows up to 4 breakpoints, and a scheme that also marks the end of
+# history could plausibly beat implicit. Nobody should turn this on again
+# without re-running `scripts/probe_gpt56_cache_rates.py --mode both
+# --grow-history` and beating the implicit arm.
+#
+# Opt-in: only the literal string "true" enables it.
 #
 # ⚠️ Deliberately NOT wired into the CDK Runtime construct.
 # `AWS::BedrockAgentCore::Runtime` caps EnvironmentVariables at 50 and
 # `inference-agentcore-construct.ts` is AT that cap — a 51st entry fails
 # CloudFormation *changeset validation*, i.e. after synth, tsc, jest and green
-# CI (it broke the dev Platform Stack deploy on 2026-08-05). A code-level flag
-# that reads os.environ and defaults ON needs no entry, which is exactly this
-# one. Turning it off in a deployed environment takes an out-of-band Runtime
-# update until a slot is freed.
+# CI (it broke the dev Platform Stack deploy on 2026-08-05).
 EXPLICIT_CACHE_ENABLED_ENV = "BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED"
 
 # Request-level cache controls. `ttl` is the string form of the same window
@@ -159,10 +175,14 @@ _CACHE_BREAKPOINT = {"mode": "explicit"}
 def explicit_prompt_cache_enabled() -> bool:
     """Whether to send explicit cache breakpoints on this transport.
 
+    **Default OFF** — see the measurement above; explicit mode cost ~57% more
+    than the model's default implicit caching on a conversation with growing
+    history. Only the literal string ``"true"`` opts in.
+
     Read per call (no module-level caching) so tests and live config changes
     behave predictably; the env read is negligible next to request assembly.
     """
-    return os.environ.get(EXPLICIT_CACHE_ENABLED_ENV, "").lower() != "false"
+    return os.environ.get(EXPLICIT_CACHE_ENABLED_ENV, "").lower() == "true"
 
 
 def build_prompt_cache_key(

--- a/backend/tests/shared/test_bedrock_responses_explicit_cache.py
+++ b/backend/tests/shared/test_bedrock_responses_explicit_cache.py
@@ -1,9 +1,15 @@
 """Explicit prompt-cache controls on the bedrock-runtime Responses transport.
 
-GPT-5.6 caches implicitly by default. Explicit mode lets us mark where the
-reusable prefix ends, so a change in conversation history costs a *read* of the
-~30k static prefix instead of a full re-write at the 1.25x premium — the
-resilience the Claude path already has.
+⛔ **This feature is OPT-IN and DEFAULT OFF.** It was built on the premise that
+a breakpoint after the static prefix would turn a history change from a full
+re-write into a read. Measured live, that premise was wrong: GPT-5.6's default
+implicit caching appends the history delta rather than re-writing, so the
+breakpoint only stops history being cached — explicit cost ~57% MORE on a
+churning conversation. The mechanism works; the placement is what failed.
+
+These tests therefore split in two: the behaviour tests opt in explicitly via
+the `model` fixture, and `TestOptInFlag` pins that the DEFAULT path — what
+production actually sends — is byte-identical to the stock Strands request.
 
 The request shape asserted here is AWS's documented one for explicit prompt
 caching: ``prompt_cache_breakpoint`` on a content block of a ``developer``
@@ -43,7 +49,21 @@ MESSAGES = [
 
 
 @pytest.fixture
-def model():
+def explicit_on(monkeypatch):
+    """Opt in. Explicit mode is DEFAULT OFF — it measured ~57% more expensive
+    than the model's implicit caching on a conversation with growing history
+    (see the module docstring in bedrock_responses.py)."""
+    monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, "true")
+
+
+@pytest.fixture
+def model(explicit_on):
+    return build_bedrock_responses_model("us.openai.gpt-5.6-sol", region="us-west-2")
+
+
+@pytest.fixture
+def default_model():
+    """The model as it behaves with no opt-in — i.e. in production."""
     return build_bedrock_responses_model("us.openai.gpt-5.6-sol", region="us-west-2")
 
 
@@ -208,37 +228,61 @@ class TestNoSystemPrompt:
         assert "prompt_cache_options" not in (request.get("extra_body") or {})
 
 
-class TestKillSwitch:
-    def test_enabled_by_default(self, monkeypatch):
+class TestOptInFlag:
+    """Default OFF, and the default path must be byte-identical to stock.
+
+    Explicit mode measured ~57% MORE expensive than implicit on a churning
+    conversation: the breakpoint after the static prefix stops history being
+    cached, so uncached input grows every turn. The mechanism works; the
+    placement is what failed. Nobody re-enables this without re-running
+    `scripts/probe_gpt56_cache_rates.py --mode both --grow-history` and beating
+    the implicit arm.
+    """
+
+    def test_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv(EXPLICIT_CACHE_ENABLED_ENV, raising=False)
 
-        assert explicit_prompt_cache_enabled() is True
+        assert explicit_prompt_cache_enabled() is False
 
-    def test_empty_string_stays_enabled(self, monkeypatch):
-        # Workflow env vars can materialize as "" — that must not disable it.
+    def test_empty_string_stays_disabled(self, monkeypatch):
+        # Workflow env vars can materialize as "" — that must not opt in.
         monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, "")
 
+        assert explicit_prompt_cache_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "True"])
+    def test_only_the_literal_true_enables(self, monkeypatch, value):
+        monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, value)
+
         assert explicit_prompt_cache_enabled() is True
 
-    @pytest.mark.parametrize("value", ["false", "FALSE", "False"])
-    def test_only_the_literal_false_disables(self, monkeypatch, value):
+    @pytest.mark.parametrize("value", ["false", "1", "yes", "on", "explicit"])
+    def test_nothing_else_enables(self, monkeypatch, value):
         monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, value)
 
         assert explicit_prompt_cache_enabled() is False
 
-    def test_disabled_leaves_the_stock_request_shape(self, model, monkeypatch):
-        monkeypatch.setenv(EXPLICIT_CACHE_ENABLED_ENV, "false")
+    def test_the_default_request_is_the_stock_shape(self, default_model, monkeypatch):
+        """What production actually sends: untouched, on implicit caching."""
+        monkeypatch.delenv(EXPLICIT_CACHE_ENABLED_ENV, raising=False)
 
-        request = _format(model)
+        request = _format(default_model)
 
         assert request["instructions"] == SYSTEM
         assert "prompt_cache_key" not in request
         assert "extra_body" not in request
         assert request["input"][0]["role"] == "user"
+        assert not any(
+            "prompt_cache_breakpoint" in block
+            for item in request["input"]
+            if isinstance(item.get("content"), list)
+            for block in item["content"]
+            if isinstance(block, dict)
+        )
 
 
 class TestOtherTransportsUnaffected:
-    def test_mantle_responses_gets_no_explicit_controls(self):
+    def test_mantle_responses_gets_no_explicit_controls(self, explicit_on):
         """openai.gpt-5.4 on Mantle is implicit-only — it has no breakpoints.
 
         Sending explicit controls there would at best be ignored and at worst

--- a/docs/specs/gpt-5-6-prompt-caching.md
+++ b/docs/specs/gpt-5-6-prompt-caching.md
@@ -260,7 +260,7 @@ than an error, which is exactly the failure the Verification section exists to
 catch. Decide before curating: either model the dimensions, or scope the row
 to standard-tier short-context and gate on staying inside it.
 
-### PR-4 — Explicit cache breakpoints + `prompt_cache_key` ✅ SHIPPED
+### PR-4 — Explicit cache breakpoints + `prompt_cache_key` ⛔ SHIPPED OFF (measured pessimization)
 
 Only worth building for 5.6, where the 1.25× write premium makes placement matter.
 
@@ -319,11 +319,41 @@ placed boundary is therefore worse than not switching at all. Two mitigations:
   changeset validation after CI is green. Flipping it in a deployed environment
   needs an out-of-band Runtime update.
 
-None of this is verified against a live model — no GPT-5.6 catalog row exists
-while PR-3 is blocked. **The Verification section below is the gate before this
-is trusted in prod**, and the specific thing to confirm is that turns 2+ report
-`cacheRead` tracking the whole static prefix. If they do not, the boundary is
-misplaced and the flag is the way out.
+#### ⛔ Measured live — the premise was wrong, so this ships OFF
+
+Run 2026-09-05 against `us.openai.gpt-5.6-sol` (dev-ai, us-west-2) via
+`backend/scripts/probe_gpt56_cache_rates.py --mode both --grow-history`:
+8k-token static prefix, 5 turns, ~1.5k tokens of history growth per turn.
+
+|          | uncached input | cacheRead | cacheWrite | input-equivalents |
+|----------|---------------:|----------:|-----------:|------------------:|
+| explicit |     **22,790** |    23,228 |      5,807 |        **32,372** |
+| implicit |         **10** |    38,410 |     13,405 |        **20,607** |
+
+(Input-equivalents price the buckets at the Price List ratios this same
+investigation confirmed: input 1×, cache read 0.1×, cache write 1.25×.)
+
+**Explicit cost ~57% more.** Per turn, explicit's uncached input grew
+1,516 → 7,600 while its `cacheRead` stayed flat at 5,807; implicit held
+uncached input at 2/turn and let `cacheRead` grow with the conversation.
+
+The reasoning above had the *counterfactual* wrong. Implicit caching does not
+re-write history when it grows — it appends the delta (measured: 1,521
+cacheWrite per turn). So a breakpoint after the static prefix saves no
+re-write; it only stops the history being cached at all, and the cost of that
+grows linearly with conversation length.
+
+The code ships behind `BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED`, **default
+OFF**, so the production path is byte-identical to stock Strands. It is kept
+rather than deleted because the *placement*, not the mechanism, is what failed
+— the API allows up to 4 breakpoints, and a scheme that also marks the end of
+history might beat implicit. **Do not re-enable without re-running that probe
+and beating the implicit arm.**
+
+Untested idea worth its own measurement: `prompt_cache_key` is currently tied
+to the explicit path, so it is off too. Applying it on the implicit path is
+plausibly free and helps cross-request routing, but that is a fleet-level
+effect a single-session probe cannot show — measure before shipping it.
 
 ### PR-5 — Observability
 
@@ -389,3 +419,36 @@ Prove the cost impact rather than assuming it — per the cost-effectiveness ten
   no write fee; PR-1 and PR-3 fix its accounting where it sits.
 - Guardrails for GPT-5.6 (Converse-only, and we're deliberately not on Converse).
 - Chat Completions on either endpoint — no caching support, no reason.
+
+## Live verification, 2026-09-05
+
+First end-to-end exercise of this work against a real model, via
+`backend/scripts/probe_gpt56_cache_rates.py` on `us.openai.gpt-5.6-sol`
+(dev-ai, us-west-2). The probe calls the transport directly — it touches no
+shared catalog row, no RBAC, and not the agent loop — so it could run while
+PR-3 is still blocked.
+
+| Step | Verdict |
+|---|---|
+| PR-1 usage normalization | ✅ buckets disjoint on every turn of every run |
+| PR-2 bedrock-runtime transport | ✅ reached the model; base URL, per-request bearer token and inference-profile id all correct |
+| PR-4 explicit breakpoints | ⛔ ~57% more expensive than implicit — shipped OFF |
+| PR-5 model-derived TTL | ✅ warm turns read the prefix, so the 30m window is the one that matters |
+
+**The finding that mattered.** Turn 1 of the first run reported
+`inputTokens=2, cacheWriteInputTokens=1,446`. Un-normalized, OpenAI reports
+`input_tokens=1448` — inclusive of the write bucket. That is PR-1's
+cache-write subtraction proving itself on live data: without it that turn
+double-bills 1,446 tokens at the input rate *plus* the 1.25× write premium.
+It also confirms the `cache_write_tokens` recovery works, since Strands drops
+the field and the bucket would otherwise read 0.
+
+**Rates.** The runs consumed ~190k tokens on usage types nothing else in dev
+uses, so Cost Explorer attribution is unambiguous. Recover the rates with:
+
+    AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py \
+        --rates-only --since 2026-09-05
+
+⚠️ Confirm the usage *unit* before trusting the derived $/MTok — Bedrock token
+usage types are reported in 1K-token units, and the script's conversion assumes
+that. Cross-check one row against the token totals the run printed.


### PR DESCRIPTION
## Follow-up to #954 — that PR shipped a measured pessimization

#954 merged at 06:26 today, before I got a live model in front of it. I did, and **the premise it was built on does not hold.** This flips it off.

No production impact today: there is no GPT-5.6 catalog row (PR-3 is blocked on missing Price List rates), so nothing routes through the transport yet. Which is exactly why it's worth fixing now, before something does.

## What the measurement showed

The plan assumed a change in conversation history forces a full cache re-write, which a breakpoint after the static prefix would downgrade to a read. Measured, GPT-5.6's default **implicit** caching does *not* re-write history when it grows — it appends the delta (1,521 `cacheWrite`/turn). So the breakpoint saves no re-write. It only stops history being cached at all, and that cost grows linearly with conversation length.

`us.openai.gpt-5.6-sol`, dev-ai us-west-2, 8k static prefix, 5 turns, ~1.5k tokens of history growth per turn, priced at the Price List ratios this investigation confirmed (input 1×, cache read 0.1×, cache write 1.25×):

|          | uncached input | cacheRead | cacheWrite | input-equivalents |
|----------|---------------:|----------:|-----------:|------------------:|
| explicit |     **22,790** |    23,228 |      5,807 |        **32,372** |
| implicit |         **10** |    38,410 |     13,405 |        **20,607** |

**~57% more.** Per turn, explicit's uncached input grew 1,516 → 7,600 while its `cacheRead` stayed flat at 5,807; implicit held uncached input at 2/turn and let `cacheRead` grow with the conversation.

## The change

`BEDROCK_RESPONSES_EXPLICIT_CACHE_ENABLED` now defaults **OFF** and only the literal `"true"` opts in, so the production request is byte-identical to stock Strands — pinned by a test that asserts no breakpoint, no `prompt_cache_key`, no `extra_body`, and `instructions` intact.

The code is kept rather than deleted because the **placement** failed, not the mechanism: the API allows 4 breakpoints, and a scheme that also marks the end of history might beat implicit. Re-enabling is gated on re-running the probe and beating the implicit arm.

`prompt_cache_key` stays tied to the explicit path, so it's off too. Applying it under implicit is plausibly free — but that's a fleet-level routing effect a single-session probe can't measure, and shipping it unmeasured would repeat the mistake this PR fixes. Recorded in the spec as its own measurement.

## `scripts/probe_gpt56_cache_rates.py`

The reproducible artifact behind all of this, and the gate on ever re-enabling explicit mode. It drives the transport **directly** — no catalog row, no RBAC, no agent loop — so it runs while PR-3 is blocked, and it produces the token denominator for deriving rates from Cost Explorer.

```bash
AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py --mode both --grow-history
```

## Bonus: this was the first live verification of the rest of the epic

- **PR-1** (#945) — buckets disjoint on every turn of every run. Turn 1 reported `inputTokens=2` with `cacheWriteInputTokens=1,446`, where raw OpenAI reports `input_tokens=1448` **inclusive**. That is direct proof the cache-*write* subtraction (the correction in #947) was necessary — without it that turn double-bills 1,446 tokens at the input rate *plus* the 1.25× premium — and that recovering `cache_write_tokens` works at all, since Strands drops it and the bucket would otherwise read 0.
- **PR-2** (#949) — the transport reached a live model: base URL, per-request bearer token and inference-profile id all correct.
- **PR-5** (#951) — warm turns read the prefix, so the 30-minute window is the one that matters.

## Rates

The runs consumed ~190k tokens on usage types nothing else in dev uses, so Cost Explorer attribution is unambiguous. Once it settles (~24h):

```bash
AWS_PROFILE=dev-ai uv run python scripts/probe_gpt56_cache_rates.py --rates-only --since 2026-09-05
```

⚠️ Confirm the usage **unit** before trusting the derived $/MTok — Bedrock token usage types are reported in 1K-token units and the script's conversion assumes that. Cross-check one row against the token totals the run printed.

## Testing

`cd backend && uv run python -m pytest tests/ -q` → **7432 passed, 3 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
