### PR TITLE
fix(infra): grant bedrock:CallWithBearerToken for the bedrock-runtime transport

### DIFF
--- a/docs/specs/gpt-5-6-prompt-caching.md
+++ b/docs/specs/gpt-5-6-prompt-caching.md
@@ -190,6 +190,46 @@ and suggests pinning `strands-agents==1.53.0`; we are on 1.51.0.
   profile. Not present in `inference-api-iam-roles.ts` today — this is a
   `platform.yml` deploy, so sequence it ahead of the backend change.
 
+#### ⚠️ CORRECTED TWICE — the real IAM gap was a different action
+
+**The `InvokeModel` half of that bullet was already satisfied.** Simulated against
+the deployed dev roles with `iam simulate-principal-policy`:
+
+| action | resource | runtime role |
+|---|---|---|
+| `bedrock:InvokeModel` | `inference-profile/us.openai.gpt-5.6-sol` | allowed |
+| `bedrock:InvokeModel` | `project/default` | allowed |
+| `bedrock:InvokeModelWithResponseStream` | inference profile | allowed |
+| **`bedrock:CallWithBearerToken`** | any | **implicitDeny** |
+
+The account-scoped `arn:aws:bedrock:{region}:{account}:*` resource on the existing
+`BedrockModelInvocation` statement already matches `project/default`, so PR-2
+shipped without an IAM change on that basis — correctly, as far as it went.
+
+**What PR-2 missed is the bearer token itself.** The `bedrock-runtime`
+OpenAI-compatible endpoint authenticates with the same short-term token
+construction as Mantle, but authorizes it under a *different IAM service
+namespace*: `bedrock:CallWithBearerToken`, not
+`bedrock-mantle:CallWithBearerToken`. Only the Mantle one was granted, so the
+first real turn failed:
+
+```
+401 ... is not authorized to perform: bedrock:CallWithBearerToken on resource: *
+because no identity-based policy allows the action
+```
+
+Both roles need it — the AgentCore runtime role (agent loop) and the app-api task
+role (`/chat/api-converse`). **This IS a `platform.yml` deploy**, and it must land
+before the transport can serve a single turn.
+
+Why no earlier step caught it: unit tests construct the model but never issue a
+request, and the `probe_gpt56_cache_rates.py` run that verified PR-1/2/5 executed
+under a developer's SSO credentials, which carry far broader permissions than the
+runtime role. Only an end-to-end turn through the deployed agent exercises the
+actual principal. Worth remembering as a general shape — a transport that
+authenticates differently from its neighbours needs its IAM verified against the
+*deployed role*, not inferred from the neighbour's grants.
+
 **Boundary check:** this is model-transport code, so it belongs in
 `apis/shared/models/` next to `mantle.py`, consumed by both `agent_factory` and the
 API-key `/chat/api-converse` handler. Don't fork the build logic.

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -548,6 +548,28 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── bedrock-runtime OpenAI bearer token ──
+  // The OpenAI-compatible endpoint on `bedrock-runtime`
+  // (provider="bedrock-responses") authenticates with the SAME short-term
+  // bearer token construction as Mantle, but authorizes it under a DIFFERENT
+  // IAM service namespace: `bedrock:CallWithBearerToken`, not
+  // `bedrock-mantle:CallWithBearerToken`. Granting only the Mantle one gets:
+  //
+  //   401 ... is not authorized to perform: bedrock:CallWithBearerToken
+  //   on resource: * because no identity-based policy allows the action
+  //
+  // Caught end-to-end in dev on 2026-09-05 — it does not show up in unit
+  // tests, and it does not show up when a developer drives the transport with
+  // their own SSO credentials, only under the runtime/task role.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'BedrockRuntimeCallWithBearerToken',
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock:CallWithBearerToken'],
+      resources: ['*'],
+    }),
+  );
+
   // ── SSM read for inference-api image tag (runtime endpoint resolution) ──
   taskRole.addToPrincipalPolicy(
     new iam.PolicyStatement({

--- a/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
+++ b/infrastructure/lib/constructs/inference-api/inference-api-iam-roles.ts
@@ -121,6 +121,26 @@ export function createRuntimeExecutionRole(
     resources: ['*'],
   }));
 
+  // ── bedrock-runtime OpenAI bearer token ──
+  // The OpenAI-compatible endpoint on `bedrock-runtime`
+  // (provider="bedrock-responses") authenticates with the SAME short-term
+  // bearer token construction as Mantle, but authorizes it under a DIFFERENT
+  // IAM service namespace: `bedrock:CallWithBearerToken`, not
+  // `bedrock-mantle:CallWithBearerToken`. Granting only the Mantle one gets:
+  //
+  //   401 ... is not authorized to perform: bedrock:CallWithBearerToken
+  //   on resource: * because no identity-based policy allows the action
+  //
+  // Caught end-to-end in dev on 2026-09-05 — it does not show up in unit
+  // tests, and it does not show up when a developer drives the transport with
+  // their own SSO credentials, only under the runtime/task role.
+  role.addToPolicy(new iam.PolicyStatement({
+    sid: 'BedrockRuntimeCallWithBearerToken',
+    effect: iam.Effect.ALLOW,
+    actions: ['bedrock:CallWithBearerToken'],
+    resources: ['*'],
+  }));
+
   // ── AWS Marketplace (model subscription validation) ──
   role.addToPolicy(new iam.PolicyStatement({
     sid: 'MarketplaceModelAccess',


### PR DESCRIPTION
## Corrects #949 — the transport cannot serve a single turn without this

The first real GPT-5.6 turn through the deployed agent failed:

```
401 ... is not authorized to perform: bedrock:CallWithBearerToken on resource: *
because no identity-based policy allows the action
```

The `bedrock-runtime` OpenAI endpoint authenticates with the **same** short-term bearer-token construction as Mantle, but authorizes it under a **different IAM service namespace**: `bedrock:CallWithBearerToken`, not `bedrock-mantle:CallWithBearerToken`. Only the Mantle one was granted.

## The gap, simulated against the deployed dev roles

`iam simulate-principal-policy` against `dev-boisestateai-v2-agentcore-runtime-role`:

| action | resource | decision |
|---|---|---|
| `bedrock:InvokeModel` | `inference-profile/us.openai.gpt-5.6-sol` | allowed |
| `bedrock:InvokeModel` | `project/default` | allowed |
| `bedrock:InvokeModelWithResponseStream` | inference profile | allowed |
| **`bedrock:CallWithBearerToken`** | any | **implicitDeny** |

Same `implicitDeny` on the app-api task role. Exactly one action missing; this grants it on both principals that build the transport — the AgentCore runtime role (agent loop) and the app-api task role (`/chat/api-converse`). Resource is `*` because the action takes no resource-level permissions, matching the existing Mantle grant beside it.

## What I got wrong in #949

#949 asserted no `platform.yml` deploy was needed. That was **right about `InvokeModel`** — the account-scoped `arn:aws:bedrock:{region}:{account}:*` resource already covers `project/default`, as the simulation above confirms — and **wrong overall**, because it reasoned about the action the spec named and never asked what authorizes the *token*.

So the spec's original instinct to sequence a `platform.yml` deploy ahead of the backend change was correct, just for a different action than it identified. Both the claim and the correction are now in the spec.

**Why nothing caught it earlier**, which is the part worth generalizing: unit tests construct the model but never issue a request, and the `probe_gpt56_cache_rates.py` run that verified PR-1/2/5 executed under a developer's SSO credentials — far broader than the runtime role. Only an end-to-end turn through the deployed agent exercises the actual principal. A transport that authenticates differently from its neighbours needs its IAM verified against the **deployed role**, not inferred from the neighbour's grants.

## Blast radius

- **Requires a `platform.yml` deploy** before `provider="bedrock-responses"` can serve traffic.
- **The Mantle path (`openai.gpt-5.4`) is unaffected** — it uses the namespace that is already granted, so nothing currently working is at risk.
- Additive IAM only; no resource is narrowed.

## How this surfaced

Adding `us.openai.gpt-5.6-sol` through the admin UI in dev and sending a turn. The model row itself is correct and already verified in DynamoDB — `provider: bedrock-responses`, `apiMode: responses` (forced by the backend, since the form offers no API-surface picker for this provider), `region: us-west-2`, caching on — and the model appears in the chat picker. Only the call is blocked.

## Testing

`cd infrastructure && npx tsc --noEmit && npx jest` → **41 suites, 783 tests, all passing**

Verification of the fix itself is the deploy: re-running the same turn should succeed. I'll confirm the token buckets and `cacheStatus` once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
