### PR TITLE
fix(models): force supportsCaching on where the provider caches unconditionally

### DIFF
--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -19,6 +19,13 @@ from .models import ManagedModel, ManagedModelCreate, ManagedModelUpdate
 logger = logging.getLogger(__name__)
 
 
+# Providers whose models prompt-cache by default when the field is unset.
+_CACHING_DEFAULT_PROVIDERS = ('bedrock', 'bedrock-responses')
+
+# Providers where caching is not optional — see _resolve_supports_caching.
+_CACHING_FORCED_PROVIDERS = ('bedrock-responses',)
+
+
 def _resolve_supports_caching(supports_caching: Optional[bool], provider: str) -> bool:
     """
     Resolve the supports_caching value based on explicit setting or provider defaults.
@@ -31,17 +38,30 @@ def _resolve_supports_caching(supports_caching: Optional[bool], provider: str) -
     Returns:
         bool: Whether the model supports caching
     """
+    normalized_provider = provider.lower()
+
+    # On bedrock-responses caching is a fact, not a setting: it is implicit and
+    # server-side, and nothing we send turns it off. A stored False there would
+    # be untrue, and its only practical effect is that the cache rates get
+    # cleared — which prices cached tokens at $0.00 while the provider bills
+    # them in full. On a warm conversation nearly every input token is a cache
+    # read, so that is close to total under-reporting of the model's spend.
+    #
+    # Normalized rather than honored, exactly like `apiMode` on the same
+    # transport, so no client can persist the impossible state.
+    if normalized_provider in _CACHING_FORCED_PROVIDERS:
+        return True
+
     if supports_caching is not None:
         return supports_caching
 
     # Default behavior: Bedrock Converse models, and the bedrock-runtime
-    # Responses transport (implicit prompt caching is ON by default there —
-    # it is the reason that transport exists). Admins can explicitly set this
-    # to False for models in either family that don't support it.
+    # Responses transport. Admins can explicitly set this to False for Bedrock
+    # models that don't support it.
     #
     # Deliberately NOT 'mantle': Mantle hosts open-weight models that mostly
     # don't cache, and openai.gpt-5.4 there is implicit-only with no write fee.
-    return provider.lower() in ('bedrock', 'bedrock-responses')
+    return normalized_provider in _CACHING_DEFAULT_PROVIDERS
 
 
 # The two OpenAI-compatible Bedrock surfaces. Both ride the OpenAI wire

--- a/backend/tests/shared/test_caching_provider_contract.py
+++ b/backend/tests/shared/test_caching_provider_contract.py
@@ -1,0 +1,70 @@
+"""Cross-package contract: the `supportsCaching` provider policy.
+
+The admin form always posts a `supportsCaching` value, so the backend's
+provider-aware default never sees ``None`` from the UI and can never apply.
+That forces the same policy to exist on both sides — and two sources of truth
+that can drift is exactly what produced the bug this test guards.
+
+The failure it prevents is not cosmetic. On ``bedrock-responses`` caching is
+implicit and server-side; nothing we send turns it off. A stored ``False``
+there is untrue, and its only practical effect is that the cache rates get
+cleared — pricing cached tokens at $0.00 while the provider bills them in full.
+A live probe on ``us.openai.gpt-5.6-sol`` measured 38,410 cache-read and 13,405
+cache-write tokens against 10 uncached input tokens on a warm conversation, so
+that is close to total under-reporting of the model's spend.
+
+So this reads the TypeScript source and asserts the two lists agree.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from apis.shared.models.managed_models import (
+    _CACHING_DEFAULT_PROVIDERS,
+    _CACHING_FORCED_PROVIDERS,
+    _resolve_supports_caching,
+)
+
+_MODEL_TS = (
+    Path(__file__).resolve().parents[2].parent
+    / "frontend"
+    / "ai.client"
+    / "src"
+    / "app"
+    / "admin"
+    / "manage-models"
+    / "models"
+    / "managed-model.model.ts"
+)
+
+
+def _ts_provider_list(name: str) -> tuple[str, ...]:
+    """Extract a `readonly ModelProvider[]` literal from the TS source."""
+    source = _MODEL_TS.read_text(encoding="utf-8")
+    match = re.search(rf"export const {name}: readonly ModelProvider\[\] = \[(.*?)\];", source, re.S)
+    assert match, f"{name} not found in {_MODEL_TS.name} — did it get renamed?"
+    return tuple(re.findall(r"'([^']+)'", match.group(1)))
+
+
+@pytest.mark.skipif(not _MODEL_TS.exists(), reason="frontend sources not present")
+class TestProviderListsAgree:
+    def test_caching_defaults_match(self):
+        assert _ts_provider_list("CACHING_DEFAULT_PROVIDERS") == _CACHING_DEFAULT_PROVIDERS
+
+    def test_forced_providers_match(self):
+        assert _ts_provider_list("CACHING_FORCED_PROVIDERS") == _CACHING_FORCED_PROVIDERS
+
+
+class TestPolicyInvariants:
+    def test_every_forced_provider_also_defaults_on(self):
+        """A provider that is forced on but not a default would contradict itself."""
+        for provider in _CACHING_FORCED_PROVIDERS:
+            assert provider in _CACHING_DEFAULT_PROVIDERS
+
+    def test_forcing_beats_an_explicit_false(self):
+        assert _resolve_supports_caching(False, "bedrock-responses") is True
+
+    def test_optional_providers_still_honour_an_explicit_false(self):
+        assert _resolve_supports_caching(False, "bedrock") is False

--- a/backend/tests/shared/test_openai_surface_model_records.py
+++ b/backend/tests/shared/test_openai_surface_model_records.py
@@ -69,7 +69,23 @@ class TestCachingDefault:
     def test_other_providers_default_off(self, provider):
         assert _resolve_supports_caching(None, provider) is False
 
-    @pytest.mark.parametrize("provider", ["bedrock", "bedrock-responses", "mantle"])
-    def test_explicit_value_always_wins(self, provider):
+    @pytest.mark.parametrize("provider", ["bedrock", "mantle", "openai", "gemini"])
+    def test_explicit_value_wins_where_caching_is_optional(self, provider):
         assert _resolve_supports_caching(False, provider) is False
         assert _resolve_supports_caching(True, provider) is True
+
+    @pytest.mark.parametrize("stored", [None, True, False])
+    def test_bedrock_responses_is_always_caching(self, stored):
+        """Not a setting: the transport caches implicitly, server-side.
+
+        A stored False would be untrue, and its only practical effect is that
+        the cache rates get cleared — pricing cached tokens at $0.00 while the
+        provider bills them in full. On a warm conversation nearly every input
+        token is a cache read, so that is close to total under-reporting.
+        Normalized rather than honored, exactly like `apiMode` on the same
+        transport.
+        """
+        assert _resolve_supports_caching(stored, "bedrock-responses") is True
+
+    def test_forcing_is_case_insensitive(self):
+        assert _resolve_supports_caching(False, "Bedrock-Responses") is True

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -462,24 +462,38 @@
                 Prompt caching
               </h3>
 
-              <!-- Supports Caching Toggle -->
-              <div>
-                <label class="flex items-center gap-3">
-                  <input
-                    type="checkbox"
-                    formControlName="supportsCaching"
-                    class="size-4 rounded border-gray-300 text-primary-600 focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
-                  />
-                  <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
-                    Model supports prompt caching
-                  </span>
-                </label>
-                <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
-                  Disable this if the model doesn't support prompt caching (e.g., some Amazon models). When disabled, the agent will skip cache-related API calls.
-                </p>
-              </div>
+              <!-- Supports Caching — a choice, except where the provider caches unconditionally -->
+              @if (cachingIsForced()) {
+                <div class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+                  <p class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                    This model always caches
+                  </p>
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Prompt caching is implicit and server-side on this transport, so it can't be
+                    turned off. Enter the cache rates below — on a warm conversation almost every
+                    input token is a cache read, so leaving them blank reports those tokens at
+                    <strong>$0.00</strong> while the provider still bills them.
+                  </p>
+                </div>
+              } @else {
+                <div>
+                  <label class="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      formControlName="supportsCaching"
+                      class="size-4 rounded border-gray-300 text-primary-600 focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+                    />
+                    <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                      Model supports prompt caching
+                    </span>
+                  </label>
+                  <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    Disable this if the model doesn't support prompt caching (e.g., some Amazon models). When disabled, the agent will skip cache-related API calls.
+                  </p>
+                </div>
+              }
 
-              @if (modelForm.value.supportsCaching) {
+              @if (modelForm.value.supportsCaching || cachingIsForced()) {
                 <p class="text-sm/6 text-gray-600 dark:text-gray-400">
                   Optional pricing for prompt caching. Cache writes typically cost ~25% more, while cache reads cost ~90% less than standard input tokens.
                 </p>

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -14,6 +14,9 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft, heroChevronDown, heroChevronRight } from '@ng-icons/heroicons/outline';
 import {
   AVAILABLE_PROVIDERS,
+  CACHING_FORCED_PROVIDERS,
+  defaultSupportsCaching,
+  supportsCachingForProvider,
   OPENAI_SURFACE_PROVIDERS,
   PROVIDER_LABELS,
   KNOWN_PARAMS,
@@ -284,6 +287,16 @@ export class ModelFormPage implements OnInit {
   readonly supportsCachingControls = computed(
     () => this.selectedProvider() === 'bedrock' || this.isBedrockResponses(),
   );
+  /**
+   * Whether caching is a fact rather than a choice for the selected provider.
+   *
+   * When true the template states it instead of offering a checkbox: the
+   * service caches regardless, so the only thing unchecking would achieve is
+   * clearing the cache rates and pricing cached tokens at $0.
+   */
+  readonly cachingIsForced = computed(() =>
+    CACHING_FORCED_PROVIDERS.includes(this.selectedProvider()),
+  );
 
   /**
    * Model-id suggestions for the Mantle escape-hatch form, sourced from the
@@ -345,7 +358,12 @@ export class ModelFormPage implements OnInit {
     cacheWritePricePerMillionTokens: this.fb.control<number | null>(null, { validators: [Validators.min(0)] }),
     cacheReadPricePerMillionTokens: this.fb.control<number | null>(null, { validators: [Validators.min(0)] }),
     knowledgeCutoffDate: this.fb.control<string | null>(null),
-    supportsCaching: this.fb.control(false, { nonNullable: true }),
+    // Seeded for the form's initial provider ('bedrock') and re-derived on
+    // every provider switch. A hardcoded `false` here disagreed with the
+    // `?? true` used when loading an existing model or a curated template,
+    // so the same model got a different answer depending on how you reached
+    // the form.
+    supportsCaching: this.fb.control(true, { nonNullable: true }),
     mantleApiMode: this.fb.control<MantleApiMode>('chat', { nonNullable: true }),
     mantleRegion: this.fb.control('', { nonNullable: true }),
     inferenceParams: this.fb.array<FormGroup<ParamRowGroup>>([], {
@@ -465,6 +483,13 @@ export class ModelFormPage implements OnInit {
         // truthful so a later provider switch doesn't carry 'chat' back in.
         this.modelForm.controls.mantleApiMode.setValue('responses');
       }
+      // Caching support is a property of the provider, so re-derive it on a
+      // provider switch rather than carrying the previous provider's answer
+      // over. Without this the form's hardcoded `false` silently wins for
+      // every caching-capable model an admin adds.
+      this.modelForm.controls.supportsCaching.setValue(
+        defaultSupportsCaching(provider),
+      );
     });
 
     // Keep the max_tokens row pinned to the model's output ceiling: pre-fill
@@ -1008,7 +1033,7 @@ export class ModelFormPage implements OnInit {
         cacheWritePricePerMillionTokens: v.cacheWritePricePerMillionTokens,
         cacheReadPricePerMillionTokens: v.cacheReadPricePerMillionTokens,
         knowledgeCutoffDate: v.knowledgeCutoffDate,
-        supportsCaching: v.supportsCaching,
+        supportsCaching: supportsCachingForProvider(v.provider, v.supportsCaching),
         // Only meaningful on an OpenAI-compatible Bedrock surface; null
         // elsewhere so the backend stores nothing for other providers. An
         // empty region means "app's region". The bedrock-runtime transport

--- a/frontend/ai.client/src/app/admin/manage-models/models/caching-providers.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/caching-providers.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AVAILABLE_PROVIDERS,
+  CACHING_DEFAULT_PROVIDERS,
+  CACHING_FORCED_PROVIDERS,
+  defaultSupportsCaching,
+  supportsCachingForProvider,
+} from './managed-model.model';
+
+/**
+ * `supportsCaching` policy.
+ *
+ * The form always posts a value, so the backend's own provider default never
+ * sees `None` from the UI and can never apply — which is why this policy has to
+ * exist on the frontend at all. It is mirrored on the backend and pinned in
+ * step by `backend/tests/shared/test_caching_provider_contract.py`.
+ */
+describe('supportsCaching policy', () => {
+  describe('defaultSupportsCaching', () => {
+    it.each(['bedrock', 'bedrock-responses'] as const)('defaults on for %s', provider => {
+      expect(defaultSupportsCaching(provider)).toBe(true);
+    });
+
+    it.each(['mantle', 'openai', 'gemini'] as const)('defaults off for %s', provider => {
+      expect(defaultSupportsCaching(provider)).toBe(false);
+    });
+  });
+
+  describe('supportsCachingForProvider', () => {
+    it('honours an explicit choice where caching is optional', () => {
+      expect(supportsCachingForProvider('bedrock', false)).toBe(false);
+      expect(supportsCachingForProvider('mantle', true)).toBe(true);
+    });
+
+    it('falls back to the provider default when nothing was chosen', () => {
+      expect(supportsCachingForProvider('bedrock', null)).toBe(true);
+      expect(supportsCachingForProvider('mantle', undefined)).toBe(false);
+    });
+
+    it.each([true, false, null, undefined])(
+      'forces bedrock-responses on regardless of the chosen value (%s)',
+      chosen => {
+        // Caching there is implicit and server-side — nothing we send turns it
+        // off. A stored false only clears the cache rates, which prices cached
+        // tokens at $0.00 while the provider bills them in full. On a warm
+        // conversation nearly every input token is a cache read.
+        expect(supportsCachingForProvider('bedrock-responses', chosen)).toBe(true);
+      },
+    );
+  });
+
+  describe('provider lists', () => {
+    it('only names providers that actually exist', () => {
+      for (const p of [...CACHING_DEFAULT_PROVIDERS, ...CACHING_FORCED_PROVIDERS]) {
+        expect(AVAILABLE_PROVIDERS).toContain(p);
+      }
+    });
+
+    it('forces only providers that also default on', () => {
+      // A forced provider that was not also a default would be contradictory.
+      for (const p of CACHING_FORCED_PROVIDERS) {
+        expect(CACHING_DEFAULT_PROVIDERS).toContain(p);
+      }
+    });
+  });
+});

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -34,6 +34,53 @@ export const AVAILABLE_PROVIDERS: ModelProvider[] = [
 export const OPENAI_SURFACE_PROVIDERS: readonly ModelProvider[] = ['mantle', 'bedrock-responses'];
 
 /**
+ * Providers whose models prompt-cache by default.
+ *
+ * Mirrors `_resolve_supports_caching` on the backend. The form has to know
+ * this because it always posts a `supportsCaching` value — so the backend's
+ * own provider default never sees `None` from the UI and can never apply.
+ */
+export const CACHING_DEFAULT_PROVIDERS: readonly ModelProvider[] = ['bedrock', 'bedrock-responses'];
+
+/**
+ * Providers where prompt caching is **not optional**.
+ *
+ * GPT-5.6 on `bedrock-runtime` caches implicitly, server-side, and we have no
+ * way to turn that off. So "supports caching = false" there is simply untrue,
+ * and the only thing it changes is that the cache rate fields get cleared —
+ * which prices cached tokens at $0.00 while AWS bills them in full. On a warm
+ * conversation nearly all input tokens sit in the cache buckets, so that is
+ * close to total under-reporting.
+ *
+ * Treated the same way as `apiMode` on this transport: normalized, not honored.
+ */
+export const CACHING_FORCED_PROVIDERS: readonly ModelProvider[] = ['bedrock-responses'];
+
+/**
+ * The caching default for a provider when nothing has been chosen.
+ *
+ * Mirrors `_resolve_supports_caching` on the backend — kept in step by
+ * `tests/shared/test_caching_provider_contract.py`, which reads this file.
+ */
+export function defaultSupportsCaching(provider: ModelProvider): boolean {
+  return CACHING_DEFAULT_PROVIDERS.includes(provider);
+}
+
+/**
+ * The `supportsCaching` value to persist for a provider.
+ *
+ * Forced on where caching is unconditional; otherwise the admin's choice wins,
+ * falling back to the provider default when unset.
+ */
+export function supportsCachingForProvider(
+  provider: ModelProvider,
+  chosen: boolean | null | undefined,
+): boolean {
+  if (CACHING_FORCED_PROVIDERS.includes(provider)) return true;
+  return chosen ?? defaultSupportsCaching(provider);
+}
+
+/**
  * Human-readable labels for the provider picker.
  *
  * The raw values are wire identifiers; `bedrock-responses` in particular says


### PR DESCRIPTION
## Found by adding GPT-5.6 through the admin UI

The `supportsCaching` checkbox defaults to `false` and is hardcoded — not provider-aware. An admin who doesn't know to check it creates a caching model with caching marked off.

**That's not a cosmetic default.** Unchecking it *clears* the cache rate fields (`model-form.page.ts:437-443`), and `CostCalculator` treats a null rate as `0.0`. The tokens are still cached — GPT-5.6's implicit caching is server-side and nothing we send disables it — they're just priced at **$0.00**.

From the live probe on `us.openai.gpt-5.6-sol`, a warm conversation:

| bucket | tokens |
|---|---:|
| cacheRead | 38,410 |
| cacheWrite | 13,405 |
| uncached input | **10** |

~99.98% of input sits in the cache buckets. So the practical result is near-total under-reporting of the model's spend — the same invisible-cost failure this whole epic exists to fix.

## Three defects, not one

1. **The form default was a hardcoded `false`**, not provider-aware.
2. **The backend's provider-aware default was dead code on the UI path.** The form always posts a value (line 1011), so `_resolve_supports_caching` never sees `None` from the UI and its provider logic could never apply. Two sources of truth, and the wrong one always won.
3. **Create and edit disagreed.** Create defaulted `false` (line 348); loading an existing model or a curated template defaulted `?? true` (lines 867, 910). Same model, different answer depending on how you reached the form.

## The fix

For `bedrock-responses`, `supportsCaching` is now **forced true on both sides** — the same normalize-don't-honor treatment `apiMode` already gets on that transport, and for the same reason: a stored `false` is untrue, and its only effect is to mis-price. The impossible state is now unreachable rather than merely discouraged.

The template states it as a fact instead of offering a checkbox, and keeps the rate fields visible with a note on what leaving them blank costs:

> Prompt caching is implicit and server-side on this transport, so it can't be turned off. Enter the cache rates below — on a warm conversation almost every input token is a cache read, so leaving them blank reports those tokens at **$0.00** while the provider still bills them.

Every other provider keeps the checkbox, and an explicit choice still wins. The create default is now derived from the provider, matching what edit and template load already did.

Policy moved out of the component into pure exported functions (`defaultSupportsCaching`, `supportsCachingForProvider`) beside the provider lists — testable without a TestBed, and living next to the data it describes.

## Testing

- `backend/tests/shared/test_caching_provider_contract.py` — **new**. Reads `managed-model.model.ts` and asserts the frontend and backend provider lists agree. Two sources of truth that can drift is precisely what caused this, so drift is now a test failure rather than a silent $0 cost row.
- `caching-providers.spec.ts` — the policy functions, including that `bedrock-responses` is forced on for every input (`true`/`false`/`null`/`undefined`).
- `test_openai_surface_model_records.py` — updated. `test_explicit_value_always_wins` was asserting the old contract for `bedrock-responses`; it's now scoped to providers where caching is genuinely optional, with a dedicated test for the forced case.

```
backend  → 7458 passed, 3 skipped, 0 failed
frontend → 2312 passed
tsc      → clean
```

## Note for reviewers

This changes a contract: `_resolve_supports_caching(False, "bedrock-responses")` now returns `True`. That's deliberate — see the test docstring. If you'd rather the backend honour an explicit `false` and only fix the form default, say so and I'll narrow it; the argument for forcing is that the API is just as capable of persisting the mis-pricing state as the UI was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
