### PR TITLE
feat(artifacts): open artifacts in-app instead of depending on a pop-up

### DIFF
--- a/frontend/ai.client/src/app/app.routes.spec.ts
+++ b/frontend/ai.client/src/app/app.routes.spec.ts
@@ -94,12 +94,23 @@ describe('app routes — shell chrome', () => {
     expect(route!.data?.['chrome']).toBe(MINIMAL_CHROME);
   });
 
+  it('asks for a minimal shell on the artifact viewer route', () => {
+    const route = routes.find(r => r.path === 'artifacts/:artifactId');
+    expect(route).toBeDefined();
+    // Not styling. The full shell's content box has no definite height,
+    // so a viewer laid out to fill it collapses to a ~150px iframe. The
+    // minimal branch is the only one that hands a route real height.
+    expect(route!.data?.['chrome']).toBe(MINIMAL_CHROME);
+  });
+
   it('leaves every other route on the full shell', () => {
     // Opt-in by design: the flag strips app navigation, so it should
-    // never spread by accident.
+    // never spread by accident. Both entries here are artifact viewers,
+    // which is the shape that needs it — one thing, filling the shell,
+    // carrying its own way back.
     const minimal = routes
       .filter(r => r.data?.['chrome'] === MINIMAL_CHROME)
       .map(r => r.path);
-    expect(minimal).toEqual(['shared-artifact/:shareId']);
+    expect(minimal).toEqual(['shared-artifact/:shareId', 'artifacts/:artifactId']);
   });
 });

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -186,6 +186,21 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        // Declared before the list route so the viewer owns the two-segment
+        // path; Angular matches in order.
+        path: 'artifacts/:artifactId',
+        loadComponent: () => import('./artifacts/artifact-view.page').then(m => m.ArtifactViewPage),
+        canActivate: [authGuard],
+        // Minimal chrome, same as the shared-artifact viewer. Not cosmetic:
+        // the padded content box has no definite height, so a viewer laid
+        // out with `h-full` inside it collapses — measured at 150px of
+        // iframe in a 720px viewport. The minimal branch is `h-full` of the
+        // scroll container, which is `flex-1` of an `h-dvh` main, so the
+        // artifact finally gets the whole shell. It costs the sidenav,
+        // which is why the header carries a labelled way back.
+        data: { chrome: 'minimal' },
+    },
+    {
         path: 'artifacts',
         loadComponent: () => import('./artifacts/artifact-library.page').then(m => m.ArtifactLibraryPage),
         canActivate: [authGuard],

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -198,8 +198,7 @@
               <button
                 type="button"
                 (click)="open(item)"
-                [disabled]="opening() === item.artifactId"
-                class="block max-w-full truncate text-left text-sm/6 font-semibold text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-white"
+                class="block max-w-full truncate text-left text-sm/6 font-semibold text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-white"
               >
                 {{ item.title || 'Untitled artifact' }}
               </button>
@@ -233,15 +232,10 @@
               <button
                 type="button"
                 (click)="open(item)"
-                [disabled]="opening() === item.artifactId"
-                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
               >
-                <ng-icon
-                  name="heroArrowTopRightOnSquare"
-                  class="size-4"
-                  aria-hidden="true"
-                />
-                <span class="sr-only">Open {{ item.title }} in a new tab</span>
+                <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
+                <span class="sr-only">Open {{ item.title }}</span>
               </button>
               <button
                 type="button"
@@ -249,7 +243,7 @@
                 [disabled]="busy() === item.artifactId"
                 [appTooltip]="'Rename'"
                 appTooltipPosition="top"
-                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
               >
                 <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
                 <span class="sr-only">Rename {{ item.title }}</span>
@@ -260,7 +254,7 @@
                 [disabled]="busy() === item.artifactId"
                 [appTooltip]="'Delete'"
                 appTooltipPosition="top"
-                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
               >
                 <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
                 <span class="sr-only">Delete {{ item.title }}</span>
@@ -299,8 +293,7 @@
                   <button
                     type="button"
                     (click)="open(item)"
-                    [disabled]="opening() === item.artifactId"
-                    class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60"
+                    class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
                   >
                     {{ item.title || 'Untitled artifact' }}
                   </button>
@@ -344,15 +337,12 @@
               <button
                 type="button"
                 (click)="open(item)"
-                [disabled]="opening() === item.artifactId"
-                [appTooltip]="'Open in a new tab'"
+                [appTooltip]="'Open'"
                 appTooltipPosition="top"
-                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700"
+                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
               >
-                <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
-                <span class="@max-[19rem]:sr-only">{{
-                  opening() === item.artifactId ? 'Opening…' : 'Open'
-                }}</span>
+                <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
+                <span class="@max-[19rem]:sr-only">Open</span>
               </button>
               @if (item.sessionId) {
                 <a
@@ -372,7 +362,7 @@
                   [disabled]="busy() === item.artifactId"
                   [appTooltip]="'Rename'"
                   appTooltipPosition="top"
-                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                 >
                   <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
                   <span class="sr-only">Rename {{ item.title }}</span>
@@ -383,7 +373,7 @@
                   [disabled]="busy() === item.artifactId"
                   [appTooltip]="'Delete'"
                   appTooltipPosition="top"
-                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 disabled:opacity-60 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
                 >
                   <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
                   <span class="sr-only">Delete {{ item.title }}</span>

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { signal } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
 import { of } from 'rxjs';
@@ -71,6 +71,7 @@ describe('ArtifactLibraryPage', () => {
         provideRouter([
           { path: '', children: [] },
           { path: 's/:sessionId', children: [] },
+          { path: 'artifacts/:artifactId', children: [] },
         ]),
         { provide: ArtifactHttpService, useValue: mockHttp },
         { provide: LocalSettingsService, useValue: mockSettings },
@@ -109,7 +110,7 @@ describe('ArtifactLibraryPage', () => {
       typeFilter: { set: (v: string) => void };
       styleFor: (t: string) => { label: string };
       setViewMode: (m: ViewMode) => void;
-      open: (item: LibraryArtifact) => Promise<void>;
+      open: (item: LibraryArtifact) => void;
       load: () => Promise<void>;
       rename: (item: LibraryArtifact) => Promise<void>;
       confirmDelete: (item: LibraryArtifact) => Promise<void>;
@@ -208,108 +209,41 @@ describe('ArtifactLibraryPage', () => {
 
   describe('open()', () => {
     /**
-     * Stands in for a real `window.open`, including the rule that bit us:
-     * per spec it returns **null** when `noopener` (or `noreferrer`, which
-     * implies it) is set, because severing the opener leaves no handle to
-     * return. A mock that hands back a tab regardless of the feature
-     * string is how the bug shipped — it agreed with the broken code
-     * instead of with the browser.
+     * The library used to open artifacts with `window.open`, which made
+     * viewing your own document contingent on a pop-up — refusable by any
+     * blocker, and refused unconditionally by embedded webviews. Opening
+     * is now in-app navigation, which nothing can block. These tests pin
+     * that down so nobody reintroduces the pop-up dependency.
      */
-    function spyOnWindowOpen() {
-      const tab = { location: { href: '' }, opener: {} as unknown, close: vi.fn() };
-      const spy = vi
-        .spyOn(window, 'open')
-        .mockImplementation((_url?: string | URL, _target?: string, features?: string) =>
-          /noopener|noreferrer/.test(features ?? '') ? null : (tab as unknown as Window),
-        );
-      return { tab, spy };
-    }
-
-    it('does not pass noopener, which would make window.open return null', async () => {
-      // Regression: 'noopener,noreferrer' reported "Pop-up blocked" on
-      // every click and left a stray about:blank tab behind.
-      const { tab, spy } = spyOnWindowOpen();
+    it('navigates to the in-app viewer instead of opening a window', async () => {
+      const openSpy = vi.spyOn(window, 'open');
+      const navigate = vi
+        .spyOn(TestBed.inject(Router), 'navigate')
+        .mockResolvedValue(true);
 
       const c = api(await createComponent());
-      await c.open(stubArtifact());
+      c.open(stubArtifact({ artifactId: 'a1' }));
 
-      const features = spy.mock.calls[0]?.[2] ?? '';
-      expect(features).not.toMatch(/noopener|noreferrer/);
-      expect(mockToast.error).not.toHaveBeenCalled();
-      expect(tab.location.href).toBe('https://artifacts.example/x?t=tok');
+      expect(navigate).toHaveBeenCalledWith(['/artifacts', 'a1']);
+      expect(openSpy).not.toHaveBeenCalled();
     });
 
-    it('severs the opener itself, since it cannot ask the browser to', async () => {
-      const { tab } = spyOnWindowOpen();
-
+    it('does not mint a render token — the viewer owns that', async () => {
+      vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
       const c = api(await createComponent());
-      await c.open(stubArtifact());
-
-      // Reverse-tabnabbing guard standing in for the unusable noopener.
-      expect(tab.opener).toBeNull();
-    });
-
-    it('still opens when the webview makes opener read-only', async () => {
-      const tab = { location: { href: '' }, close: vi.fn() };
-      Object.defineProperty(tab, 'opener', {
-        get: () => null,
-        set: () => {
-          throw new TypeError('read only');
-        },
-      });
-      vi.spyOn(window, 'open').mockImplementation(() => tab as unknown as Window);
-
-      const c = api(await createComponent());
-      await c.open(stubArtifact());
-
-      expect(tab.location.href).toBe('https://artifacts.example/x?t=tok');
-      expect(mockToast.error).not.toHaveBeenCalled();
-    });
-
-    it('opens the tab before awaiting the mint, then points it at the URL', async () => {
-      // The ordering is the whole contract: a window.open() after the await
-      // is no longer tied to the click gesture and every browser blocks it.
-      const { tab, spy: openSpy } = spyOnWindowOpen();
-
-      let mintStarted = false;
-      mockHttp.mintRenderToken.mockImplementation(async () => {
-        mintStarted = true;
-        expect(openSpy).toHaveBeenCalled();
-        return { url: 'https://artifacts.example/a1', expiresAt: '' };
-      });
-
-      const c = api(await createComponent());
-      await c.open(stubArtifact({ artifactId: 'a1', version: 3, sessionId: 's9' }));
-
-      expect(mintStarted).toBe(true);
-      expect(mockHttp.mintRenderToken).toHaveBeenCalledWith('a1', 3, 's9');
-      expect(tab.location.href).toBe('https://artifacts.example/a1');
-      expect(tab.close).not.toHaveBeenCalled();
-    });
-
-    it('closes the blank tab and reports the failure when minting fails', async () => {
-      const { tab } = spyOnWindowOpen();
-      mockHttp.mintRenderToken.mockRejectedValue(new Error('500'));
-
-      const c = api(await createComponent());
-      await c.open(stubArtifact());
-
-      // Leaving an about:blank tab open would look like a broken app.
-      expect(tab.close).toHaveBeenCalled();
-      expect(mockToast.error).toHaveBeenCalled();
-    });
-
-    it('reports a blocked pop-up without minting a token', async () => {
-      vi.spyOn(window, 'open').mockImplementation(() => null);
-
-      const c = api(await createComponent());
-      await c.open(stubArtifact());
+      c.open(stubArtifact());
 
       expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
-      expect(mockToast.error).toHaveBeenCalledWith(
-        'Pop-up blocked',
-        expect.stringContaining('Allow pop-ups'),
-      );
+    });
+
+    it('cannot fail in a way the user has to be told about', async () => {
+      // A route change has no blocked/failed path to report, so the old
+      // "Pop-up blocked" and "Could not open artifact" toasts are gone.
+      vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+      const c = api(await createComponent());
+      c.open(stubArtifact());
+
+      expect(mockToast.error).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -6,18 +6,18 @@ import {
   signal,
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { Dialog } from '@angular/cdk/dialog';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
-  heroArrowTopRightOnSquare,
   heroBars3,
   heroChatBubbleLeftRight,
   heroChevronDown,
   heroCodeBracket,
   heroDocument,
   heroDocumentText,
+  heroEye,
   heroMagnifyingGlass,
   heroPencilSquare,
   heroPhoto,
@@ -131,13 +131,13 @@ const DEFAULT_TYPE_STYLE: TypeStyle = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   viewProviders: [
     provideIcons({
-      heroArrowTopRightOnSquare,
-      heroBars3,
+          heroBars3,
       heroChatBubbleLeftRight,
       heroChevronDown,
       heroCodeBracket,
       heroDocument,
       heroDocumentText,
+      heroEye,
       heroMagnifyingGlass,
       heroPencilSquare,
       heroPhoto,
@@ -151,6 +151,7 @@ export class ArtifactLibraryPage {
   private readonly artifacts = inject(ArtifactHttpService);
   private readonly localSettings = inject(LocalSettingsService);
   private readonly toast = inject(ToastService);
+  private readonly router = inject(Router);
   private readonly dialog = inject(Dialog);
 
   protected readonly items = signal<LibraryArtifact[]>([]);
@@ -158,8 +159,6 @@ export class ArtifactLibraryPage {
   protected readonly error = signal<string | null>(null);
   protected readonly search = signal('');
   protected readonly typeFilter = signal<string>('all');
-  /** Artifact id whose render URL is being minted, so its button can wait. */
-  protected readonly opening = signal<string | null>(null);
   /** Artifact id currently being renamed or deleted, so its row can wait. */
   protected readonly busy = signal<string | null>(null);
 
@@ -247,65 +246,23 @@ export class ArtifactLibraryPage {
   }
 
   /**
-   * Open the rendered artifact in a new tab.
+   * Open an artifact in the in-app viewer.
    *
-   * The tab is opened *before* the await, then pointed at the minted URL.
-   * Opening it afterwards would be a popup blocked by every browser,
-   * because by then the click is no longer the active user gesture.
+   * This used to mint a render token and hand it to `window.open`, which
+   * made viewing your own artifact contingent on a pop-up — the one thing
+   * a browser is entitled to refuse. Anyone with a blocker got a toast
+   * instead of their document, and embedded webviews (the Claude Code
+   * browser pane among them) refuse `window.open` unconditionally, with
+   * or without a feature string, so for them the library was decorative.
    *
-   * Minting is per-click rather than up front for the whole list: a
-   * render token is a short-lived (~120s) bearer credential in a URL, so
-   * pre-minting one per row would both expire before use and mean a
-   * round trip per artifact just to draw the page.
-   *
-   * The feature string must NOT contain `noopener` (nor `noreferrer`,
-   * which implies it). `window.open()` returns **null** whenever
-   * `noopener` is set — that is the specified behaviour, not a failure:
-   * severing the opener relationship means there is no handle to hand
-   * back. Passing it here opened a stray blank tab, made the null check
-   * below read as a blocked pop-up, and reported "Pop-up blocked" on
-   * every single click. We need the handle, so the opener is severed
-   * afterwards by assignment instead, which is the pre-`rel=noopener`
-   * mitigation and equally durable across the navigation.
+   * Navigation cannot be blocked, so opening is now a route change.
+   * `/artifacts/:id` mints the token itself and renders through the same
+   * `ArtifactViewerComponent` as the docked panel. The new-tab affordance
+   * moved into that page, where a refusal is harmless because the
+   * artifact is already on screen beside it.
    */
-  protected async open(item: LibraryArtifact): Promise<void> {
-    const tab = window.open('', '_blank');
-    if (!tab) {
-      this.toast.error(
-        'Pop-up blocked',
-        'Allow pop-ups for this site to open artifacts in a new tab.',
-      );
-      return;
-    }
-
-    // Reverse-tabnabbing guard, standing in for the `noopener` we cannot
-    // pass. Set while the tab is still same-origin about:blank; it
-    // survives the navigation, so the artifact origin never gets a
-    // handle back to this window.
-    try {
-      tab.opener = null;
-    } catch {
-      // Some embedded webviews make `opener` read-only. Not worth
-      // abandoning the open over — the destination is our own origin.
-    }
-
-    this.opening.set(item.artifactId);
-    try {
-      const token = await this.artifacts.mintRenderToken(
-        item.artifactId,
-        item.version,
-        item.sessionId,
-      );
-      tab.location.href = token.url;
-    } catch {
-      tab.close();
-      this.toast.error(
-        'Could not open artifact',
-        'The preview link could not be created. Try again in a moment.',
-      );
-    } finally {
-      this.opening.set(null);
-    }
+  protected open(item: LibraryArtifact): void {
+    void this.router.navigate(['/artifacts', item.artifactId]);
   }
 
   /**

--- a/frontend/ai.client/src/app/artifacts/artifact-view.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-view.page.html
@@ -1,0 +1,187 @@
+<div class="flex h-full min-h-0 flex-col bg-white dark:bg-gray-900">
+  @if (isLoading()) {
+    <div class="flex flex-1 items-center justify-center py-20">
+      <div class="text-center">
+        <div
+          class="mx-auto size-8 animate-spin rounded-full border-2 border-gray-300 border-t-primary-600 dark:border-gray-600 dark:border-t-primary-400"
+        ></div>
+        <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">Loading artifact…</p>
+      </div>
+    </div>
+  } @else if (notFound() || loadFailed()) {
+    <div class="flex flex-1 items-center justify-center py-20">
+      <div class="max-w-sm text-center">
+        <ng-icon
+          name="heroExclamationTriangle"
+          class="mx-auto size-12 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+        @if (notFound()) {
+          <h1 class="mt-4 text-lg/7 font-semibold text-gray-900 dark:text-white">
+            Artifact not found
+          </h1>
+          <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+            It may have been deleted, or it belongs to someone else.
+          </p>
+        } @else {
+          <h1 class="mt-4 text-lg/7 font-semibold text-gray-900 dark:text-white">
+            Something went wrong
+          </h1>
+          <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+            We couldn't load this artifact. Try again in a moment.
+          </p>
+        }
+        <a
+          routerLink="/artifacts"
+          class="mt-6 inline-flex items-center gap-2 rounded-2xl bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Back to artifacts
+        </a>
+      </div>
+    </div>
+  } @else if (artifact(); as a) {
+    <header
+      class="flex items-center gap-2 border-b border-gray-200 px-3 py-3 sm:px-4 dark:border-gray-700"
+    >
+      <!-- Labelled, not an icon: this route runs on minimal chrome, so
+           there is no sidenav and this is the only way back. -->
+      <a
+        routerLink="/artifacts"
+        class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl px-2 py-1 text-sm/6 font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+      >
+        <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+        Artifacts
+      </a>
+
+      <div class="min-w-0 flex-1">
+        <h1 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-gray-100">
+          {{ a.title || 'Untitled artifact' }}
+        </h1>
+        <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+          Version {{ a.version }}
+          @if (a.updatedAt) {
+            · Updated {{ a.updatedAt | date: 'mediumDate' }}
+          }
+        </p>
+      </div>
+
+      <div
+        role="group"
+        aria-label="Artifact view mode"
+        class="flex shrink-0 items-center gap-0.5 rounded-2xl border border-gray-200 p-0.5 dark:border-gray-700"
+      >
+        <button
+          type="button"
+          class="flex size-7 items-center justify-center rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible"
+          [class]="
+            view() === 'preview'
+              ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+              : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+          "
+          [attr.aria-pressed]="view() === 'preview'"
+          aria-label="Preview"
+          [appTooltip]="'Preview'"
+          appTooltipPosition="bottom"
+          (click)="setView('preview')"
+        >
+          <ng-icon name="heroEye" class="text-base" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          class="flex size-7 items-center justify-center rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible"
+          [class]="
+            view() === 'code'
+              ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+              : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100'
+          "
+          [attr.aria-pressed]="view() === 'code'"
+          aria-label="View code"
+          [appTooltip]="'View code'"
+          appTooltipPosition="bottom"
+          (click)="setView('code')"
+        >
+          <ng-icon name="heroCodeBracket" class="text-base" aria-hidden="true" />
+        </button>
+      </div>
+
+      @if (view() === 'code') {
+        <button
+          type="button"
+          class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          [attr.aria-label]="copied() ? 'Copied' : 'Copy code'"
+          [appTooltip]="copied() ? 'Copied' : 'Copy code'"
+          appTooltipPosition="bottom"
+          [disabled]="!source()"
+          (click)="copy()"
+        >
+          <ng-icon
+            [name]="copied() ? 'heroCheck' : 'heroClipboard'"
+            class="text-lg"
+            [class.text-state-success-600]="copied()"
+            aria-hidden="true"
+          />
+        </button>
+      }
+
+      @if (a.sessionId) {
+        <a
+          [routerLink]="['/s', a.sessionId]"
+          [appTooltip]="'Open the conversation'"
+          appTooltipPosition="bottom"
+          class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+        >
+          <ng-icon name="heroChatBubbleLeftRight" class="text-lg" aria-hidden="true" />
+          <span class="sr-only">Open the conversation for this artifact</span>
+        </a>
+      }
+
+      <!-- Secondary by design. A blocked pop-up here costs nothing — the
+           artifact is already rendered below — so there is no error path. -->
+      <button
+        type="button"
+        class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+        [appTooltip]="'Open in a new tab'"
+        appTooltipPosition="bottom"
+        [disabled]="!safeUrl()"
+        (click)="openInNewTab()"
+      >
+        <ng-icon name="heroArrowTopRightOnSquare" class="text-lg" aria-hidden="true" />
+        <span class="sr-only">Open this artifact in a new tab</span>
+      </button>
+
+      <button
+        type="button"
+        class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accessible disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+        [attr.aria-label]="downloading() ? 'Downloading artifact…' : 'Download artifact'"
+        [appTooltip]="'Download'"
+        appTooltipPosition="bottom"
+        [attr.aria-busy]="downloading()"
+        [disabled]="downloading() || !safeUrl()"
+        (click)="download()"
+      >
+        <ng-icon
+          [name]="downloading() ? 'heroArrowPath' : 'heroArrowDownTray'"
+          class="text-lg"
+          [class.animate-spin]="downloading()"
+          aria-hidden="true"
+        />
+      </button>
+    </header>
+
+    <div class="relative flex min-h-0 flex-1 flex-col">
+      <app-artifact-viewer
+        [safeUrl]="safeUrl()"
+        [title]="a.title"
+        [view]="view()"
+        [source]="source()"
+        [error]="renderError()"
+        [sourceError]="sourceError()"
+        [previewReady]="previewReady()"
+        (retry)="retry()"
+        (retrySource)="retrySource()"
+        (iframeLoad)="onIframeLoad()"
+      />
+    </div>
+  }
+</div>

--- a/frontend/ai.client/src/app/artifacts/artifact-view.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-view.page.spec.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { ArtifactViewPage } from './artifact-view.page';
+import {
+  ArtifactHttpService,
+  type LibraryArtifact,
+} from '../session/services/artifacts/artifact-http.service';
+import { ArtifactDownloadService } from '../session/services/artifacts/artifact-download.service';
+
+function stubArtifact(overrides: Partial<LibraryArtifact> = {}): LibraryArtifact {
+  return {
+    artifactId: 'a1',
+    version: 3,
+    title: 'Quarterly plan',
+    contentType: 'text/markdown',
+    createdAt: '2026-05-01T09:00:00+00:00',
+    updatedAt: '2026-05-15T10:00:00+00:00',
+    sessionId: 'sess-1',
+    ...overrides,
+  };
+}
+
+describe('ArtifactViewPage', () => {
+  let mockHttp: {
+    listLibrary: ReturnType<typeof vi.fn>;
+    mintRenderToken: ReturnType<typeof vi.fn>;
+    getArtifactContent: ReturnType<typeof vi.fn>;
+  };
+  let mockDownload: { download: ReturnType<typeof vi.fn> };
+  let paramId: string | null;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    paramId = 'a1';
+
+    mockHttp = {
+      listLibrary: vi.fn().mockResolvedValue([stubArtifact()]),
+      mintRenderToken: vi
+        .fn()
+        .mockResolvedValue({ url: 'https://artifacts.example/a1?t=tok', expiresAt: '' }),
+      getArtifactContent: vi.fn().mockResolvedValue({
+        content: '# Hello',
+        contentType: 'text/markdown',
+        version: 3,
+      }),
+    };
+    mockDownload = { download: vi.fn().mockResolvedValue(true) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'artifacts', children: [] },
+          { path: 's/:sessionId', children: [] },
+        ]),
+        { provide: ArtifactHttpService, useValue: mockHttp },
+        { provide: ArtifactDownloadService, useValue: mockDownload },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => paramId } } },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+  });
+
+  async function createComponent() {
+    const fixture = TestBed.createComponent(ArtifactViewPage);
+    fixture.detectChanges(); // runs ngOnInit
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function api(fixture: Awaited<ReturnType<typeof createComponent>>) {
+    return fixture.componentInstance as unknown as {
+      artifact: () => LibraryArtifact | null;
+      isLoading: () => boolean;
+      notFound: () => boolean;
+      loadFailed: () => boolean;
+      safeUrl: () => unknown;
+      renderError: () => string | null;
+      view: () => 'preview' | 'code';
+      setView: (v: 'preview' | 'code') => void;
+      source: () => unknown;
+      sourceError: () => string | null;
+      download: () => Promise<void>;
+      openInNewTab: () => void;
+      retry: () => void;
+    };
+  }
+
+  it('renders the artifact without needing a pop-up', async () => {
+    // The whole point of this page: a render token is minted and shown
+    // in-app, so nothing a browser can refuse stands between the user and
+    // their document.
+    const openSpy = vi.spyOn(window, 'open');
+    const c = api(await createComponent());
+
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledWith('a1', 3, 'sess-1');
+    expect(c.safeUrl()).not.toBeNull();
+    expect(c.renderError()).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing artifact as not-found rather than a blank viewer', async () => {
+    mockHttp.listLibrary.mockResolvedValue([stubArtifact({ artifactId: 'other' })]);
+    const c = api(await createComponent());
+
+    expect(c.notFound()).toBe(true);
+    expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes a failed lookup from a missing artifact', async () => {
+    // "We couldn't reach the server" and "this does not exist" are
+    // different problems and get different copy.
+    mockHttp.listLibrary.mockRejectedValue(new Error('503'));
+    const c = api(await createComponent());
+
+    expect(c.loadFailed()).toBe(true);
+    expect(c.notFound()).toBe(false);
+  });
+
+  it('surfaces a retryable error when minting fails', async () => {
+    mockHttp.mintRenderToken.mockRejectedValue(new Error('500'));
+    const c = api(await createComponent());
+
+    expect(c.renderError()).toContain("couldn't be loaded");
+    expect(c.safeUrl()).toBeNull();
+  });
+
+  it('fetches source only when the code view is opened, and only once', async () => {
+    const c = api(await createComponent());
+    expect(mockHttp.getArtifactContent).not.toHaveBeenCalled();
+
+    c.setView('code');
+    await Promise.resolve();
+    await Promise.resolve();
+    c.setView('preview');
+    c.setView('code');
+    await Promise.resolve();
+
+    expect(mockHttp.getArtifactContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('steers an oversized artifact to download instead of the code view', async () => {
+    mockHttp.getArtifactContent.mockRejectedValue(
+      new HttpErrorResponse({ status: 413 }),
+    );
+    const c = api(await createComponent());
+
+    c.setView('code');
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+
+    expect(c.sourceError()).toContain('too large');
+  });
+
+  it('downloads against the artifact id, the owner authority', async () => {
+    // Recipients download by share id; an owner has the artifact itself.
+    const c = api(await createComponent());
+    await c.download();
+
+    expect(mockDownload.download).toHaveBeenCalledWith({
+      artifactId: 'a1',
+      version: 3,
+    });
+  });
+
+  it('treats a blocked pop-up on the new-tab action as a non-event', async () => {
+    // Unlike the library's old primary action, a refusal here costs the
+    // user nothing — the artifact is already rendered on this page — so it
+    // must not throw or complain.
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+    const c = api(await createComponent());
+
+    expect(() => c.openInNewTab()).not.toThrow();
+  });
+
+  it('opens the new tab without noopener, and severs the opener itself', async () => {
+    const tab = { location: { href: '' }, opener: {} as unknown, close: vi.fn() };
+    const spy = vi
+      .spyOn(window, 'open')
+      .mockImplementation((_u?: string | URL, _t?: string, features?: string) =>
+        /noopener|noreferrer/.test(features ?? '') ? null : (tab as unknown as Window),
+      );
+
+    const c = api(await createComponent());
+    c.openInNewTab();
+
+    expect(spy.mock.calls[0]?.[2] ?? '').not.toMatch(/noopener|noreferrer/);
+    expect(tab.opener).toBeNull();
+    expect(tab.location.href).toBe('https://artifacts.example/a1?t=tok');
+  });
+
+  it('re-mints on retry rather than reusing an expired token', async () => {
+    // The token lives ~120s; a retry that replayed the old URL would load
+    // an expired page and look like the retry failed.
+    const c = api(await createComponent());
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledTimes(1);
+
+    c.retry();
+    await Promise.resolve();
+
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a missing route param as not-found', async () => {
+    paramId = null;
+    const c = api(await createComponent());
+
+    expect(c.notFound()).toBe(true);
+    expect(mockHttp.listLibrary).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/artifacts/artifact-view.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-view.page.ts
@@ -1,0 +1,270 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowDownTray,
+  heroArrowLeft,
+  heroArrowPath,
+  heroArrowTopRightOnSquare,
+  heroChatBubbleLeftRight,
+  heroCheck,
+  heroClipboard,
+  heroCodeBracket,
+  heroExclamationTriangle,
+  heroEye,
+} from '@ng-icons/heroicons/outline';
+
+import {
+  ArtifactHttpService,
+  type ArtifactContent,
+  type LibraryArtifact,
+} from '../session/services/artifacts/artifact-http.service';
+import { ArtifactDownloadService } from '../session/services/artifacts/artifact-download.service';
+import { ArtifactViewerComponent } from '../session/components/message-list/components/artifact/artifact-viewer.component';
+import { TooltipDirective } from '../components/tooltip/tooltip.directive';
+
+/**
+ * Owner-facing artifact viewer at `/artifacts/:artifactId`.
+ *
+ * This exists because the library's original open path did not survive
+ * contact with reality. It minted a render token and handed it to
+ * `window.open`, which made viewing your own artifact contingent on a
+ * pop-up — and a pop-up is the one thing a browser is entitled to refuse.
+ * Anyone with a blocker, and every embedded webview (the Claude Code
+ * browser pane blocks `window.open` unconditionally, feature string or
+ * not), got a toast instead of their document. A viewer that a browser
+ * setting can switch off is not a viewer.
+ *
+ * So opening is now in-app navigation, which nothing can block. "Open in
+ * a new tab" survives as a secondary action *inside* this page, where a
+ * blocked pop-up costs the user nothing: the artifact is already on
+ * screen next to it.
+ *
+ * Modelled on `shared-artifact-view.page.ts` and rendering through the
+ * same `ArtifactViewerComponent` as the docked panel, so the owner and
+ * recipient surfaces stay recognisably the same thing. The differences
+ * are ownership-shaped: this one mints against the artifact id rather
+ * than a share id, offers a route back to the library, and links to the
+ * conversation that produced it.
+ */
+@Component({
+  selector: 'app-artifact-view',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgIcon,
+    DatePipe,
+    RouterLink,
+    ArtifactViewerComponent,
+    TooltipDirective,
+  ],
+  providers: [
+    provideIcons({
+      heroArrowDownTray,
+      heroArrowLeft,
+      heroArrowPath,
+      heroArrowTopRightOnSquare,
+      heroChatBubbleLeftRight,
+      heroCheck,
+      heroClipboard,
+      heroCodeBracket,
+      heroExclamationTriangle,
+      heroEye,
+    }),
+  ],
+  templateUrl: './artifact-view.page.html',
+})
+export class ArtifactViewPage implements OnInit {
+  private route = inject(ActivatedRoute);
+  private artifacts = inject(ArtifactHttpService);
+  private downloadService = inject(ArtifactDownloadService);
+  private sanitizer = inject(DomSanitizer);
+
+  protected readonly artifact = signal<LibraryArtifact | null>(null);
+  protected readonly isLoading = signal(true);
+  protected readonly notFound = signal(false);
+  protected readonly loadFailed = signal(false);
+
+  protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
+  protected readonly renderError = signal<string | null>(null);
+  private readonly iframeLoaded = signal(false);
+  protected readonly previewReady = computed(
+    () => !!this.safeUrl() && this.iframeLoaded(),
+  );
+
+  protected readonly view = signal<'preview' | 'code'>('preview');
+  protected readonly source = signal<ArtifactContent | null>(null);
+  protected readonly sourceError = signal<string | null>(null);
+  private sourceLoading = false;
+
+  protected readonly copied = signal(false);
+  protected readonly downloading = signal(false);
+  private copiedTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Bumped per mint so a slow response that resolves after a retry is
+   *  discarded rather than overwriting the newer one. */
+  private requestSeq = 0;
+
+  async ngOnInit(): Promise<void> {
+    const artifactId = this.route.snapshot.paramMap.get('artifactId');
+    if (!artifactId) {
+      this.notFound.set(true);
+      this.isLoading.set(false);
+      return;
+    }
+
+    // Read the record out of the library listing rather than adding a
+    // get-one endpoint. The listing is deliberately unpaginated because a
+    // single user's artifacts sit far under one DynamoDB page, so this is
+    // one small call — and it keeps the viewer shipping without a backend
+    // deploy to sequence against. If that endpoint ever gains paging,
+    // this needs a real `GET /artifacts/{id}` behind it.
+    try {
+      const found = (await this.artifacts.listLibrary()).find(
+        (a) => a.artifactId === artifactId,
+      );
+      if (!found) {
+        this.notFound.set(true);
+        this.isLoading.set(false);
+        return;
+      }
+      this.artifact.set(found);
+    } catch {
+      this.loadFailed.set(true);
+      this.isLoading.set(false);
+      return;
+    }
+    this.isLoading.set(false);
+    await this.mint();
+  }
+
+  protected retry(): void {
+    void this.mint();
+  }
+
+  protected onIframeLoad(): void {
+    this.iframeLoaded.set(true);
+  }
+
+  protected setView(next: 'preview' | 'code'): void {
+    if (this.view() === next) return;
+    this.view.set(next);
+    if (next === 'code') void this.ensureSource();
+  }
+
+  protected retrySource(): void {
+    this.source.set(null);
+    this.sourceError.set(null);
+    void this.ensureSource();
+  }
+
+  protected async copy(): Promise<void> {
+    const src = this.source();
+    if (!src) return;
+    try {
+      await navigator.clipboard.writeText(src.content);
+      this.copied.set(true);
+      if (this.copiedTimer) clearTimeout(this.copiedTimer);
+      this.copiedTimer = setTimeout(() => this.copied.set(false), 2000);
+    } catch {
+      /* clipboard blocked (permissions/insecure context) — the user can
+         still select the visible source manually */
+    }
+  }
+
+  protected async download(): Promise<void> {
+    const a = this.artifact();
+    if (!a || this.downloading()) return;
+    this.downloading.set(true);
+    try {
+      await this.downloadService.download({
+        artifactId: a.artifactId,
+        version: a.version,
+      });
+    } finally {
+      this.downloading.set(false);
+    }
+  }
+
+  /**
+   * Secondary affordance only. Unlike the library's old primary action,
+   * a refusal here is harmless — the artifact is already rendered on this
+   * page — so a blocked pop-up needs no error, and gets none.
+   */
+  protected openInNewTab(): void {
+    const url = this.rawUrl;
+    if (!url) return;
+    const tab = window.open('', '_blank');
+    if (!tab) return;
+    try {
+      tab.opener = null;
+    } catch {
+      /* read-only in some embedded webviews; destination is our origin */
+    }
+    tab.location.href = url;
+  }
+
+  /** The unsanitized render URL, kept for the new-tab affordance —
+   *  `SafeResourceUrl` is opaque and cannot be read back out. */
+  private rawUrl: string | null = null;
+
+  /** Mint a fresh render URL. The token is a ~120s bearer credential —
+   *  never cached, re-minted on retry. */
+  private async mint(): Promise<void> {
+    const a = this.artifact();
+    if (!a) return;
+    const seq = ++this.requestSeq;
+    this.renderError.set(null);
+    this.safeUrl.set(null);
+    this.rawUrl = null;
+    this.iframeLoaded.set(false);
+    try {
+      const token = await this.artifacts.mintRenderToken(
+        a.artifactId,
+        a.version,
+        a.sessionId,
+      );
+      if (seq !== this.requestSeq) return; // superseded — drop
+      this.rawUrl = token.url;
+      this.safeUrl.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(token.url),
+      );
+    } catch {
+      if (seq !== this.requestSeq) return;
+      this.renderError.set(
+        "This artifact couldn't be loaded. Try again in a moment.",
+      );
+    }
+  }
+
+  /** Fetch the raw source once. No-op while a fetch is in flight or the
+   *  source is already loaded. */
+  private async ensureSource(): Promise<void> {
+    const a = this.artifact();
+    if (!a || this.sourceLoading || this.source()) return;
+    this.sourceLoading = true;
+    this.sourceError.set(null);
+    try {
+      this.source.set(
+        await this.artifacts.getArtifactContent(a.artifactId, a.version),
+      );
+    } catch (err: unknown) {
+      this.sourceError.set(
+        err instanceof HttpErrorResponse && err.status === 413
+          ? 'This artifact is too large to preview here — download it instead.'
+          : "This artifact's source couldn't be loaded.",
+      );
+    } finally {
+      this.sourceLoading = false;
+    }
+  }
+}


### PR DESCRIPTION
## What you reported

Clicking an artifact still showed **"Pop-up blocked"** after #953 shipped.

## Why #953 wasn't enough

#953 was a correct fix — it removed a `noopener` flag that made `window.open` return `null` by specification. But it fixed the *flag*, not the *design*. The design was the actual bug: **opening your own document was contingent on a pop-up**, and a pop-up is the one thing a browser is entitled to refuse.

Measured in the Claude Code browser pane, on the deployed (fixed) bundle:

```
bare         window.open('', '_blank')                        → BLOCKED (null)
noFeatures   window.open('about:blank', '_blank')             → BLOCKED (null)
withFeatures window.open('', '_blank', 'width=800,height=600')→ BLOCKED (null)
```

Every form. For that environment — and for anyone running a pop-up blocker — the library was decorative. My design mistake, not just a flag mistake.

## The fix

Opening is now **in-app navigation**, which nothing can block. `/artifacts/:artifactId` mints the render token itself and renders through the same `ArtifactViewerComponent` as the docked panel and the recipient's shared view: preview/code toggle, copy, download, and a link to the originating conversation.

"Open in a new tab" survives as a *secondary* action inside that page, where a refusal costs nothing — the artifact is already on screen beside it — so it has no error path at all.

### Minimal chrome is load-bearing, not cosmetic

The route uses `data: { chrome: 'minimal' }`. The full shell's content box (`mx-auto max-w-7xl px-4 py-10`) has no definite height, so the viewer's `h-full` collapsed:

| | iframe height |
|---|---|
| Full shell | **150px** in a 720px viewport |
| Minimal chrome | **731px** in an 800px viewport |

The minimal branch is `h-full` of a scroll container that is `flex-1` of an `h-dvh` main — the only path that hands a route real height. It costs the sidenav, so the header carries a labelled "Artifacts" link rather than a bare icon.

## Verification

Driven in the pane that exhibits the bug, against a local stack on dev data: clicking an artifact navigates in-app, **the artifact renders**, and the code view highlights its source. No toast, no pop-up.

Two things looked like failures on the way and were not — recording them because they will confuse the next person:

- The artifact origin's CSP is `frame-ancestors https://dev.boisestate.ai http://localhost:4200`. A dev server on **any other port** frames a blank box with only a console error to show for it.
- The local `backend/src/.env` carries a **stale `ARTIFACTS_ORIGIN`** pointing at `artifacts.alpha.boisestate.ai` instead of `artifacts.dev.boisestate.ai`. Worth correcting in your own checkout.

`ng test`: 2289 passed across 208 files. `tsc --noEmit` clean.

## Tests

The library's old `open()` tests described behaviour that no longer exists and went with it. Replaced by three that pin the *absence* of the pop-up dependency (navigates, mints nothing, cannot fail), plus 11 for the viewer — including that a blocked pop-up on the secondary action is a non-event, and that the new tab still avoids `noopener` and severs the opener itself.

The route-chrome guard now asserts both viewer routes deliberately, rather than being loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)