### PR TITLE
feat(artifacts): preview the artifact on library grid cards

### DIFF
--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -130,13 +130,35 @@
       </div>
     }
 
-    <!-- Loading -->
+    <!-- Loading. Shaped like the view it is standing in for — a column of
+         row-height bars where cards are about to appear reads as a layout
+         change rather than as loading. -->
     @if (loading()) {
-      <div class="mt-6 space-y-2" aria-busy="true" aria-label="Loading artifacts">
-        @for (placeholder of [1, 2, 3, 4, 5]; track placeholder) {
-          <div class="h-16 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
-        }
-      </div>
+      @if (viewMode() === 'grid') {
+        <div
+          class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3"
+          aria-busy="true"
+          aria-label="Loading artifacts"
+        >
+          @for (placeholder of [1, 2, 3, 4, 5, 6]; track placeholder) {
+            <div
+              class="animate-pulse rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div class="aspect-[16/10] rounded-t-2xl bg-gray-200 dark:bg-gray-700"></div>
+              <div class="space-y-2 p-5">
+                <div class="h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-700"></div>
+                <div class="h-3 w-1/2 rounded bg-gray-200 dark:bg-gray-700"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="mt-6 space-y-2" aria-busy="true" aria-label="Loading artifacts">
+          @for (placeholder of [1, 2, 3, 4, 5]; track placeholder) {
+            <div class="h-16 animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-700"></div>
+          }
+        </div>
+      }
     }
 
     <!-- Empty: nothing has ever been created -->
@@ -269,115 +291,123 @@
     @if (!loading() && filtered().length > 0 && viewMode() === 'grid') {
       <ul role="list" class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
         @for (item of filtered(); track item.artifactId) {
-          <!-- @container: the footer below collapses its button labels on a
-               narrow card. The card is sized by the grid (three columns at
-               `lg`, so ~13rem on a 1080px window), not by the viewport, so a
-               container query is correct here and a media query is not. -->
           <li
-            class="@container flex flex-col rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+            class="flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
           >
-            <div class="flex items-start gap-3">
-              <span
-                class="grid size-10 shrink-0 place-items-center rounded-2xl"
-                [class]="styleFor(item.contentType).bg"
-                aria-hidden="true"
-              >
-                <ng-icon
-                  [name]="styleFor(item.contentType).icon"
-                  class="size-5"
-                  [class]="styleFor(item.contentType).text"
-                />
-              </span>
-              <div class="min-w-0 flex-1">
-                <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
-                  <button
-                    type="button"
-                    (click)="open(item)"
-                    class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                  >
-                    {{ item.title || 'Untitled artifact' }}
-                  </button>
-                </h2>
-                <span
-                  class="mt-1.5 inline-flex items-center rounded-2xl px-2 py-0.5 text-xs/5 font-medium"
-                  [class]="styleFor(item.contentType).bg + ' ' + styleFor(item.contentType).text"
-                >
-                  {{ styleFor(item.contentType).label }}
-                </span>
-              </div>
+            <!-- The preview, and a redundant click target over it.
+                 `aria-hidden` on the wrapper is deliberate: this div opens the
+                 same artifact as the title heading directly below it and the
+                 Open button below that, both of which are real, focusable
+                 controls. Exposing a third identical action would make a
+                 keyboard or screen-reader user tab past one destination three
+                 times, so the picture stays a picture and the mouse
+                 affordance rides along with it. -->
+            <div
+              (click)="open(item)"
+              aria-hidden="true"
+              class="cursor-pointer border-b border-gray-200 dark:border-gray-700"
+            >
+              <app-artifact-thumbnail
+                [artifactId]="item.artifactId"
+                [version]="item.version"
+                [sessionId]="item.sessionId"
+                [contentType]="item.contentType"
+              />
             </div>
 
-            <p class="mt-4 grow text-xs/5 text-gray-500 dark:text-gray-400">
-              @if (item.updatedAt) {
-                Updated {{ item.updatedAt | date: 'mediumDate' }}
-              } @else {
-                Date unknown
-              }
-              @if (item.version > 1) {
-                <span aria-hidden="true"> · </span>{{ versionLabel(item.version) }}
-              }
-            </p>
+            <!-- @container on the padded body rather than on the <li>: the
+                 footer below collapses its button labels on a narrow card, and
+                 the threshold is measured against the container's content box.
+                 The card is sized by the grid (three columns at `lg`, so ~13rem
+                 on a 1080px window), not by the viewport, so a container query
+                 is correct here and a media query is not. -->
+            <div class="@container flex flex-1 flex-col p-5">
+              <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                <button
+                  type="button"
+                  (click)="open(item)"
+                  class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                >
+                  {{ item.title || 'Untitled artifact' }}
+                </button>
+              </h2>
 
-            <!-- Four controls in one row: labelled Open + Conversation need
-                 ~290px, and three columns give the card far less than that on
-                 a narrow window (~166px at 1080px), so the two text labels
-                 drop to `sr-only` below 19rem — kept in the accessible name,
-                 since these controls have no aria-label of their own and
-                 would otherwise become nameless icons, with [appTooltip]
-                 standing in for the text a sighted user can no longer see.
+              <p class="mt-1 grow text-xs/5 text-gray-500 dark:text-gray-400">
+                {{ styleFor(item.contentType).label }}
+                @if (item.version > 1) {
+                  <span aria-hidden="true"> · </span>{{ versionLabel(item.version) }}
+                }
+                <span aria-hidden="true"> · </span>
+                @if (item.updatedAt) {
+                  Updated {{ item.updatedAt | date: 'mediumDate' }}
+                } @else {
+                  Date unknown
+                }
+              </p>
 
-                 19rem is measured against the card's CONTENT box, which is
-                 what an `inline-size` container query reports — `p-5` means
-                 the border box is 40px wider. Sizing the threshold off the
-                 border box (the intuitive reading) leaves the labels hidden
-                 on cards that could comfortably show them. -->
-            <div
-              class="mt-4 flex items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700"
-            >
-              <button
-                type="button"
-                (click)="open(item)"
-                [appTooltip]="'Open'"
-                appTooltipPosition="top"
-                class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
+              <!-- Four controls in one row: labelled Open + Conversation need
+                   ~290px, and three columns give the card far less than that
+                   on a narrow window (~166px at 1080px), so the two text
+                   labels drop to `sr-only` below 19rem — kept in the
+                   accessible name, since these controls have no aria-label of
+                   their own and would otherwise become nameless icons, with
+                   [appTooltip] standing in for the text a sighted user can no
+                   longer see.
+
+                   19rem is measured against the container's CONTENT box, which
+                   is what an `inline-size` container query reports — the
+                   body's `p-5` means the card is 40px wider than the number
+                   here. Sizing the threshold off the card (the intuitive
+                   reading) leaves the labels hidden on cards that could
+                   comfortably show them. -->
+              <div
+                class="mt-4 flex items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700"
               >
-                <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
-                <span class="@max-[19rem]:sr-only">Open</span>
-              </button>
-              @if (item.sessionId) {
-                <a
-                  [routerLink]="['/s', item.sessionId]"
-                  [appTooltip]="'Open the conversation'"
+                <button
+                  type="button"
+                  (click)="open(item)"
+                  [appTooltip]="'Open'"
                   appTooltipPosition="top"
                   class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
                 >
-                  <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
-                  <span class="@max-[19rem]:sr-only">Conversation</span>
-                </a>
-              }
-              <div class="ml-auto flex items-center gap-1">
-                <button
-                  type="button"
-                  (click)="rename(item)"
-                  [disabled]="busy() === item.artifactId"
-                  [appTooltip]="'Rename'"
-                  appTooltipPosition="top"
-                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-                >
-                  <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
-                  <span class="sr-only">Rename {{ item.title }}</span>
+                  <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
+                  <span class="@max-[19rem]:sr-only">Open</span>
                 </button>
-                <button
-                  type="button"
-                  (click)="confirmDelete(item)"
-                  [disabled]="busy() === item.artifactId"
-                  [appTooltip]="'Delete'"
-                  appTooltipPosition="top"
-                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
-                >
-                  <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
-                  <span class="sr-only">Delete {{ item.title }}</span>
-                </button>
+                @if (item.sessionId) {
+                  <a
+                    [routerLink]="['/s', item.sessionId]"
+                    [appTooltip]="'Open the conversation'"
+                    appTooltipPosition="top"
+                    class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
+                  >
+                    <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
+                    <span class="@max-[19rem]:sr-only">Conversation</span>
+                  </a>
+                }
+                <div class="ml-auto flex items-center gap-1">
+                  <button
+                    type="button"
+                    (click)="rename(item)"
+                    [disabled]="busy() === item.artifactId"
+                    [appTooltip]="'Rename'"
+                    appTooltipPosition="top"
+                    class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                  >
+                    <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                    <span class="sr-only">Rename {{ item.title }}</span>
+                  </button>
+                  <button
+                    type="button"
+                    (click)="confirmDelete(item)"
+                    [disabled]="busy() === item.artifactId"
+                    [appTooltip]="'Delete'"
+                    appTooltipPosition="top"
+                    class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                  >
+                    <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                    <span class="sr-only">Delete {{ item.title }}</span>
+                  </button>
+                </div>
               </div>
             </div>
           </li>

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -270,6 +270,29 @@ describe('ArtifactLibraryPage', () => {
       expect(fixture.nativeElement.textContent).toContain('Conversation');
     });
 
+    it('previews the artifact on grid cards but not on list rows', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+
+      const listFixture = await createComponent();
+      // A row is a scanning surface; a preview per row would spend a render
+      // Lambda invocation each on a picture 24px tall.
+      expect(
+        listFixture.nativeElement.querySelector('app-artifact-thumbnail'),
+      ).toBeNull();
+      listFixture.destroy();
+
+      mockSettings.artifactsViewMode.set('grid');
+      const gridFixture = await createComponent();
+      const thumbnail = gridFixture.nativeElement.querySelector(
+        'app-artifact-thumbnail',
+      );
+      expect(thumbnail).not.toBeNull();
+      // The preview opens the same artifact as the title and the Open button,
+      // so it stays out of the accessibility tree rather than becoming a third
+      // route to one destination.
+      expect(thumbnail.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
     it('falls back to a placeholder title and an undated label', async () => {
       mockHttp.listLibrary.mockResolvedValue([
         stubArtifact({ title: '', updatedAt: '' }),

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -37,6 +37,7 @@ import {
   ConfirmationDialogComponent,
   type ConfirmationDialogData,
 } from '../components/confirmation-dialog';
+import { ArtifactThumbnailComponent } from './components/artifact-thumbnail.component';
 import {
   RenameArtifactDialogComponent,
   type RenameArtifactDialogData,
@@ -126,7 +127,13 @@ const DEFAULT_TYPE_STYLE: TypeStyle = {
  */
 @Component({
   selector: 'app-artifact-library',
-  imports: [RouterLink, NgIcon, DatePipe, TooltipDirective],
+  imports: [
+    RouterLink,
+    NgIcon,
+    DatePipe,
+    TooltipDirective,
+    ArtifactThumbnailComponent,
+  ],
   templateUrl: './artifact-library.page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   viewProviders: [

--- a/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.spec.ts
@@ -1,0 +1,238 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { ArtifactThumbnailComponent } from './artifact-thumbnail.component';
+import { ArtifactHttpService } from '../../session/services/artifacts/artifact-http.service';
+
+describe('ArtifactThumbnailComponent', () => {
+  let fixture: ComponentFixture<ArtifactThumbnailComponent>;
+  let mockHttp: { mintRenderToken: ReturnType<typeof vi.fn> };
+
+  /** Fires the observed element into view. Null until one is observed. */
+  let intersect: (() => void) | null;
+  /** Re-runs the size measurement, as a real resize would. */
+  let fireResize: () => void;
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  const iframe = () => el().querySelector('iframe');
+  /** The inert wrapper the frame is scaled inside. */
+  const frame = () => el().querySelector('[inert]') as HTMLElement | null;
+
+  function stubObservers(withIntersectionObserver = true): void {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(cb: () => void) {
+          fireResize = cb;
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+
+    if (!withIntersectionObserver) {
+      // `typeof IntersectionObserver === 'undefined'` is the branch under
+      // test, so the global has to actually be absent rather than stubbed
+      // with something falsy.
+      vi.stubGlobal('IntersectionObserver', undefined);
+      return;
+    }
+
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(private cb: (entries: { isIntersecting: boolean }[]) => void) {}
+        observe() {
+          intersect = () => this.cb([{ isIntersecting: true }]);
+        }
+        disconnect() {
+          intersect = null;
+        }
+      },
+    );
+  }
+
+  /** Give the host a width, since jsdom lays nothing out. */
+  function setHostWidth(px: number): void {
+    Object.defineProperty(el(), 'clientWidth', {
+      value: px,
+      configurable: true,
+    });
+  }
+
+  async function create(
+    inputs: Record<string, unknown> = {},
+  ): Promise<ComponentFixture<ArtifactThumbnailComponent>> {
+    fixture = TestBed.createComponent(ArtifactThumbnailComponent);
+    fixture.componentRef.setInput('artifactId', 'a1');
+    fixture.componentRef.setInput('version', 2);
+    fixture.componentRef.setInput('sessionId', 'sess-9');
+    fixture.componentRef.setInput('contentType', 'text/html');
+    for (const [k, v] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(k, v);
+    }
+    setHostWidth(512);
+    fixture.detectChanges(); // runs ngAfterViewInit → wires the observers
+    return fixture;
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    intersect = null;
+    fireResize = () => undefined;
+    stubObservers();
+
+    mockHttp = {
+      mintRenderToken: vi.fn().mockResolvedValue({
+        url: 'https://artifacts.example/a1?t=jwt',
+        expiresAt: '2026-09-05T00:02:00+00:00',
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ArtifactThumbnailComponent],
+      providers: [{ provide: ArtifactHttpService, useValue: mockHttp }],
+    });
+  });
+
+  afterEach(() => {
+    // isolate:false shares one DOM across every spec file, so a fixture left
+    // mounted keeps its placeholder mounted for the rest of the suite.
+    fixture?.destroy();
+    vi.restoreAllMocks();
+  });
+
+  // ----------------------------------------------------------------
+  // Isolation — the invariants that make framing user HTML safe
+  // ----------------------------------------------------------------
+
+  it('sandboxes the iframe without allow-same-origin', async () => {
+    await create();
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const sandbox = iframe()!.getAttribute('sandbox');
+    expect(sandbox).toBe('allow-scripts');
+    // `allow-same-origin` alongside `allow-scripts` would hand
+    // attacker-authored markup the artifact origin itself. The thumbnail
+    // frames the same untrusted bytes as the full viewer and is bound by
+    // the same rule.
+    expect(sandbox).not.toContain('allow-same-origin');
+    expect(iframe()!.getAttribute('referrerpolicy')).toBe('no-referrer');
+  });
+
+  it('hides the frame from the keyboard and the accessibility tree', async () => {
+    await create();
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Without these, twelve cards put twelve whole documents in the tab
+    // order and a keyboard user tabs through artifact *contents* to reach
+    // the next card. `inert` is also what makes `aria-hidden` legitimate:
+    // aria-hidden over focusable content is a defect on its own.
+    expect(frame()).not.toBeNull();
+    expect(frame()!.getAttribute('aria-hidden')).toBe('true');
+    // The picture must not swallow the click the card wrapper is listening
+    // for either.
+    expect(iframe()!.className).toContain('pointer-events-none');
+  });
+
+  // ----------------------------------------------------------------
+  // Cost — every mount is a Lambda invocation, so mounting is the budget
+  // ----------------------------------------------------------------
+
+  it('does not mint until the card is scrolled into view', async () => {
+    await create();
+
+    expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
+    expect(iframe()).toBeNull();
+
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledTimes(1);
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledWith('a1', 2, 'sess-9');
+    expect(iframe()).not.toBeNull();
+  });
+
+  it('mints once even if the card re-enters the viewport', async () => {
+    await create();
+
+    const fire = intersect!;
+    fire();
+    await fixture.whenStable();
+    // The observer disconnects on the first hit, so a real one would never
+    // fire again — but scrolling back to a card must not re-invoke the
+    // render Lambda even if it did.
+    fire();
+    await fixture.whenStable();
+
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('mints immediately where IntersectionObserver is unavailable', async () => {
+    stubObservers(false);
+    await create();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Costs more than lazy mounting; a preview that never arrives at all is
+    // worse.
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledTimes(1);
+    expect(iframe()).not.toBeNull();
+  });
+
+  // ----------------------------------------------------------------
+  // Rendering
+  // ----------------------------------------------------------------
+
+  it('scales the virtual viewport down to the measured card width', async () => {
+    await create();
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // 512px card / 1024px virtual viewport.
+    expect(frame()!.style.transform).toBe('scale(0.5)');
+    expect(frame()!.style.width).toBe('1024px');
+
+    setHostWidth(256);
+    fireResize();
+    fixture.detectChanges();
+
+    expect(frame()!.style.transform).toBe('scale(0.25)');
+  });
+
+  it('keeps the placeholder until the frame has painted', async () => {
+    await create();
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // The frame is mounted but transparent — a half-painted artifact
+    // flashing into place reads as a broken card.
+    expect(frame()!.className).toContain('opacity-0');
+
+    iframe()!.dispatchEvent(new Event('load'));
+    fixture.detectChanges();
+
+    expect(frame()!.className).not.toContain('opacity-0');
+  });
+
+  it('falls back to the type glyph when minting fails', async () => {
+    mockHttp.mintRenderToken.mockRejectedValue(new Error('503'));
+    await create({ contentType: 'text/csv' });
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // No frame, no error message: a card without a picture, which is the
+    // card this page shipped with. The real failure surfaces on open.
+    expect(iframe()).toBeNull();
+    expect(el().querySelector('ng-icon')).not.toBeNull();
+    expect(el().textContent).not.toContain('Try again');
+  });
+});

--- a/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.ts
+++ b/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.ts
@@ -1,0 +1,298 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroCodeBracket,
+  heroDocument,
+  heroDocumentText,
+  heroPhoto,
+  heroTableCells,
+} from '@ng-icons/heroicons/outline';
+
+import { ArtifactHttpService } from '../../session/services/artifacts/artifact-http.service';
+
+/**
+ * The virtual viewport an artifact is rendered at before being scaled
+ * down to card size.
+ *
+ * Fixed rather than derived from the card, because the card is the wrong
+ * size to render a document at: a 340px-wide iframe makes an HTML
+ * artifact reflow into its mobile layout, so the thumbnail would show a
+ * different design from the one the user gets when they open it. Render
+ * at a desktop width and scale the *pixels* down, and the thumbnail is a
+ * true miniature of the real thing.
+ *
+ * 16:10 because that is roughly what the artifact view page gives a
+ * document, so the crop the card shows is the crop the viewer opens on.
+ */
+const VIRTUAL_WIDTH = 1024;
+const VIRTUAL_HEIGHT = 640;
+
+/**
+ * Distance outside the viewport at which a card starts loading. One card
+ * height of runway, so a preview is usually painted by the time it is
+ * scrolled to, without loading the whole library up front.
+ */
+const PRELOAD_MARGIN_PX = 400;
+
+/** Fallback glyph per content type, matching the library's type styling. */
+const TYPE_ICONS: Record<string, string> = {
+  'text/markdown': 'heroDocumentText',
+  'text/x-markdown': 'heroDocumentText',
+  'text/html': 'heroCodeBracket',
+  'application/xhtml+xml': 'heroCodeBracket',
+  'text/csv': 'heroTableCells',
+  'image/svg+xml': 'heroPhoto',
+};
+
+/**
+ * A live, scaled-down render of one artifact, for the library's grid
+ * cards.
+ *
+ * ## Why a real iframe and not a screenshot
+ *
+ * The obvious way to build this is the way Claude does: rasterise each
+ * artifact server-side and serve a PNG. That needs a headless-Chromium
+ * Lambda, a bucket path, a backfill, and — the part that actually
+ * decides it — executing user-authored HTML *server-side in our own
+ * account*, which is a materially different threat model from the
+ * client-side null-origin sandbox we already trust.
+ *
+ * Everything needed to render the artifact in the browser is already
+ * built and deployed: an isolated artifact origin, a short-lived render
+ * token, a strict CSP, and a `frame-ancestors` that already names the
+ * SPA. So a thumbnail is the render path we have, scaled down — no new
+ * AWS resources, no new IAM, no new way for artifact bytes to be
+ * executed.
+ *
+ * ## Isolation
+ *
+ * Identical to `ArtifactViewerComponent`: `sandbox="allow-scripts"`
+ * **without** `allow-same-origin`, so the framed document is a null
+ * origin and cannot touch the artifact origin's storage or cookies. Do
+ * not add `allow-same-origin` here either.
+ *
+ * The frame is additionally wrapped in an `inert` + `aria-hidden`
+ * container. That is not decoration: a thumbnail is a picture, and
+ * without it every card would inject a whole focusable document into the
+ * page's tab order — a keyboard user would tab through the *contents* of
+ * twelve artifacts to reach the next card. `inert` is what makes the
+ * `aria-hidden` honest, since `aria-hidden` over focusable content is an
+ * a11y defect on its own.
+ *
+ * ## Cost
+ *
+ * Every mounted preview is one mint (DynamoDB GetItem + an HS256 sign),
+ * one render-Lambda invocation, and one S3 GetObject. The render path is
+ * `CACHING_DISABLED` at CloudFront — it has to be, the token is in the
+ * URL — so none of that is cached and a page view costs one round of it
+ * per visible card.
+ *
+ * Two things keep that bounded. Previews mount lazily, on intersection,
+ * so a library of any size costs only what is looked at. And a mounted
+ * preview is never unmounted: scrolling back up must not re-mint and
+ * re-invoke. The ceiling is therefore "artifacts the user actually
+ * scrolled past", which is fine while `/artifacts/library` is
+ * unpaginated (a user's whole library fits well inside one DynamoDB
+ * page). If that endpoint ever gains paging, this needs LRU eviction of
+ * off-screen frames to go with it.
+ */
+@Component({
+  selector: 'app-artifact-thumbnail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  // The host *is* the frame: a block box with the aspect ratio the
+  // virtual viewport is scaled into. `display: block` is load-bearing
+  // rather than styling — an inline host measures 0 wide, which would
+  // leave `scale()` pinned at 0 and every preview invisible.
+  host: {
+    class: 'relative block aspect-[16/10] overflow-hidden',
+  },
+  viewProviders: [
+    provideIcons({
+      heroCodeBracket,
+      heroDocument,
+      heroDocumentText,
+      heroPhoto,
+      heroTableCells,
+    }),
+  ],
+  template: `
+    <div class="absolute inset-0 overflow-hidden bg-white dark:bg-gray-900">
+      @if (safeUrl(); as url) {
+        <!-- inert + aria-hidden: this is a picture of the artifact, not a
+             copy of it. See the isolation note on the component. -->
+        <div
+          inert
+          aria-hidden="true"
+          class="absolute left-0 top-0 origin-top-left transition-opacity duration-300"
+          [class.opacity-0]="!loaded()"
+          [style.width.px]="virtualWidth"
+          [style.height.px]="virtualHeight"
+          [style.transform]="'scale(' + scale() + ')'"
+        >
+          <iframe
+            [src]="url"
+            title=""
+            class="pointer-events-none h-full w-full border-0"
+            sandbox="allow-scripts"
+            referrerpolicy="no-referrer"
+            loading="lazy"
+            (load)="onLoad()"
+          ></iframe>
+        </div>
+      }
+
+      <!-- Placeholder underneath, revealed by the frame's opacity until it
+           paints and left in place for good when there is nothing to show.
+           A tinted glyph rather than a spinner: a preview that fails is not
+           an error the user needs to act on, it is a card without a picture. -->
+      @if (!loaded()) {
+        <div
+          class="absolute inset-0 grid place-items-center bg-gray-50 dark:bg-gray-900"
+          aria-hidden="true"
+        >
+          <ng-icon [name]="fallbackIcon()" class="size-8 text-gray-300 dark:text-gray-600" />
+        </div>
+      }
+    </div>
+  `,
+})
+export class ArtifactThumbnailComponent implements AfterViewInit, OnDestroy {
+  private readonly artifacts = inject(ArtifactHttpService);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  readonly artifactId = input.required<string>();
+  readonly version = input.required<number>();
+  readonly sessionId = input<string>('');
+  readonly contentType = input<string>('');
+
+  protected readonly virtualWidth = VIRTUAL_WIDTH;
+  protected readonly virtualHeight = VIRTUAL_HEIGHT;
+
+  protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
+  protected readonly loaded = signal(false);
+
+  /** Card width, remeasured on resize. 0 until first measurement. */
+  private readonly boxWidth = signal(0);
+
+  /**
+   * Scale that fits the virtual viewport to the card.
+   *
+   * Held at 0 before the first measurement so a freshly mounted frame is
+   * not painted at full 1024px size for a frame or two — at three cards
+   * per row that flash is the entire page jumping.
+   */
+  protected readonly scale = computed(() => this.boxWidth() / VIRTUAL_WIDTH);
+
+  protected readonly fallbackIcon = computed(
+    () => TYPE_ICONS[this.contentType().split(';')[0].trim().toLowerCase()] ?? 'heroDocument',
+  );
+
+  private intersectionObserver?: IntersectionObserver;
+  private resizeObserver?: ResizeObserver;
+  /** Guards the async mint against resolving into a torn-down view. */
+  private destroyed = false;
+  /**
+   * Set the moment a mint is asked for, never cleared.
+   *
+   * A second mint would be a second render-Lambda invocation for a picture
+   * already on screen, so "at most one per component" is enforced here
+   * rather than left to the observer disconnecting — an observer can
+   * deliver a batch, and the no-IntersectionObserver path has no observer
+   * to rely on at all.
+   */
+  private requested = false;
+
+  ngAfterViewInit(): void {
+    const el = this.host.nativeElement;
+
+    // Both observers are guarded on presence rather than assumed. They are
+    // universally supported in browsers we target, but this component
+    // renders inside every consumer's tests too, and a hard `new
+    // ResizeObserver` in a lifecycle hook turns "your spec renders a card"
+    // into "your spec throws". The degraded paths below are correct, not
+    // just non-fatal.
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.boxWidth.set(el.clientWidth));
+      this.resizeObserver.observe(el);
+    }
+    // Measure once regardless — without a ResizeObserver this is the only
+    // measurement there will be, and with one it beats waiting a frame for
+    // the observer's initial callback.
+    this.boxWidth.set(el.clientWidth);
+
+    // No IntersectionObserver: mint immediately rather than leaving a card
+    // permanently blank. Costs more than lazy mounting; a preview that
+    // never arrives is worse.
+    if (typeof IntersectionObserver === 'undefined') {
+      void this.mint();
+      return;
+    }
+
+    this.intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) {
+          return;
+        }
+        // One-shot: a mounted preview is never torn down, so there is
+        // nothing left to observe once it has been asked for.
+        this.intersectionObserver?.disconnect();
+        this.intersectionObserver = undefined;
+        void this.mint();
+      },
+      { rootMargin: `${PRELOAD_MARGIN_PX}px` },
+    );
+    this.intersectionObserver.observe(el);
+  }
+
+  ngOnDestroy(): void {
+    this.intersectionObserver?.disconnect();
+    this.resizeObserver?.disconnect();
+    this.destroyed = true;
+  }
+
+  protected onLoad(): void {
+    this.loaded.set(true);
+  }
+
+  /**
+   * Mint a render URL for this artifact's HEAD.
+   *
+   * A failure is deliberately silent: the placeholder is already on
+   * screen and stays there, so a card whose preview could not be minted
+   * degrades to the card this page shipped with rather than growing an
+   * error the user cannot act on. The real errors — a deleted or
+   * unreadable artifact — surface when they open it.
+   */
+  private async mint(): Promise<void> {
+    if (this.requested) {
+      return;
+    }
+    this.requested = true;
+    try {
+      const token = await this.artifacts.mintRenderToken(
+        this.artifactId(),
+        this.version(),
+        this.sessionId(),
+      );
+      if (this.destroyed) {
+        return;
+      }
+      this.safeUrl.set(this.sanitizer.bypassSecurityTrustResourceUrl(token.url));
+    } catch {
+      /* no preview for this card — the placeholder stands */
+    }
+  }
+}

--- a/frontend/ai.client/src/app/services/local-settings.service.ts
+++ b/frontend/ai.client/src/app/services/local-settings.service.ts
@@ -28,12 +28,21 @@ export class LocalSettingsService {
   );
 
   /**
-   * List is the default here, unlike Agents. An agent tile earns its size by
-   * showing artwork you recognise; an artifact has no artwork, so a grid card
-   * spends a lot of space to show the same title and date a row does. Most
-   * artifacts are documents — text/markdown outnumbers text/html roughly two
-   * to one in production — and a document library is something you scan, not
-   * something you browse.
+   * List is still the default here, unlike Agents — but the reason has changed
+   * and is now a much closer call.
+   *
+   * It used to be that a grid card spent a lot of space to show the same title
+   * and date a row does, because an artifact had no artwork. Grid cards now
+   * carry a live scaled-down render of the artifact itself
+   * (`ArtifactThumbnailComponent`), so that argument is gone: a grid card
+   * shows something a row cannot.
+   *
+   * What keeps list the default is cost, not density. Every visible grid card
+   * mints a render token and invokes the render Lambda, uncached; a list view
+   * costs one request for the whole page. Defaulting everyone into the
+   * expensive view is a fleet-wide change to make on purpose, with the numbers
+   * in hand, rather than as a side effect of shipping previews. Revisit once
+   * the render path's traffic is known.
    */
   readonly artifactsViewMode = signal<ViewMode>(
     this.loadViewMode(this.ARTIFACTS_VIEW_MODE_KEY, 'list'),


### PR DESCRIPTION
## What

Grid cards in the artifact library now show a live, scaled-down render of the artifact itself, instead of a type icon next to the same title and date the list row already shows.

## Why an iframe and not a screenshot

Claude's gallery rasterises artifacts server-side into PNGs. Doing that here would need a headless-Chromium Lambda, a bucket path, a backfill, and — the part that actually decided it — executing user-authored HTML **server-side in our own account**, which is a materially different threat model from the client-side null-origin sandbox we already trust.

Everything needed to render an artifact in the browser is already built and deployed: an isolated artifact origin, a short-lived render token, a strict CSP, and a `frame-ancestors` that already names the SPA. So a thumbnail is that same iframe at `scale(cardWidth / 1024)`. **No new AWS resources, no new IAM, no infra deploy** — this PR is frontend-only.

The frame renders at a fixed 1024px virtual viewport rather than at card width, so the miniature is a true reduction of the desktop layout the user will actually open, not a mobile reflow of it.

## Cost

Every mounted preview is one mint (DynamoDB GetItem + HS256 sign), one render-Lambda invocation and one S3 GetObject, on a `CACHING_DISABLED` CloudFront path. Two things bound that:

- **Lazy mount.** An `IntersectionObserver` (400px runway) means a library costs only what is actually looked at, not what it contains.
- **Mount once.** A mounted preview is never unmounted, and `mint()` is guarded so it can never fire twice — scrolling back up must not re-invoke the Lambda.

**List view is untouched and stays the default.** Flipping that default would put every user into the expensive view; that's a fleet-wide cost change worth making deliberately with the numbers in hand, so the rationale on `LocalSettingsService.artifactsViewMode` is updated to say so rather than the change being made here. Happy to flip it in a follow-up if you'd rather.

No batch-mint endpoint: batching would collapse N cheap round trips into one, while the dominant cost (Lambda + CloudFront + S3) stays N either way. Lazy mounting is the lever that matters.

## Accessibility

The frame is wrapped `inert` + `aria-hidden`, and the click target over it is hidden from the accessibility tree. Without that, every card injects a whole focusable document into the tab order — a keyboard user would tab through the *contents* of twelve artifacts to reach the next card. The title heading and the Open button remain the real, focusable routes to the same artifact.

## Isolation

Unchanged from `ArtifactViewerComponent`: `sandbox="allow-scripts"` **without** `allow-same-origin`, plus `referrerpolicy="no-referrer"`. Covered by a test, same as the viewer's.

## Layout note

`@container` moves from the `<li>` to the padded card body. The footer's 19rem label-collapse threshold is measured against the container's *content* box, and the `<li>` no longer carries the `p-5` — leaving the container on the `<li>` would have shifted that threshold by ~40px and shown labels on cards too narrow for them.

## Verification

- `npx ng test` — 2324 passed / 210 files.
- Browser-verified against the compiled stylesheet at 1280px and 1080px, light and dark: 16:10 crop, `scale = cardWidth/1024`, footer labels still collapsing at three columns, no horizontal overflow, card heights equalising per row.
- 8 new specs on the thumbnail (isolation, inert/aria-hidden, lazy mint, mint-once, no-IntersectionObserver fallback, scale math, fade-in, silent failure) + 1 on the library page.

A failed mint is deliberately silent — the placeholder stands and the card degrades to what shipped before. The real errors surface on open.

## Not in this PR

The "All / Yours / Shared with you" tabs. That one needs a recipient-side share index that doesn't exist yet (sharing is link-delivery only today, for conversations as well as artifacts), plus a product call on how `public` shares appear in an inbox. Separate PR pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
