### PR TITLE
feat(announcements): data layer, admin CRUD, and table (PR-1)

### DIFF
--- a/backend/src/apis/app_api/admin/announcements/routes.py
+++ b/backend/src/apis/app_api/admin/announcements/routes.py
@@ -1,0 +1,204 @@
+"""Admin API routes for feature announcements.
+
+Authoring, scheduling, and lifecycle for the notices users see. There is no
+user-facing counterpart yet — PR-2 adds ``GET /announcements`` and the ack
+endpoint. Until then this surface ships dark: admins can author drafts and
+nothing renders anywhere.
+
+See ``docs/specs/feature-announcements.md`` §6.
+"""
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from apis.shared.announcements.models import (
+    AnnouncementCreate,
+    AnnouncementState,
+    AnnouncementListResponse,
+    AnnouncementResponse,
+    AnnouncementUpdate,
+)
+from apis.shared.announcements.service import get_announcements_service
+from apis.shared.auth import User, require_admin_scope
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/announcements", tags=["admin-announcements"])
+
+# Every route in this package is guarded by this one scope, so the
+# permission boundary is the package boundary. Enforced by
+# tests/architecture/test_admin_scope_coverage.py.
+require_announcements_admin = require_admin_scope("admin.announcements")
+
+
+def _not_found(announcement_id: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Announcement '{announcement_id}' not found",
+    )
+
+
+@router.get(
+    "/",
+    response_model=AnnouncementListResponse,
+    summary="List announcements",
+)
+async def list_announcements(
+    state: Optional[List[AnnouncementState]] = Query(
+        None, description="Filter to these states (repeatable)"
+    ),
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementListResponse:
+    """List every announcement, in every state — drafts included."""
+    service = get_announcements_service()
+    announcements = await service.list_announcements(states=state)
+    return AnnouncementListResponse(
+        announcements=[
+            AnnouncementResponse.from_announcement(a) for a in announcements
+        ],
+        total=len(announcements),
+    )
+
+
+@router.get(
+    "/{announcement_id}",
+    response_model=AnnouncementResponse,
+    summary="Get an announcement",
+)
+async def get_announcement(
+    announcement_id: str,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    service = get_announcements_service()
+    announcement = await service.get_announcement(announcement_id)
+    if not announcement:
+        raise _not_found(announcement_id)
+    return AnnouncementResponse.from_announcement(announcement)
+
+
+@router.post(
+    "/",
+    response_model=AnnouncementResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create an announcement",
+)
+async def create_announcement(
+    data: AnnouncementCreate,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    """Create an announcement. Defaults to ``draft`` — publishing is its own
+    action, so an in-progress edit is never live."""
+    try:
+        service = get_announcements_service()
+        announcement = await service.create_announcement(
+            data, created_by=admin_user.email
+        )
+        return AnnouncementResponse.from_announcement(announcement)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.patch(
+    "/{announcement_id}",
+    response_model=AnnouncementResponse,
+    summary="Update an announcement",
+)
+async def update_announcement(
+    announcement_id: str,
+    updates: AnnouncementUpdate,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    """Edit body/title/targeting. ``revision`` is untouched, so an edit does
+    **not** re-show the announcement to anyone who already dismissed it — that
+    is what ``/revise`` is for (§D4)."""
+    try:
+        service = get_announcements_service()
+        announcement = await service.update_announcement(announcement_id, updates)
+        if not announcement:
+            raise _not_found(announcement_id)
+        return AnnouncementResponse.from_announcement(announcement)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post(
+    "/{announcement_id}/publish",
+    response_model=AnnouncementResponse,
+    summary="Publish an announcement",
+)
+async def publish_announcement(
+    announcement_id: str,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    try:
+        service = get_announcements_service()
+        announcement = await service.publish(announcement_id)
+        if not announcement:
+            raise _not_found(announcement_id)
+        return AnnouncementResponse.from_announcement(announcement)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post(
+    "/{announcement_id}/archive",
+    response_model=AnnouncementResponse,
+    summary="Archive an announcement",
+)
+async def archive_announcement(
+    announcement_id: str,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    """Stop showing it. Acknowledgements are kept."""
+    service = get_announcements_service()
+    announcement = await service.archive(announcement_id)
+    if not announcement:
+        raise _not_found(announcement_id)
+    return AnnouncementResponse.from_announcement(announcement)
+
+
+@router.post(
+    "/{announcement_id}/revise",
+    response_model=AnnouncementResponse,
+    summary='Bump the revision ("show this again")',
+)
+async def revise_announcement(
+    announcement_id: str,
+    admin_user: User = Depends(require_announcements_admin),
+) -> AnnouncementResponse:
+    """Increment ``revision``, so everyone's suppression lapses at once (§D4).
+
+    The old acks stay readable under their own revision, which is what lets the
+    panel mark the entry *Updated* rather than plain unread.
+    """
+    service = get_announcements_service()
+    announcement = await service.revise(announcement_id)
+    if not announcement:
+        raise _not_found(announcement_id)
+    return AnnouncementResponse.from_announcement(announcement)
+
+
+@router.delete(
+    "/{announcement_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete an announcement",
+)
+async def delete_announcement(
+    announcement_id: str,
+    admin_user: User = Depends(require_announcements_admin),
+) -> None:
+    service = get_announcements_service()
+    deleted = await service.delete_announcement(announcement_id)
+    if not deleted:
+        raise _not_found(announcement_id)

--- a/backend/src/apis/app_api/admin/routes.py
+++ b/backend/src/apis/app_api/admin/routes.py
@@ -30,7 +30,7 @@ from apis.shared.models.models import (
     ModelRoleAssignment,
 )
 from apis.shared.auth import User, require_admin_scope
-from apis.shared.feature_flags import skills_enabled
+from apis.shared.feature_flags import announcements_enabled, skills_enabled
 from apis.shared.models.managed_models import (
     create_managed_model,
     get_managed_model,
@@ -941,6 +941,15 @@ router.include_router(user_menu_links_admin_router)
 from .system_prompts.routes import router as system_prompts_admin_router
 
 router.include_router(system_prompts_admin_router)
+
+# ========== Include Announcements Admin Subrouter (conditional) ==========
+# Default ON with a kill switch. While ANNOUNCEMENTS_ENABLED=false the admin
+# authoring API is unmounted so the surface 404s, but the data and code remain
+# intact (the SKILLS_ENABLED mount pattern).
+if announcements_enabled():
+    from .announcements.routes import router as announcements_admin_router
+
+    router.include_router(announcements_admin_router)
 
 # ========== Include Fine-Tuning Admin Subrouter (conditional) ==========
 if os.environ.get("FINE_TUNING_ENABLED", "false").lower() == "true":

--- a/backend/src/apis/shared/announcements/__init__.py
+++ b/backend/src/apis/shared/announcements/__init__.py
@@ -1,0 +1,5 @@
+"""Feature announcements: admin-authored notices with per-user acknowledgement.
+
+See ``docs/specs/feature-announcements.md``. PR-1 ships the storage layer and
+the admin CRUD only — nothing here is read by a user-facing surface yet.
+"""

--- a/backend/src/apis/shared/announcements/models.py
+++ b/backend/src/apis/shared/announcements/models.py
@@ -1,0 +1,445 @@
+"""Models for admin-authored feature announcements and per-user acknowledgements.
+
+See ``docs/specs/feature-announcements.md``.
+
+Two item shapes share one table:
+
+  - **Announcement** — ``PK: ANNOUNCEMENTS``, ``SK: ANNOUNCEMENT#<uuid>``.
+    A single fixed partition, exactly as ``user_menu_links`` uses, because the
+    data is global / single-tenant. When per-org scoping is needed the PK
+    becomes ``ANNOUNCEMENTS#<org_id>`` without touching the SK shape.
+  - **Acknowledgement** — ``PK: USER#<user_id>``,
+    ``SK: ACK#<announcement_id>#R<revision>``. The same per-user partition
+    shape ``user_settings`` established. Revision-keyed (§D4) so editing an
+    announcement does not un-dismiss it for everybody, while an explicit
+    "show this again" does.
+
+The whole field set is modelled here even though PR-1 consumes only part of it:
+the table is the expensive thing to change, the routes are not.
+"""
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from apis.shared.timestamps import from_iso, to_iso, utc_now_iso
+# One implementation of the http(s)-only check, not two — announcements
+# validate ``ctaUrl`` for exactly the reason ``user_menu_links`` validates
+# ``url`` (Angular's DomSanitizer never sees a request made with curl).
+from apis.shared.user_menu_links.models import validate_http_url
+
+AnnouncementSurface = Literal["panel", "banner", "modal"]
+AnnouncementSeverity = Literal["info", "success", "warning"]
+AnnouncementState = Literal["draft", "scheduled", "published", "archived"]
+AckAction = Literal["seen", "dismissed", "acknowledged"]
+
+ANNOUNCEMENTS_PK = "ANNOUNCEMENTS"
+ANNOUNCEMENT_SK_PREFIX = "ANNOUNCEMENT#"
+ACK_SK_PREFIX = "ACK#"
+
+TITLE_MAX_LENGTH = 140
+BODY_MAX_BYTES = 16 * 1024
+
+#: Acknowledgement actions are *ranked*, and the stored rank only ever
+#: increases (§D2). ``seen`` is written automatically on render, so it races
+#: the user's click on the ✕; without a monotonic guard a late ``seen`` write
+#: would clobber ``dismissed`` and the banner would come back. Same failure
+#: class as #741 / #751 — per-user state moving backwards — so it gets the
+#: same discipline: the guard lives in the DynamoDB condition expression, not
+#: in application ordering.
+ACTION_RANKS: Dict[str, int] = {"seen": 1, "dismissed": 2, "acknowledged": 3}
+
+#: A rank at or above this suppresses the loud surfaces (banner, modal).
+SUPPRESSING_RANK = ACTION_RANKS["dismissed"]
+
+#: Ack TTLs (§5). Bounded forever without a sweeper.
+ACK_TTL_AFTER_EXPIRY = timedelta(days=90)
+ACK_TTL_OPEN_ENDED = timedelta(days=730)
+
+_LOUD_SURFACES = frozenset({"banner", "modal"})
+
+
+def action_rank(action: str) -> int:
+    """Rank for an ack action; raises on an unknown one."""
+    try:
+        return ACTION_RANKS[action]
+    except KeyError:
+        raise ValueError(f"unknown acknowledgement action: {action!r}") from None
+
+
+def _validate_iso(value: Optional[str], field_name: str) -> Optional[str]:
+    """Normalize an ISO-8601 timestamp, or raise.
+
+    Stored normalized (``…Z``) so string comparison against ``utc_now_iso()``
+    in the visibility filter is a valid instant comparison.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        return to_iso(from_iso(value))
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from e
+
+
+def _validate_surfaces_expiry(
+    surfaces: List[str], expires_at: Optional[str]
+) -> None:
+    """A loud surface must say when it stops being loud (§5, §11).
+
+    An unbounded banner or modal is the announcement-fatigue failure mode with
+    no backstop, so the requirement is enforced at the model layer rather than
+    left to the admin form.
+    """
+    if expires_at:
+        return
+    loud = sorted(_LOUD_SURFACES.intersection(surfaces))
+    if loud:
+        raise ValueError(
+            "expiresAt is required when surfaces include " + ", ".join(loud)
+        )
+
+
+def _validate_body_size(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return value
+    if len(value.encode("utf-8")) > BODY_MAX_BYTES:
+        raise ValueError(f"body_markdown must be at most {BODY_MAX_BYTES} bytes")
+    return value
+
+
+# =============================================================================
+# Stored items
+# =============================================================================
+
+
+@dataclass
+class Announcement:
+    """One admin-authored announcement stored in DynamoDB."""
+
+    announcement_id: str
+    title: str
+    body_markdown: str
+    created_at: str
+    updated_at: str
+    publish_at: str
+    summary: Optional[str] = None
+    surfaces: List[str] = field(default_factory=lambda: ["panel"])
+    severity: str = "info"
+    state: str = "draft"
+    expires_at: Optional[str] = None
+    # ⚠️ **Display filter, not an RBAC grant (§D9).** CLAUDE.md's rule that a
+    # role list on a resource must be written through to each role's
+    # ``granted*`` list governs tools, models, and skills — things with a
+    # ``can_access_*`` predicate behind them. Announcement visibility is not
+    # access control: there is no capability conferred and nothing to inherit,
+    # so this list is matched against ``User.roles`` at read time and lives
+    # **only** on this item. Do not "fix" it into ``apis/shared/rbac/``; doing
+    # so would put display metadata into the access-decision path.
+    target_roles: List[str] = field(default_factory=lambda: ["*"])
+    show_to_new_users: bool = False
+    requires_ack: bool = False
+    cta_label: Optional[str] = None
+    cta_url: Optional[str] = None
+    revision: int = 1
+    created_by: Optional[str] = None
+
+    def to_dynamo_item(self) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "PK": ANNOUNCEMENTS_PK,
+            "SK": f"{ANNOUNCEMENT_SK_PREFIX}{self.announcement_id}",
+            "announcementId": self.announcement_id,
+            "title": self.title,
+            "bodyMarkdown": self.body_markdown,
+            "surfaces": list(self.surfaces),
+            "severity": self.severity,
+            "state": self.state,
+            "publishAt": self.publish_at,
+            "targetRoles": list(self.target_roles),
+            "showToNewUsers": self.show_to_new_users,
+            "requiresAck": self.requires_ack,
+            "revision": int(self.revision),
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+        if self.summary:
+            item["summary"] = self.summary
+        if self.expires_at:
+            item["expiresAt"] = self.expires_at
+        if self.cta_label:
+            item["ctaLabel"] = self.cta_label
+        if self.cta_url:
+            item["ctaUrl"] = self.cta_url
+        if self.created_by:
+            item["createdBy"] = self.created_by
+        return item
+
+    @classmethod
+    def from_dynamo_item(cls, item: Dict[str, Any]) -> "Announcement":
+        try:
+            created_at = item["createdAt"]
+            updated_at = item["updatedAt"]
+            publish_at = item["publishAt"]
+        except KeyError as e:
+            raise ValueError(
+                f"Announcement item {item.get('SK', '?')} is missing required "
+                f"field: {e.args[0]}"
+            ) from e
+        return cls(
+            announcement_id=item["announcementId"],
+            title=item["title"],
+            body_markdown=item.get("bodyMarkdown", ""),
+            summary=item.get("summary"),
+            surfaces=list(item.get("surfaces") or ["panel"]),
+            severity=item.get("severity", "info"),
+            state=item.get("state", "draft"),
+            publish_at=publish_at,
+            expires_at=item.get("expiresAt"),
+            target_roles=list(item.get("targetRoles") or ["*"]),
+            show_to_new_users=bool(item.get("showToNewUsers", False)),
+            requires_ack=bool(item.get("requiresAck", False)),
+            cta_label=item.get("ctaLabel"),
+            cta_url=item.get("ctaUrl"),
+            revision=int(item.get("revision", 1)),
+            created_at=created_at,
+            updated_at=updated_at,
+            created_by=item.get("createdBy"),
+        )
+
+    def ack_ttl(self, action: str) -> Optional[int]:
+        """Epoch-seconds TTL for an ack on this announcement, or None to keep it.
+
+        ``acknowledged`` on a ``requiresAck`` announcement is a compliance
+        record, so it is deliberately **not** expired — the archive path
+        disposes of those on purpose (§5).
+        """
+        if self.requires_ack and action == "acknowledged":
+            return None
+        if self.expires_at:
+            anchor = from_iso(self.expires_at) + ACK_TTL_AFTER_EXPIRY
+        else:
+            anchor = from_iso(self.publish_at) + ACK_TTL_OPEN_ENDED
+        return int(anchor.timestamp())
+
+
+@dataclass
+class AnnouncementAck:
+    """One user's acknowledgement of one revision of one announcement."""
+
+    user_id: str
+    announcement_id: str
+    revision: int
+    action: str
+    action_at: str
+    surface: str
+    action_rank: int = 0
+    ttl: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.action_rank:
+            self.action_rank = action_rank(self.action)
+
+    @staticmethod
+    def sort_key(announcement_id: str, revision: int) -> str:
+        return f"{ACK_SK_PREFIX}{announcement_id}#R{int(revision)}"
+
+    @staticmethod
+    def partition_key(user_id: str) -> str:
+        return f"USER#{user_id}"
+
+    @classmethod
+    def from_dynamo_item(cls, item: Dict[str, Any]) -> "AnnouncementAck":
+        pk = item.get("PK", "")
+        return cls(
+            user_id=pk[len("USER#"):] if pk.startswith("USER#") else pk,
+            announcement_id=item["announcementId"],
+            revision=int(item["revision"]),
+            action=item["action"],
+            action_rank=int(item.get("actionRank", 0)),
+            action_at=item.get("actionAt", ""),
+            surface=item.get("surface", ""),
+            ttl=int(item["ttl"]) if item.get("ttl") is not None else None,
+        )
+
+
+# =============================================================================
+# Pydantic request/response models
+# =============================================================================
+
+
+class AnnouncementCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=TITLE_MAX_LENGTH)
+    body_markdown: str = Field(..., min_length=1)
+    summary: Optional[str] = Field(None, max_length=280)
+    surfaces: List[AnnouncementSurface] = Field(default_factory=lambda: ["panel"])
+    severity: AnnouncementSeverity = "info"
+    # Only an *unpublished* state may be chosen at create time. Going live is
+    # its own action, so an announcement can never be published by the same
+    # call that is still validating its body.
+    state: Literal["draft", "scheduled"] = "draft"
+    publish_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    target_roles: List[str] = Field(default_factory=lambda: ["*"])
+    show_to_new_users: bool = False
+    requires_ack: bool = False
+    cta_label: Optional[str] = Field(None, max_length=64)
+    cta_url: Optional[str] = Field(None, max_length=2048)
+
+    @field_validator("body_markdown")
+    @classmethod
+    def _check_body_size(cls, v: str) -> str:
+        return _validate_body_size(v)
+
+    @field_validator("cta_url")
+    @classmethod
+    def _check_cta_url(cls, v: Optional[str]) -> Optional[str]:
+        return validate_http_url(v)
+
+    @field_validator("publish_at")
+    @classmethod
+    def _check_publish_at(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_iso(v, "publish_at")
+
+    @field_validator("expires_at")
+    @classmethod
+    def _check_expires_at(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_iso(v, "expires_at")
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> "AnnouncementCreate":
+        validate_announcement_invariants(
+            surfaces=list(self.surfaces),
+            expires_at=self.expires_at,
+            publish_at=self.publish_at,
+            cta_label=self.cta_label,
+            cta_url=self.cta_url,
+        )
+        return self
+
+
+class AnnouncementUpdate(BaseModel):
+    """Partial update — all fields optional.
+
+    Two fields are deliberately **absent**, because both are transitions rather
+    than content:
+
+    * ``state`` — ``/publish`` and ``/archive`` own it. Accepting it here would
+      make the publish guard decorative: an archived announcement could be put
+      back on screen by a PATCH that looks like an ordinary body edit.
+    * ``revision`` — bumping it re-shows the announcement to everyone who
+      already dismissed it, so it is the explicit ``/revise`` action (§D4) and
+      never a side effect of fixing a typo.
+    """
+
+    title: Optional[str] = Field(None, min_length=1, max_length=TITLE_MAX_LENGTH)
+    body_markdown: Optional[str] = Field(None, min_length=1)
+    summary: Optional[str] = Field(None, max_length=280)
+    surfaces: Optional[List[AnnouncementSurface]] = None
+    severity: Optional[AnnouncementSeverity] = None
+    publish_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    target_roles: Optional[List[str]] = None
+    show_to_new_users: Optional[bool] = None
+    requires_ack: Optional[bool] = None
+    cta_label: Optional[str] = Field(None, max_length=64)
+    cta_url: Optional[str] = Field(None, max_length=2048)
+
+    @field_validator("body_markdown")
+    @classmethod
+    def _check_body_size(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_body_size(v)
+
+    @field_validator("cta_url")
+    @classmethod
+    def _check_cta_url(cls, v: Optional[str]) -> Optional[str]:
+        return validate_http_url(v)
+
+    @field_validator("publish_at")
+    @classmethod
+    def _check_publish_at(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_iso(v, "publish_at")
+
+    @field_validator("expires_at")
+    @classmethod
+    def _check_expires_at(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_iso(v, "expires_at")
+
+
+class AnnouncementAckRequest(BaseModel):
+    """Body of ``POST /announcements/{id}/ack`` (consumed in PR-2)."""
+
+    action: AckAction
+    surface: AnnouncementSurface
+
+
+class AnnouncementResponse(BaseModel):
+    announcement_id: str
+    title: str
+    body_markdown: str
+    summary: Optional[str] = None
+    surfaces: List[str]
+    severity: str
+    state: str
+    publish_at: str
+    expires_at: Optional[str] = None
+    target_roles: List[str]
+    show_to_new_users: bool
+    requires_ack: bool
+    cta_label: Optional[str] = None
+    cta_url: Optional[str] = None
+    revision: int
+    created_at: str
+    updated_at: str
+    created_by: Optional[str] = None
+
+    @classmethod
+    def from_announcement(cls, a: Announcement) -> "AnnouncementResponse":
+        return cls(
+            announcement_id=a.announcement_id,
+            title=a.title,
+            body_markdown=a.body_markdown,
+            summary=a.summary,
+            surfaces=list(a.surfaces),
+            severity=a.severity,
+            state=a.state,
+            publish_at=a.publish_at,
+            expires_at=a.expires_at,
+            target_roles=list(a.target_roles),
+            show_to_new_users=a.show_to_new_users,
+            requires_ack=a.requires_ack,
+            cta_label=a.cta_label,
+            cta_url=a.cta_url,
+            revision=a.revision,
+            created_at=a.created_at,
+            updated_at=a.updated_at,
+            created_by=a.created_by,
+        )
+
+
+class AnnouncementListResponse(BaseModel):
+    announcements: List[AnnouncementResponse]
+    total: int
+
+
+def validate_announcement_invariants(
+    *,
+    surfaces: List[str],
+    expires_at: Optional[str],
+    publish_at: Optional[str] = None,
+    cta_label: Optional[str] = None,
+    cta_url: Optional[str] = None,
+) -> None:
+    """Cross-field rules, shared by create validation and post-merge update.
+
+    Raised as ``ValueError`` so pydantic reports it as a 422 on create and the
+    route maps it to a 400 on a partial update whose *merged* result is
+    invalid — the same split ``user_menu_links`` uses.
+    """
+    _validate_surfaces_expiry(surfaces, expires_at)
+    if cta_url and not cta_label:
+        raise ValueError("cta_label is required when cta_url is set")
+    if cta_label and not cta_url:
+        raise ValueError("cta_url is required when cta_label is set")
+    if publish_at and expires_at and expires_at <= publish_at:
+        raise ValueError("expires_at must be after publish_at")

--- a/backend/src/apis/shared/announcements/repository.py
+++ b/backend/src/apis/shared/announcements/repository.py
@@ -1,0 +1,403 @@
+"""DynamoDB repository for feature announcements and per-user acknowledgements.
+
+Two access patterns, one table:
+
+  - announcements: ``query`` on the fixed ``ANNOUNCEMENTS`` partition, exactly
+    as ``UserMenuLinksRepository.list_links`` does. Volume is tens of items, so
+    no GSI.
+  - acknowledgements: ``query`` on ``USER#<id>`` with ``begins_with(SK, "ACK#")``,
+    bounded by the number of announcements a user has ever interacted with.
+
+The write worth reading closely is :meth:`record_ack`.
+"""
+
+import logging
+import os
+import uuid
+from typing import List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from apis.shared.timestamps import utc_now_iso
+
+from .models import (
+    ACK_SK_PREFIX,
+    ANNOUNCEMENT_SK_PREFIX,
+    ANNOUNCEMENTS_PK,
+    Announcement,
+    AnnouncementAck,
+    AnnouncementCreate,
+    AnnouncementUpdate,
+    action_rank,
+    validate_announcement_invariants,
+)
+from apis.shared.user_menu_links.models import validate_http_url
+
+logger = logging.getLogger(__name__)
+
+
+class AnnouncementsRepository:
+    """CRUD for announcements + the monotonic ack write path."""
+
+    def __init__(self, table_name: Optional[str] = None, region: Optional[str] = None):
+        self._table_name = table_name or os.getenv("DYNAMODB_ANNOUNCEMENTS_TABLE_NAME")
+        self._region = region or os.getenv("AWS_REGION", "us-west-2")
+        self._enabled = bool(self._table_name)
+
+        if not self._enabled:
+            logger.warning(
+                "DYNAMODB_ANNOUNCEMENTS_TABLE_NAME not set. "
+                "Announcements repository is disabled."
+            )
+            return
+
+        profile = os.getenv("AWS_PROFILE")
+        if profile:
+            session = boto3.Session(profile_name=profile)
+            self._dynamodb = session.resource("dynamodb", region_name=self._region)
+        else:
+            self._dynamodb = boto3.resource("dynamodb", region_name=self._region)
+        self._table = self._dynamodb.Table(self._table_name)
+        logger.info(f"Initialized announcements repository: table={self._table_name}")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    # ------------------------------------------------------------------
+    # Announcements
+    # ------------------------------------------------------------------
+
+    async def list_announcements(
+        self, states: Optional[List[str]] = None
+    ) -> List[Announcement]:
+        if not self._enabled:
+            return []
+
+        kwargs = dict(
+            KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+            ExpressionAttributeValues={
+                ":pk": ANNOUNCEMENTS_PK,
+                ":sk": ANNOUNCEMENT_SK_PREFIX,
+            },
+        )
+        try:
+            response = self._table.query(**kwargs)
+            items = response.get("Items", [])
+            while "LastEvaluatedKey" in response:
+                response = self._table.query(
+                    ExclusiveStartKey=response["LastEvaluatedKey"], **kwargs
+                )
+                items.extend(response.get("Items", []))
+        except ClientError:
+            logger.error("Error listing announcements", exc_info=True)
+            raise
+
+        announcements = [Announcement.from_dynamo_item(item) for item in items]
+        if states:
+            wanted = set(states)
+            announcements = [a for a in announcements if a.state in wanted]
+        # Newest first — the admin list and the What's-New panel both read
+        # reverse-chronologically.
+        announcements.sort(key=lambda a: (a.publish_at, a.created_at), reverse=True)
+        return announcements
+
+    async def get_announcement(self, announcement_id: str) -> Optional[Announcement]:
+        if not self._enabled:
+            return None
+        try:
+            response = self._table.get_item(
+                Key={
+                    "PK": ANNOUNCEMENTS_PK,
+                    "SK": f"{ANNOUNCEMENT_SK_PREFIX}{announcement_id}",
+                }
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return Announcement.from_dynamo_item(item)
+        except ClientError:
+            logger.error("Error getting announcement", exc_info=True)
+            raise
+
+    async def create_announcement(
+        self, data: AnnouncementCreate, created_by: Optional[str] = None
+    ) -> Announcement:
+        if not self._enabled:
+            raise RuntimeError("Announcements repository is not enabled")
+
+        now = utc_now_iso()
+        announcement = Announcement(
+            announcement_id=str(uuid.uuid4()),
+            title=data.title,
+            body_markdown=data.body_markdown,
+            summary=data.summary,
+            surfaces=list(data.surfaces),
+            severity=data.severity,
+            state=data.state,
+            publish_at=data.publish_at or now,
+            expires_at=data.expires_at,
+            target_roles=list(data.target_roles),
+            show_to_new_users=data.show_to_new_users,
+            requires_ack=data.requires_ack,
+            cta_label=data.cta_label,
+            cta_url=data.cta_url,
+            revision=1,
+            created_at=now,
+            updated_at=now,
+            created_by=created_by,
+        )
+
+        try:
+            self._table.put_item(
+                Item=announcement.to_dynamo_item(),
+                ConditionExpression="attribute_not_exists(SK)",
+            )
+        except ClientError:
+            logger.error("Error creating announcement", exc_info=True)
+            raise
+
+        logger.info(f"Created announcement: {announcement.announcement_id}")
+        return announcement
+
+    async def update_announcement(
+        self, announcement_id: str, updates: AnnouncementUpdate
+    ) -> Optional[Announcement]:
+        """Partial update. ``revision`` is untouched by design (§D4) — a typo
+        fix must not re-fire a modal at the whole user base."""
+        if not self._enabled:
+            return None
+
+        existing = await self.get_announcement(announcement_id)
+        if not existing:
+            return None
+
+        for field_name, value in updates.model_dump(exclude_none=True).items():
+            setattr(existing, field_name, value)
+        existing.updated_at = utc_now_iso()
+
+        # Re-validate the merged record: a PATCH that only adds `banner` to
+        # `surfaces` is individually valid and jointly not.
+        validate_announcement_invariants(
+            surfaces=list(existing.surfaces),
+            expires_at=existing.expires_at,
+            publish_at=existing.publish_at,
+            cta_label=existing.cta_label,
+            cta_url=existing.cta_url,
+        )
+        validate_http_url(existing.cta_url)
+
+        try:
+            self._table.put_item(Item=existing.to_dynamo_item())
+        except ClientError:
+            logger.error("Error updating announcement", exc_info=True)
+            raise
+
+        logger.info(f"Updated announcement: {announcement_id}")
+        return existing
+
+    async def set_state(
+        self, announcement_id: str, state: str
+    ) -> Optional[Announcement]:
+        if not self._enabled:
+            return None
+        existing = await self.get_announcement(announcement_id)
+        if not existing:
+            return None
+        existing.state = state
+        existing.updated_at = utc_now_iso()
+        try:
+            self._table.put_item(Item=existing.to_dynamo_item())
+        except ClientError:
+            logger.error("Error updating announcement state", exc_info=True)
+            raise
+        logger.info(f"Announcement {announcement_id} state -> {state}")
+        return existing
+
+    async def bump_revision(self, announcement_id: str) -> Optional[Announcement]:
+        """"Show this again" (§D4).
+
+        Every user's suppression lapses at once because their acks are keyed by
+        the old revision. The R1 acks stay readable, which is what lets the
+        panel mark the entry *Updated* rather than plain unread.
+        """
+        if not self._enabled:
+            return None
+        existing = await self.get_announcement(announcement_id)
+        if not existing:
+            return None
+        existing.revision = int(existing.revision) + 1
+        existing.updated_at = utc_now_iso()
+        try:
+            self._table.put_item(Item=existing.to_dynamo_item())
+        except ClientError:
+            logger.error("Error bumping announcement revision", exc_info=True)
+            raise
+        logger.info(
+            f"Announcement {announcement_id} revision -> {existing.revision}"
+        )
+        return existing
+
+    async def delete_announcement(self, announcement_id: str) -> bool:
+        if not self._enabled:
+            return False
+        existing = await self.get_announcement(announcement_id)
+        if not existing:
+            return False
+        try:
+            self._table.delete_item(
+                Key={
+                    "PK": ANNOUNCEMENTS_PK,
+                    "SK": f"{ANNOUNCEMENT_SK_PREFIX}{announcement_id}",
+                }
+            )
+        except ClientError:
+            logger.error("Error deleting announcement", exc_info=True)
+            raise
+        logger.info(f"Deleted announcement: {announcement_id}")
+        return True
+
+    # ------------------------------------------------------------------
+    # Acknowledgements
+    # ------------------------------------------------------------------
+
+    async def record_ack(
+        self,
+        *,
+        user_id: str,
+        announcement_id: str,
+        revision: int,
+        action: str,
+        surface: str,
+        ttl: Optional[int] = None,
+    ) -> bool:
+        """Record an ack, **monotonically** (§D2).
+
+        Returns True if this write raised the stored rank, False if the guard
+        rejected it because an equal-or-stronger action was already recorded.
+        **False is success, not an error.** ``seen`` is written automatically
+        the moment a surface renders, so it races the user's click on the ✕;
+        without the condition a late ``seen`` would overwrite ``dismissed`` and
+        the banner would come back on the next load. The guard belongs in the
+        database, not in application ordering — see #741 / #751, whose shape
+        was exactly this.
+        """
+        if not self._enabled:
+            return False
+
+        rank = action_rank(action)
+        now = utc_now_iso()
+
+        expression_values = {
+            ":rank": rank,
+            ":action": action,
+            ":now": now,
+            ":announcementId": announcement_id,
+            ":revision": int(revision),
+            ":surface": surface,
+        }
+        set_clause = (
+            "SET actionRank = :rank, #action = :action, actionAt = :now, "
+            "announcementId = :announcementId, #revision = :revision, "
+            "#surface = :surface"
+        )
+        names = {
+            "#action": "action",       # reserved word
+            "#revision": "revision",
+            "#surface": "surface",
+        }
+        if ttl is None:
+            # A compliance-bearing ack (§5): clear any TTL a weaker earlier
+            # action may have set, rather than letting it expire the record.
+            update_expression = f"{set_clause} REMOVE #ttl"
+            names["#ttl"] = "ttl"
+        else:
+            update_expression = f"{set_clause}, #ttl = :ttl"
+            names["#ttl"] = "ttl"
+            expression_values[":ttl"] = int(ttl)
+
+        try:
+            self._table.update_item(
+                Key={
+                    "PK": AnnouncementAck.partition_key(user_id),
+                    "SK": AnnouncementAck.sort_key(announcement_id, revision),
+                },
+                UpdateExpression=update_expression,
+                ConditionExpression=(
+                    "attribute_not_exists(actionRank) OR actionRank < :rank"
+                ),
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues=expression_values,
+            )
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                # Already at or above this rank. Nothing to do, and nothing wrong.
+                logger.debug(
+                    "Ack not raised (already >= rank): user=%s announcement=%s "
+                    "revision=%s action=%s",
+                    user_id,
+                    announcement_id,
+                    revision,
+                    action,
+                )
+                return False
+            logger.error("Error recording announcement ack", exc_info=True)
+            raise
+        return True
+
+    async def list_acks(self, user_id: str) -> List[AnnouncementAck]:
+        """Every ack this user has ever written, across revisions."""
+        if not self._enabled:
+            return []
+
+        kwargs = dict(
+            KeyConditionExpression="PK = :pk AND begins_with(SK, :sk)",
+            ExpressionAttributeValues={
+                ":pk": AnnouncementAck.partition_key(user_id),
+                ":sk": ACK_SK_PREFIX,
+            },
+        )
+        try:
+            response = self._table.query(**kwargs)
+            items = response.get("Items", [])
+            while "LastEvaluatedKey" in response:
+                response = self._table.query(
+                    ExclusiveStartKey=response["LastEvaluatedKey"], **kwargs
+                )
+                items.extend(response.get("Items", []))
+        except ClientError:
+            logger.error("Error listing announcement acks", exc_info=True)
+            raise
+
+        return [AnnouncementAck.from_dynamo_item(item) for item in items]
+
+    async def get_ack(
+        self, user_id: str, announcement_id: str, revision: int
+    ) -> Optional[AnnouncementAck]:
+        if not self._enabled:
+            return None
+        try:
+            response = self._table.get_item(
+                Key={
+                    "PK": AnnouncementAck.partition_key(user_id),
+                    "SK": AnnouncementAck.sort_key(announcement_id, revision),
+                }
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return AnnouncementAck.from_dynamo_item(item)
+        except ClientError:
+            logger.error("Error getting announcement ack", exc_info=True)
+            raise
+
+
+_repository: Optional[AnnouncementsRepository] = None
+
+
+def get_announcements_repository() -> AnnouncementsRepository:
+    global _repository
+    if _repository is None:
+        _repository = AnnouncementsRepository()
+    return _repository

--- a/backend/src/apis/shared/announcements/service.py
+++ b/backend/src/apis/shared/announcements/service.py
@@ -1,0 +1,135 @@
+"""Service layer for feature announcements.
+
+Thin over the repository, with two pieces of policy that must not live in a
+route handler because PR-2's user-facing surface will call the same methods:
+
+  - ``panel`` is forced into ``surfaces`` (§D1) — dismissing a loud surface can
+    never destroy the information.
+  - ack TTLs are derived from the announcement, not supplied by the caller
+    (§5), so a client cannot pick its own retention.
+"""
+
+import logging
+from typing import List, Optional
+
+from .models import (
+    Announcement,
+    AnnouncementAck,
+    AnnouncementCreate,
+    AnnouncementUpdate,
+)
+from .repository import AnnouncementsRepository, get_announcements_repository
+
+logger = logging.getLogger(__name__)
+
+#: A published announcement can only come from these; archived is terminal.
+PUBLISHABLE_STATES = frozenset({"draft", "scheduled", "published"})
+
+#: Canonical surface order, so the stored list is deterministic regardless of
+#: what order the admin form submitted.
+_SURFACE_ORDER = ("panel", "banner", "modal")
+
+
+def _normalize_surfaces(surfaces: Optional[List[str]]) -> List[str]:
+    """Force ``panel`` on and put the list in canonical order (§D1)."""
+    chosen = set(surfaces or [])
+    chosen.add("panel")
+    return [s for s in _SURFACE_ORDER if s in chosen]
+
+
+class AnnouncementsService:
+    def __init__(self, repository: AnnouncementsRepository):
+        self._repo = repository
+
+    @property
+    def enabled(self) -> bool:
+        return self._repo.enabled
+
+    # ── Announcements ────────────────────────────────────────────────────
+
+    async def list_announcements(
+        self, states: Optional[List[str]] = None
+    ) -> List[Announcement]:
+        return await self._repo.list_announcements(states=states)
+
+    async def get_announcement(self, announcement_id: str) -> Optional[Announcement]:
+        return await self._repo.get_announcement(announcement_id)
+
+    async def create_announcement(
+        self, data: AnnouncementCreate, created_by: Optional[str] = None
+    ) -> Announcement:
+        data = data.model_copy(update={"surfaces": _normalize_surfaces(data.surfaces)})
+        return await self._repo.create_announcement(data, created_by=created_by)
+
+    async def update_announcement(
+        self, announcement_id: str, updates: AnnouncementUpdate
+    ) -> Optional[Announcement]:
+        if updates.surfaces is not None:
+            updates = updates.model_copy(
+                update={"surfaces": _normalize_surfaces(updates.surfaces)}
+            )
+        return await self._repo.update_announcement(announcement_id, updates)
+
+    async def publish(self, announcement_id: str) -> Optional[Announcement]:
+        existing = await self._repo.get_announcement(announcement_id)
+        if not existing:
+            return None
+        if existing.state not in PUBLISHABLE_STATES:
+            raise ValueError(
+                f"cannot publish an announcement in state '{existing.state}'"
+            )
+        return await self._repo.set_state(announcement_id, "published")
+
+    async def archive(self, announcement_id: str) -> Optional[Announcement]:
+        """Stop showing it. Acks are deliberately kept — the record of who saw
+        what outlives the notice."""
+        return await self._repo.set_state(announcement_id, "archived")
+
+    async def revise(self, announcement_id: str) -> Optional[Announcement]:
+        return await self._repo.bump_revision(announcement_id)
+
+    async def delete_announcement(self, announcement_id: str) -> bool:
+        return await self._repo.delete_announcement(announcement_id)
+
+    # ── Acknowledgements ─────────────────────────────────────────────────
+
+    async def record_ack(
+        self,
+        *,
+        user_id: str,
+        announcement: Announcement,
+        action: str,
+        surface: str,
+    ) -> bool:
+        """Record an ack against the announcement's **current** revision.
+
+        Returns whether the stored rank was raised; False means an
+        equal-or-stronger action was already recorded, which is a no-op, not a
+        failure (§D2).
+        """
+        return await self._repo.record_ack(
+            user_id=user_id,
+            announcement_id=announcement.announcement_id,
+            revision=announcement.revision,
+            action=action,
+            surface=surface,
+            ttl=announcement.ack_ttl(action),
+        )
+
+    async def list_acks(self, user_id: str) -> List[AnnouncementAck]:
+        return await self._repo.list_acks(user_id)
+
+    async def get_ack(
+        self, user_id: str, announcement_id: str, revision: int
+    ) -> Optional[AnnouncementAck]:
+        return await self._repo.get_ack(user_id, announcement_id, revision)
+
+
+_service: Optional[AnnouncementsService] = None
+
+
+def get_announcements_service() -> AnnouncementsService:
+    global _service
+    if _service is None:
+        _service = AnnouncementsService(get_announcements_repository())
+    return _service

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -171,3 +171,23 @@ def mid_turn_steering_enabled() -> bool:
     transitional: a turn that calls no tools has no boundary to inject at.
     """
     return os.environ.get("MID_TURN_STEERING_ENABLED", "").strip().lower() != "false"
+
+
+def announcements_enabled() -> bool:
+    """Whether the feature-announcement system is enabled for this environment.
+
+    Covers the admin authoring surface (``/admin/announcements``) today, and
+    the user-facing ``GET /announcements`` + ack endpoint and the panel /
+    banner / modal surfaces as those land. **Default ON with a kill switch**
+    (house style, mirroring ``scheduled_runs_enabled``): unset or empty
+    resolves to enabled; only the literal ``"false"`` (case-insensitive)
+    disables.
+
+    While off, the admin router is unmounted so the surface 404s; the data and
+    code remain intact. There is no separate RBAC capability on this axis —
+    *who* may author is the delegable ``admin.announcements`` scope, and *who
+    sees* a published announcement is the announcement's own ``targetRoles``
+    display filter (which is deliberately **not** an RBAC grant; see
+    ``docs/specs/feature-announcements.md`` §D9).
+    """
+    return os.environ.get("ANNOUNCEMENTS_ENABLED", "").strip().lower() != "false"

--- a/backend/src/apis/shared/rbac/admin_scopes.py
+++ b/backend/src/apis/shared/rbac/admin_scopes.py
@@ -139,6 +139,13 @@ ADMIN_SCOPES: tuple[AdminScope, ...] = (
         group=GROUP_CUSTOMIZATION,
         description="Manage the custom links shown in the user menu.",
     ),
+    AdminScope(
+        id="admin.announcements",
+        label="Announcements",
+        group=GROUP_CUSTOMIZATION,
+        description="Author and publish feature announcements shown to all users.",
+        delegable=True,
+    ),
     # ── Non-delegable ────────────────────────────────────────────────────────
     # Present in the registry so they are named, documented, and covered by the
     # route-coverage test — but rejected by validation if anyone tries to grant

--- a/backend/src/apis/shared/user_menu_links/models.py
+++ b/backend/src/apis/shared/user_menu_links/models.py
@@ -34,6 +34,12 @@ def _validate_http_url(value: Optional[str]) -> Optional[str]:
     return value
 
 
+# Public handle on the same check. ``announcements`` validates its ``ctaUrl``
+# for exactly this reason, and one implementation is better than two that can
+# drift apart.
+validate_http_url = _validate_http_url
+
+
 @dataclass
 class UserMenuLink:
     """Admin-managed user-menu link stored in DynamoDB."""

--- a/backend/tests/architecture/test_admin_scope_coverage.py
+++ b/backend/tests/architecture/test_admin_scope_coverage.py
@@ -52,6 +52,7 @@ EXPECTED_MODULE_SCOPES = {
     "file_sources/routes.py": "admin.file_sources",
     "export_targets/routes.py": "admin.export_targets",
     "user_menu_links/routes.py": "admin.user_menu_links",
+    "announcements/routes.py": "admin.announcements",
     "system_prompts/routes.py": "admin.system_prompts",
     "fine_tuning/routes.py": "admin.fine_tuning",
 }

--- a/backend/tests/shared/test_announcements.py
+++ b/backend/tests/shared/test_announcements.py
@@ -1,0 +1,546 @@
+"""Tests for the announcements shared module (models + repository + service).
+
+The first class is the one that matters. Everything else here is ordinary CRUD
+coverage; ``TestMonotonicAck`` is the §D2 regression, and the reason the write
+is a conditional ``update_item`` rather than a ``put_item``.
+"""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from pydantic import ValidationError
+
+from apis.shared.announcements.models import (
+    ACTION_RANKS,
+    Announcement,
+    AnnouncementAck,
+    AnnouncementCreate,
+    AnnouncementUpdate,
+)
+from apis.shared.announcements.repository import AnnouncementsRepository
+from apis.shared.announcements.service import AnnouncementsService
+from apis.shared.timestamps import from_iso
+
+AWS_REGION = "us-west-2"
+TABLE_NAME = "test-announcements"
+
+FUTURE = "2099-01-01T00:00:00Z"
+PAST = "2020-01-01T00:00:00Z"
+
+
+@pytest.fixture()
+def announcements_table(aws, monkeypatch):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    ddb.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    monkeypatch.setenv("DYNAMODB_ANNOUNCEMENTS_TABLE_NAME", TABLE_NAME)
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE_NAME)
+
+
+@pytest.fixture()
+def repo(announcements_table):
+    return AnnouncementsRepository(table_name=TABLE_NAME, region=AWS_REGION)
+
+
+@pytest.fixture()
+def service(repo):
+    return AnnouncementsService(repo)
+
+
+def _create(**kw) -> AnnouncementCreate:
+    defaults = dict(
+        title="Skills are here",
+        body_markdown="# Skills\n\nTry them.",
+        publish_at=PAST,
+    )
+    defaults.update(kw)
+    return AnnouncementCreate(**defaults)
+
+
+# ======================================================================
+# §D2 — the monotonic ack guard. Written first; it is the regression.
+# ======================================================================
+
+
+class TestMonotonicAck:
+    @pytest.mark.asyncio
+    async def test_seen_after_dismissed_leaves_dismissed_intact(self, service):
+        """`seen` is written on render and races the user's ✕ click.
+
+        Without the conditional write, the late `seen` wins and the banner is
+        back on the next load. Same failure class as #741 / #751.
+        """
+        announcement = await service.create_announcement(_create())
+
+        assert await service.record_ack(
+            user_id="u1",
+            announcement=announcement,
+            action="dismissed",
+            surface="banner",
+        )
+
+        # The straggler.
+        raised = await service.record_ack(
+            user_id="u1",
+            announcement=announcement,
+            action="seen",
+            surface="banner",
+        )
+
+        assert raised is False, "a weaker action must not raise the stored rank"
+
+        ack = await service.get_ack(
+            "u1", announcement.announcement_id, announcement.revision
+        )
+        assert ack.action == "dismissed"
+        assert ack.action_rank == ACTION_RANKS["dismissed"]
+
+    @pytest.mark.asyncio
+    async def test_a_stronger_action_does_raise_the_rank(self, service):
+        announcement = await service.create_announcement(_create())
+
+        await service.record_ack(
+            user_id="u1", announcement=announcement, action="seen", surface="panel"
+        )
+        raised = await service.record_ack(
+            user_id="u1",
+            announcement=announcement,
+            action="acknowledged",
+            surface="modal",
+        )
+
+        assert raised is True
+        ack = await service.get_ack(
+            "u1", announcement.announcement_id, announcement.revision
+        )
+        assert ack.action == "acknowledged"
+        assert ack.surface == "modal"
+
+    @pytest.mark.asyncio
+    async def test_repeating_the_same_action_is_a_no_op(self, service):
+        """Idempotent: `dismissed` twice must not error and must not downgrade."""
+        announcement = await service.create_announcement(_create())
+
+        assert await service.record_ack(
+            user_id="u1",
+            announcement=announcement,
+            action="dismissed",
+            surface="banner",
+        )
+        assert not await service.record_ack(
+            user_id="u1",
+            announcement=announcement,
+            action="dismissed",
+            surface="banner",
+        )
+
+        ack = await service.get_ack(
+            "u1", announcement.announcement_id, announcement.revision
+        )
+        assert ack.action == "dismissed"
+
+    @pytest.mark.asyncio
+    async def test_acks_are_scoped_to_the_user(self, service):
+        announcement = await service.create_announcement(_create())
+        await service.record_ack(
+            user_id="u1", announcement=announcement, action="dismissed", surface="banner"
+        )
+
+        assert (
+            await service.get_ack(
+                "u2", announcement.announcement_id, announcement.revision
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_is_rejected(self, service):
+        announcement = await service.create_announcement(_create())
+        with pytest.raises(ValueError):
+            await service.record_ack(
+                user_id="u1",
+                announcement=announcement,
+                action="skimmed",
+                surface="panel",
+            )
+
+
+# ======================================================================
+# §D4 — revision keying
+# ======================================================================
+
+
+class TestRevisionKeying:
+    @pytest.mark.asyncio
+    async def test_bumping_revision_leaves_the_new_slot_unacked(self, service):
+        announcement = await service.create_announcement(_create())
+        await service.record_ack(
+            user_id="u1", announcement=announcement, action="dismissed", surface="modal"
+        )
+
+        revised = await service.revise(announcement.announcement_id)
+        assert revised.revision == 2
+
+        # The R2 slot is empty — the user's suppression has lapsed.
+        assert await service.get_ack("u1", revised.announcement_id, 2) is None
+        # …and the R1 history is still readable, which is what lets the panel
+        # mark the entry "Updated" rather than plain unread.
+        r1 = await service.get_ack("u1", revised.announcement_id, 1)
+        assert r1 is not None and r1.action == "dismissed"
+
+        acks = await service.list_acks("u1")
+        assert {a.revision for a in acks} == {1}
+
+    @pytest.mark.asyncio
+    async def test_an_edit_does_not_bump_the_revision(self, service):
+        """A typo fix must not re-fire a modal at the whole user base."""
+        announcement = await service.create_announcement(_create())
+        updated = await service.update_announcement(
+            announcement.announcement_id, AnnouncementUpdate(title="Skills are here!")
+        )
+        assert updated.title == "Skills are here!"
+        assert updated.revision == 1
+
+    @pytest.mark.asyncio
+    async def test_ack_after_revise_records_the_new_revision(self, service):
+        announcement = await service.create_announcement(_create())
+        await service.record_ack(
+            user_id="u1", announcement=announcement, action="seen", surface="panel"
+        )
+        revised = await service.revise(announcement.announcement_id)
+
+        await service.record_ack(
+            user_id="u1", announcement=revised, action="dismissed", surface="banner"
+        )
+
+        acks = {a.revision: a.action for a in await service.list_acks("u1")}
+        assert acks == {1: "seen", 2: "dismissed"}
+
+
+# ======================================================================
+# Validation
+# ======================================================================
+
+
+class TestValidation:
+    def test_banner_requires_expires_at(self):
+        with pytest.raises(ValidationError, match="expiresAt is required"):
+            _create(surfaces=["panel", "banner"])
+
+    def test_modal_requires_expires_at(self):
+        with pytest.raises(ValidationError, match="expiresAt is required"):
+            _create(surfaces=["modal"])
+
+    def test_banner_with_expires_at_is_accepted(self):
+        data = _create(surfaces=["panel", "banner"], expires_at=FUTURE)
+        assert "banner" in data.surfaces
+
+    def test_panel_only_needs_no_expiry(self):
+        assert _create(surfaces=["panel"]).expires_at is None
+
+    def test_cta_url_rejects_javascript_scheme(self):
+        with pytest.raises(ValidationError):
+            _create(cta_label="Learn more", cta_url="javascript:alert(1)")
+
+    def test_cta_url_and_label_travel_together(self):
+        with pytest.raises(ValidationError, match="cta_label is required"):
+            _create(cta_url="https://example.test/x")
+        with pytest.raises(ValidationError, match="cta_url is required"):
+            _create(cta_label="Learn more")
+
+    def test_title_is_capped_at_140(self):
+        with pytest.raises(ValidationError):
+            _create(title="x" * 141)
+
+    def test_body_is_capped_at_16kb(self):
+        with pytest.raises(ValidationError):
+            _create(body_markdown="x" * (16 * 1024 + 1))
+
+    def test_body_cap_counts_bytes_not_characters(self):
+        """A 3-byte character must count as three."""
+        with pytest.raises(ValidationError):
+            _create(body_markdown="✅" * 6000)
+
+    def test_expiry_must_follow_publish(self):
+        with pytest.raises(ValidationError, match="after publish_at"):
+            _create(surfaces=["banner"], publish_at=FUTURE, expires_at=PAST)
+
+    def test_unparseable_timestamp_is_rejected(self):
+        with pytest.raises(ValidationError, match="ISO-8601"):
+            _create(publish_at="last tuesday")
+
+    @pytest.mark.asyncio
+    async def test_patch_that_makes_the_record_invalid_raises(self, service):
+        """Adding `banner` to a record with no `expiresAt` is individually
+        valid and jointly not — so the merged record is re-validated."""
+        announcement = await service.create_announcement(_create())
+        with pytest.raises(ValueError, match="expiresAt is required"):
+            await service.update_announcement(
+                announcement.announcement_id,
+                AnnouncementUpdate(surfaces=["panel", "banner"]),
+            )
+
+
+# ======================================================================
+# Surfaces, state, and storage
+# ======================================================================
+
+
+class TestSurfaces:
+    @pytest.mark.asyncio
+    async def test_panel_is_forced_on(self, service):
+        """Dismissing a loud surface can never destroy the information (§D1)."""
+        created = await service.create_announcement(
+            _create(surfaces=["banner"], expires_at=FUTURE)
+        )
+        assert created.surfaces == ["panel", "banner"]
+
+    @pytest.mark.asyncio
+    async def test_surfaces_are_stored_in_canonical_order(self, service):
+        created = await service.create_announcement(
+            _create(surfaces=["modal", "banner", "panel"], expires_at=FUTURE)
+        )
+        assert created.surfaces == ["panel", "banner", "modal"]
+
+    @pytest.mark.asyncio
+    async def test_patched_surfaces_also_get_panel_forced_on(self, service):
+        announcement = await service.create_announcement(_create())
+        updated = await service.update_announcement(
+            announcement.announcement_id,
+            AnnouncementUpdate(surfaces=["modal"], expires_at=FUTURE),
+        )
+        assert updated.surfaces == ["panel", "modal"]
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_create_defaults_to_draft(self, service):
+        created = await service.create_announcement(_create())
+        assert created.state == "draft"
+        assert created.revision == 1
+        assert created.target_roles == ["*"]
+        assert created.show_to_new_users is False
+
+    @pytest.mark.asyncio
+    async def test_publish_then_archive(self, service):
+        created = await service.create_announcement(_create())
+        published = await service.publish(created.announcement_id)
+        assert published.state == "published"
+        archived = await service.archive(created.announcement_id)
+        assert archived.state == "archived"
+
+    @pytest.mark.asyncio
+    async def test_publishing_an_archived_announcement_is_refused(self, service):
+        created = await service.create_announcement(_create())
+        await service.archive(created.announcement_id)
+        with pytest.raises(ValueError, match="cannot publish"):
+            await service.publish(created.announcement_id)
+
+    @pytest.mark.asyncio
+    async def test_archive_keeps_acks(self, service):
+        """The record of who saw what outlives the notice."""
+        created = await service.create_announcement(_create())
+        await service.record_ack(
+            user_id="u1", announcement=created, action="acknowledged", surface="modal"
+        )
+        await service.archive(created.announcement_id)
+        assert len(await service.list_acks("u1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_id_returns_none_everywhere(self, service):
+        assert await service.get_announcement("nope") is None
+        assert await service.update_announcement("nope", AnnouncementUpdate()) is None
+        assert await service.publish("nope") is None
+        assert await service.archive("nope") is None
+        assert await service.revise("nope") is None
+        assert await service.delete_announcement("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_then_get_is_none(self, service):
+        created = await service.create_announcement(_create())
+        assert await service.delete_announcement(created.announcement_id) is True
+        assert await service.get_announcement(created.announcement_id) is None
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_state_and_sorts_newest_first(self, service):
+        old = await service.create_announcement(
+            _create(title="Old", publish_at="2021-01-01T00:00:00Z")
+        )
+        new = await service.create_announcement(
+            _create(title="New", publish_at="2026-01-01T00:00:00Z")
+        )
+        await service.publish(new.announcement_id)
+
+        every = await service.list_announcements()
+        assert [a.title for a in every] == ["New", "Old"]
+
+        drafts = await service.list_announcements(states=["draft"])
+        assert [a.announcement_id for a in drafts] == [old.announcement_id]
+
+
+class TestStorageShape:
+    @pytest.mark.asyncio
+    async def test_announcement_key_shape(self, service, announcements_table):
+        created = await service.create_announcement(_create())
+        item = announcements_table.get_item(
+            Key={
+                "PK": "ANNOUNCEMENTS",
+                "SK": f"ANNOUNCEMENT#{created.announcement_id}",
+            }
+        )["Item"]
+        assert item["title"] == "Skills are here"
+        assert "ttl" not in item, "announcement rows must never expire"
+
+    @pytest.mark.asyncio
+    async def test_ack_key_shape(self, service, announcements_table):
+        created = await service.create_announcement(_create())
+        await service.record_ack(
+            user_id="u1", announcement=created, action="seen", surface="panel"
+        )
+        item = announcements_table.get_item(
+            Key={
+                "PK": "USER#u1",
+                "SK": f"ACK#{created.announcement_id}#R1",
+            }
+        )["Item"]
+        assert item["action"] == "seen"
+        assert int(item["actionRank"]) == 1
+        assert int(item["revision"]) == 1
+
+    def test_round_trip_preserves_fields(self):
+        a = Announcement(
+            announcement_id="a1",
+            title="T",
+            body_markdown="B",
+            created_at=PAST,
+            updated_at=PAST,
+            publish_at=PAST,
+            summary="S",
+            surfaces=["panel", "modal"],
+            severity="warning",
+            state="published",
+            expires_at=FUTURE,
+            target_roles=["faculty"],
+            show_to_new_users=True,
+            requires_ack=True,
+            cta_label="Read",
+            cta_url="https://example.test/policy",
+            revision=3,
+            created_by="admin@example.test",
+        )
+        assert Announcement.from_dynamo_item(a.to_dynamo_item()) == a
+
+    def test_ack_partition_and_sort_keys(self):
+        assert AnnouncementAck.partition_key("u1") == "USER#u1"
+        assert AnnouncementAck.sort_key("a1", 2) == "ACK#a1#R2"
+
+
+class TestAckTtl:
+    def _announcement(self, **kw) -> Announcement:
+        defaults = dict(
+            announcement_id="a1",
+            title="T",
+            body_markdown="B",
+            created_at=PAST,
+            updated_at=PAST,
+            publish_at=PAST,
+        )
+        defaults.update(kw)
+        return Announcement(**defaults)
+
+    def test_expiring_announcement_ttl_is_expiry_plus_90_days(self):
+        a = self._announcement(expires_at="2030-01-01T00:00:00Z")
+        assert a.ack_ttl("seen") == int(from_iso("2030-04-01T00:00:00Z").timestamp())
+
+    def test_open_ended_announcement_ttl_is_publish_plus_two_years(self):
+        a = self._announcement(publish_at="2030-01-01T00:00:00Z")
+        assert a.ack_ttl("dismissed") == int(
+            from_iso("2032-01-01T00:00:00Z").timestamp()
+        )
+
+    def test_compliance_ack_is_never_expired(self):
+        """A `requiresAck` acknowledgement is a record, so it keeps no TTL."""
+        a = self._announcement(requires_ack=True, expires_at="2030-01-01T00:00:00Z")
+        assert a.ack_ttl("acknowledged") is None
+        # A weaker action on the same announcement still expires.
+        assert a.ack_ttl("seen") is not None
+
+    @pytest.mark.asyncio
+    async def test_upgrading_to_a_compliance_ack_clears_the_ttl(
+        self, service, announcements_table
+    ):
+        """`seen` sets a TTL; the later `acknowledged` must remove it, or the
+        compliance record silently evaporates on the earlier schedule."""
+        created = await service.create_announcement(
+            _create(surfaces=["modal"], expires_at=FUTURE, requires_ack=True)
+        )
+        await service.record_ack(
+            user_id="u1", announcement=created, action="seen", surface="modal"
+        )
+        key = {"PK": "USER#u1", "SK": f"ACK#{created.announcement_id}#R1"}
+        assert "ttl" in announcements_table.get_item(Key=key)["Item"]
+
+        await service.record_ack(
+            user_id="u1", announcement=created, action="acknowledged", surface="modal"
+        )
+        assert "ttl" not in announcements_table.get_item(Key=key)["Item"]
+
+
+class TestDisabledRepository:
+    """No table configured is a disabled repository, not a crash — the table
+    ships in platform.yml while this code ships in backend.yml."""
+
+    @pytest.mark.asyncio
+    async def test_reads_are_empty_and_writes_refuse(self, monkeypatch):
+        monkeypatch.delenv("DYNAMODB_ANNOUNCEMENTS_TABLE_NAME", raising=False)
+        repo = AnnouncementsRepository()
+        assert repo.enabled is False
+        assert await repo.list_announcements() == []
+        assert await repo.get_announcement("a1") is None
+        assert await repo.list_acks("u1") == []
+        assert (
+            await repo.record_ack(
+                user_id="u1",
+                announcement_id="a1",
+                revision=1,
+                action="seen",
+                surface="panel",
+            )
+            is False
+        )
+        with pytest.raises(RuntimeError):
+            await repo.create_announcement(_create())
+
+
+class TestRepositoryErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_a_non_conditional_client_error_is_not_swallowed(self, repo):
+        """Only ConditionalCheckFailedException means "already acked". Any
+        other ClientError is a real fault and must surface."""
+
+        class _Boom:
+            def update_item(self, **_):
+                raise ClientError(
+                    {"Error": {"Code": "ProvisionedThroughputExceededException"}},
+                    "UpdateItem",
+                )
+
+        repo._table = _Boom()
+        with pytest.raises(ClientError):
+            await repo.record_ack(
+                user_id="u1",
+                announcement_id="a1",
+                revision=1,
+                action="seen",
+                surface="panel",
+            )

--- a/backend/tests/shared/test_announcements_routes.py
+++ b/backend/tests/shared/test_announcements_routes.py
@@ -1,0 +1,351 @@
+"""Route tests for the admin announcements endpoints.
+
+PR-1 ships no user-facing surface, so there is only one router to cover. The
+two checks worth naming: ``ctaUrl`` is rejected at the **API**, not only in the
+admin form (anyone can curl this), and the whole package disappears when the
+kill switch is thrown.
+"""
+
+import importlib
+import os
+
+import boto3
+import pytest
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import apis.app_api.admin.routes as admin_routes_module
+from apis.shared.announcements import repository as repo_module
+from apis.shared.announcements import service as service_module
+from apis.shared.auth.models import User
+from tests.conftest import override_admin_auth
+
+AWS_REGION = "us-east-1"
+TABLE_NAME = "test-announcements-routes"
+
+FUTURE = "2099-01-01T00:00:00Z"
+
+
+def _make_user(email: str = "admin@example.com", roles=None) -> User:
+    return User(
+        email=email,
+        user_id="admin-001",
+        name="Test Admin",
+        roles=roles if roles is not None else ["system_admin"],
+    )
+
+
+@pytest.fixture()
+def announcements_table(aws, monkeypatch):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    ddb.create_table(
+        TableName=TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    monkeypatch.setenv("DYNAMODB_ANNOUNCEMENTS_TABLE_NAME", TABLE_NAME)
+    monkeypatch.setenv("AWS_REGION", AWS_REGION)
+    # Module-level singletons; reset so the next get_*() builds against moto.
+    monkeypatch.setattr(repo_module, "_repository", None)
+    monkeypatch.setattr(service_module, "_service", None)
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE_NAME)
+
+
+def _build_app(user: User = None) -> FastAPI:
+    from apis.app_api.admin.announcements.routes import router as admin_router
+
+    app = FastAPI()
+    parent = APIRouter(prefix="/admin")
+    parent.include_router(admin_router)
+    app.include_router(parent)
+    override_admin_auth(app, (lambda: user) if user else (lambda: _make_user()))
+    return app
+
+
+def _client(user: User = None) -> TestClient:
+    return TestClient(_build_app(user))
+
+
+def _payload(**kw) -> dict:
+    body = {
+        "title": "Skills are here",
+        "body_markdown": "# Skills",
+        "publish_at": "2020-01-01T00:00:00Z",
+    }
+    body.update(kw)
+    return body
+
+
+class TestAdminCrud:
+    def test_create_returns_201_as_draft(self, announcements_table):
+        resp = _client().post("/admin/announcements/", json=_payload())
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["state"] == "draft"
+        assert body["revision"] == 1
+        assert body["surfaces"] == ["panel"]
+        assert body["created_by"] == "admin@example.com"
+
+    def test_list_then_get_round_trips(self, announcements_table):
+        client = _client()
+        created = client.post("/admin/announcements/", json=_payload()).json()
+
+        listed = client.get("/admin/announcements/")
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+
+        got = client.get(f"/admin/announcements/{created['announcement_id']}")
+        assert got.status_code == 200
+        assert got.json()["title"] == "Skills are here"
+
+    def test_list_filters_by_state(self, announcements_table):
+        client = _client()
+        created = client.post("/admin/announcements/", json=_payload()).json()
+        client.post("/admin/announcements/", json=_payload(title="Second"))
+        client.post(f"/admin/announcements/{created['announcement_id']}/publish")
+
+        published = client.get("/admin/announcements/?state=published").json()
+        assert [a["title"] for a in published["announcements"]] == ["Skills are here"]
+
+    def test_get_missing_returns_404(self, announcements_table):
+        assert _client().get("/admin/announcements/nope").status_code == 404
+
+    def test_publish_archive_revise(self, announcements_table):
+        client = _client()
+        created = client.post("/admin/announcements/", json=_payload()).json()
+        aid = created["announcement_id"]
+
+        assert client.post(f"/admin/announcements/{aid}/publish").json()["state"] == (
+            "published"
+        )
+        assert client.post(f"/admin/announcements/{aid}/revise").json()["revision"] == 2
+        assert client.post(f"/admin/announcements/{aid}/archive").json()["state"] == (
+            "archived"
+        )
+
+    def test_publishing_an_archived_announcement_returns_400(self, announcements_table):
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        client.post(f"/admin/announcements/{aid}/archive")
+        assert client.post(f"/admin/announcements/{aid}/publish").status_code == 400
+
+    def test_patch_leaves_revision_alone(self, announcements_table):
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        patched = client.patch(
+            f"/admin/announcements/{aid}", json={"title": "Skills are here!"}
+        ).json()
+        assert patched["title"] == "Skills are here!"
+        assert patched["revision"] == 1
+
+    def test_patch_to_an_invalid_merged_record_returns_400(self, announcements_table):
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        resp = client.patch(
+            f"/admin/announcements/{aid}", json={"surfaces": ["panel", "banner"]}
+        )
+        assert resp.status_code == 400
+        assert "expiresAt" in resp.json()["detail"]
+
+    def test_patch_cannot_change_state(self, announcements_table):
+        """The publish guard must not be reachable around.
+
+        If PATCH accepted `state`, an archived announcement could be put back
+        in front of every user by a request that looks like a body edit — and
+        the /publish state machine would be decorative.
+        """
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        client.post(f"/admin/announcements/{aid}/archive")
+
+        resp = client.patch(f"/admin/announcements/{aid}", json={"state": "published"})
+
+        # Unknown field: pydantic ignores it rather than 422-ing, so assert on
+        # the outcome that matters — the state did not move.
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "archived"
+
+    def test_create_cannot_start_published(self, announcements_table):
+        """Going live is its own call, never a side effect of authoring."""
+        resp = _client().post("/admin/announcements/", json=_payload(state="published"))
+        assert resp.status_code == 422
+
+    def test_create_may_start_scheduled(self, announcements_table):
+        resp = _client().post("/admin/announcements/", json=_payload(state="scheduled"))
+        assert resp.status_code == 201
+        assert resp.json()["state"] == "scheduled"
+
+    def test_unknown_state_filter_is_rejected(self, announcements_table):
+        assert _client().get("/admin/announcements/?state=nonsense").status_code == 422
+
+    def test_delete_returns_204_then_404(self, announcements_table):
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        assert client.delete(f"/admin/announcements/{aid}").status_code == 204
+        assert client.delete(f"/admin/announcements/{aid}").status_code == 404
+
+
+class TestApiLevelValidation:
+    def test_cta_url_rejects_javascript_scheme(self, announcements_table):
+        """Rejected at the API, not only in the form.
+
+        Angular's DomSanitizer strips `javascript:` from `[href]`, but the SPA
+        form is not the only client this endpoint has — and the announcement
+        scope is delegable, so the author may not be a platform admin (§D10).
+        """
+        resp = _client().post(
+            "/admin/announcements/",
+            json=_payload(cta_label="Learn more", cta_url="javascript:alert(1)"),
+        )
+        assert resp.status_code == 422
+
+    def test_patch_cta_url_rejects_javascript_scheme(self, announcements_table):
+        client = _client()
+        aid = client.post("/admin/announcements/", json=_payload()).json()[
+            "announcement_id"
+        ]
+        resp = client.patch(
+            f"/admin/announcements/{aid}",
+            json={"cta_label": "Learn more", "cta_url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 422
+
+    def test_banner_without_expiry_returns_422(self, announcements_table):
+        resp = _client().post(
+            "/admin/announcements/", json=_payload(surfaces=["panel", "banner"])
+        )
+        assert resp.status_code == 422
+
+    def test_oversized_body_returns_422(self, announcements_table):
+        resp = _client().post(
+            "/admin/announcements/",
+            json=_payload(body_markdown="x" * (16 * 1024 + 1)),
+        )
+        assert resp.status_code == 422
+
+    def test_target_roles_are_stored_verbatim_and_grant_nothing(
+        self, announcements_table
+    ):
+        """§D9 — a display filter, never an RBAC grant.
+
+        The role list lands on the announcement item and nowhere else; the
+        role records are not touched. Pinned here so a future "fix" that writes
+        it through to `AppRole.granted*` has to delete a test that says why.
+        """
+        created = _client().post(
+            "/admin/announcements/",
+            json=_payload(target_roles=["faculty", "staff"]),
+        ).json()
+
+        assert created["target_roles"] == ["faculty", "staff"]
+        item = announcements_table.get_item(
+            Key={
+                "PK": "ANNOUNCEMENTS",
+                "SK": f"ANNOUNCEMENT#{created['announcement_id']}",
+            }
+        )["Item"]
+        assert item["targetRoles"] == ["faculty", "staff"]
+
+
+class TestAuthorization:
+    def test_non_admin_gets_403(self, announcements_table):
+        app = _build_app()
+
+        def _forbid():
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        override_admin_auth(app, _forbid)
+        assert TestClient(app).get("/admin/announcements/").status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# ANNOUNCEMENTS_ENABLED kill switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_router_paths():
+    """Reload the admin router under a chosen ANNOUNCEMENTS_ENABLED value.
+
+    Restores the module (flag unset → enabled) on teardown so a reload here
+    cannot leak an unmounted router into later tests.
+    """
+
+    def _load(*, enabled: bool) -> set[str]:
+        # Default-ON, so "disabled" must be set EXPLICITLY.
+        os.environ["ANNOUNCEMENTS_ENABLED"] = "true" if enabled else "false"
+        importlib.reload(admin_routes_module)
+        return {
+            getattr(route, "path", "") for route in admin_routes_module.router.routes
+        }
+
+    yield _load
+
+    os.environ.pop("ANNOUNCEMENTS_ENABLED", None)
+    importlib.reload(admin_routes_module)
+
+
+class TestFeatureFlag:
+    def test_defaults_on_when_unset(self, monkeypatch):
+        from apis.shared.feature_flags import announcements_enabled
+
+        monkeypatch.delenv("ANNOUNCEMENTS_ENABLED", raising=False)
+        assert announcements_enabled() is True
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("false", False),
+            ("False", False),
+            (" false ", False),
+            ("true", True),
+            ("0", True),
+            # An unset GitHub Actions variable forwards as the empty string; it
+            # must resolve ENABLED, or the kill switch dark-ships a live feature.
+            ("", True),
+            ("   ", True),
+        ],
+    )
+    def test_only_literal_false_disables(self, monkeypatch, value, expected):
+        from apis.shared.feature_flags import announcements_enabled
+
+        monkeypatch.setenv("ANNOUNCEMENTS_ENABLED", value)
+        assert announcements_enabled() is expected
+
+    def test_admin_router_unmounted_when_disabled(self, admin_router_paths):
+        paths = admin_router_paths(enabled=False)
+        assert not any("/announcements" in p for p in paths)
+
+    def test_admin_router_mounted_when_enabled(self, admin_router_paths):
+        paths = admin_router_paths(enabled=True)
+        assert any("/announcements" in p for p in paths)
+
+    def test_disabled_router_404s_the_surface(self, announcements_table):
+        """The end a caller actually sees: the path is gone, not 403."""
+        os.environ["ANNOUNCEMENTS_ENABLED"] = "false"
+        try:
+            importlib.reload(admin_routes_module)
+            app = FastAPI()
+            app.include_router(admin_routes_module.router)
+            override_admin_auth(app, lambda: _make_user())
+            assert TestClient(app).get("/admin/announcements/").status_code == 404
+        finally:
+            os.environ.pop("ANNOUNCEMENTS_ENABLED", None)
+            importlib.reload(admin_routes_module)

--- a/frontend/ai.client/src/app/admin/admin-scope.model.ts
+++ b/frontend/ai.client/src/app/admin/admin-scope.model.ts
@@ -26,6 +26,7 @@ export const ADMIN_SCOPE_IDS = [
   'admin.users',
   'admin.system_prompts',
   'admin.user_menu_links',
+  'admin.announcements',
   'admin.roles',
   'admin.auth_providers',
   'admin.audit',

--- a/infrastructure/gsi-inventory.json
+++ b/infrastructure/gsi-inventory.json
@@ -1,5 +1,6 @@
 {
   "tables": {
+    "announcements": [],
     "api-keys": [
       "KeyHashIndex"
     ],

--- a/infrastructure/lib/constructs/app-api/app-api-environment.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-environment.ts
@@ -55,6 +55,8 @@ export interface AppApiSsmParams {
   userSettingsTableArn: string;
   userMenuLinksTableName: string;
   userMenuLinksTableArn: string;
+  announcementsTableName: string;
+  announcementsTableArn: string;
   systemPromptsTableName: string;
   systemPromptsTableArn: string;
   authProvidersTableName: string;
@@ -172,6 +174,8 @@ export function resolveAppApiParams(
     userSettingsTableArn: refs.userSettingsTable.tableArn,
     userMenuLinksTableName: refs.userMenuLinksTable.tableName,
     userMenuLinksTableArn: refs.userMenuLinksTable.tableArn,
+    announcementsTableName: refs.announcementsTable.tableName,
+    announcementsTableArn: refs.announcementsTable.tableArn,
     systemPromptsTableName: refs.systemPromptsTable.tableName,
     systemPromptsTableArn: refs.systemPromptsTable.tableArn,
     authProvidersTableName: refs.authProvidersTable.tableName,
@@ -294,6 +298,7 @@ export function buildAppApiEnvironment(
     AUTH_PROVIDER_SECRETS_ARN: params.authProviderSecretsArn,
     DYNAMODB_USER_SETTINGS_TABLE_NAME: params.userSettingsTableName,
     DYNAMODB_USER_MENU_LINKS_TABLE_NAME: params.userMenuLinksTableName,
+    DYNAMODB_ANNOUNCEMENTS_TABLE_NAME: params.announcementsTableName,
     DYNAMODB_SYSTEM_PROMPTS_TABLE_NAME: params.systemPromptsTableName,
     COGNITO_USER_POOL_ID: params.cognitoUserPoolId,
     COGNITO_APP_CLIENT_ID: params.cognitoAppClientId,

--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -99,6 +99,21 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
     }),
   );
 
+  // ── Announcements (admin-authored notices + per-user acks) ──
+  // One table, two item shapes: the announcement rows under the fixed
+  // `ANNOUNCEMENTS` partition, and each user's ack rows under `USER#<id>`.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'AnnouncementsTableAccess',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'dynamodb:GetItem', 'dynamodb:PutItem', 'dynamodb:UpdateItem',
+        'dynamodb:DeleteItem', 'dynamodb:Query', 'dynamodb:Scan',
+      ],
+      resources: [props.refs.announcementsTable.tableArn, `${props.refs.announcementsTable.tableArn}/index/*`],
+    }),
+  );
+
   // ── System prompts (Conversation Modes catalog) ──
   // Admin-managed CRUD; per-user reads (name + description) go through
   // the user-facing `/system-prompts` endpoint, which uses the same

--- a/infrastructure/lib/constructs/data/admin-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/admin-tables-construct.ts
@@ -16,6 +16,13 @@ export interface AdminTablesConstructProps {
  *   - UserMenuLinksTable   — admin-managed links rendered in the SPA
  *                            user menu (fixed PK `USER_MENU_LINKS`,
  *                            SK `LINK#<uuid>`)
+ *   - AnnouncementsTable   — admin-authored feature announcements
+ *                            (fixed PK `ANNOUNCEMENTS`, SK
+ *                            `ANNOUNCEMENT#<uuid>`) *and* the per-user
+ *                            acknowledgement rows (PK `USER#<id>`, SK
+ *                            `ACK#<announcementId>#R<revision>`). The acks
+ *                            are why this table — alone among its siblings —
+ *                            has a TTL attribute.
  *   - SystemPromptsTable   — admin-managed catalog of custom system
  *                            prompts ("Conversation Modes"). PK
  *                            `PROMPT#<uuid>`, SK `METADATA`. Users
@@ -25,6 +32,7 @@ export interface AdminTablesConstructProps {
 export class AdminTablesConstruct extends Construct {
   public readonly userSettingsTable: dynamodb.Table;
   public readonly userMenuLinksTable: dynamodb.Table;
+  public readonly announcementsTable: dynamodb.Table;
   public readonly systemPromptsTable: dynamodb.Table;
 
   constructor(
@@ -58,6 +66,20 @@ export class AdminTablesConstruct extends Construct {
       encryption: dynamodb.TableEncryption.AWS_MANAGED,
     });
 
+    this.announcementsTable = new dynamodb.Table(this, 'AnnouncementsTable', {
+      tableName: getResourceName(config, 'announcements'),
+      partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: getRemovalPolicy(config),
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      // Acknowledgement rows carry a `ttl` so the per-user partition stays
+      // bounded forever without a sweeper. Announcement rows never set it,
+      // and a compliance-bearing ack deliberately clears it.
+      timeToLiveAttribute: 'ttl',
+    });
+
     this.systemPromptsTable = new dynamodb.Table(this, 'SystemPromptsTable', {
       tableName: getResourceName(config, 'system-prompts'),
       partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
@@ -80,6 +102,13 @@ export class AdminTablesConstruct extends Construct {
       parameterName: `/${config.projectPrefix}/admin/user-menu-links-table-name`,
       stringValue: this.userMenuLinksTable.tableName,
       description: 'User menu links table name',
+      tier: ssm.ParameterTier.STANDARD,
+    });
+
+    new ssm.StringParameter(this, 'AnnouncementsTableNameParameter', {
+      parameterName: `/${config.projectPrefix}/admin/announcements-table-name`,
+      stringValue: this.announcementsTable.tableName,
+      description: 'Announcements table name',
       tier: ssm.ParameterTier.STANDARD,
     });
 

--- a/infrastructure/lib/constructs/platform-compute-refs.ts
+++ b/infrastructure/lib/constructs/platform-compute-refs.ts
@@ -84,6 +84,7 @@ export interface PlatformComputeRefs {
   managedModelsTable: dynamodb.ITable;
   userSettingsTable: dynamodb.ITable;
   userMenuLinksTable: dynamodb.ITable;
+  announcementsTable: dynamodb.ITable;
   systemPromptsTable: dynamodb.ITable;
   sharedConversationsTable: dynamodb.ITable;
   sharedConversationsBucket: s3.IBucket;

--- a/infrastructure/lib/platform-stack.ts
+++ b/infrastructure/lib/platform-stack.ts
@@ -183,6 +183,7 @@ export class PlatformStack extends cdk.Stack {
   public readonly managedModelsTable: dynamodb.ITable;
   public readonly userSettingsTable: dynamodb.ITable;
   public readonly userMenuLinksTable: dynamodb.ITable;
+  public readonly announcementsTable: dynamodb.ITable;
   public readonly systemPromptsTable: dynamodb.ITable;
   public readonly sharedConversationsTable: dynamodb.ITable;
   public readonly sharedConversationsBucket: s3.IBucket;
@@ -423,6 +424,7 @@ export class PlatformStack extends cdk.Stack {
     });
     this.userSettingsTable = adminTables.userSettingsTable;
     this.userMenuLinksTable = adminTables.userMenuLinksTable;
+    this.announcementsTable = adminTables.announcementsTable;
     this.systemPromptsTable = adminTables.systemPromptsTable;
 
     const fileUpload = new FileUploadConstruct(this, 'FileUpload', { config });
@@ -826,6 +828,7 @@ export class PlatformStack extends cdk.Stack {
       managedModelsTable: this.managedModelsTable,
       userSettingsTable: this.userSettingsTable,
       userMenuLinksTable: this.userMenuLinksTable,
+      announcementsTable: this.announcementsTable,
       systemPromptsTable: this.systemPromptsTable,
       sharedConversationsTable: this.sharedConversationsTable,
       sharedConversationsBucket: this.sharedConversationsBucket,
@@ -1000,6 +1003,7 @@ export class PlatformStack extends cdk.Stack {
         { name: 'managed-models', table: this.managedModelsTable },
         { name: 'user-settings', table: this.userSettingsTable },
         { name: 'user-menu-links', table: this.userMenuLinksTable },
+        { name: 'announcements', table: this.announcementsTable },
         { name: 'system-prompts', table: this.systemPromptsTable },
         { name: 'shared-conversations', table: this.sharedConversationsTable },
         { name: 'user-file-uploads', table: this.fileUploadTable },

--- a/infrastructure/test/constructs.test.ts
+++ b/infrastructure/test/constructs.test.ts
@@ -211,11 +211,27 @@ describe('CostTrackingTablesConstruct', () => {
 });
 
 describe('AdminTablesConstruct', () => {
-  it('creates 3 DDB tables', () => {
+  it('creates 4 DDB tables', () => {
     const stack = testStack();
     new AdminTablesConstruct(stack, 'Admin', { config: createMockConfig() });
     const t = Template.fromStack(stack);
-    t.resourceCountIs('AWS::DynamoDB::Table', 3);
+    // user-settings, user-menu-links, announcements, system-prompts.
+    t.resourceCountIs('AWS::DynamoDB::Table', 4);
+  });
+
+  it('gives only the announcements table a TTL attribute', () => {
+    // The ack rows (PK `USER#<id>`) expire; the announcement rows and every
+    // sibling table's rows do not. A TTL that spread to a sibling would
+    // silently delete admin-authored content.
+    const stack = testStack();
+    new AdminTablesConstruct(stack, 'Admin', { config: createMockConfig() });
+    const t = Template.fromStack(stack);
+    const ttlTables = Object.values(t.findResources('AWS::DynamoDB::Table'))
+      .filter((table: any) => table.Properties.TimeToLiveSpecification !== undefined)
+      .map((table: any) => table.Properties.TableName as string);
+
+    expect(ttlTables).toHaveLength(1);
+    expect(ttlTables[0]).toContain('announcements');
   });
 });
 

--- a/infrastructure/test/observability-dynamodb-alarms.test.ts
+++ b/infrastructure/test/observability-dynamodb-alarms.test.ts
@@ -40,8 +40,8 @@ describe('DynamoDB per-table alarms', () => {
 
   // Tied to the real table count, so a new table without an alarm fails here.
   it('covers every table in the stack — one throttle alarm each', () => {
-    expect(tableCount).toBe(26);
-    // 26 per-table throttle alarms + 1 account-level UserErrors alarm.
+    expect(tableCount).toBe(27);
+    // 27 per-table throttle alarms + 1 account-level UserErrors alarm.
     expect(ddbAlarmNames()).toHaveLength(tableCount + 1);
   });
 

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -151,16 +151,18 @@ describe('PlatformStack', () => {
 
   describe('DynamoDB tables', () => {
     it('creates all shared tables', () => {
-      // 26 tables. Was 25 — the audit-log table was added for the
-      // administrative audit trail (delegated admin scopes, PR-5). Prior
-      // note: the memory-spaces table was added for the Memory Spaces
+      // 27 tables. Was 26 — the announcements table was added for the
+      // feature-announcement system (admin-authored notices + per-user
+      // acknowledgement rows). Prior note: the audit-log table was added
+      // for the administrative audit trail (delegated admin scopes, PR-5);
+      // before that the memory-spaces table was added for the Memory Spaces
       // feature; before that the system-prompts table was added for
       // admin-managed Conversation Modes (custom system prompt catalog);
       // previously 24 before the standalone "assistants" table was
       // decommissioned (the python app uses rag-assistants for both
       // assistant config and document metadata via
       // DYNAMODB_ASSISTANTS_TABLE_NAME).
-      template.resourceCountIs('AWS::DynamoDB::Table', 26);
+      template.resourceCountIs('AWS::DynamoDB::Table', 27);
     });
   });
 

--- a/scripts/backup-data/backup.py
+++ b/scripts/backup-data/backup.py
@@ -73,6 +73,7 @@ DYNAMODB_TABLES: list[dict[str, Any]] = [
     {"logical": "system-cost-rollup",   "ssm": "/cost-tracking/system-cost-rollup-table-name"},
     {"logical": "managed-models",       "ssm": "/admin/managed-models-table-name"},
     {"logical": "user-menu-links",      "ssm": "/admin/user-menu-links-table-name"},
+    {"logical": "announcements",        "ssm": "/admin/announcements-table-name",       "optional": True},
     {"logical": "user-settings",        "ssm": "/settings/user-settings-table-name"},
     {"logical": "user-file-uploads",    "ssm": "/user-file-uploads/table-name"},
     {"logical": "shared-conversations", "ssm": "/shares/shared-conversations-table-name"},

--- a/scripts/restore-data/restore.py
+++ b/scripts/restore-data/restore.py
@@ -92,6 +92,7 @@ TABLE_SSM_MAP: dict[str, str] = {
     "system-cost-rollup":   "/cost-tracking/system-cost-rollup-table-name",
     "managed-models":       "/admin/managed-models-table-name",
     "user-menu-links":      "/admin/user-menu-links-table-name",
+    "announcements":        "/admin/announcements-table-name",
     "user-settings":        "/settings/user-settings-table-name",
     "user-file-uploads":    "/user-file-uploads/table-name",
     "shared-conversations": "/shares/shared-conversations-table-name",


### PR DESCRIPTION
PR-1 of [`docs/specs/feature-announcements.md`](docs/specs/feature-announcements.md) — the storage layer, the admin authoring API, the delegated admin scope, and the DynamoDB table.

## This ships dark

There is **no user-facing surface in this PR**. Admins can author drafts; users see nothing. `GET /announcements`, the ack endpoint, and the What's-New panel land in PR-2.

## ⚠️ Deploy order

This PR adds a CDK table, so **`platform.yml` must deploy before `backend.yml`** or app-api will have no `DYNAMODB_ANNOUNCEMENTS_TABLE_NAME` and no IAM grant. That failure mode is benign — the repository logs a warning and disables itself rather than crashing (the same posture `AuditService` takes for the same reason), so a backend-first deploy degrades to "the admin API returns empty" rather than taking anything down. But the admin surface is not usable until the platform deploy lands.

No GSI, so none of the GSI deploy-ordering hazards apply.

## What's here

**Storage** — `backend/src/apis/shared/announcements/{models,repository,service}.py`

- Announcement items on the fixed `ANNOUNCEMENTS` partition, `SK: ANNOUNCEMENT#<uuid>` — the same shape `user_menu_links` uses.
- Acknowledgement items under `PK: USER#<user_id>`, `SK: ACK#<announcementId>#R<revision>` — the per-user partition `user_settings` established, revision-keyed per spec D4.
- The **whole** field set is modelled now, including `revision` / `showToNewUsers` / `requiresAck` / `targetRoles` that later PRs consume. The table is the expensive thing to change; the routes are not.

**Admin API** — `POST/GET/PATCH/DELETE /admin/announcements` plus `/publish`, `/archive`, `/revise`. Guarded package-wide by the new delegable `admin.announcements` scope, in both the backend registry and the duplicated SPA literal union. (`/stats` is deliberately PR-6.)

**Feature flag** — `ANNOUNCEMENTS_ENABLED`, default ON with a kill switch (`!= "false"`), matching `skills_enabled` / `scheduled_runs_enabled`. Explicitly false unmounts the admin router so the surface 404s.

**CDK** — `AnnouncementsTable` beside `UserMenuLinksTable` with `timeToLiveAttribute: 'ttl'`, SSM param, `PlatformComputeRefs` threading, `DYNAMODB_ANNOUNCEMENTS_TABLE_NAME`, an IAM grant, DDB throttle-alarm coverage, and the backup/restore table lists.

## Three things worth reading closely

**The ack write is monotonic at the database (spec D2).** `record_ack` is a conditional `UpdateExpression` guarded by `attribute_not_exists(actionRank) OR actionRank < :rank`, and a `ConditionalCheckFailedException` is swallowed as success. `seen` is written the moment a surface renders, so it races the user's click on the ✕; without the guard the late `seen` overwrites `dismissed` and the banner comes back on the next load. This is the same failure class as #741 and #751 — per-user state moving backwards — so it gets the same discipline: the guard is in the condition expression, not in application ordering. The write path is built here even though PR-2 is what calls it, and `TestMonotonicAck` is the first class in the test file.

**`targetRoles` is a display filter, not an RBAC grant (spec D9).** CLAUDE.md's rule that a role list on a resource must be written through to each `AppRole.granted*` governs tools, models, and skills — things with a `can_access_*` predicate behind them. Announcement visibility confers no capability and inherits nothing, so the list lives only on the announcement item and `apis/shared/rbac/` is untouched beyond adding the scope. There's a comment on the field saying so, and a test that pins it, because "fixing" this into the role service would put display metadata into the access-decision path.

**One thing not in the spec, added here.** `state` is absent from the `AnnouncementUpdate` body. If PATCH accepted it, an archived announcement could be put back in front of every user by a request that looks like an ordinary body edit, and the `/publish` guard would be decorative. For the same reason create accepts only `draft` / `scheduled` — going live is its own call. Both are covered by tests. Flagging it as a deviation in case you'd rather PATCH stay fully general.

## Also deferred deliberately

- **Audit logging of announcement writes (spec D10).** `AuditAction` is a closed constant namespace that today names only role actions, and extending it touches the non-delegable `admin.audit` area. Better as its own change than smuggled into this one — worth doing before the scope is actually delegated to comms staff.
- **`config.announcements.enabled` CDK threading (spec §8.4).** Not wired, matching `MID_TURN_STEERING_ENABLED`, which also relies on default-ON with no env var. Nothing is needed for the flag to resolve enabled.

## Testing

```bash
cd backend && uv run python -m pytest tests/ -q
```

**7399 passed, 3 skipped.** 70 of those are new, covering:

- the monotonic-ack regression (`seen` after `dismissed` leaves `dismissed` intact), plus idempotency, user scoping, and that a *stronger* action still raises the rank;
- revision keying — ack at R1, bump, the R2 slot is un-acked while the R1 history stays readable;
- ack TTLs, including that upgrading `seen` → `acknowledged` on a `requiresAck` announcement **removes** the TTL rather than letting the compliance record expire on the earlier schedule;
- `expiresAt` required for banner/modal, enforced on create *and* on a PATCH whose merged result is invalid;
- `ctaUrl` rejecting `javascript:` at the API layer, on both POST and PATCH;
- flag off → the admin router is unmounted and the path 404s.

`tests/architecture/test_admin_scope_coverage.py` picks up the new admin package — verified by running it, not assumed; its `EXPECTED_MODULE_SCOPES` map needed the new entry, which is the mechanism working as designed.

```bash
cd infrastructure && npx tsc --noEmit && npx jest && npx cdk synth
```

**784 infra tests pass**, tsc clean, synth clean. Four table-count assertions needed updating (26 → 27 tables, `AdminTablesConstruct` 3 → 4, the DDB alarm count) and `gsi-inventory.json` was regenerated — it now records `announcements: []`, confirming no index was added. Added a construct test asserting the TTL attribute is on the announcements table **only**, since a TTL that spread to a sibling would silently delete admin-authored content.

```bash
cd frontend/ai.client && npm test
```

**205 files / 2234 tests pass** — the SPA change is the one-line scope-union addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
