### PR TITLE
fix(models): let Mantle models expose the caching controls

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -14,6 +14,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowLeft, heroChevronDown, heroChevronRight } from '@ng-icons/heroicons/outline';
 import {
   AVAILABLE_PROVIDERS,
+  CACHING_CAPABLE_PROVIDERS,
   CACHING_FORCED_PROVIDERS,
   defaultSupportsCaching,
   supportsCachingForProvider,
@@ -284,8 +285,8 @@ export class ModelFormPage implements OnInit {
   );
   readonly providerLabels = PROVIDER_LABELS;
   /** Providers whose models can prompt-cache — drives the caching form block. */
-  readonly supportsCachingControls = computed(
-    () => this.selectedProvider() === 'bedrock' || this.isBedrockResponses(),
+  readonly supportsCachingControls = computed(() =>
+    CACHING_CAPABLE_PROVIDERS.includes(this.selectedProvider()),
   );
   /**
    * Whether caching is a fact rather than a choice for the selected provider.

--- a/frontend/ai.client/src/app/admin/manage-models/models/caching-providers.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/caching-providers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   AVAILABLE_PROVIDERS,
+  CACHING_CAPABLE_PROVIDERS,
   CACHING_DEFAULT_PROVIDERS,
   CACHING_FORCED_PROVIDERS,
   defaultSupportsCaching,
@@ -47,6 +48,30 @@ describe('supportsCaching policy', () => {
         expect(supportsCachingForProvider('bedrock-responses', chosen)).toBe(true);
       },
     );
+  });
+
+  describe('CACHING_CAPABLE_PROVIDERS', () => {
+    it('includes mantle even though it is not a caching default', () => {
+      // Most Mantle models are open-weight and don't cache, so it is rightly
+      // not a default — but openai.gpt-5.x there DOES cache implicitly. Hiding
+      // the caching controls for Mantle left no way to enter a cache-read
+      // rate, so those tokens were priced at $0.00 while the provider billed
+      // them. Measured live on openai.gpt-5.4: a warm turn read 3,642 tokens
+      // from cache and contributed nothing to the recorded cost.
+      expect(CACHING_CAPABLE_PROVIDERS).toContain('mantle');
+      expect(CACHING_DEFAULT_PROVIDERS).not.toContain('mantle');
+    });
+
+    it('is a superset of the providers that default on', () => {
+      for (const p of CACHING_DEFAULT_PROVIDERS) {
+        expect(CACHING_CAPABLE_PROVIDERS).toContain(p);
+      }
+    });
+
+    it('excludes providers with no Bedrock cache accounting', () => {
+      expect(CACHING_CAPABLE_PROVIDERS).not.toContain('openai');
+      expect(CACHING_CAPABLE_PROVIDERS).not.toContain('gemini');
+    });
   });
 
   describe('provider lists', () => {

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -57,6 +57,25 @@ export const CACHING_DEFAULT_PROVIDERS: readonly ModelProvider[] = ['bedrock', '
 export const CACHING_FORCED_PROVIDERS: readonly ModelProvider[] = ['bedrock-responses'];
 
 /**
+ * Providers whose models *can* prompt-cache, and therefore need the caching
+ * controls and cache-rate fields on the admin form.
+ *
+ * Wider than {@link CACHING_DEFAULT_PROVIDERS} on purpose. `mantle` is not a
+ * caching default — most Mantle models are open-weight and don't cache — but
+ * `openai.gpt-5.x` there *does*, implicitly, with a cache-read discount and no
+ * write fee. Excluding Mantle from the form meant an admin had no way to enable
+ * caching or enter a cache-read rate for those models, so their cached tokens
+ * were priced at $0.00 while the provider billed them. Measured live on
+ * `openai.gpt-5.4`: a warm turn read 3,642 tokens from cache and contributed
+ * nothing to the recorded cost.
+ */
+export const CACHING_CAPABLE_PROVIDERS: readonly ModelProvider[] = [
+  'bedrock',
+  'bedrock-responses',
+  'mantle',
+];
+
+/**
  * The caching default for a provider when nothing has been chosen.
  *
  * Mirrors `_resolve_supports_caching` on the backend — kept in step by


### PR DESCRIPTION
## Found by stepping through the admin UI

`openai.gpt-5.4` (`provider="mantle"`) **is caching**, and we are pricing those tokens at **$0.00**.

Measured live in dev, two turns on gpt-5.4:

| turn | status | input | cacheRead | cost |
|---|---|---:|---:|---:|
| 1 | `uncached` | 3,681 | 0 | $0.01021 |
| 2 | `hit` | 60 | **3,642** | $0.000264 |

Turn 2's cost reproduces **exactly** from input + output alone (`60/1e6×2.75 + 6/1e6×16.50 = $0.000264`), so the 3,642 cached tokens contributed nothing. At the family's confirmed 0.1× cache-read ratio they're worth ~$0.0012 — that turn is a **~5.5× under-report**.

## Why the row can't be fixed today

The admin form gated the caching block on `bedrock` / `bedrock-responses`, so for Mantle the checkbox **and the cache-rate fields were never rendered**. An admin had no way to enable caching or enter a cache-read rate for a Mantle model — the row could only ever carry the provider default of `false`.

That exclusion was correct when Mantle meant open-weight models that don't cache, and it predates `gpt-5.x` arriving there. The spec already anticipated the right end state for those rows: `supportsCaching: true` with `cacheWritePricePerMillionTokens: 0`, since the Price List shows a cache-read SKU ($0.33 GovCloud) and **no cache-write SKU at all**.

## The change

Adds `CACHING_CAPABLE_PROVIDERS`, deliberately **wider** than `CACHING_DEFAULT_PROVIDERS`:

| list | members | meaning |
|---|---|---|
| `CACHING_DEFAULT_PROVIDERS` | `bedrock`, `bedrock-responses` | caching on unless told otherwise |
| `CACHING_FORCED_PROVIDERS` | `bedrock-responses` | not a choice |
| **`CACHING_CAPABLE_PROVIDERS`** | + `mantle` | **controls are shown** |

Mantle stays **off by default** — most Mantle models genuinely don't cache — it just becomes *selectable*, which is all gpt-5.4/5.5 need.

This is deliberately narrow: it changes **no stored record**. The dev `gpt-5.4` row still needs its `supportsCaching` and cache-read rate set once this deploys, which is now possible through the UI.

## Testing

`frontend → 2315 passed`, `tsc` clean. Three cases added covering that `mantle` is capable-but-not-default, that capable is a superset of default, and that `openai`/`gemini` stay excluded.

## Follow-up (not in this PR)

Once deployed, `gpt-5.4` should be set to `supportsCaching: true`, `cacheReadPricePerMillionTokens: 0.275` (0.1× our catalog's $2.75 input, matching the family ratio), `cacheWritePricePerMillionTokens: 0`. I can do that through the UI and re-measure to confirm the cached tokens start pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
