### PR TITLE
feat(artifacts): recipient share inbox, dark behind a flag

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -99,6 +99,15 @@ jobs:
       # http://localhost:4200 for a local SPA pointed at this deployment.
       # Empty on prod. Mirrors CDK_MCP_SANDBOX_EXTRA_FRAME_ANCESTORS below.
       CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS: ${{ vars.CDK_ARTIFACTS_EXTRA_FRAME_ANCESTORS }}
+      # "Shared with you" inbox on the artifact library. Default OFF,
+      # opt-in — the reverse of the flags above, because the surface ships
+      # ahead of the product decision about it. Unset resolves to an empty
+      # string, which config.ts treats as off; set the
+      # `CDK_ARTIFACT_SHARE_INBOX_ENABLED` variable to "true" in an
+      # environment to reveal it there. The fan-out rows the inbox reads are
+      # written regardless of this flag, so turning it on shows a complete
+      # inbox with no backfill.
+      CDK_ARTIFACT_SHARE_INBOX_ENABLED: ${{ vars.CDK_ARTIFACT_SHARE_INBOX_ENABLED }}
       CDK_FRONTEND_CERTIFICATE_ARN: ${{ vars.CDK_FRONTEND_CERTIFICATE_ARN }}
       # MCP Apps sandbox-proxy origin (mcp-sandbox.{domain}). Without the
       # cert ARN the construct silently falls back to the CloudFront default

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -915,6 +915,24 @@ S3_SKILL_RESOURCES_BUCKET_NAME=
 # Default: true
 SKILLS_ENABLED=true
 
+# ---------------------------------------------------------------------
+# Artifact share inbox ("Shared with you")
+# ---------------------------------------------------------------------
+# Whether recipients can DISCOVER artifacts shared with them, i.e. the
+# GET /shared-artifacts endpoint behind the artifact library's
+# "Shared with you" tab.
+#
+# Default OFF and opt-in — the reverse of SKILLS_ENABLED and the other
+# kill-switch flags above. Only the literal "true" enables it; unset,
+# empty and anything else resolve to off. The surface shipped ahead of
+# the product decision about it, so revealing it is a deliberate act.
+#
+# This gates the READ ONLY. The recipient fan-out rows the inbox reads
+# are written by every share whether this is on or off, so turning it on
+# shows a complete inbox rather than one that starts from the flip.
+# Do not "optimise" by gating the write path.
+ARTIFACT_SHARE_INBOX_ENABLED=false
+
 # =============================================================================
 # FINE-TUNING (OPTIONAL)
 # =============================================================================

--- a/backend/src/apis/app_api/artifacts/models.py
+++ b/backend/src/apis/app_api/artifacts/models.py
@@ -265,3 +265,52 @@ class SharedArtifactResponse(BaseModel):
         "recipient who can view can also download — surfaced as a field "
         "so a future policy can withhold it without a shape change.",
     )
+
+
+class SharedWithMeArtifact(BaseModel):
+    """One artifact somebody else shared with the caller.
+
+    Deliberately the recipient shape, not the owner one: no `ownerId`,
+    no `artifactId`, no `allowedEmails`. A recipient addresses a shared
+    artifact by its share id and nothing else — `shareUrl` is the only
+    route they have to it, and handing them the owner's artifact id
+    would imply an addressability they do not have.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    share_id: str = Field(..., alias="shareId")
+    title: str = Field(default="")
+    content_type: str = Field(default="", alias="contentType")
+    version: int
+    owner_email: str = Field(
+        ..., alias="ownerEmail", description="Who shared this"
+    )
+    shared_at: str = Field(
+        ...,
+        alias="sharedAt",
+        description="When the share was created — not when the artifact "
+        "was made or last edited, which are the owner's timestamps and "
+        "mean nothing to a recipient",
+    )
+    share_url: str = Field(..., alias="shareUrl")
+
+
+class SharedWithMeResponse(BaseModel):
+    """A page of the caller's share inbox.
+
+    `nextCursor` terminates the listing, not the page size: rows are
+    dropped after the underlying query (a share revoked since it was
+    fanned out, an allowlist edited), so a short page can still have
+    more behind it. Page until the cursor is null.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    artifacts: List[SharedWithMeArtifact] = Field(default_factory=list)
+    next_cursor: Optional[str] = Field(
+        default=None,
+        alias="nextCursor",
+        description="Opaque continuation token; null when the listing is "
+        "complete",
+    )

--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -685,6 +685,105 @@ def get_artifact_content_service() -> ArtifactContentService:
 
 _SHARE_LOOKUP_SK = "META"
 
+# ---------------------------------------------------------------------
+# Recipient fan-out rows ("shared with you")
+#
+#   recipient row  PK = SHARED_WITH#{email_lower}
+#                  SK = SHARE#{created_at}#{share_id}
+#
+# One row per (share, recipient). This is the only shape that answers
+# "what has been shared with me" without a table scan, and it is not a
+# convenience choice over an index: `allowed_emails` is a LIST, and a
+# DynamoDB GSI cannot project one item into N index entries, so *any*
+# recipient-lookup design needs a row per recipient. Given that, the row
+# belongs in the recipient's own partition, where the query is already
+# partitioned by exactly the access dimension, ordered by time via the
+# sort key, and natively paginable. Moving those same rows into the
+# owner's partition and adding a GSI over them would cost an index for
+# no gain. (The table's index budget is better spent on the
+# `UserArtifactsIndex` the writer already stamps GSI2PK/GSI2SK for —
+# that one buys server-side ordering and pagination for the library.)
+#
+# The row is a POINTER, deliberately carrying no title or content type.
+# Share rows denormalize those, and until this module's `rename` cascade
+# they went stale on rename; copying them across N recipients would
+# multiply that. The inbox resolves display fields from the share lookup
+# row at read time instead — one GetItem per row, always current.
+#
+# Fan-out is NOT part of the two-row share transaction. It is written
+# per item, after the core rows commit, and torn down before them. A
+# transaction would cap the allowlist at ~40 (TransactWriteItems allows
+# 100 items, and a full allowlist swap is N deletes + N puts + 2), which
+# is a product limit invented by a storage choice. Per-item writes have
+# no such ceiling and isolate failures.
+#
+# The failure direction is what makes that safe: these rows are a
+# DISCOVERY surface, never an authorization one. `_check_share_access`
+# against the share row remains the only thing that grants access, so a
+# fan-out row that failed to write costs a recipient a listing, not
+# their access — and a fan-out row that outlives its share grants
+# nothing, because the inbox resolves every row through the share
+# lookup row and drops the ones that no longer exist.
+# ---------------------------------------------------------------------
+
+_RECIPIENT_PK_PREFIX = "SHARED_WITH#"
+_RECIPIENT_SK_PREFIX = "SHARE#"
+
+
+def _normalize_email(email: str) -> str:
+    """Fold an address to its partition-key form.
+
+    Share rows store addresses exactly as the owner typed them and
+    lowercase only at compare time (`_check_share_access`), so folding
+    here is load-bearing rather than tidy: a share addressed to
+    `Ada.Lovelace@x.edu` read by a viewer whose token says
+    `ada.lovelace@x.edu` would land on a different partition and return
+    an empty inbox — a wrong answer indistinguishable from "nobody has
+    shared anything with you".
+    """
+    return (email or "").strip().lower()
+
+
+def _recipient_pk(email: str) -> str:
+    return f"{_RECIPIENT_PK_PREFIX}{_normalize_email(email)}"
+
+
+def _recipient_sk(created_at: str, share_id: str) -> str:
+    """Recipient-row sort key: time first, so a Query returns newest-first
+    with no sort at read time and pages without a filter."""
+    return f"{_RECIPIENT_SK_PREFIX}{created_at}#{share_id}"
+
+
+# Largest inbox page a caller may ask for. Each row costs a GetItem to
+# resolve, so this caps the fan-out of one request, not just its payload.
+_MAX_INBOX_PAGE = 100
+
+
+def _encode_inbox_cursor(sort_key: Optional[str]) -> Optional[str]:
+    """Opaque continuation token for the inbox — the sort key, and only
+    the sort key. See the security note in `list_for_recipient`."""
+    if not sort_key:
+        return None
+    return base64.urlsafe_b64encode(str(sort_key).encode()).decode()
+
+
+def _decode_inbox_cursor(cursor: Optional[str]) -> Optional[str]:
+    """Recover a sort key from a cursor, or None if it is unusable.
+
+    A malformed cursor restarts the listing rather than erroring: it is
+    an opaque token the caller was handed, so the only way it can be
+    wrong is if it was tampered with or truncated, and neither deserves
+    a 500. It also cannot be used to reach another partition — the
+    caller of this function rebuilds the partition key from the session.
+    """
+    if not cursor:
+        return None
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode()).decode()
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return decoded if decoded.startswith(_RECIPIENT_SK_PREFIX) else None
+
 
 class ArtifactShareError(Exception):
     """Base class for artifact-share failures."""
@@ -836,6 +935,9 @@ class ArtifactShareService:
             attrs["allowed_emails"] = resolved
 
         self._write_share_rows(attrs)
+        # After, never before: a fan-out row must never point at a share
+        # that does not exist yet.
+        self._sync_recipient_rows(attrs)
         logger.info(
             "created artifact share share=%s artifact=%s v=%s access=%s",
             scrub_log(share_id),
@@ -897,6 +999,9 @@ class ArtifactShareService:
             raise NotShareOwnerError("not the share owner")
 
         updated = self._strip_keys(share)
+        # Snapshot before mutation — the fan-out diff needs the allowlist
+        # as it was, and `updated` is edited in place below.
+        previous = dict(updated)
         new_access = access_level or updated.get("access_level", "specific")
         updated["access_level"] = new_access
 
@@ -914,6 +1019,10 @@ class ArtifactShareService:
         updated["updated_at"] = _now_iso()
 
         self._write_share_rows(updated)
+        # Covers specific→public too: the allowlist is gone, so every
+        # fan-out row is a removal and the share drops out of every
+        # inbox while staying reachable by link.
+        self._sync_recipient_rows(updated, previous=previous)
         logger.info(
             "updated artifact share share=%s access=%s",
             scrub_log(share_id),
@@ -930,6 +1039,9 @@ class ArtifactShareService:
             raise NotShareOwnerError("not the share owner")
 
         table = _table()
+        # Discovery first, then reachability, then visibility — the same
+        # ordering principle as `ArtifactLifecycleService.delete`.
+        self._delete_recipient_rows(table, share)
         owner_sk = _owner_share_sk(
             str(share.get("artifact_id", "")),
             int(share.get("version", 0)),
@@ -958,6 +1070,110 @@ class ArtifactShareService:
         except ClientError as exc:
             raise ArtifactQueryError("share revoke failed") from exc
         logger.info("revoked artifact share share=%s", scrub_log(share_id))
+
+    @staticmethod
+    def _recipient_emails(share: Optional[dict]) -> set:
+        """Addresses that should hold a fan-out row for this share.
+
+        Empty for a `public` share: "any authenticated tenant user" has
+        no recipient list to fan out to, so public shares stay
+        link-delivered and never appear in anyone's inbox. That is a
+        product decision, not a limitation — an inbox listing every
+        public share in the tenant is a different feature.
+
+        The owner is filtered out even though `_resolve_allowed_emails`
+        deliberately keeps them on the allowlist: without this, sharing
+        your own artifact files it under "shared with you".
+        """
+        if not share or share.get("access_level") != "specific":
+            return set()
+        owner = _normalize_email(str(share.get("owner_email", "")))
+        return {
+            email
+            for email in (
+                _normalize_email(str(raw))
+                for raw in (share.get("allowed_emails") or [])
+            )
+            if email and email != owner
+        }
+
+    @staticmethod
+    def _recipient_key(share: dict, email: str) -> dict:
+        """Fan-out row key for one recipient of one share.
+
+        Keyed on `created_at`, never `updated_at`: the sort key has to be
+        stable for the life of the share, or editing the allowlist would
+        strand a duplicate row under the old timestamp for every
+        recipient who was already on it.
+        """
+        return {
+            "PK": _recipient_pk(email),
+            "SK": _recipient_sk(
+                str(share.get("created_at", "")), str(share["share_id"])
+            ),
+        }
+
+    def _sync_recipient_rows(
+        self, share: dict, *, previous: Optional[dict] = None
+    ) -> None:
+        """Reconcile fan-out rows to the share's current allowlist.
+
+        A diff, not a rewrite: only added and removed addresses are
+        touched, so re-saving a share with an unchanged allowlist costs
+        nothing and an edit costs one write per changed address.
+
+        Best-effort by design. These rows are discovery, not access (see
+        the block comment above `_RECIPIENT_PK_PREFIX`), so a failure
+        here must not fail the share write that already committed — the
+        link works, the recipient simply has to follow it rather than
+        find it. Raising would be worse: the caller has no way to undo
+        the committed share, so it would report failure for a share that
+        exists.
+        """
+        desired = self._recipient_emails(share)
+        existing = self._recipient_emails(previous)
+        if desired == existing:
+            return
+
+        table = _table()
+        # Removals first: an address taken off the allowlist has already
+        # lost access at `_check_share_access`, so clearing its listing
+        # is the more urgent of the two.
+        for email in existing - desired:
+            self.delete_quietly(table, self._recipient_key(share, email))
+
+        for email in desired - existing:
+            row = {
+                **self._recipient_key(share, email),
+                "share_id": str(share["share_id"]),
+                "artifact_id": str(share.get("artifact_id", "")),
+                "version": int(share.get("version", 0)),
+                "owner_id": str(share.get("owner_id", "")),
+                "owner_email": str(share.get("owner_email", "")),
+                "shared_at": str(share.get("created_at", "")),
+            }
+            try:
+                table.put_item(Item=row)
+            except ClientError:
+                logger.warning(
+                    "could not fan out artifact share %s to a recipient",
+                    scrub_log(str(share["share_id"])),
+                    exc_info=True,
+                )
+
+    def _delete_recipient_rows(self, table, share: dict) -> None:
+        """Drop every fan-out row for one share.
+
+        Called before the lookup row on every teardown path. A crash
+        between the two leaves a live share that nobody can discover,
+        which is inert; the reverse order would leave a dead share
+        sitting in someone's inbox. (The inbox resolves each row through
+        the lookup row and skips what has gone, so a stranded row is
+        already harmless — this ordering keeps it from mattering at
+        all.)
+        """
+        for email in self._recipient_emails(share):
+            self.delete_quietly(table, self._recipient_key(share, email))
 
     @staticmethod
     def _write_share_rows(attrs: dict) -> None:
@@ -1058,6 +1274,8 @@ class ArtifactShareService:
             # row can't strand the rest of the cascade.
             revoked = 0
             for share in shares:
+                self._delete_recipient_rows(table, share)
+            for share in shares:
                 if self.delete_quietly(
                     table, _share_lookup_key(str(share["share_id"]))
                 ):
@@ -1120,6 +1338,8 @@ class ArtifactShareService:
 
         revoked = 0
         for share in shares:
+            self._delete_recipient_rows(table, share)
+        for share in shares:
             if self.delete_quietly(
                 table, _share_lookup_key(str(share["share_id"]))
             ):
@@ -1168,6 +1388,220 @@ class ArtifactShareService:
         except ClientError as exc:
             raise ArtifactQueryError("share list query failed") from exc
         return shares
+
+    def list_for_recipient(
+        self,
+        *,
+        viewer: User,
+        limit: int = 25,
+        cursor: Optional[str] = None,
+    ) -> tuple[list[dict], Optional[str]]:
+        """Artifacts other people have shared with this viewer, newest first.
+
+        One Query on the viewer's own `SHARED_WITH#{email}` partition —
+        no index, no scan, no filter — followed by one GetItem per row
+        to resolve the share it points at.
+
+        ############################################################
+        # The fan-out row is a POINTER and is never trusted for
+        # display or for access. Every row is resolved through the
+        # share lookup row, and a row whose share has gone is dropped.
+        # That is what makes best-effort fan-out safe: a stranded
+        # pointer (a revoke that failed halfway, a crash between the
+        # two teardown passes) lists nothing and grants nothing.
+        #
+        # `_check_share_access` is re-run per row even though the
+        # pointer's existence implies the viewer was on the allowlist
+        # when it was written. The allowlist can have changed since,
+        # and this endpoint must agree with the recipient page about
+        # who may see what — one predicate, both surfaces.
+        ############################################################
+
+        Per-item GetItem, never BatchGetItem: `dynamodb:BatchGetItem` is
+        its own IAM action and is NOT authorized by the item actions the
+        task role holds, so a batch read would fail closed at runtime
+        while passing every moto-backed test. That is not hypothetical —
+        it is exactly how `BatchWriteItem` shipped broken in the delete
+        cascade. Per-item reads also isolate failures, so one bad row
+        costs one listing rather than the page.
+
+        Pagination is real, not decorative: this partition grows by one
+        row per share received, for the life of the account, and unlike
+        `list_for_user` it has no natural ceiling — it is bounded by how
+        many people share with you, which is not a number this service
+        controls.
+
+        A page can come back shorter than `limit` (rows are dropped
+        after the Query, by the resolve step above) while still having a
+        next cursor. Callers must page until the cursor is None rather
+        than until a short page, which is standard DynamoDB semantics
+        and why the cursor, not the count, terminates the loop.
+        """
+        table = _table()
+        viewer_email = _normalize_email(viewer.email)
+        if not viewer_email:
+            # A token with no email cannot be on any allowlist, so there
+            # is nothing to look up. Empty, not an error.
+            return [], None
+
+        kwargs: dict = {
+            "KeyConditionExpression": Key("PK").eq(_recipient_pk(viewer_email))
+            & Key("SK").begins_with(_RECIPIENT_SK_PREFIX),
+            # Sort key leads with the share's creation time, so this is
+            # newest-first with no sort at read time.
+            "ScanIndexForward": False,
+            "Limit": max(1, min(limit, _MAX_INBOX_PAGE)),
+        }
+        start_sk = _decode_inbox_cursor(cursor)
+        if start_sk:
+            ############################################################
+            # The partition key is rebuilt from the authenticated
+            # viewer and only the SORT key is taken from the cursor.
+            # An opaque cursor is still attacker-supplied input, and a
+            # cursor carrying its own PK would be a paging primitive
+            # into another user's inbox. Do not "simplify" this by
+            # round-tripping the whole LastEvaluatedKey.
+            ############################################################
+            kwargs["ExclusiveStartKey"] = {
+                "PK": _recipient_pk(viewer_email),
+                "SK": start_sk,
+            }
+
+        try:
+            resp = table.query(**kwargs)
+        except ClientError as exc:
+            raise ArtifactQueryError("share inbox query failed") from exc
+
+        items: list[dict] = []
+        for pointer in resp.get("Items", []):
+            share = _get_share_lookup(str(pointer.get("share_id", "")))
+            if not share:
+                continue  # revoked, or the artifact was deleted
+            if share.get("owner_id") == viewer.user_id:
+                continue  # your own artifact is not "shared with you"
+            try:
+                _check_share_access(share, viewer)
+            except ShareAccessDeniedError:
+                continue  # taken off the allowlist since
+            items.append(
+                {
+                    "share_id": str(share.get("share_id", "")),
+                    "title": str(share.get("title", "")),
+                    "content_type": str(share.get("content_type", "")),
+                    "version": int(share.get("version", 0)),
+                    "owner_email": str(share.get("owner_email", "")),
+                    "shared_at": str(
+                        pointer.get("shared_at")
+                        or share.get("created_at", "")
+                    ),
+                }
+            )
+
+        last = resp.get("LastEvaluatedKey") or {}
+        return items, _encode_inbox_cursor(last.get("SK"))
+
+    def retitle_for_artifact(
+        self, *, owner_id: str, artifact_id: str, title: str
+    ) -> int:
+        """Push a renamed artifact's title onto its share rows.
+
+        Share records denormalize `title` at creation time so the
+        recipient header needs no second read. Nothing kept them current
+        until this method: `ArtifactLifecycleService.rename` rewrote the
+        HEAD and version rows, so the owner saw the new name on every
+        surface they own while every recipient kept seeing the old one
+        indefinitely. The owner cannot see the discrepancy and the
+        recipient has nothing to compare against.
+
+        Both rows per share, always together — the owner row and the
+        lookup row must never disagree, which is the same invariant
+        `_write_share_rows` holds atomically on the write path.
+
+        Recipient fan-out rows are deliberately untouched: they carry no
+        title (see `_RECIPIENT_PK_PREFIX`), precisely so that a rename
+        stays bounded by the number of shares rather than by the number
+        of shares times their recipients.
+
+        Best-effort per row, like the delete cascades and for the same
+        reason: one unwritable row must not strand the rest. Returns the
+        number of shares retitled.
+
+        ############################################################
+        # Nothing this method does may raise. It runs AFTER the rename
+        # has already committed to the HEAD and version rows, so an
+        # exception escaping here would report failure for a rename the
+        # caller can see succeeded everywhere they look — and would
+        # invite a retry of an operation that is already done. The
+        # blanket `except Exception` at the bottom is deliberate and
+        # mirrors `delete_for_session`; do not narrow it to the
+        # exceptions this code happens to raise today.
+        ############################################################
+        """
+        try:
+            return self._retitle_for_artifact(
+                owner_id=owner_id, artifact_id=artifact_id, title=title
+            )
+        except RenderTokenConfigError:
+            # Artifacts aren't configured here at all — a normal no-op.
+            return 0
+        except Exception:
+            logger.error(
+                "could not retitle shares for artifact %s",
+                scrub_log(artifact_id),
+                exc_info=True,
+            )
+            return 0
+
+    def _retitle_for_artifact(
+        self, *, owner_id: str, artifact_id: str, title: str
+    ) -> int:
+        """Cascade body. See `retitle_for_artifact` for the contract —
+        in particular that this one is allowed to raise and its caller
+        is not."""
+        table = _table()
+        shares = self._shares_for_artifact(table, owner_id, artifact_id)
+
+        retitled = 0
+        for share in shares:
+            share_id = str(share.get("share_id", ""))
+            keys = [
+                {
+                    "PK": f"USER#{owner_id}",
+                    "SK": _owner_share_sk(
+                        str(share.get("artifact_id", "")),
+                        int(share.get("version", 0)),
+                        share_id,
+                    ),
+                },
+                _share_lookup_key(share_id),
+            ]
+            ok = True
+            for key in keys:
+                try:
+                    table.update_item(
+                        Key=key,
+                        UpdateExpression="SET title = :t",
+                        ExpressionAttributeValues={":t": title},
+                        # Never resurrect a row a concurrent revoke removed.
+                        ConditionExpression="attribute_exists(SK)",
+                    )
+                except ClientError:
+                    ok = False
+                    logger.warning(
+                        "could not retitle artifact share %s",
+                        scrub_log(share_id),
+                        exc_info=True,
+                    )
+            if ok:
+                retitled += 1
+
+        if retitled:
+            logger.info(
+                "retitled %s artifact share(s) for artifact %s",
+                retitled,
+                scrub_log(artifact_id),
+            )
+        return retitled
 
     @staticmethod
     def delete_quietly(table, key: dict) -> bool:
@@ -1320,6 +1754,15 @@ class ArtifactLifecycleService:
         the same artifact would show its new title on `/artifacts` and
         its old one on the conversation that produced it.
 
+        Share rows denormalize the title too, so they are cascaded last
+        (see `ArtifactShareService.retitle_for_artifact`). Before that
+        cascade existed, a rename left every recipient looking at the
+        title the artifact had on the day it was shared, with no way for
+        either party to notice — the owner sees the new name everywhere
+        they look. Best-effort: the rows that decide what the owner sees
+        are already written by then, so a share that fails to retitle is
+        exactly the old behaviour rather than a failed rename.
+
         ############################################################
         # This is a bare `SET title`. It must never touch `version`.
         # `update_artifact_record` re-points HEAD under an optimistic
@@ -1373,6 +1816,10 @@ class ArtifactLifecycleService:
                 # The row went away under us — a concurrent delete.
                 raise ArtifactNotFoundError(artifact_id) from exc
             raise ArtifactQueryError("artifact rename failed") from exc
+
+        self._shares.retitle_for_artifact(
+            owner_id=user_id, artifact_id=artifact_id, title=title
+        )
 
         logger.info(
             "renamed artifact user=%s artifact=%s versions=%s",

--- a/backend/src/apis/app_api/artifacts/shares.py
+++ b/backend/src/apis/app_api/artifacts/shares.py
@@ -22,9 +22,10 @@ before touching it.
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.feature_flags import artifact_share_inbox_enabled
 from apis.shared.security.log_sanitize import scrub_log
 
 from .models import (
@@ -34,6 +35,8 @@ from .models import (
     CreateArtifactShareRequest,
     RenderTokenResponse,
     SharedArtifactResponse,
+    SharedWithMeArtifact,
+    SharedWithMeResponse,
     UpdateArtifactShareRequest,
 )
 from .service import (
@@ -250,6 +253,78 @@ async def revoke_artifact_share(
 # ------------------------------------------------------------------
 # Recipient endpoints
 # ------------------------------------------------------------------
+
+
+@shared_artifacts_router.get(
+    "",
+    response_model=SharedWithMeResponse,
+    response_model_by_alias=True,
+)
+async def list_shared_with_me(
+    limit: int = Query(
+        25, ge=1, le=100, description="Maximum shares to return"
+    ),
+    cursor: str | None = Query(
+        None, description="Opaque continuation token from a previous page"
+    ),
+    user: User = Depends(get_current_user_from_session),
+    service: ArtifactShareService = Depends(get_artifact_share_service),
+) -> SharedWithMeResponse:
+    """Artifacts other people have shared with the caller, newest first.
+
+    Scoped by construction, like every other listing in this domain: the
+    partition is built from the authenticated session's email and there
+    is no parameter that could widen it. There is no way to ask this
+    endpoint about somebody else's inbox.
+
+    Only `specific` shares appear. `public` means "any authenticated
+    tenant user", which has no recipient list to fan out to — those stay
+    link-delivered. Listing every public share in the tenant would be a
+    different feature with a different consent story.
+
+    404s while `ARTIFACT_SHARE_INBOX_ENABLED` is off, matching the
+    mid-turn-steering endpoint's behaviour under its own flag: the
+    surface does not exist in this environment, which is exactly what a
+    404 says. The SPA reads that as "no tabs" and renders the library it
+    always did. Note the flag gates only this read — the rows behind it
+    are written regardless, so turning it on shows a complete inbox
+    rather than one that starts from the flip.
+    """
+    if not artifact_share_inbox_enabled():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found")
+
+    try:
+        items, next_cursor = service.list_for_recipient(
+            viewer=user, limit=limit, cursor=cursor
+        )
+    except RenderTokenConfigError:
+        logger.exception("artifact share inbox misconfigured")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "Artifact sharing is unavailable",
+        )
+    except ArtifactQueryError:
+        logger.exception("artifact share inbox query failed")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Artifact sharing is temporarily unavailable",
+        )
+
+    return SharedWithMeResponse(
+        artifacts=[
+            SharedWithMeArtifact(
+                share_id=item["share_id"],
+                title=item["title"],
+                content_type=item["content_type"],
+                version=item["version"],
+                owner_email=item["owner_email"],
+                shared_at=item["shared_at"],
+                share_url=f"/shared-artifact/{item['share_id']}",
+            )
+            for item in items
+        ],
+        next_cursor=next_cursor,
+    )
 
 
 @shared_artifacts_router.get(

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -171,3 +171,36 @@ def mid_turn_steering_enabled() -> bool:
     transitional: a turn that calls no tools has no boundary to inject at.
     """
     return os.environ.get("MID_TURN_STEERING_ENABLED", "").strip().lower() != "false"
+
+
+def artifact_share_inbox_enabled() -> bool:
+    """Whether a recipient can *discover* artifacts shared with them.
+
+    Covers the ``GET /shared-artifacts`` inbox endpoint and, through it,
+    the library page's "Shared with you" tab. **Default OFF, opt-in**
+    (the deferred-feature pattern, mirroring the long-deleted
+    ``FINE_TUNING_ENABLED``): only the literal ``"true"``
+    (case-insensitive) enables it. Every other flag in this module ships
+    default-on with a kill switch; this one is deliberately the other
+    way round, because the surface it gates lands before the product
+    decision about it does.
+
+    ############################################################
+    # This flag gates the READ ONLY. The recipient fan-out rows the
+    # inbox reads are written UNCONDITIONALLY, by every share write,
+    # whether or not this is on.
+    #
+    # That asymmetry is the whole point. If the writes were gated too,
+    # turning this on would expose an inbox missing every share created
+    # while it was off — a wrong answer rather than an empty one, and
+    # one nobody can see is wrong. Writing the pointer rows regardless
+    # costs one small row per recipient and makes the flip complete and
+    # instant, with no backfill to sequence.
+    #
+    # So: do not "optimise" the write path by wrapping it in this flag.
+    ############################################################
+    """
+    return (
+        os.environ.get("ARTIFACT_SHARE_INBOX_ENABLED", "").strip().lower()
+        == "true"
+    )

--- a/backend/tests/apis/app_api/artifacts/test_artifact_lifecycle.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_lifecycle.py
@@ -208,6 +208,78 @@ def test_rename_updates_head_and_every_version_row(client):
         assert row["title"] == "Renamed"
 
 
+def test_rename_cascades_the_title_onto_share_rows(client):
+    """A recipient must not be left looking at the name the artifact had
+    on the day it was shared.
+
+    Share rows denormalize `title` so the recipient header needs no
+    second read, and nothing kept them current: the owner saw the new
+    name on every surface they own while every recipient kept seeing the
+    old one, with neither party able to notice the difference."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=2)
+    _seed_share(ddb, version=1, share_id="share-1")
+    _seed_share(ddb, version=2, share_id="share-2")
+
+    assert api.patch(
+        "/artifacts/art-1", json={"title": "Renamed"}
+    ).status_code == 200
+
+    for share_id, version in (("share-1", 1), ("share-2", 2)):
+        # Both rows, always together — the owner's view of a share and
+        # the one the recipient path resolves must never disagree.
+        owner_row = _row(
+            ddb,
+            f"USER#{USER_ID}",
+            f"SHARE#art-1#V#{version:05d}#{share_id}",
+        )
+        lookup_row = _row(ddb, f"SHARE#{share_id}", "META")
+        assert owner_row["title"] == "Renamed"
+        assert lookup_row["title"] == "Renamed"
+
+
+def test_rename_leaves_shares_of_other_artifacts_alone(client):
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+    _seed_share(ddb, artifact="art-2", share_id="other-share")
+
+    assert api.patch(
+        "/artifacts/art-1", json={"title": "Renamed"}
+    ).status_code == 200
+
+    assert _row(ddb, "SHARE#other-share", "META")["title"] == (
+        "Original title"
+    )
+
+
+def test_rename_succeeds_even_if_the_share_cascade_fails(
+    client, monkeypatch
+):
+    """The rows that decide what the OWNER sees are written first, so a
+    share that cannot be retitled is exactly the old behaviour rather
+    than a failed rename. Reporting failure here would be worse: the
+    rename the caller asked for has already happened."""
+    api, ddb, s3 = client
+    _seed_artifact(ddb, s3, versions=1)
+    _seed_share(ddb)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("dynamo is down")
+
+    monkeypatch.setattr(
+        artifact_service.ArtifactShareService,
+        "_shares_for_artifact",
+        staticmethod(boom),
+    )
+
+    resp = api.patch("/artifacts/art-1", json={"title": "Renamed"})
+
+    assert resp.status_code == 200
+    assert _row(ddb, f"USER#{USER_ID}", "ARTIFACT#art-1#HEAD")["title"] == (
+        "Renamed"
+    )
+
+
 def test_rename_does_not_touch_version_or_updated_at(client):
     """`version` is the writer's optimistic-lock attribute and
     `updated_at` is baked into HEAD's GSI sort keys. A rename that moved

--- a/backend/tests/apis/app_api/artifacts/test_artifact_share_inbox.py
+++ b/backend/tests/apis/app_api/artifacts/test_artifact_share_inbox.py
@@ -1,0 +1,634 @@
+"""Tests for the recipient share inbox ("Shared with you").
+
+Three things are under test here, and they are not the same thing:
+
+* the **fan-out rows** — written unconditionally by every share write,
+  torn down by every teardown path;
+* the **inbox read** — which never trusts those rows, resolving each one
+  through the share lookup row before showing or counting it;
+* the **flag** — which gates the read and must never gate the write.
+
+The last of those is the one worth breaking a test over: if the writes
+were ever put behind the flag, enabling it would surface an inbox
+missing every share created while it was off.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.artifacts import service as token_service
+from apis.app_api.artifacts.shares import (
+    artifact_shares_router,
+    shared_artifacts_router,
+)
+from apis.shared.auth import User, get_current_user_from_session
+
+TABLE = "test-user-artifacts"
+REGION = "us-east-1"
+OWNER_ID = "owner-1"
+OWNER_EMAIL = "owner@x.com"
+FRIEND_ID = "friend-1"
+FRIEND_EMAIL = "friend@x.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    token_service._reset_caches_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _inbox_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Most tests here exercise the surface, so default it on. The tests
+    that care about the flag set it themselves."""
+    monkeypatch.setenv("ARTIFACT_SHARE_INBOX_ENABLED", "true")
+
+
+def _owner() -> User:
+    return User(email=OWNER_EMAIL, user_id=OWNER_ID, name="Owner", roles=[])
+
+
+def _friend(email: str = FRIEND_EMAIL) -> User:
+    return User(email=email, user_id=FRIEND_ID, name="Friend", roles=[])
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch):
+    with mock_aws():
+        monkeypatch.setenv("AWS_REGION", REGION)
+        boto3.client("dynamodb", region_name=REGION).create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "SessionIndex",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        )
+        monkeypatch.setenv("DYNAMODB_ARTIFACTS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("ARTIFACTS_ORIGIN", "https://a.test.example.com")
+
+        def make_client(user: User | None = None) -> TestClient:
+            app = FastAPI()
+            app.include_router(artifact_shares_router)
+            app.include_router(shared_artifacts_router)
+            app.dependency_overrides[get_current_user_from_session] = (
+                lambda: user or _owner()
+            )
+            return TestClient(app)
+
+        yield make_client, boto3.resource("dynamodb", region_name=REGION)
+
+
+def _put_version(
+    ddb,
+    *,
+    artifact: str = "art-1",
+    version: int = 1,
+    title: str = "My Chart",
+    session_id: str = "sess-1",
+) -> None:
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"USER#{OWNER_ID}",
+            "SK": f"ARTIFACT#{artifact}#V#{version:05d}",
+            "artifact_id": artifact,
+            "user_id": OWNER_ID,
+            "version": version,
+            "storage": "s3",
+            "content_key": f"{OWNER_ID}/{artifact}/v{version}/index.html",
+            "content_type": "text/html; charset=utf-8",
+            "title": title,
+            "session_id": session_id,
+        }
+    )
+
+
+def _share_with(
+    tc: TestClient, emails: list[str], *, artifact: str = "art-1"
+) -> dict:
+    resp = tc.post(
+        f"/artifacts/{artifact}/shares",
+        json={
+            "version": 1,
+            "accessLevel": "specific",
+            "allowedEmails": emails,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _recipient_rows(ddb, email: str) -> list[dict]:
+    resp = ddb.Table(TABLE).query(
+        KeyConditionExpression=boto3.dynamodb.conditions.Key("PK").eq(
+            f"SHARED_WITH#{email}"
+        )
+    )
+    return resp.get("Items", [])
+
+
+def _inbox(tc: TestClient, **params) -> dict:
+    resp = tc.get("/shared-artifacts", params=params)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ------------------------------------------------------------------
+# Fan-out rows
+# ------------------------------------------------------------------
+
+
+def test_share_fans_out_one_row_per_recipient(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL, "other@x.com"])
+
+    assert len(_recipient_rows(ddb, FRIEND_EMAIL)) == 1
+    assert len(_recipient_rows(ddb, "other@x.com")) == 1
+
+
+def test_fan_out_row_is_a_pointer_carrying_no_title(env) -> None:
+    """The row must not denormalize display fields.
+
+    Share rows carry a title; copying it per recipient would multiply
+    every future staleness bug by the size of the allowlist, and would
+    make a rename cost one write per recipient instead of one per
+    share."""
+    make_client, ddb = env
+    _put_version(ddb, title="Quarterly Deck")
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    row = _recipient_rows(ddb, FRIEND_EMAIL)[0]
+    assert "title" not in row
+    assert "content_type" not in row
+    assert row["share_id"]
+    assert row["owner_id"] == OWNER_ID
+
+
+def test_fan_out_normalizes_the_email_to_lower_case(env) -> None:
+    """Addresses are stored as typed and lowercased only at compare time,
+    so the partition key has to fold explicitly. Without this, sharing to
+    a capitalised address returns an empty inbox to the person it was
+    shared with — a wrong answer that looks exactly like "nobody has
+    shared anything with you"."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), ["Friend@X.com"])
+
+    assert len(_recipient_rows(ddb, FRIEND_EMAIL)) == 1
+
+    body = _inbox(make_client(_friend()))
+    assert len(body["artifacts"]) == 1
+
+
+def test_owner_is_not_fanned_out_to_themselves(env) -> None:
+    """`_resolve_allowed_emails` deliberately keeps the owner on the
+    allowlist, so the fan-out has to filter them back out — otherwise
+    sharing your own artifact files it under "shared with you"."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    assert _recipient_rows(ddb, OWNER_EMAIL) == []
+    assert _inbox(make_client())["artifacts"] == []
+
+
+def test_public_shares_are_not_fanned_out(env) -> None:
+    """"Public" means any authenticated tenant user — there is no
+    recipient list to fan out to, and an inbox listing every public share
+    in the tenant is a different feature."""
+    make_client, ddb = env
+    _put_version(ddb)
+    resp = make_client().post(
+        "/artifacts/art-1/shares",
+        json={"version": 1, "accessLevel": "public"},
+    )
+    assert resp.status_code == 201
+
+    assert _recipient_rows(ddb, FRIEND_EMAIL) == []
+    assert _inbox(make_client(_friend()))["artifacts"] == []
+
+
+def test_update_diffs_the_allowlist_rather_than_rewriting_it(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL, "dropped@x.com"])
+
+    resp = make_client().patch(
+        f"/artifacts/shares/{share['shareId']}",
+        json={
+            "accessLevel": "specific",
+            "allowedEmails": [FRIEND_EMAIL, "added@x.com"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert len(_recipient_rows(ddb, FRIEND_EMAIL)) == 1  # kept, not duped
+    assert len(_recipient_rows(ddb, "added@x.com")) == 1
+    assert _recipient_rows(ddb, "dropped@x.com") == []
+
+
+def test_switching_a_share_to_public_clears_every_inbox(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    resp = make_client().patch(
+        f"/artifacts/shares/{share['shareId']}",
+        json={"accessLevel": "public"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Still reachable by link, no longer discoverable.
+    assert _recipient_rows(ddb, FRIEND_EMAIL) == []
+    assert (
+        make_client(_friend()).get(
+            f"/shared-artifacts/{share['shareId']}"
+        ).status_code
+        == 200
+    )
+
+
+def test_revoke_removes_the_fan_out_rows(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    assert make_client().delete(
+        f"/artifacts/shares/{share['shareId']}"
+    ).status_code == 204
+
+    assert _recipient_rows(ddb, FRIEND_EMAIL) == []
+    assert _inbox(make_client(_friend()))["artifacts"] == []
+
+
+# ------------------------------------------------------------------
+# The read — never trusts the pointer
+# ------------------------------------------------------------------
+
+
+def test_inbox_lists_shares_received(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb, title="Quarterly Deck")
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    body = _inbox(make_client(_friend()))
+    assert len(body["artifacts"]) == 1
+    row = body["artifacts"][0]
+    assert row["shareId"] == share["shareId"]
+    assert row["title"] == "Quarterly Deck"
+    assert row["ownerEmail"] == OWNER_EMAIL
+    assert row["shareUrl"] == f"/shared-artifact/{share['shareId']}"
+    assert body["nextCursor"] is None
+
+
+def test_inbox_never_leaks_the_rest_of_the_allowlist(env) -> None:
+    """The recipient shape must not carry `allowedEmails` or the owner's
+    internal ids — a recipient learns who shared with them, not who else
+    it was shared with."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL, "someone.else@x.com"])
+
+    row = _inbox(make_client(_friend()))["artifacts"][0]
+    assert "allowedEmails" not in row
+    assert "ownerId" not in row
+    assert "artifactId" not in row
+    assert "someone.else@x.com" not in str(row)
+
+
+def test_a_stranded_pointer_lists_nothing(env) -> None:
+    """A fan-out row whose share is gone must resolve to nothing.
+
+    This is what makes best-effort fan-out safe: teardown that fails
+    halfway, or a crash between the two passes, can leave a pointer
+    behind, and it must never become a permanent tombstone in somebody's
+    inbox."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    # Kill the share the way a half-finished revoke would, leaving the
+    # pointer in place.
+    ddb.Table(TABLE).delete_item(
+        Key={"PK": f"SHARE#{share['shareId']}", "SK": "META"}
+    )
+    assert len(_recipient_rows(ddb, FRIEND_EMAIL)) == 1
+
+    assert _inbox(make_client(_friend()))["artifacts"] == []
+
+
+def test_a_pointer_whose_allowlist_dropped_you_lists_nothing(env) -> None:
+    """Access is re-checked per row against the live share, so the inbox
+    and the recipient page can never disagree about who may see what."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    # Rewrite the allowlist behind the fan-out row's back, as a partially
+    # failed update would.
+    table = ddb.Table(TABLE)
+    for key in (
+        {"PK": f"SHARE#{share['shareId']}", "SK": "META"},
+        {
+            "PK": f"USER#{OWNER_ID}",
+            "SK": f"SHARE#art-1#V#00001#{share['shareId']}",
+        },
+    ):
+        table.update_item(
+            Key=key,
+            UpdateExpression="SET allowed_emails = :e",
+            ExpressionAttributeValues={":e": [OWNER_EMAIL]},
+        )
+
+    assert _inbox(make_client(_friend()))["artifacts"] == []
+
+
+def test_your_own_share_never_appears_in_your_inbox(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    # Fan-out row planted directly, so this tests the read's guard rather
+    # than the write's.
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+    ddb.Table(TABLE).put_item(
+        Item={
+            "PK": f"SHARED_WITH#{OWNER_EMAIL}",
+            "SK": f"SHARE#2026-01-01T00:00:00+00:00#{share['shareId']}",
+            "share_id": share["shareId"],
+            "owner_id": OWNER_ID,
+            "owner_email": OWNER_EMAIL,
+            "shared_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    assert _inbox(make_client())["artifacts"] == []
+
+
+def test_inbox_is_scoped_to_the_caller(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    stranger = User(
+        email="stranger@x.com", user_id="s-1", name="S", roles=[]
+    )
+    assert _inbox(make_client(stranger))["artifacts"] == []
+
+
+def test_a_viewer_with_no_email_gets_an_empty_inbox(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    nameless = User(email="", user_id="n-1", name="N", roles=[])
+    body = _inbox(make_client(nameless))
+    assert body["artifacts"] == []
+    assert body["nextCursor"] is None
+
+
+# ------------------------------------------------------------------
+# Pagination
+# ------------------------------------------------------------------
+
+
+def test_inbox_pages_newest_first(env) -> None:
+    make_client, ddb = env
+    for n in range(1, 4):
+        _put_version(ddb, artifact=f"art-{n}", title=f"Doc {n}")
+        _share_with(make_client(), [FRIEND_EMAIL], artifact=f"art-{n}")
+
+    friend = make_client(_friend())
+    first = _inbox(friend, limit=2)
+    assert len(first["artifacts"]) == 2
+    assert first["nextCursor"]
+
+    second = _inbox(friend, limit=2, cursor=first["nextCursor"])
+    seen = [a["shareId"] for a in first["artifacts"] + second["artifacts"]]
+    assert len(set(seen)) == 3  # every share exactly once, no overlap
+
+
+def test_a_cursor_cannot_reach_another_partition(env) -> None:
+    """The cursor carries the sort key only; the partition is rebuilt from
+    the session. A cursor forged to name someone else's partition must
+    page the caller's own inbox, not theirs."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    forged = base64.urlsafe_b64encode(
+        f"SHARED_WITH#{FRIEND_EMAIL}".encode()
+    ).decode()
+    stranger = User(
+        email="stranger@x.com", user_id="s-1", name="S", roles=[]
+    )
+    assert _inbox(make_client(stranger), cursor=forged)["artifacts"] == []
+
+
+def test_a_malformed_cursor_restarts_rather_than_erroring(env) -> None:
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    body = _inbox(make_client(_friend()), cursor="not-base64!!")
+    assert len(body["artifacts"]) == 1
+
+
+# ------------------------------------------------------------------
+# The flag
+# ------------------------------------------------------------------
+
+
+def test_inbox_404s_while_the_flag_is_off(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    make_client, ddb = env
+    monkeypatch.delenv("ARTIFACT_SHARE_INBOX_ENABLED", raising=False)
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    assert make_client(_friend()).get("/shared-artifacts").status_code == 404
+
+
+def test_fan_out_rows_are_written_while_the_flag_is_off(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The load-bearing test for the whole flag design.
+
+    If the writes were gated too, turning the flag on would reveal an
+    inbox missing every share created while it was off — a wrong answer
+    rather than an empty one, and one with no backfill to fix it. So a
+    share created dark must still be discoverable the moment the flag
+    flips."""
+    make_client, ddb = env
+    monkeypatch.setenv("ARTIFACT_SHARE_INBOX_ENABLED", "false")
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    assert len(_recipient_rows(ddb, FRIEND_EMAIL)) == 1
+
+    monkeypatch.setenv("ARTIFACT_SHARE_INBOX_ENABLED", "true")
+    assert len(_inbox(make_client(_friend()))["artifacts"]) == 1
+
+
+def test_only_the_literal_true_enables_the_inbox(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Opt-in, not a kill switch. An unset GitHub Actions variable
+    forwards an empty string, which must resolve to off rather than
+    revealing the surface by accident."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+    friend = make_client(_friend())
+
+    for value in ("", "  ", "false", "1", "yes", "TRUE!"):
+        monkeypatch.setenv("ARTIFACT_SHARE_INBOX_ENABLED", value)
+        assert friend.get("/shared-artifacts").status_code == 404, value
+
+    for value in ("true", "TRUE", " True "):
+        monkeypatch.setenv("ARTIFACT_SHARE_INBOX_ENABLED", value)
+        assert friend.get("/shared-artifacts").status_code == 200, value
+
+
+# ------------------------------------------------------------------
+# Teardown ordering and the IAM surface
+# ------------------------------------------------------------------
+
+
+class _RecordingTable:
+    """Delegates to the real table, recording the DynamoDB API used and,
+    for deletes, which key space was hit."""
+
+    def __init__(self, inner, calls: list):
+        self._inner = inner
+        self._calls = calls
+
+    def __getattr__(self, name):
+        attr = getattr(self._inner, name)
+        if callable(attr):
+
+            def _recorded(*args, **kwargs):
+                self._calls.append((name, None))
+                return attr(*args, **kwargs)
+
+            return _recorded
+        return attr
+
+    def delete_item(self, Key):  # noqa: N803 — boto3 kwarg name
+        pk = Key["PK"]
+        if pk.startswith("SHARED_WITH#"):
+            space = "recipient"
+        elif pk.startswith("SHARE#"):
+            space = "lookup"
+        else:
+            space = "owner"
+        self._calls.append(("delete_item", space))
+        return self._inner.delete_item(Key=Key)
+
+
+def _record(monkeypatch) -> list:
+    calls: list = []
+    real = token_service._table()
+    monkeypatch.setattr(
+        token_service, "_table", lambda: _RecordingTable(real, calls)
+    )
+    return calls
+
+
+def test_revoke_deletes_recipient_rows_before_the_lookup_row(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery dies before reachability.
+
+    A crash between the two then leaves a live share nobody can find,
+    which is inert. The reverse order leaves a dead share sitting in
+    somebody's inbox. Both orders look identical when nothing fails, so
+    assert the order rather than the end state."""
+    make_client, ddb = env
+    _put_version(ddb)
+    share = _share_with(make_client(), [FRIEND_EMAIL])
+
+    calls = _record(monkeypatch)
+    assert (
+        make_client().delete(
+            f"/artifacts/shares/{share['shareId']}"
+        ).status_code
+        == 204
+    )
+
+    # The owner and lookup rows go together in the transaction that
+    # follows, reached via `table.meta.client` — which this recorder
+    # cannot see — so `delete_item` here is exactly the fan-out pass, and
+    # its presence proves the fan-out ran before that transaction.
+    spaces = [space for name, space in calls if name == "delete_item"]
+    assert spaces == ["recipient"], spaces
+    # End state, so the ordering assertion above cannot pass on a revoke
+    # that did nothing else.
+    assert _recipient_rows(ddb, FRIEND_EMAIL) == []
+    assert (
+        ddb.Table(TABLE)
+        .get_item(Key={"PK": f"SHARE#{share['shareId']}", "SK": "META"})
+        .get("Item")
+        is None
+    )
+
+
+def test_inbox_read_uses_only_iam_granted_dynamodb_actions(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same guard as the delete cascade's, for the read path.
+
+    The app-api task role holds GetItem/PutItem/UpdateItem/DeleteItem/
+    Query on this table and nothing else. `BatchGetItem` is its own IAM
+    action and is NOT covered by those, so resolving inbox rows with a
+    batch read would fail closed in a deployed environment while passing
+    every moto test — exactly how `BatchWriteItem` shipped broken in the
+    session-delete cascade. Pinning the surface is the only way a unit
+    test can catch it."""
+    make_client, ddb = env
+    _put_version(ddb)
+    _share_with(make_client(), [FRIEND_EMAIL])
+
+    calls = _record(monkeypatch)
+    _inbox(make_client(_friend()))
+
+    used = {name for name, _ in calls}
+    assert "batch_get_item" not in used, used
+    assert used <= {"query", "get_item"}, used
+
+
+def test_fan_out_write_uses_only_iam_granted_dynamodb_actions(
+    env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """And the write path. `BatchWriteItem` is the trap here."""
+    make_client, ddb = env
+    _put_version(ddb)
+
+    calls = _record(monkeypatch)
+    _share_with(make_client(), [FRIEND_EMAIL, "other@x.com"])
+
+    used = {name for name, _ in calls}
+    assert "batch_writer" not in used, used
+    assert "batch_write_item" not in used, used

--- a/docs-site/src/content/docs/features/artifacts.md
+++ b/docs-site/src/content/docs/features/artifacts.md
@@ -104,6 +104,48 @@ The consequence: **the ACL check in app-api is the only thing standing between
 "sharing" and "read any artifact by id."** Every recipient request — metadata,
 render token, content — re-checks the share record before resolving the owner.
 
+### Finding what has been shared with you
+
+The library's "Shared with you" tab is backed by `GET /shared-artifacts`, and it
+is worth knowing how it is stored, because the obvious answer is wrong.
+
+Every share writes one **fan-out row per recipient**, keyed
+`PK=SHARED_WITH#{email}` / `SK=SHARE#{createdAt}#{shareId}`. That is not a
+workaround for avoiding an index — `allowedEmails` is a *list*, and a DynamoDB
+GSI cannot project one item into several index entries, so any recipient lookup
+needs a row per recipient no matter where it lives. Given that, the row belongs
+in the recipient's own partition, where the query is already partitioned by the
+access dimension, ordered newest-first by the sort key, and paginable with no
+filter.
+
+Three properties hold this together:
+
+- **The fan-out row is a pointer.** It carries no title or content type. Share
+  rows denormalize those, so copying them per recipient would multiply every
+  staleness bug by the size of the allowlist and make a rename cost one write per
+  recipient instead of one per share.
+- **The read never trusts the pointer.** Each row is resolved through the share
+  lookup row and re-checked against `_check_share_access`, so a stranded pointer
+  lists nothing and grants nothing. That is what makes the fan-out safe to write
+  best-effort, outside the share's two-row transaction — which in turn is what
+  keeps the allowlist from being capped at ~40 by `TransactWriteItems`' 100-item
+  limit.
+- **Fan-out is discovery, never authorization.** A row that failed to write costs
+  a recipient a listing, not their access; the link still works and the ACL check
+  is unchanged.
+
+Addresses are folded to lower case for the partition key. Share rows store them
+exactly as typed and lowercase only at compare time, so skipping that fold
+returns an empty inbox to the person a share was addressed to — a wrong answer
+that looks exactly like "nobody has shared anything with you".
+
+Only `specific` shares appear. `public` means "any authenticated tenant user",
+which has no recipient list to fan out to, so public shares stay link-delivered.
+
+The read path uses per-item `GetItem`, never `BatchGetItem`, for exactly the
+reason the delete cascade avoids `BatchWriteItem` — see the note under
+[Lifecycle](#lifecycle).
+
 ## Lifecycle
 
 Artifacts outlive the turn that produced them, but not the conversation.
@@ -129,6 +171,20 @@ which infrastructure sets only when the artifacts stack is deployed for the
 environment. The sharing routes ride the same signal: a share is only ever
 consumed by minting a render token, so it cannot be useful without artifacts
 being on.
+
+The "Shared with you" inbox has a flag of its own: `ARTIFACT_SHARE_INBOX_ENABLED`
+(CDK: `CDK_ARTIFACT_SHARE_INBOX_ENABLED`). Unlike the kill-switch flags elsewhere
+in the platform it is **default off and opt-in** — only the literal `"true"`
+enables it — because the surface shipped ahead of the product decision about it.
+While off, `GET /shared-artifacts` 404s and the SPA renders the library without
+tabs.
+
+The flag gates the **read only**. Fan-out rows are written by every share
+regardless of it. That asymmetry is deliberate: if the writes were gated too,
+turning the flag on would reveal an inbox missing every share created while it
+was off — a wrong answer rather than an empty one, and one nobody could see was
+wrong. Writing the rows regardless makes the flip complete and instant, with no
+backfill to sequence.
 
 ## Known gap: artifacts inside a shared conversation
 

--- a/infrastructure/lib/config.ts
+++ b/infrastructure/lib/config.ts
@@ -104,6 +104,13 @@ export interface ArtifactsConfig {
   // iframes via CSP frame-ancestors — e.g. http://localhost:4200 for a
   // local SPA pointed at this deployment. Empty on prod.
   extraFrameAncestors: string[];
+  // Whether recipients can *discover* artifacts shared with them (the
+  // library's "Shared with you" tab, backed by GET /shared-artifacts).
+  // Default OFF and opt-in, unlike the kill-switch flags elsewhere in this
+  // file: the surface lands before the product decision about it. Gates the
+  // read only — the fan-out rows behind it are written unconditionally, so
+  // enabling this never needs a backfill.
+  shareInboxEnabled: boolean;
 }
 
 export interface FrontendConfig {
@@ -814,6 +821,14 @@ export function loadConfig(scope: cdk.App): AppConfig {
         .map((s) => s.trim()).filter(Boolean)
         || scope.node.tryGetContext('artifacts')?.extraFrameAncestors
         || [],
+      // Default OFF, opt-in — the inverse of the kill-switch ternary used by
+      // scheduledRuns/memorySpaces/skills above. Only the literal "true"
+      // enables, so the empty string an unset GitHub Actions variable
+      // forwards resolves to off, which is the intended default rather than
+      // an accident.
+      shareInboxEnabled: process.env.CDK_ARTIFACT_SHARE_INBOX_ENABLED
+        ? process.env.CDK_ARTIFACT_SHARE_INBOX_ENABLED === 'true'
+        : scope.node.tryGetContext('artifacts')?.shareInboxEnabled ?? false,
     },
     mcpSandbox: {
       certificateArn: process.env.CDK_MCP_SANDBOX_CERTIFICATE_ARN || scope.node.tryGetContext('mcpSandbox')?.certificateArn,

--- a/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-service-construct.ts
@@ -182,6 +182,12 @@ export class AppApiServiceConstruct extends Construct {
     environment['DYNAMODB_ARTIFACTS_TABLE_NAME'] = props.refs.artifactsTable.tableName;
     environment['ARTIFACTS_ORIGIN'] = props.artifactsOrigin;
     environment['ARTIFACTS_RENDER_TOKEN_SECRET_ARN'] = props.refs.artifactRenderTokenSecret.secretArn;
+    // "Shared with you" inbox. Default off; read by
+    // apis/shared/feature_flags.py::artifact_share_inbox_enabled, which gates
+    // the GET /shared-artifacts route ONLY. The recipient fan-out rows are
+    // written by every share regardless, so flipping this on reveals a
+    // complete inbox rather than one that begins at the flip.
+    environment['ARTIFACT_SHARE_INBOX_ENABLED'] = config.artifacts.shareInboxEnabled ? 'true' : 'false';
 
     // Skill reference-file bucket (admin-managed Skills, PR-4). Read by
     // apis/shared/skills/resource_store.py via S3_SKILL_RESOURCES_BUCKET_NAME.

--- a/infrastructure/test/artifacts-cert-guard.test.ts
+++ b/infrastructure/test/artifacts-cert-guard.test.ts
@@ -52,7 +52,8 @@ describe('ArtifactsDistributionConstruct — domain/cert guard', () => {
       buildConstruct({
         domainName: 'example.com',
         infrastructureHostedZoneDomain: 'example.com',
-        artifacts: { retentionDays: 90, extraFrameAncestors: [] }, // no certificateArn
+        artifacts: {
+          shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [] }, // no certificateArn
       }),
     ).toThrow(/Artifacts iframe origin requires an ACM certificate/);
   });
@@ -62,7 +63,8 @@ describe('ArtifactsDistributionConstruct — domain/cert guard', () => {
       buildConstruct({
         domainName: 'example.com',
         infrastructureHostedZoneDomain: 'example.com',
-        artifacts: { retentionDays: 90, extraFrameAncestors: [] },
+        artifacts: {
+          shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [] },
       }),
     ).toThrow(
       /CDK_ARTIFACTS_CERTIFICATE_ARN.*CDK_CLOUDFRONT_CERTIFICATE_ARN.*artifacts\.example\.com/s,
@@ -74,7 +76,8 @@ describe('ArtifactsDistributionConstruct — domain/cert guard', () => {
       buildConstruct({
         domainName: 'example.com',
         infrastructureHostedZoneDomain: 'example.com',
-        artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: CERT },
+        artifacts: {
+          shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: CERT },
       }),
     ).not.toThrow();
   });
@@ -86,7 +89,8 @@ describe('ArtifactsDistributionConstruct — domain/cert guard', () => {
     // default domain like McpSandboxDistributionConstruct.
     expect(() =>
       buildConstruct({
-        artifacts: { retentionDays: 90, extraFrameAncestors: [] }, // no domain, no cert
+        artifacts: {
+          shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [] }, // no domain, no cert
       }),
     ).not.toThrow();
   });

--- a/infrastructure/test/compute-image-resolution.test.ts
+++ b/infrastructure/test/compute-image-resolution.test.ts
@@ -40,7 +40,8 @@ describe('Compute image URI resolution', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/gsi-update-limit.test.ts
+++ b/infrastructure/test/gsi-update-limit.test.ts
@@ -61,7 +61,8 @@ function buildInventory(): Inventory {
     infrastructureHostedZoneDomain: 'example.com',
     certificateArn: cert,
     frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-    artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+    artifacts: {
+      shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
     mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
     fineTuning: {
       enabled: true,

--- a/infrastructure/test/helpers/mock-config.ts
+++ b/infrastructure/test/helpers/mock-config.ts
@@ -133,6 +133,7 @@ export function createMockConfig(overrides: Partial<AppConfig> = {}): AppConfig 
       defaultQuotaHours: 0,
     },
     artifacts: {
+      shareInboxEnabled: false,
       retentionDays: 90,
       extraFrameAncestors: [],
     },

--- a/infrastructure/test/integration.test.ts
+++ b/infrastructure/test/integration.test.ts
@@ -19,7 +19,8 @@ describe('Single-stack integration', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/kb-migration.test.ts
+++ b/infrastructure/test/kb-migration.test.ts
@@ -979,7 +979,8 @@ describe('KbMigration wiring on PlatformStack', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/managed-kb.test.ts
+++ b/infrastructure/test/managed-kb.test.ts
@@ -554,7 +554,8 @@ describe('Managed_KB retrieval wiring on PlatformStack', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/observability-agentcore-alarms.test.ts
+++ b/infrastructure/test/observability-agentcore-alarms.test.ts
@@ -29,7 +29,8 @@ describe('AgentCore Runtime alarms — verified metric binding', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-ai-path-alarms.test.ts
+++ b/infrastructure/test/observability-ai-path-alarms.test.ts
@@ -29,7 +29,8 @@ describe('AI-path alarms (Bedrock, Memory, Gateway, Code Interpreter)', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-alarm-routing.test.ts
+++ b/infrastructure/test/observability-alarm-routing.test.ts
@@ -21,7 +21,8 @@ describe('Alarm routing — every alarm reaches a human', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
       // Every optional alarm-bearing subsystem ON, so the guard sees the

--- a/infrastructure/test/observability-alarm-topic.test.ts
+++ b/infrastructure/test/observability-alarm-topic.test.ts
@@ -113,7 +113,8 @@ describe('PlatformStack alarm topic gating', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-alb-ecs-alarms.test.ts
+++ b/infrastructure/test/observability-alb-ecs-alarms.test.ts
@@ -27,7 +27,8 @@ describe('ALB and ECS service alarms', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-dynamodb-alarms.test.ts
+++ b/infrastructure/test/observability-dynamodb-alarms.test.ts
@@ -22,7 +22,8 @@ describe('DynamoDB per-table alarms', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-lambda-alarms.test.ts
+++ b/infrastructure/test/observability-lambda-alarms.test.ts
@@ -28,7 +28,8 @@ describe('Lambda and DLQ alarms', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
       kbSync: { enabled: true },

--- a/infrastructure/test/observability-log-retention.test.ts
+++ b/infrastructure/test/observability-log-retention.test.ts
@@ -15,7 +15,8 @@ function synth(logRetentionDays: number): Template {
     infrastructureHostedZoneDomain: 'example.com',
     certificateArn: cert,
     frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-    artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+    artifacts: {
+      shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
     mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
     fineTuning: { enabled: true, defaultQuotaHours: 0 },
     kbSync: { enabled: true },
@@ -75,7 +76,8 @@ describe('Log retention — one configured value everywhere', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
     });

--- a/infrastructure/test/observability-platform-dashboard.test.ts
+++ b/infrastructure/test/observability-platform-dashboard.test.ts
@@ -16,7 +16,8 @@ describe('Unified platform dashboard', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: { enabled: true, defaultQuotaHours: 0 },
       kbSync: { enabled: true },

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -22,7 +22,8 @@ describe('PlatformStack', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,
@@ -288,7 +289,8 @@ describe('PlatformStack', () => {
         infrastructureHostedZoneDomain: 'example.com',
         certificateArn: cert,
         frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-        artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+        artifacts: {
+          shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
         mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
         fineTuning: {
           enabled: true,

--- a/infrastructure/test/runtime-env-var-limit.test.ts
+++ b/infrastructure/test/runtime-env-var-limit.test.ts
@@ -48,7 +48,8 @@ describe('AgentCore Runtime environment variable ceiling', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/security-policy.test.ts
+++ b/infrastructure/test/security-policy.test.ts
@@ -51,7 +51,8 @@ describe('Security policy hardening', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,

--- a/infrastructure/test/ssm-safety.test.ts
+++ b/infrastructure/test/ssm-safety.test.ts
@@ -51,7 +51,8 @@ describe('Same-stack SSM safety', () => {
       infrastructureHostedZoneDomain: 'example.com',
       certificateArn: cert,
       frontend: { cloudFrontPriceClass: 'PriceClass_100', certificateArn: cert },
-      artifacts: { retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
+      artifacts: {
+        shareInboxEnabled: false, retentionDays: 90, extraFrameAncestors: [], certificateArn: cert },
       mcpSandbox: { extraFrameAncestors: [], certificateArn: cert },
       fineTuning: {
         enabled: true,


### PR DESCRIPTION
PR-1 of the "All / Yours / Shared with you" pair — backend only, shipped dark. PR-2 is the SPA tabs.

## The storage question, answered on the merits

You said adding an index shouldn't be off limits, so I re-derived this rather than defaulting to the cheap option. The answer is that an index genuinely loses here, for a reason that isn't about deployments:

**`allowed_emails` is a list, and a DynamoDB GSI cannot project one item into several index entries.** So no index can turn one share row into N recipient entries. Any recipient-lookup design needs a row per (share, recipient) regardless — the only real question is which partition it lives in. Putting it in the recipient's own partition gives a query that is already partitioned by the access dimension, ordered newest-first by the sort key, and paginable with no filter. Relocating those same rows into the owner's partition and adding a GSI over them buys nothing and costs an index.

Which leaves the index budget where it should go: the `UserArtifactsIndex` the writer already stamps `GSI2PK`/`GSI2SK` for. That one is a real scalability need — `list_for_user` currently reads ~3× what it returns and sorts in memory — and it's the natural companion to PR-2. Happy to tee it up.

## Design

One pointer row per recipient: `PK=SHARED_WITH#{email}` / `SK=SHARE#{createdAt}#{shareId}`.

- **The row is a pointer** — no title, no content type. Share rows denormalize those; copying them per recipient would multiply every staleness bug by the size of the allowlist and make a rename cost one write *per recipient* instead of one per share.
- **The read never trusts it.** Each row resolves through the share lookup row and re-runs `_check_share_access`, so a stranded pointer lists nothing and grants nothing.
- **Fan-out is discovery, never authorization.** That's what makes it safe to write best-effort, per item, *outside* the share's two-row transaction — which in turn keeps the allowlist off the ~40-address cap that `TransactWriteItems`' 100-item limit would otherwise impose. A row that fails to write costs a recipient a listing, not their access.

Teardown deletes fan-out rows *before* the lookup row on all three paths (revoke, artifact delete, session delete): a half-finished cleanup leaves a live share nobody can find, rather than a dead one sitting in someone's inbox.

## A real bug fixed on the way past

`rename` wrote HEAD and version rows but never the share rows, which denormalize `title`. **Every recipient has been seeing the name the artifact had on the day it was shared** — indefinitely, and invisibly to both parties, since the owner sees the new name everywhere they look. Renames now cascade to both share rows. That's also what lets the inbox resolve with one `GetItem` per row instead of two.

## The flag

`ARTIFACT_SHARE_INBOX_ENABLED`, default **off**, opt-in — the deferred pattern already in `feature_flags.py`, not the kill-switch pattern. While off, `GET /shared-artifacts` 404s (matching the mid-turn-steering endpoint under its flag) and the SPA renders the library it always did.

**It gates the read only; the fan-out rows are written unconditionally.** If the writes were gated too, enabling it would reveal an inbox missing every share created while it was off — a wrong answer rather than an empty one, and one nobody could see was wrong. There's a test pinning exactly that, and a comment on the flag telling the next person not to "optimise" it.

## Sharp edges handled

| | |
|---|---|
| Owner is on their own allowlist (`_resolve_allowed_emails` keeps them there) | Filtered from fan-out, and guarded again on read — your own artifact never lands in your own inbox |
| Emails stored as typed, lowercased only at compare time | Partition key folds explicitly. Without it, sharing to `Ada.Lovelace@…` returns an empty inbox to `ada.lovelace@…` — a wrong answer that looks like "nobody shared anything with you" |
| Cursor is attacker-supplied | Carries the **sort key only**; the partition is rebuilt from the session, so a forged cursor pages your own inbox, not someone else's. Test included |
| `BatchGetItem` is its own IAM action | Per-item `GetItem` only, pinned by a test on both read and write paths — this is exactly how `BatchWriteItem` shipped broken in the delete cascade (e2c9a97a) |

`public` shares are excluded per your call: "any authenticated tenant user" has no recipient list to fan out to, so those stay link-delivered.

## Verification

- Backend: **7518 passed** (8 pre-existing fine-tuning failures from a missing local `pandas`, unrelated).
- Infrastructure: **783 passed**, `tsc --noEmit` clean.
- 24 new inbox tests + 3 rename-cascade tests. One of them caught a real gap while I was writing it: `retitle_for_artifact` claimed best-effort but only caught `ArtifactQueryError`, so an unexpected failure would have reported a failed rename for a rename that had already committed. Fixed with a blanket guard and a comment saying why it must stay blanket.

**No new AWS resources, no new IAM, no GSI.** Infra change is one env var plus the config/workflow plumbing for it.

## Not verified

Dev-data reconciliation. Existing dev shares predate the fan-out and have no pointer rows, so they won't appear in the inbox until re-created. Since sharing isn't in prod, that's a dev-only cleanup — simplest is to delete the handful of test shares rather than write a migration. Say the word and I'll do it when the flag flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)