### PR TITLE
feat(artifacts): card delete/rename + fix the library grid footer overflow

### DIFF
--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -270,8 +270,12 @@
     @if (!loading() && filtered().length > 0 && viewMode() === 'grid') {
       <ul role="list" class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
         @for (item of filtered(); track item.artifactId) {
+          <!-- @container: the footer below collapses its button labels on a
+               narrow card. The card is sized by the grid (three columns at
+               `lg`, so ~13rem on a 1080px window), not by the viewport, so a
+               container query is correct here and a media query is not. -->
           <li
-            class="flex flex-col rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+            class="@container flex flex-col rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
           >
             <div class="flex items-start gap-3">
               <span
@@ -316,6 +320,19 @@
               }
             </p>
 
+            <!-- Four controls in one row: labelled Open + Conversation need
+                 ~290px, and three columns give the card far less than that on
+                 a narrow window (~166px at 1080px), so the two text labels
+                 drop to `sr-only` below 19rem — kept in the accessible name,
+                 since these controls have no aria-label of their own and
+                 would otherwise become nameless icons, with [appTooltip]
+                 standing in for the text a sighted user can no longer see.
+
+                 19rem is measured against the card's CONTENT box, which is
+                 what an `inline-size` container query reports — `p-5` means
+                 the border box is 40px wider. Sizing the threshold off the
+                 border box (the intuitive reading) leaves the labels hidden
+                 on cards that could comfortably show them. -->
             <div
               class="mt-4 flex items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700"
             >
@@ -323,18 +340,24 @@
                 type="button"
                 (click)="open(item)"
                 [disabled]="opening() === item.artifactId"
+                [appTooltip]="'Open in a new tab'"
+                appTooltipPosition="top"
                 class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700"
               >
                 <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
-                {{ opening() === item.artifactId ? 'Opening…' : 'Open' }}
+                <span class="@max-[19rem]:sr-only">{{
+                  opening() === item.artifactId ? 'Opening…' : 'Open'
+                }}</span>
               </button>
               @if (item.sessionId) {
                 <a
                   [routerLink]="['/s', item.sessionId]"
+                  [appTooltip]="'Open the conversation'"
+                  appTooltipPosition="top"
                   class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
                 >
                   <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
-                  Conversation
+                  <span class="@max-[19rem]:sr-only">Conversation</span>
                 </a>
               }
               <div class="ml-auto flex items-center gap-1">

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -449,4 +449,45 @@ describe('ArtifactLibraryPage', () => {
       expect(c.busy()).toBeNull();
     });
   });
+
+  describe('grid card footer', () => {
+    it('keeps both button labels in the DOM when they collapse', async () => {
+      // The footer carries four controls and the card is ~13rem wide at
+      // three columns on a 1080px window, so a container query drops the
+      // "Open" / "Conversation" text below 19rem. It must be dropped to
+      // `sr-only`, never `hidden`: these buttons have no aria-label, so
+      // removing the text would leave them with no accessible name at
+      // exactly the width where they become bare icons.
+      mockSettings.artifactsViewMode.set('grid');
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const fixture = await createComponent();
+      const host = fixture.nativeElement as HTMLElement;
+
+      const labels = [...host.querySelectorAll('ul.grid span')].filter((el) =>
+        ['Open', 'Conversation'].includes((el.textContent ?? '').trim()),
+      );
+      expect(labels).toHaveLength(2);
+      for (const label of labels) {
+        expect(label.className).toContain('@max-[19rem]:sr-only');
+        expect(label.className).not.toContain('hidden');
+      }
+    });
+
+    it('gives the collapsing buttons a tooltip to stand in for the text', async () => {
+      mockSettings.artifactsViewMode.set('grid');
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const fixture = await createComponent();
+      const host = fixture.nativeElement as HTMLElement;
+
+      const open = [...host.querySelectorAll('ul.grid button')].find((b) =>
+        (b.textContent ?? '').includes('Open'),
+      )!;
+      // TooltipDirective binds no attribute of its own, so assert via the
+      // directive instance the template wired up.
+      const de = fixture.debugElement
+        .queryAll((n) => n.nativeElement === open)
+        .at(0);
+      expect(de?.attributes['appTooltipPosition']).toBe('top');
+    });
+  });
 });

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.spec.ts
@@ -2,11 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Dialog } from '@angular/cdk/dialog';
 import { signal } from '@angular/core';
+import { of } from 'rxjs';
 import { ArtifactCardComponent } from './artifact-card.component';
 import { ArtifactShareModalComponent } from './artifact-share-modal.component';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import { UserService } from '../../../../../auth/user.service';
+import { ToastService } from '../../../../../services/toast/toast.service';
+import { ConfirmationDialogComponent } from '../../../../../components/confirmation-dialog';
+import { RenameArtifactDialogComponent } from '../../../../../artifacts/components/rename-artifact-dialog.component';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 
 const ARTIFACT: Artifact = {
@@ -20,8 +25,24 @@ const ARTIFACT: Artifact = {
 describe('ArtifactCardComponent', () => {
   let fixture: ComponentFixture<ArtifactCardComponent>;
   let dialog: { open: ReturnType<typeof vi.fn> };
-  let artifactState: { openArtifactPanel: ReturnType<typeof vi.fn> };
+  let artifactState: {
+    openArtifactPanel: ReturnType<typeof vi.fn>;
+    versionsFor: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+    rename: ReturnType<typeof vi.fn>;
+  };
   let download: { download: ReturnType<typeof vi.fn> };
+  let http: {
+    renameArtifact: ReturnType<typeof vi.fn>;
+    deleteArtifact: ReturnType<typeof vi.fn>;
+  };
+  let toast: { error: ReturnType<typeof vi.fn> };
+  /** What the stubbed CDK dialog "returns" — the user's choice. */
+  let dialogResult: unknown;
+
+  async function flush(): Promise<void> {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  }
 
   const el = () => fixture.nativeElement as HTMLElement;
   const button = (label: RegExp): HTMLButtonElement => {
@@ -35,9 +56,22 @@ describe('ArtifactCardComponent', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();
 
-    dialog = { open: vi.fn() };
-    artifactState = { openArtifactPanel: vi.fn() };
+    dialogResult = undefined;
+    dialog = { open: vi.fn(() => ({ closed: of(dialogResult) })) };
+    artifactState = {
+      openArtifactPanel: vi.fn(),
+      versionsFor: vi.fn(() => [ARTIFACT]),
+      remove: vi.fn(),
+      rename: vi.fn(),
+    };
     download = { download: vi.fn().mockResolvedValue(true) };
+    http = {
+      renameArtifact: vi
+        .fn()
+        .mockResolvedValue({ artifactId: 'art-1', title: 'Renamed' }),
+      deleteArtifact: vi.fn().mockResolvedValue(undefined),
+    };
+    toast = { error: vi.fn() };
 
     TestBed.configureTestingModule({
       imports: [ArtifactCardComponent],
@@ -45,6 +79,8 @@ describe('ArtifactCardComponent', () => {
         { provide: Dialog, useValue: dialog },
         { provide: ArtifactStateService, useValue: artifactState },
         { provide: ArtifactDownloadService, useValue: download },
+        { provide: ArtifactHttpService, useValue: http },
+        { provide: ToastService, useValue: toast },
         {
           provide: UserService,
           useValue: { currentUser: signal({ email: 'owner@example.com' }) },
@@ -96,6 +132,8 @@ describe('ArtifactCardComponent', () => {
         { provide: Dialog, useValue: dialog },
         { provide: ArtifactStateService, useValue: artifactState },
         { provide: ArtifactDownloadService, useValue: download },
+        { provide: ArtifactHttpService, useValue: http },
+        { provide: ToastService, useValue: toast },
         { provide: UserService, useValue: { currentUser: signal(null) } },
       ],
     });
@@ -136,5 +174,92 @@ describe('ArtifactCardComponent', () => {
     // still holds and the buttons keep their [appTooltip].
     expect(button(/^Share /).textContent).toContain('Share');
     expect(button(/^Download /).textContent).toContain('Download');
+  });
+
+  describe('rename and delete', () => {
+    it('names no version on the whole-artifact actions', () => {
+      // Share and Download really are scoped to this card's version and
+      // say so. These two are not, so a matching "version 3" suffix
+      // would promise something they do not do.
+      expect(button(/^Rename /).getAttribute('aria-label')).toBe(
+        'Rename artifact Quarterly Chart',
+      );
+      expect(button(/^Delete /).getAttribute('aria-label')).toBe(
+        'Delete artifact Quarterly Chart and all versions',
+      );
+    });
+
+    it('renames the whole artifact in local state', async () => {
+      dialogResult = 'Renamed';
+      button(/^Rename /).click();
+      await flush();
+
+      expect(dialog.open.mock.calls[0][0]).toBe(RenameArtifactDialogComponent);
+      expect(http.renameArtifact).toHaveBeenCalledWith('art-1', 'Renamed');
+      expect(artifactState.rename).toHaveBeenCalledWith('art-1', 'Renamed');
+    });
+
+    it('leaves state alone when a rename fails', async () => {
+      dialogResult = 'Renamed';
+      http.renameArtifact.mockRejectedValue(new Error('503'));
+      button(/^Rename /).click();
+      await flush();
+
+      expect(artifactState.rename).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it('spells out the version count before deleting', async () => {
+      // The card is captioned "v3" and sits beside version-scoped
+      // buttons, so the dialog is the last chance to correct the reading
+      // that this removes one version.
+      artifactState.versionsFor.mockReturnValue([ARTIFACT, ARTIFACT, ARTIFACT]);
+      dialogResult = false;
+      button(/^Delete /).click();
+      await flush();
+
+      expect(dialog.open.mock.calls[0][0]).toBe(ConfirmationDialogComponent);
+      const data = dialog.open.mock.calls[0][1].data;
+      expect(data.destructive).toBe(true);
+      expect(data.message).toContain('all 3 versions');
+      expect(data.message).toContain('not just the version on this card');
+    });
+
+    it('deletes the whole artifact and clears every sibling card', async () => {
+      dialogResult = true;
+      button(/^Delete /).click();
+      await flush();
+
+      expect(http.deleteArtifact).toHaveBeenCalledWith('art-1');
+      // One registry call is what removes this card, its siblings for
+      // the same artifact, and the docked panel.
+      expect(artifactState.remove).toHaveBeenCalledWith('art-1');
+    });
+
+    it('does nothing when the confirmation is declined', async () => {
+      dialogResult = false;
+      button(/^Delete /).click();
+      await flush();
+
+      expect(http.deleteArtifact).not.toHaveBeenCalled();
+      expect(artifactState.remove).not.toHaveBeenCalled();
+    });
+
+    it('keeps the card when the delete fails', async () => {
+      dialogResult = true;
+      http.deleteArtifact.mockRejectedValue(new Error('503'));
+      button(/^Delete /).click();
+      await flush();
+
+      expect(artifactState.remove).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it('does not steal the card body click', () => {
+      const hit = el().querySelector<HTMLButtonElement>('.artifact-card__hit');
+      hit!.click();
+      expect(artifactState.openArtifactPanel).toHaveBeenCalled();
+      expect(dialog.open).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/artifact/artifact-card.component.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
+import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
   heroCodeBracket,
@@ -14,9 +15,12 @@ import {
   heroArrowDownTray,
   heroArrowPath,
   heroArrowUpOnSquare,
+  heroPencilSquare,
+  heroTrash,
 } from '@ng-icons/heroicons/outline';
 import type { Artifact } from '../../../../services/artifacts/artifact.model';
 import { ArtifactStateService } from '../../../../services/artifacts/artifact-state.service';
+import { ArtifactHttpService } from '../../../../services/artifacts/artifact-http.service';
 import { ArtifactDownloadService } from '../../../../services/artifacts/artifact-download.service';
 import {
   ArtifactShareModalComponent,
@@ -24,6 +28,16 @@ import {
 } from './artifact-share-modal.component';
 import { UserService } from '../../../../../auth/user.service';
 import { TooltipDirective } from '../../../../../components/tooltip/tooltip.directive';
+import { ToastService } from '../../../../../services/toast/toast.service';
+import {
+  ConfirmationDialogComponent,
+  type ConfirmationDialogData,
+} from '../../../../../components/confirmation-dialog';
+import {
+  RenameArtifactDialogComponent,
+  type RenameArtifactDialogData,
+  type RenameArtifactDialogResult,
+} from '../../../../../artifacts/components/rename-artifact-dialog.component';
 import { parseIso } from '../../../../../utils/date';
 
 /** Visual treatment derived from an artifact's content type. */
@@ -67,6 +81,8 @@ interface ArtifactKind {
       heroArrowDownTray,
       heroArrowPath,
       heroArrowUpOnSquare,
+      heroPencilSquare,
+      heroTrash,
     }),
   ],
   template: `
@@ -135,6 +151,28 @@ interface ArtifactKind {
               aria-hidden="true"
             />
             <span class="artifact-card__action-label">Download</span>
+          </button>
+
+          <button
+            type="button"
+            class="artifact-card__action artifact-card__action--icon"
+            [attr.aria-label]="renameAriaLabel()"
+            [appTooltip]="'Rename artifact'"
+            [disabled]="mutating()"
+            (click)="rename()"
+          >
+            <ng-icon name="heroPencilSquare" aria-hidden="true" />
+          </button>
+
+          <button
+            type="button"
+            class="artifact-card__action artifact-card__action--icon artifact-card__action--danger"
+            [attr.aria-label]="deleteAriaLabel()"
+            [appTooltip]="'Delete artifact'"
+            [disabled]="mutating()"
+            (click)="confirmDelete()"
+          >
+            <ng-icon name="heroTrash" aria-hidden="true" />
           </button>
         </span>
       </span>
@@ -326,7 +364,32 @@ interface ArtifactKind {
       opacity: 0.4;
     }
 
-    /* Secondary actions (Share, Download) sit in the grid's last column.
+    /* Rename and Delete are icon-only at every width. They act on the
+       whole artifact while Share and Download act on the version this
+       card shows, and giving the whole-artifact pair the quieter
+       treatment is what keeps that difference readable — four equally
+       weighted labelled buttons would read as four peers. Their labels
+       are visually hidden rather than absent, so the accessible name
+       survives (WCAG 2.5.3), and [appTooltip] is what a sighted user
+       gets in place of text. */
+    .artifact-card__action--icon {
+      padding-left: 0.4rem;
+      padding-right: 0.4rem;
+    }
+
+    .artifact-card__action--danger:hover {
+      color: #b42318;
+      border-color: color-mix(in srgb, #b42318 45%, transparent);
+      background: rgba(180, 35, 24, 0.07);
+    }
+
+    :host-context(html.dark) .artifact-card__action--danger:hover {
+      color: #f9a8a0;
+      border-color: color-mix(in srgb, #f9a8a0 45%, transparent);
+      background: rgba(249, 168, 160, 0.12);
+    }
+
+    /* Secondary actions sit in the grid's last column.
        The row re-enables pointer events for itself so the buttons
        capture their own clicks while the rest of the card falls through
        to the stretched open button beneath. */
@@ -417,16 +480,19 @@ interface ArtifactKind {
       }
     }
 
-    /* Narrow card (docked artifact panel, split view, mobile): the two
+    /* Narrow card (docked artifact panel, split view, mobile): the
        labelled buttons would otherwise consume the whole row and the
        title would clip to nothing. Drop the labels to icons and let the
-       title win the space back.
+       title win the space back. The threshold is 34rem rather than the
+       original 26rem because the row now carries four controls, not
+       two — Share and Download have to shed their text sooner to leave
+       the title anything to occupy.
 
        The label is visually hidden rather than removed, so it stays in
        the accessible name (WCAG 2.5.3) — and the buttons carry
        [appTooltip], which is what a sighted user gets in place of the
        text they can no longer see. */
-    @container (max-width: 26rem) {
+    @container (max-width: 34rem) {
       .artifact-card__action-label {
         position: absolute;
         width: 1px;
@@ -459,11 +525,15 @@ export class ArtifactCardComponent {
   artifact = input.required<Artifact>();
 
   private artifactState = inject(ArtifactStateService);
+  private artifactHttp = inject(ArtifactHttpService);
   private artifactDownload = inject(ArtifactDownloadService);
   private dialog = inject(Dialog);
   private userService = inject(UserService);
+  private toast = inject(ToastService);
 
   protected readonly downloading = signal(false);
+  /** A rename or delete is in flight, so both of those buttons wait. */
+  protected readonly mutating = signal(false);
 
   protected readonly kind = computed<ArtifactKind>(() =>
     classifyContentType(this.artifact().contentType),
@@ -492,6 +562,21 @@ export class ArtifactCardComponent {
       `Share ${this.kind().label} artifact ${this.artifact().title || 'Untitled'}, version ${this.artifact().version}`,
   );
 
+  /* Rename and Delete name no version, deliberately — and Delete says
+     "and all versions" outright. This card is one of possibly several
+     for the same artifact, each captioned with its own version number,
+     so a label reading "Delete … version 2" next to the neighbouring
+     "Download … version 2" would promise something these controls do
+     not do: both act on the whole artifact. */
+  protected readonly renameAriaLabel = computed(
+    () => `Rename artifact ${this.artifact().title || 'Untitled'}`,
+  );
+
+  protected readonly deleteAriaLabel = computed(
+    () =>
+      `Delete artifact ${this.artifact().title || 'Untitled'} and all versions`,
+  );
+
   protected open(): void {
     const a = this.artifact();
     this.artifactState.openArtifactPanel({
@@ -516,6 +601,87 @@ export class ArtifactCardComponent {
         ownerEmail: this.userService.currentUser()?.email ?? '',
       } as ArtifactShareModalData,
     });
+  }
+
+  /** Retitle the whole artifact, not this version.
+   *
+   *  The backend writes the title to every version row, so the local
+   *  registry follows — otherwise the sibling cards for the same
+   *  artifact would keep the old name until a reload. */
+  protected async rename(): Promise<void> {
+    const a = this.artifact();
+    const data: RenameArtifactDialogData = { title: a.title };
+    const dialogRef = this.dialog.open<RenameArtifactDialogResult>(
+      RenameArtifactDialogComponent,
+      { data },
+    );
+    const title = await firstValueFrom(dialogRef.closed);
+    if (!title) return;
+
+    this.mutating.set(true);
+    try {
+      const updated = await this.artifactHttp.renameArtifact(
+        a.artifactId,
+        title,
+      );
+      this.artifactState.rename(a.artifactId, updated.title);
+    } catch {
+      this.toast.error(
+        'Could not rename artifact',
+        'The change was not saved. Try again in a moment.',
+      );
+    } finally {
+      this.mutating.set(false);
+    }
+  }
+
+  /** Delete the whole artifact after confirmation.
+   *
+   *  The confirmation copy leads with the version count, because this
+   *  control sits on a card captioned "v2" and the neighbouring Share
+   *  and Download buttons really are scoped to that version. The dialog
+   *  is the last chance to correct that reading before the other cards
+   *  vanish alongside this one.
+   *
+   *  Removal goes through the registry, which is what every sibling card
+   *  and the docked panel read — one call clears them all. Only after
+   *  the request succeeds: an optimistic removal would look like success
+   *  and then reappear on the next session load. */
+  protected async confirmDelete(): Promise<void> {
+    const a = this.artifact();
+    const versions = this.artifactState.versionsFor(a.artifactId).length;
+    const scope =
+      versions > 1
+        ? `all ${versions} versions of "${a.title || 'Untitled artifact'}"`
+        : `"${a.title || 'Untitled artifact'}"`;
+    const data: ConfirmationDialogData = {
+      title: 'Delete this artifact?',
+      message:
+        `This deletes ${scope} permanently, not just the version on this ` +
+        'card, along with any share links you have created. This cannot be ' +
+        'undone.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    };
+    const dialogRef = this.dialog.open<boolean>(ConfirmationDialogComponent, {
+      data,
+    });
+    const confirmed = await firstValueFrom(dialogRef.closed);
+    if (!confirmed) return;
+
+    this.mutating.set(true);
+    try {
+      await this.artifactHttp.deleteArtifact(a.artifactId);
+      this.artifactState.remove(a.artifactId);
+    } catch {
+      this.toast.error(
+        'Could not delete artifact',
+        'Nothing was removed. Try again in a moment.',
+      );
+    } finally {
+      this.mutating.set(false);
+    }
   }
 
   protected async download(): Promise<void> {


### PR DESCRIPTION
Follow-up to #952. Two things: the artifact-card commit missed that merge, and browser-testing #952 on dev turned up a layout bug.

## 1. The card commit missed #952

`53131cd7` (delete/rename on the inline artifact card) was pushed after #952 was already merged, so it never landed. Cherry-picked here unchanged.

The card is per *version* while these two actions are per *artifact*, so the difference is carried in the design: Rename and Delete are icon-only while Share and Download keep their text; their accessible names carry no version, and Delete says "and all versions"; and the confirm copy leads with the count. Verified on dev against a real two-version artifact:

- `Share HTML artifact Quarterly Revenue Chart, version 1` / `version 2`
- `Rename artifact Quarterly Revenue Chart` (no version)
- `Delete artifact Quarterly Revenue Chart and all versions`
- dialog: *"This deletes all 2 versions of "Quarterly Revenue Chart" permanently, not just the version on this card…"*

## 2. The grid footer overflowed its card — found in the browser

This one is live in develop right now. The library grid card's footer rendered **124px wider than the card**, so Rename and Delete painted outside it: in the third column they spilled into the page gutter, and in the first two they sat underneath the neighbouring card. Unreachable either way.

Measured on dev at a 1080px window:

| | width |
|---|---|
| footer available | 166px |
| Open (labelled) | 76px |
| Conversation (labelled) | 130px |
| Rename + Delete | 68px |
| **content / overflow** | **290px / +124px** |

**The row was already overflowing by 48px before my buttons** — 76 + 130 + 8 = 214 into 166. Three columns at `lg` simply do not leave room for two text labels. The new buttons turned a latent clip into an obvious one; the fix addresses both.

Both labels now drop to `sr-only` below 19rem of card, with `[appTooltip]` standing in — the same treatment the inline artifact card already uses. `sr-only` and not `hidden`: neither control has an aria-label, so removing the text would leave them nameless icons at exactly the width where they become icons.

**The threshold is measured against the card's CONTENT box**, which is what an `inline-size` container query reports. Sizing it off the border box — the intuitive reading, and my first attempt — left the labels hidden at every realistic width: `p-5` makes the border box 40px wider, so a 21rem threshold demanded a 376px card to show a label set that fits in 307px. The unit tests passed on that broken version; only measuring the rendered page caught it.

## Verified in the browser

Local worktree stack (app-api :8000 + SPA :4200) against dev data, since this branch isn't deployed:

- 1800px viewport → card content 307px: labels **visible**, overflow **0**
- 1280px viewport → card content 233px: labels **`sr-only` (1px)**, overflow **0**
- session view, two-version artifact: two cards, four buttons each, overflow **0**, last control at 1112px inside a card ending at 1128px
- no console errors on any surface

#952's own endpoints were also validated end to end on dev — `PATCH → 200`, title propagating to HEAD *and* version rows (survives reload), `updated_at` untouched, `DELETE → 204`, share cascade killing the live link (`/shared-artifacts/{id}` → 404), DynamoDB rows gone, and the S3 object tagged `lifecycle-class=deleted` against an `expire-soft-deleted` rule confirmed Enabled.

Frontend: 2290 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)