### PR TITLE
feat(announcements): user feed, acknowledgements, and What's New panel (PR-2)

### DIFF
--- a/backend/src/apis/app_api/announcements/routes.py
+++ b/backend/src/apis/app_api/announcements/routes.py
@@ -1,0 +1,147 @@
+"""User-facing announcement surface: read the feed, record an acknowledgement.
+
+Cookie session auth on every route (CLAUDE.md's rule — the SPA sends an
+httpOnly session cookie, and a Bearer-only dependency here would 401 into the
+centralized redirect loop).
+
+Admin authoring lives at ``/admin/announcements``. See
+``docs/specs/feature-announcements.md`` §6.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from apis.shared.announcements.models import (
+    AnnouncementAckRequest,
+    AnnouncementFeedResponse,
+    UserAnnouncement,
+)
+from apis.shared.announcements.service import get_announcements_service
+from apis.shared.announcements.visibility import VisibleAnnouncement
+from apis.shared.auth import User, get_current_user_from_session
+from apis.shared.feature_flags import announcements_enabled
+from apis.shared.users.repository import UserRepository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/announcements", tags=["announcements"])
+
+
+async def require_announcements_user(
+    user: User = Depends(get_current_user_from_session),
+) -> User:
+    """Cookie auth plus the environment kill switch.
+
+    404 while ``ANNOUNCEMENTS_ENABLED`` is off, so the surface behaves as if it
+    were never mounted (the ``memory_spaces`` / ``schedules`` pattern). Checked
+    per request rather than at import so a test can flip the flag without a
+    module reload.
+    """
+    if not announcements_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return user
+
+
+async def _user_created_at(user_id: str) -> Optional[str]:
+    """This user's signup timestamp, for the new-user suppression rule (§D6).
+
+    Returns None if the profile is missing or the lookup fails, which
+    ``compute_feed`` reads as "treat them as an existing user and show the
+    announcement". Failing toward showing a message is recoverable; failing
+    toward silence is not — and a directory blip must not decide what a user
+    reads.
+    """
+    try:
+        repo = UserRepository()
+        if not repo.enabled:
+            return None
+        profile = await repo.get_user(user_id)
+        return profile.created_at if profile else None
+    except Exception:
+        logger.warning(
+            "Could not read created_at for %s; treating as an existing user",
+            user_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _to_response(visible: Optional[VisibleAnnouncement]) -> Optional[UserAnnouncement]:
+    if visible is None:
+        return None
+    return UserAnnouncement.from_announcement(
+        visible.announcement,
+        is_unread=visible.is_unread,
+        is_updated=visible.is_updated,
+    )
+
+
+@router.get(
+    "/",
+    response_model=AnnouncementFeedResponse,
+    summary="Announcements visible to the current user",
+)
+async def get_announcements(
+    current_user: User = Depends(require_announcements_user),
+) -> AnnouncementFeedResponse:
+    """Return only what this user should see, already filtered and capped.
+
+    The client renders this; it does not evaluate targeting, dates, or ack
+    state (§D5).
+    """
+    service = get_announcements_service()
+    feed = await service.build_feed(
+        user_id=current_user.user_id,
+        user_roles=current_user.roles or [],
+        user_created_at=await _user_created_at(current_user.user_id),
+    )
+    return AnnouncementFeedResponse(
+        panel=[_to_response(v) for v in feed.panel],
+        banner=_to_response(feed.banner),
+        modal=_to_response(feed.modal),
+        unread_count=feed.unread_count,
+    )
+
+
+@router.post(
+    "/{announcement_id}/ack",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Record an acknowledgement",
+)
+async def acknowledge_announcement(
+    announcement_id: str,
+    body: AnnouncementAckRequest,
+    current_user: User = Depends(require_announcements_user),
+) -> Response:
+    """Record ``seen`` / ``dismissed`` / ``acknowledged`` for this user.
+
+    Idempotent and monotonic — a weaker action arriving late is a no-op, not an
+    error (§D2), so this returns 204 either way.
+
+    **404 when the id is not visible to this caller**, deliberately not 403:
+    an announcement targeted at another role should not have its existence
+    confirmed by the error code on a guessed id.
+    """
+    service = get_announcements_service()
+    feed = await service.build_feed(
+        user_id=current_user.user_id,
+        user_roles=current_user.roles or [],
+        user_created_at=await _user_created_at(current_user.user_id),
+    )
+
+    announcement = feed.get(announcement_id)
+    if announcement is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Announcement '{announcement_id}' not found",
+        )
+
+    await service.record_ack(
+        user_id=current_user.user_id,
+        announcement=announcement,
+        action=body.action,
+        surface=body.surface,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -204,6 +204,7 @@ from apis.app_api.system.routes import router as system_router
 from apis.app_api.shares.routes import conversations_share_router, shares_router, shared_view_router
 from apis.app_api.voice import router as voice_router
 from apis.app_api.user_menu_links.routes import router as user_menu_links_router
+from apis.app_api.announcements.routes import router as announcements_router
 from apis.app_api.system_prompts.routes import router as system_prompts_router
 from apis.app_api.runs.routes import router as runs_router
 from apis.app_api.schedules.routes import router as schedules_router
@@ -242,6 +243,7 @@ app.include_router(shares_router)  # Share management (update, revoke, export)
 app.include_router(shared_view_router)  # Shared conversation read-only view
 app.include_router(voice_router)  # Cookie-authenticated WS proxy for Nova Sonic voice mode (#211)
 app.include_router(user_menu_links_router)  # Public read of admin-managed user-menu links
+app.include_router(announcements_router)  # Feature announcements feed + ack; 404s while ANNOUNCEMENTS_ENABLED off
 app.include_router(system_prompts_router)   # Public read of admin-managed system prompts
 app.include_router(runs_router)  # Headless "Run now" + grant lifecycle (scheduled-runs PR-1; SCHEDULED_RUNS_ENABLED + RBAC gated at runtime)
 app.include_router(schedules_router)  # Schedule CRUD (scheduled-runs B1; inert — SCHEDULED_RUNS_ENABLED + RBAC gated, nothing fires yet)

--- a/backend/src/apis/shared/announcements/models.py
+++ b/backend/src/apis/shared/announcements/models.py
@@ -422,6 +422,75 @@ class AnnouncementListResponse(BaseModel):
     total: int
 
 
+# =============================================================================
+# User-facing response models
+#
+# Deliberately NOT a subset alias of ``AnnouncementResponse``. That model is
+# the admin view and carries ``state``, ``targetRoles``, ``showToNewUsers``,
+# ``createdBy`` and the audit timestamps — telling a user which roles a notice
+# was aimed at, or that one exists in a state they cannot see, is a small
+# information leak with no upside. Two explicit models means adding an admin
+# field can never widen the user payload by accident.
+# =============================================================================
+
+
+class UserAnnouncement(BaseModel):
+    """One announcement as a user sees it."""
+
+    announcement_id: str
+    title: str
+    body_markdown: str
+    summary: Optional[str] = None
+    surfaces: List[str]
+    severity: str
+    publish_at: str
+    expires_at: Optional[str] = None
+    requires_ack: bool
+    cta_label: Optional[str] = None
+    cta_url: Optional[str] = None
+    revision: int
+    #: No acknowledgement recorded at this revision — drives the unread dot.
+    is_unread: bool
+    #: Acked an earlier revision but not this one, so the panel says "Updated"
+    #: rather than "New" (§D4).
+    is_updated: bool
+
+    @classmethod
+    def from_announcement(
+        cls, a: Announcement, *, is_unread: bool, is_updated: bool
+    ) -> "UserAnnouncement":
+        return cls(
+            announcement_id=a.announcement_id,
+            title=a.title,
+            body_markdown=a.body_markdown,
+            summary=a.summary,
+            surfaces=list(a.surfaces),
+            severity=a.severity,
+            publish_at=a.publish_at,
+            expires_at=a.expires_at,
+            requires_ack=a.requires_ack,
+            cta_label=a.cta_label,
+            cta_url=a.cta_url,
+            revision=a.revision,
+            is_unread=is_unread,
+            is_updated=is_updated,
+        )
+
+
+class AnnouncementFeedResponse(BaseModel):
+    """``GET /announcements`` — already filtered and capped (§D5, §D7).
+
+    ``banner`` and ``modal`` are populated from PR-2 onward even though no SPA
+    surface renders them until PR-4 / PR-5; the contract is complete so those
+    PRs are pure frontend.
+    """
+
+    panel: List[UserAnnouncement]
+    banner: Optional[UserAnnouncement] = None
+    modal: Optional[UserAnnouncement] = None
+    unread_count: int
+
+
 def validate_announcement_invariants(
     *,
     surfaces: List[str],

--- a/backend/src/apis/shared/announcements/service.py
+++ b/backend/src/apis/shared/announcements/service.py
@@ -1,16 +1,19 @@
 """Service layer for feature announcements.
 
-Thin over the repository, with two pieces of policy that must not live in a
-route handler because PR-2's user-facing surface will call the same methods:
+Thin over the repository, with the policy that must not live in a route
+handler because both the admin surface and the user surface go through it:
 
   - ``panel`` is forced into ``surfaces`` (§D1) — dismissing a loud surface can
     never destroy the information.
   - ack TTLs are derived from the announcement, not supplied by the caller
     (§5), so a client cannot pick its own retention.
+  - the user feed is assembled here, so ``GET /announcements`` and the ack
+    endpoint's 404 check answer "can this user see it?" the same way.
 """
 
 import logging
-from typing import List, Optional
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence
 
 from .models import (
     Announcement,
@@ -19,6 +22,7 @@ from .models import (
     AnnouncementUpdate,
 )
 from .repository import AnnouncementsRepository, get_announcements_repository
+from .visibility import AnnouncementFeed, compute_feed
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +127,32 @@ class AnnouncementsService:
         self, user_id: str, announcement_id: str, revision: int
     ) -> Optional[AnnouncementAck]:
         return await self._repo.get_ack(user_id, announcement_id, revision)
+
+    # ── User-facing feed ─────────────────────────────────────────────────
+
+    async def build_feed(
+        self,
+        *,
+        user_id: str,
+        user_roles: Sequence[str],
+        user_created_at: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> AnnouncementFeed:
+        """What this user should see, already filtered and capped (§D5, §D7).
+
+        Two DynamoDB queries — the published announcements and this user's
+        acks. Both are tens of items, and neither is on the model call path
+        (§D12).
+        """
+        announcements = await self._repo.list_announcements(states=["published"])
+        acks = await self._repo.list_acks(user_id)
+        return compute_feed(
+            announcements=announcements,
+            user_roles=user_roles,
+            acks=acks,
+            now=now or datetime.now(timezone.utc),
+            user_created_at=user_created_at,
+        )
 
 
 _service: Optional[AnnouncementsService] = None

--- a/backend/src/apis/shared/announcements/visibility.py
+++ b/backend/src/apis/shared/announcements/visibility.py
@@ -1,0 +1,249 @@
+"""Who sees which announcement — the whole of it, in one pure function.
+
+Spec §D5: **the server computes visibility, the client renders what it is
+handed.** The alternative — ship every announcement plus the ack list and
+filter in the SPA — puts these rules in two languages, lets them drift, and
+leaks announcements to users who were never targeted.
+
+So this module is deliberately dependency-free: no DynamoDB, no FastAPI, no
+clock of its own. It takes the announcements, the user's roles, the user's
+acks, and `now`, and returns exactly what the response should contain. That
+makes the rules table-testable without moto, which is the point — this is
+where the logic lives, so this is where the tests are.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from apis.shared.timestamps import from_iso
+
+from .models import SUPPRESSING_RANK, Announcement, AnnouncementAck
+
+logger = logging.getLogger(__name__)
+
+#: Tie-break order when more than one announcement wants the single banner or
+#: modal slot. Not a semantic severity scale — it is the loudness the banner
+#: colours already imply, used only to decide which of several eligible items
+#: goes first. Lower sorts earlier.
+SEVERITY_ORDER: Dict[str, int] = {"warning": 0, "success": 1, "info": 2}
+
+_TARGET_EVERYONE = "*"
+
+
+@dataclass
+class VisibleAnnouncement:
+    """One announcement plus this user's relationship to it."""
+
+    announcement: Announcement
+    #: No ack at all for the current revision — drives the unread dot.
+    is_unread: bool
+    #: Acked an *earlier* revision but not this one. The panel says "Updated"
+    #: rather than plain "New", which is the whole reason acks are keyed by
+    #: revision (§D4).
+    is_updated: bool
+
+
+@dataclass
+class AnnouncementFeed:
+    """Everything ``GET /announcements`` returns, already filtered and capped."""
+
+    panel: List[VisibleAnnouncement] = field(default_factory=list)
+    banner: Optional[VisibleAnnouncement] = None
+    modal: Optional[VisibleAnnouncement] = None
+    unread_count: int = 0
+
+    def contains(self, announcement_id: str) -> bool:
+        """Whether this user may act on ``announcement_id`` at all.
+
+        Membership is checked against the **panel**, which holds every eligible
+        announcement — the banner and modal are capped subsets of it, and a
+        dismissed item leaves those two but stays here.
+        """
+        return any(v.announcement.announcement_id == announcement_id for v in self.panel)
+
+    def get(self, announcement_id: str) -> Optional[Announcement]:
+        for v in self.panel:
+            if v.announcement.announcement_id == announcement_id:
+                return v.announcement
+        return None
+
+
+def _parse(value: Optional[str], *, what: str) -> Optional[datetime]:
+    """Parse a stored timestamp, or None if it is absent or unusable.
+
+    Never raises. Every caller here treats None as "no constraint", so a row
+    hand-written into DynamoDB with a broken date fails toward *showing* the
+    announcement. That is the recoverable direction — the spec makes the same
+    choice for a missing ``created_at`` (§D6), and for the same reason: an
+    announcement that appears when it should not is visible and fixable, while
+    one that silently never appears is neither.
+    """
+    if not value:
+        return None
+    try:
+        return from_iso(value)
+    except (ValueError, TypeError):
+        logger.warning("Unparseable %s on announcement row: %r", what, value)
+        return None
+
+
+def _targets_user(announcement: Announcement, roles: Sequence[str]) -> bool:
+    """§D9 — a display filter over ``User.roles``, never an RBAC grant.
+
+    There is no ``can_access_*`` predicate behind this and nothing is inherited;
+    it decides what a notice board shows, not what a user may do.
+    """
+    targets = announcement.target_roles or [_TARGET_EVERYONE]
+    if _TARGET_EVERYONE in targets:
+        return True
+    return bool(set(targets) & set(roles or []))
+
+
+def _joined_before_publication(
+    announcement: Announcement, user_created_at: Optional[datetime]
+) -> bool:
+    """§D6 — new-user backfill suppression.
+
+    A user who joined *after* an announcement was published does not see it:
+    without this, someone signing up eighteen months from now meets a queue of
+    modals about features that have always existed from their point of view.
+
+    ``showToNewUsers`` is the deliberate exception, for a standing notice that
+    genuinely applies to everyone who ever joins.
+
+    Fallback: no usable ``created_at`` means treat the user as **existing** and
+    show the announcement.
+    """
+    if announcement.show_to_new_users:
+        return True
+    if user_created_at is None:
+        return True
+    published_at = _parse(announcement.publish_at, what="publishAt")
+    if published_at is None:
+        return True
+    return published_at > user_created_at
+
+
+def _within_window(announcement: Announcement, now: datetime) -> bool:
+    published_at = _parse(announcement.publish_at, what="publishAt")
+    if published_at is not None and published_at > now:
+        return False
+    expires_at = _parse(announcement.expires_at, what="expiresAt")
+    if expires_at is not None and expires_at <= now:
+        return False
+    return True
+
+
+def _sort_key_for_slot(visible: VisibleAnnouncement) -> tuple:
+    """Highest severity, then oldest ``publishAt`` (§D7).
+
+    Oldest-first drains the queue in the order things happened; whatever loses
+    the slot stays eligible for the next page load.
+    """
+    a = visible.announcement
+    published_at = _parse(a.publish_at, what="publishAt")
+    return (
+        SEVERITY_ORDER.get(a.severity, len(SEVERITY_ORDER)),
+        published_at.timestamp() if published_at else 0.0,
+        a.announcement_id,
+    )
+
+
+def compute_feed(
+    *,
+    announcements: Iterable[Announcement],
+    user_roles: Sequence[str],
+    acks: Iterable[AnnouncementAck],
+    now: datetime,
+    user_created_at: Optional[str] = None,
+) -> AnnouncementFeed:
+    """Filter and cap the announcements this user should see.
+
+    Note where the ack check lands. The spec's filter chain lists it as step 5,
+    before the caps — but D1 and D2 are explicit that dismissing a loud surface
+    keeps the entry in the panel, so a literal reading would delete the durable
+    record the whole design is built around. The eligibility filter is
+    therefore steps 1–4, and the ack suppression applies **only when choosing
+    the banner and the modal**.
+    """
+    # Every datetime this function compares comes from `from_iso`, which is
+    # always tz-aware. A naive `now` would therefore raise on the first
+    # comparison rather than mis-sort, so normalize it instead of trusting
+    # each caller.
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    joined_at = _parse(user_created_at, what="user createdAt")
+
+    # Highest rank this user has recorded per (announcement, revision).
+    ranks: Dict[tuple, int] = {}
+    revisions_seen: Dict[str, set] = {}
+    for ack in acks:
+        key = (ack.announcement_id, int(ack.revision))
+        ranks[key] = max(ranks.get(key, 0), int(ack.action_rank))
+        revisions_seen.setdefault(ack.announcement_id, set()).add(int(ack.revision))
+
+    eligible: List[VisibleAnnouncement] = []
+    for a in announcements:
+        if a.state != "published":
+            continue
+        if not _within_window(a, now):
+            continue
+        if not _targets_user(a, user_roles):
+            continue
+        if not _joined_before_publication(a, joined_at):
+            continue
+
+        current = (a.announcement_id, int(a.revision))
+        acked_current = current in ranks
+        acked_earlier = any(
+            r < int(a.revision) for r in revisions_seen.get(a.announcement_id, ())
+        )
+        eligible.append(
+            VisibleAnnouncement(
+                announcement=a,
+                is_unread=not acked_current,
+                is_updated=not acked_current and acked_earlier,
+            )
+        )
+
+    # The panel is uncapped and newest-first — it is a list, and a list of five
+    # is fine.
+    eligible.sort(
+        key=lambda v: (
+            _parse(v.announcement.publish_at, what="publishAt")
+            or datetime.min.replace(tzinfo=timezone.utc),
+            v.announcement.announcement_id,
+        ),
+        reverse=True,
+    )
+
+    def _unsuppressed(surface: str) -> List[VisibleAnnouncement]:
+        return [
+            v
+            for v in eligible
+            if surface in v.announcement.surfaces
+            and ranks.get(
+                (v.announcement.announcement_id, int(v.announcement.revision)), 0
+            )
+            < SUPPRESSING_RANK
+        ]
+
+    banner_candidates = sorted(_unsuppressed("banner"), key=_sort_key_for_slot)
+    # `requiresAck` first, so a blocking notice is never queued behind an
+    # informational one.
+    modal_candidates = sorted(
+        _unsuppressed("modal"),
+        key=lambda v: (not v.announcement.requires_ack, *_sort_key_for_slot(v)),
+    )
+
+    return AnnouncementFeed(
+        panel=eligible,
+        banner=banner_candidates[0] if banner_candidates else None,
+        modal=modal_candidates[0] if modal_candidates else None,
+        unread_count=sum(1 for v in eligible if v.is_unread),
+    )

--- a/backend/tests/shared/test_announcements_user_routes.py
+++ b/backend/tests/shared/test_announcements_user_routes.py
@@ -1,0 +1,382 @@
+"""Route tests for the user-facing announcement surface.
+
+The filter rules themselves are covered exhaustively (and without moto) in
+``test_announcements_visibility.py``. What is tested here is the wiring: that
+the endpoint serves the computed feed, that the ack path is monotonic
+end-to-end, that an id targeted at another role 404s rather than 403s, and
+that the payload does not leak admin metadata.
+"""
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.shared.announcements import repository as repo_module
+from apis.shared.announcements import service as service_module
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+
+AWS_REGION = "us-east-1"
+TABLE_NAME = "test-announcements-user-routes"
+USERS_TABLE = "test-announcements-users"
+
+PAST = "2020-01-01T00:00:00Z"
+FUTURE = "2099-01-01T00:00:00Z"
+
+
+def _make_user(user_id: str = "u1", roles=None) -> User:
+    return User(
+        email=f"{user_id}@example.com",
+        user_id=user_id,
+        name="Test User",
+        roles=roles if roles is not None else ["User"],
+    )
+
+
+@pytest.fixture()
+def announcements_table(aws, monkeypatch):
+    ddb = boto3.client("dynamodb", region_name=AWS_REGION)
+    for name in (TABLE_NAME, USERS_TABLE):
+        ddb.create_table(
+            TableName=name,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+    monkeypatch.setenv("DYNAMODB_ANNOUNCEMENTS_TABLE_NAME", TABLE_NAME)
+    monkeypatch.setenv("AWS_REGION", AWS_REGION)
+    # No users table configured: `_user_created_at` returns None, which the
+    # filter reads as "existing user". The new-user rule has its own coverage.
+    monkeypatch.delenv("DYNAMODB_USERS_TABLE_NAME", raising=False)
+    monkeypatch.setattr(repo_module, "_repository", None)
+    monkeypatch.setattr(service_module, "_service", None)
+    return boto3.resource("dynamodb", region_name=AWS_REGION).Table(TABLE_NAME)
+
+
+def _client(user: User = None) -> TestClient:
+    from apis.app_api.announcements.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_from_session] = lambda: user or _make_user()
+    return TestClient(app)
+
+
+async def _seed(**kw):
+    """Create + publish one announcement straight through the service."""
+    from apis.shared.announcements.models import AnnouncementCreate
+
+    service = service_module.get_announcements_service()
+    defaults = dict(title="Skills are here", body_markdown="# Skills", publish_at=PAST)
+    defaults.update(kw)
+    created = await service.create_announcement(AnnouncementCreate(**defaults))
+    return await service.publish(created.announcement_id)
+
+
+class TestFeed:
+    @pytest.mark.asyncio
+    async def test_returns_published_announcements(self, announcements_table):
+        await _seed()
+        body = _client().get("/announcements/").json()
+
+        assert len(body["panel"]) == 1
+        assert body["panel"][0]["title"] == "Skills are here"
+        assert body["unread_count"] == 1
+        assert body["banner"] is None and body["modal"] is None
+
+    @pytest.mark.asyncio
+    async def test_drafts_are_invisible(self, announcements_table):
+        from apis.shared.announcements.models import AnnouncementCreate
+
+        await service_module.get_announcements_service().create_announcement(
+            AnnouncementCreate(title="Draft", body_markdown="x", publish_at=PAST)
+        )
+        assert _client().get("/announcements/").json()["panel"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_banner_announcement_fills_the_banner_slot(self, announcements_table):
+        await _seed(surfaces=["panel", "banner"], expires_at=FUTURE)
+        body = _client().get("/announcements/").json()
+
+        assert body["banner"] is not None
+        assert len(body["panel"]) == 1, "the banner item is also a panel item"
+
+    @pytest.mark.asyncio
+    async def test_targeting_scopes_the_feed_per_user(self, announcements_table):
+        await _seed(title="Faculty only", target_roles=["faculty"])
+
+        assert _client(_make_user("u1", ["student"])).get("/announcements/").json()["panel"] == []
+        assert (
+            len(_client(_make_user("u2", ["faculty"])).get("/announcements/").json()["panel"]) == 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_payload_omits_admin_metadata(self, announcements_table):
+        """A user must not learn which roles a notice was aimed at, who wrote
+        it, or that it exists in a state they cannot see."""
+        await _seed(target_roles=["faculty", "staff"])
+        item = _client(_make_user("u1", ["faculty"])).get("/announcements/").json()["panel"][0]
+
+        for leaked in ("target_roles", "state", "created_by", "show_to_new_users", "updated_at"):
+            assert leaked not in item, f"{leaked} leaked into the user payload"
+
+    @pytest.mark.asyncio
+    async def test_acks_are_scoped_to_the_caller(self, announcements_table):
+        announcement = await _seed()
+        _client(_make_user("u1")).post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "seen", "surface": "panel"},
+        )
+
+        assert _client(_make_user("u1")).get("/announcements/").json()["unread_count"] == 0
+        assert _client(_make_user("u2")).get("/announcements/").json()["unread_count"] == 1
+
+
+class TestNewUserSuppressionWiring:
+    """The §D6 rule itself is covered in the visibility tests. What is covered
+    here is the *wiring* — that the route actually reads `created_at` off the
+    user profile. A bug here (wrong repository, wrong field, an exception
+    swallowed too eagerly) would silently disable new-user suppression while
+    every unit test still passed."""
+
+    @pytest.fixture()
+    def users_table(self, announcements_table, monkeypatch):
+        monkeypatch.setenv("DYNAMODB_USERS_TABLE_NAME", USERS_TABLE)
+        return boto3.resource("dynamodb", region_name=AWS_REGION).Table(USERS_TABLE)
+
+    def _put_user(self, table, user_id: str, created_at: str) -> None:
+        table.put_item(
+            Item={
+                "PK": f"USER#{user_id}",
+                "SK": "PROFILE",
+                "userId": user_id,
+                "email": f"{user_id}@example.com",
+                "name": "Test User",
+                "emailDomain": "example.com",
+                "createdAt": created_at,
+                "lastLoginAt": created_at,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_user_who_joined_after_publication_sees_nothing(self, users_table):
+        await _seed(publish_at="2026-01-01T00:00:00Z")
+        self._put_user(users_table, "newbie", "2026-06-01T00:00:00Z")
+
+        body = _client(_make_user("newbie")).get("/announcements/").json()
+        assert body["panel"] == []
+        assert body["unread_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_user_who_joined_earlier_still_sees_it(self, users_table):
+        await _seed(publish_at="2026-01-01T00:00:00Z")
+        self._put_user(users_table, "oldtimer", "2025-01-01T00:00:00Z")
+
+        assert len(_client(_make_user("oldtimer")).get("/announcements/").json()["panel"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_missing_profile_fails_toward_showing(self, users_table):
+        """Failing toward showing a message is recoverable; failing toward
+        silence is not — a directory blip must not decide what a user reads."""
+        await _seed(publish_at="2026-01-01T00:00:00Z")
+
+        assert len(_client(_make_user("ghost")).get("/announcements/").json()["panel"]) == 1
+
+
+class TestAck:
+    @pytest.mark.asyncio
+    async def test_ack_returns_204_and_clears_unread(self, announcements_table):
+        announcement = await _seed()
+        client = _client()
+
+        resp = client.post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "seen", "surface": "panel"},
+        )
+        assert resp.status_code == 204
+        assert client.get("/announcements/").json()["unread_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_dismiss_drops_the_banner_but_keeps_the_panel_entry(
+        self, announcements_table
+    ):
+        announcement = await _seed(surfaces=["panel", "banner"], expires_at=FUTURE)
+        client = _client()
+
+        client.post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "dismissed", "surface": "banner"},
+        )
+
+        body = client.get("/announcements/").json()
+        assert body["banner"] is None
+        assert len(body["panel"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_late_seen_does_not_resurrect_a_dismissed_banner(
+        self, announcements_table
+    ):
+        """The §D2 race, end to end through the HTTP surface.
+
+        `seen` is written on render and can land after the user's ✕. If the
+        monotonic guard were only in a unit test, this is the path that would
+        regress.
+        """
+        announcement = await _seed(surfaces=["panel", "banner"], expires_at=FUTURE)
+        client = _client()
+        url = f"/announcements/{announcement.announcement_id}/ack"
+
+        client.post(url, json={"action": "dismissed", "surface": "banner"})
+        late = client.post(url, json={"action": "seen", "surface": "banner"})
+
+        assert late.status_code == 204, "a no-op ack is success, not an error"
+        assert client.get("/announcements/").json()["banner"] is None
+
+    @pytest.mark.asyncio
+    async def test_ack_is_idempotent(self, announcements_table):
+        announcement = await _seed()
+        client = _client()
+        url = f"/announcements/{announcement.announcement_id}/ack"
+
+        assert client.post(url, json={"action": "seen", "surface": "panel"}).status_code == 204
+        assert client.post(url, json={"action": "seen", "surface": "panel"}).status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_ack_on_an_unknown_id_is_404(self, announcements_table):
+        resp = _client().post(
+            "/announcements/does-not-exist/ack",
+            json={"action": "seen", "surface": "panel"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_ack_on_another_roles_announcement_is_404_not_403(
+        self, announcements_table
+    ):
+        """403 would confirm the announcement exists. 404 does not."""
+        announcement = await _seed(target_roles=["faculty"])
+
+        resp = _client(_make_user("u1", ["student"])).post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "dismissed", "surface": "panel"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_ack_on_a_draft_is_404(self, announcements_table):
+        from apis.shared.announcements.models import AnnouncementCreate
+
+        draft = await service_module.get_announcements_service().create_announcement(
+            AnnouncementCreate(title="Draft", body_markdown="x", publish_at=PAST)
+        )
+        resp = _client().post(
+            f"/announcements/{draft.announcement_id}/ack",
+            json={"action": "seen", "surface": "panel"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_action_is_422(self, announcements_table):
+        announcement = await _seed()
+        resp = _client().post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "skimmed", "surface": "panel"},
+        )
+        assert resp.status_code == 422
+
+
+class TestRevision:
+    @pytest.mark.asyncio
+    async def test_a_revise_makes_a_dismissed_item_unread_and_updated(
+        self, announcements_table
+    ):
+        announcement = await _seed(surfaces=["panel", "banner"], expires_at=FUTURE)
+        client = _client()
+        client.post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "dismissed", "surface": "banner"},
+        )
+        assert client.get("/announcements/").json()["banner"] is None
+
+        await service_module.get_announcements_service().revise(announcement.announcement_id)
+
+        body = client.get("/announcements/").json()
+        assert body["banner"] is not None, "the revision lapsed the suppression"
+        assert body["panel"][0]["is_updated"] is True
+        assert body["panel"][0]["revision"] == 2
+        assert body["unread_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_an_edit_does_not_re_show_a_dismissed_item(self, announcements_table):
+        """A typo fix must not re-fire at everyone who already dismissed."""
+        from apis.shared.announcements.models import AnnouncementUpdate
+
+        announcement = await _seed(surfaces=["panel", "banner"], expires_at=FUTURE)
+        client = _client()
+        client.post(
+            f"/announcements/{announcement.announcement_id}/ack",
+            json={"action": "dismissed", "surface": "banner"},
+        )
+
+        await service_module.get_announcements_service().update_announcement(
+            announcement.announcement_id, AnnouncementUpdate(title="Skills are here!")
+        )
+
+        body = client.get("/announcements/").json()
+        assert body["banner"] is None
+        assert body["panel"][0]["title"] == "Skills are here!"
+
+
+class TestFeatureFlag:
+    @pytest.mark.asyncio
+    async def test_both_routes_404_when_disabled(self, announcements_table, monkeypatch):
+        announcement = await _seed()
+        monkeypatch.setenv("ANNOUNCEMENTS_ENABLED", "false")
+        client = _client()
+
+        assert client.get("/announcements/").status_code == 404
+        assert (
+            client.post(
+                f"/announcements/{announcement.announcement_id}/ack",
+                json={"action": "seen", "surface": "panel"},
+            ).status_code
+            == 404
+        )
+
+    @pytest.mark.asyncio
+    async def test_routes_serve_when_the_flag_is_unset(self, announcements_table, monkeypatch):
+        await _seed()
+        monkeypatch.delenv("ANNOUNCEMENTS_ENABLED", raising=False)
+        assert _client().get("/announcements/").status_code == 200
+
+
+class TestAuth:
+    def test_every_route_requires_a_session(self):
+        """Cookie session auth, never Bearer — CLAUDE.md's app_api rule."""
+        from apis.app_api.announcements import routes as announcement_routes
+
+        unauthenticated = []
+        for route in announcement_routes.router.routes:
+            names = {
+                sub.call.__name__
+                for sub in getattr(getattr(route, "dependant", None), "dependencies", [])
+                if getattr(sub, "call", None)
+            }
+            nested = set()
+            for sub in getattr(getattr(route, "dependant", None), "dependencies", []):
+                nested |= {
+                    inner.call.__name__
+                    for inner in getattr(sub, "dependencies", [])
+                    if getattr(inner, "call", None)
+                }
+            if "get_current_user_from_session" not in (names | nested):
+                unauthenticated.append(getattr(route, "path", "?"))
+
+        assert unauthenticated == []

--- a/backend/tests/shared/test_announcements_visibility.py
+++ b/backend/tests/shared/test_announcements_visibility.py
@@ -1,0 +1,367 @@
+"""The visibility filter — state, dates, roles, new-user suppression, acks, caps.
+
+This is where the logic is, so this is where the tests are (spec §10).
+``compute_feed`` is pure, so none of this needs moto: the cases below are the
+rules stated as data.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from apis.shared.announcements.models import Announcement, AnnouncementAck
+from apis.shared.announcements.visibility import SEVERITY_ORDER, compute_feed
+
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+LAST_WEEK = _iso(NOW - timedelta(days=7))
+YESTERDAY = _iso(NOW - timedelta(days=1))
+TOMORROW = _iso(NOW + timedelta(days=1))
+NEXT_YEAR = _iso(NOW + timedelta(days=365))
+TWO_YEARS_AGO = _iso(NOW - timedelta(days=730))
+
+
+def _announcement(announcement_id: str = "a1", **kw) -> Announcement:
+    defaults = dict(
+        announcement_id=announcement_id,
+        title=f"Title {announcement_id}",
+        body_markdown="Body",
+        created_at=LAST_WEEK,
+        updated_at=LAST_WEEK,
+        publish_at=LAST_WEEK,
+        state="published",
+        surfaces=["panel"],
+    )
+    defaults.update(kw)
+    return Announcement(**defaults)
+
+
+def _ack(announcement_id: str, action: str, revision: int = 1) -> AnnouncementAck:
+    return AnnouncementAck(
+        user_id="u1",
+        announcement_id=announcement_id,
+        revision=revision,
+        action=action,
+        action_at=YESTERDAY,
+        surface="panel",
+    )
+
+
+def _feed(announcements, *, roles=("user",), acks=(), created_at=None, now=NOW):
+    return compute_feed(
+        announcements=list(announcements),
+        user_roles=list(roles),
+        acks=list(acks),
+        now=now,
+        user_created_at=created_at,
+    )
+
+
+def _panel_ids(feed) -> list:
+    return [v.announcement.announcement_id for v in feed.panel]
+
+
+# ======================================================================
+# Steps 1-2: state and the publish window
+# ======================================================================
+
+
+class TestStateAndDates:
+    @pytest.mark.parametrize("state", ["draft", "scheduled", "archived"])
+    def test_only_published_announcements_are_visible(self, state):
+        assert _panel_ids(_feed([_announcement(state=state)])) == []
+
+    def test_published_is_visible(self):
+        assert _panel_ids(_feed([_announcement()])) == ["a1"]
+
+    def test_a_future_publish_at_is_not_yet_visible(self):
+        assert _panel_ids(_feed([_announcement(publish_at=TOMORROW)])) == []
+
+    def test_an_expired_announcement_is_gone(self):
+        assert (
+            _panel_ids(_feed([_announcement(publish_at=TWO_YEARS_AGO, expires_at=YESTERDAY)]))
+            == []
+        )
+
+    def test_an_unexpired_announcement_is_visible(self):
+        assert _panel_ids(_feed([_announcement(expires_at=TOMORROW)])) == ["a1"]
+
+    def test_no_expiry_means_never_expires(self):
+        assert _panel_ids(_feed([_announcement(expires_at=None)])) == ["a1"]
+
+    def test_expiry_exactly_now_is_expired(self):
+        """`expiresAt > now` per the spec — the boundary closes the window."""
+        assert _panel_ids(_feed([_announcement(expires_at=_iso(NOW))])) == []
+
+    def test_publish_exactly_now_is_live(self):
+        """`publishAt <= now` — the boundary opens the window."""
+        assert _panel_ids(_feed([_announcement(publish_at=_iso(NOW))])) == ["a1"]
+
+    def test_a_naive_now_is_normalized_rather_than_raising(self):
+        """Everything else here is tz-aware, so a naive `now` would blow up on
+        the first comparison instead of merely mis-sorting."""
+        naive = NOW.replace(tzinfo=None)
+        assert _panel_ids(_feed([_announcement()], now=naive)) == ["a1"]
+
+    def test_an_unparseable_date_fails_toward_showing(self):
+        """A hand-written row must not silently disappear."""
+        a = _announcement()
+        a.publish_at = "not a date"
+        assert _panel_ids(_feed([a])) == ["a1"]
+
+
+# ======================================================================
+# Step 3: targetRoles — a display filter, not an RBAC grant (§D9)
+# ======================================================================
+
+
+class TestTargetRoles:
+    def test_wildcard_targets_everyone(self):
+        assert _panel_ids(_feed([_announcement(target_roles=["*"])], roles=["anything"])) == ["a1"]
+
+    def test_a_matching_role_sees_it(self):
+        assert _panel_ids(
+            _feed([_announcement(target_roles=["faculty"])], roles=["staff", "faculty"])
+        ) == ["a1"]
+
+    def test_a_non_matching_role_does_not(self):
+        assert _panel_ids(_feed([_announcement(target_roles=["faculty"])], roles=["student"])) == []
+
+    def test_a_user_with_no_roles_still_sees_wildcard_items(self):
+        assert _panel_ids(_feed([_announcement()], roles=[])) == ["a1"]
+
+    def test_a_user_with_no_roles_sees_no_targeted_items(self):
+        assert _panel_ids(_feed([_announcement(target_roles=["faculty"])], roles=[])) == []
+
+    def test_empty_target_roles_is_treated_as_everyone(self):
+        """A hand-written row with no targeting must not vanish."""
+        assert _panel_ids(_feed([_announcement(target_roles=[])], roles=["student"])) == ["a1"]
+
+
+# ======================================================================
+# Step 4: new-user backfill suppression (§D6)
+# ======================================================================
+
+
+class TestNewUserSuppression:
+    def test_a_user_who_joined_after_publication_sees_nothing(self):
+        """The most common failure mode of announcement systems: a first login
+        that opens onto a queue of notices about features that, to this user,
+        have always existed."""
+        assert _panel_ids(_feed([_announcement(publish_at=LAST_WEEK)], created_at=YESTERDAY)) == []
+
+    def test_a_user_who_joined_before_publication_sees_it(self):
+        assert _panel_ids(
+            _feed([_announcement(publish_at=YESTERDAY)], created_at=LAST_WEEK)
+        ) == ["a1"]
+
+    def test_show_to_new_users_overrides_it(self):
+        """The standing-policy exception."""
+        assert _panel_ids(
+            _feed(
+                [_announcement(publish_at=LAST_WEEK, show_to_new_users=True)],
+                created_at=YESTERDAY,
+            )
+        ) == ["a1"]
+
+    def test_a_missing_created_at_fails_toward_showing(self):
+        assert _panel_ids(_feed([_announcement()], created_at=None)) == ["a1"]
+
+    def test_a_malformed_created_at_fails_toward_showing(self):
+        assert _panel_ids(_feed([_announcement()], created_at="tuesday")) == ["a1"]
+
+    def test_a_legacy_offset_and_z_created_at_still_parses(self):
+        """Rows written before the timestamp fix carry `+00:00Z` forever."""
+        legacy = (NOW - timedelta(days=30)).isoformat() + "Z"
+        assert _panel_ids(_feed([_announcement(publish_at=YESTERDAY)], created_at=legacy)) == ["a1"]
+
+
+# ======================================================================
+# Acks: suppression is loud-surface-only; the panel is durable
+# ======================================================================
+
+
+class TestAckSuppression:
+    def test_a_dismissed_announcement_stays_in_the_panel(self):
+        """§D1/§D2 — dismissing a loud surface must never destroy the record.
+
+        The spec's filter chain lists the ack check before the caps, which read
+        literally would drop the entry from the panel too. D1 and D2 are
+        explicit that it stays, so suppression applies only to banner/modal.
+        """
+        feed = _feed(
+            [_announcement(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)],
+            acks=[_ack("a1", "dismissed")],
+        )
+        assert _panel_ids(feed) == ["a1"]
+        assert feed.banner is None
+
+    def test_seen_does_not_suppress_the_banner(self):
+        """`seen` clears the unread dot and nothing else."""
+        feed = _feed(
+            [_announcement(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)],
+            acks=[_ack("a1", "seen")],
+        )
+        assert feed.banner is not None
+        assert feed.unread_count == 0
+
+    def test_acknowledged_suppresses_the_modal(self):
+        feed = _feed(
+            [_announcement(surfaces=["panel", "modal"], expires_at=NEXT_YEAR)],
+            acks=[_ack("a1", "acknowledged")],
+        )
+        assert feed.modal is None
+
+    def test_an_ack_at_an_older_revision_does_not_suppress(self):
+        """§D4 — bumping the revision lapses everyone's suppression at once."""
+        feed = _feed(
+            [
+                _announcement(
+                    surfaces=["panel", "banner"], expires_at=NEXT_YEAR, revision=2
+                )
+            ],
+            acks=[_ack("a1", "dismissed", revision=1)],
+        )
+        assert feed.banner is not None
+
+    def test_an_ack_belonging_to_another_announcement_is_ignored(self):
+        feed = _feed(
+            [_announcement("a1", surfaces=["panel", "banner"], expires_at=NEXT_YEAR)],
+            acks=[_ack("a2", "dismissed")],
+        )
+        assert feed.banner is not None
+
+
+class TestUnreadAndUpdated:
+    def test_a_never_acked_announcement_is_unread_and_not_updated(self):
+        feed = _feed([_announcement()])
+        assert feed.panel[0].is_unread is True
+        assert feed.panel[0].is_updated is False
+        assert feed.unread_count == 1
+
+    def test_acking_the_current_revision_clears_unread(self):
+        feed = _feed([_announcement()], acks=[_ack("a1", "seen")])
+        assert feed.panel[0].is_unread is False
+        assert feed.unread_count == 0
+
+    def test_a_bumped_revision_reads_as_updated_not_merely_new(self):
+        """Acked R1, now on R2 — the panel says *Updated*, which is the whole
+        reason acks are keyed by revision."""
+        feed = _feed([_announcement(revision=2)], acks=[_ack("a1", "dismissed", revision=1)])
+        assert feed.panel[0].is_unread is True
+        assert feed.panel[0].is_updated is True
+
+    def test_unread_count_counts_only_unacked_items(self):
+        feed = _feed(
+            [_announcement("a1"), _announcement("a2"), _announcement("a3")],
+            acks=[_ack("a2", "seen")],
+        )
+        assert feed.unread_count == 2
+
+
+# ======================================================================
+# Step 6: the caps (§D7)
+# ======================================================================
+
+
+class TestCaps:
+    def test_five_eligible_yield_five_panel_one_banner_one_modal(self):
+        loud = dict(surfaces=["panel", "banner", "modal"], expires_at=NEXT_YEAR)
+        feed = _feed([_announcement(f"a{i}", **loud) for i in range(5)])
+
+        assert len(feed.panel) == 5
+        assert feed.banner is not None
+        assert feed.modal is not None
+
+    def test_requires_ack_wins_the_modal_slot(self):
+        """A blocking notice is never queued behind an informational one, even
+        when the informational one is older and more severe."""
+        loud = dict(surfaces=["panel", "modal"], expires_at=NEXT_YEAR)
+        informational = _announcement(
+            "info", severity="warning", publish_at=TWO_YEARS_AGO, **loud
+        )
+        blocking = _announcement("blocking", requires_ack=True, publish_at=YESTERDAY, **loud)
+
+        feed = _feed([informational, blocking])
+        assert feed.modal.announcement.announcement_id == "blocking"
+
+    def test_banner_prefers_the_higher_severity(self):
+        loud = dict(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)
+        feed = _feed(
+            [
+                _announcement("info-item", severity="info", **loud),
+                _announcement("warn-item", severity="warning", **loud),
+            ]
+        )
+        assert feed.banner.announcement.announcement_id == "warn-item"
+
+    def test_banner_ties_break_on_oldest_first(self):
+        """Oldest-first drains the queue in the order things happened."""
+        loud = dict(surfaces=["panel", "banner"], severity="info", expires_at=NEXT_YEAR)
+        feed = _feed(
+            [
+                _announcement("newer", publish_at=YESTERDAY, **loud),
+                _announcement("older", publish_at=TWO_YEARS_AGO, **loud),
+            ]
+        )
+        assert feed.banner.announcement.announcement_id == "older"
+
+    def test_a_panel_only_announcement_fills_no_loud_slot(self):
+        feed = _feed([_announcement(surfaces=["panel"])])
+        assert feed.banner is None and feed.modal is None
+        assert len(feed.panel) == 1
+
+    def test_the_panel_is_newest_first(self):
+        feed = _feed(
+            [
+                _announcement("oldest", publish_at=TWO_YEARS_AGO),
+                _announcement("newest", publish_at=YESTERDAY),
+                _announcement("middle", publish_at=LAST_WEEK),
+            ]
+        )
+        assert _panel_ids(feed) == ["newest", "middle", "oldest"]
+
+    def test_the_loser_of_a_slot_stays_in_the_panel(self):
+        """Whatever loses the cap stays eligible for the next page load."""
+        loud = dict(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)
+        feed = _feed([_announcement("a1", **loud), _announcement("a2", **loud)])
+        assert len(feed.panel) == 2
+        assert feed.banner is not None
+
+
+class TestFeedHelpers:
+    def test_contains_and_get_answer_over_the_panel(self):
+        feed = _feed([_announcement("a1")])
+        assert feed.contains("a1") is True
+        assert feed.get("a1").announcement_id == "a1"
+        assert feed.contains("nope") is False
+        assert feed.get("nope") is None
+
+    def test_a_dismissed_item_is_still_ackable(self):
+        """A user who dismissed can ack again — idempotent, not a 404."""
+        feed = _feed(
+            [_announcement(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)],
+            acks=[_ack("a1", "dismissed")],
+        )
+        assert feed.contains("a1") is True
+
+    def test_an_empty_feed_is_empty(self):
+        feed = _feed([])
+        assert feed.panel == [] and feed.banner is None and feed.modal is None
+        assert feed.unread_count == 0
+
+    def test_an_unknown_severity_sorts_last_rather_than_crashing(self):
+        loud = dict(surfaces=["panel", "banner"], expires_at=NEXT_YEAR)
+        feed = _feed(
+            [
+                _announcement("weird", severity="chartreuse", **loud),
+                _announcement("known", severity="info", **loud),
+            ]
+        )
+        assert feed.banner.announcement.announcement_id == "known"
+        assert "chartreuse" not in SEVERITY_ORDER

--- a/frontend/ai.client/src/app/components/topnav/components/user-dropdown.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/user-dropdown.component.ts
@@ -19,6 +19,7 @@ import {
   heroCog6Tooth,
   heroArrowTopRightOnSquare,
   heroDocumentText,
+  heroMegaphone,
 } from '@ng-icons/heroicons/outline';
 import { ThemeService, ThemePreference } from './theme-toggle/theme.service';
 import { VERSION } from '../../../../version';
@@ -28,6 +29,8 @@ import {
   UserMenuLinkModalComponent,
   UserMenuLinkModalData,
 } from './user-menu-link-modal/user-menu-link-modal.component';
+import { WhatsNewPanelComponent } from './whats-new-panel/whats-new-panel.component';
+import { AnnouncementsService } from '../../../services/announcements/announcements.service';
 
 export interface User {
   firstName: string;
@@ -56,6 +59,7 @@ export interface User {
       heroCog6Tooth,
       heroArrowTopRightOnSquare,
       heroDocumentText,
+      heroMegaphone,
     })
   ],
   template: `
@@ -68,6 +72,16 @@ export interface User {
         aria-label="User menu"
       >
         <span class="sr-only">Open user menu</span>
+
+        <!-- Unread announcements. The count is in the label, not the colour —
+             a coloured dot alone is not an accessible signal. -->
+        @if (unreadCount() > 0) {
+          <span
+            class="absolute left-7 top-1.5 size-2.5 rounded-full bg-primary-600 ring-2 ring-white dark:ring-gray-900"
+            role="status"
+            [attr.aria-label]="unreadLabel()"
+          ></span>
+        }
 
         @if (user().picture) {
           <img
@@ -144,6 +158,31 @@ export interface User {
                 />
                 <span>Settings</span>
               </a>
+            </div>
+
+            <!-- What's New (feature announcements) -->
+            <div class="border-t border-gray-200 py-1 dark:border-gray-700">
+              <button
+                cdkMenuItem
+                type="button"
+                (click)="openWhatsNew()"
+                class="flex w-full items-center gap-3 px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700 rounded-xs outline-hidden text-left"
+                role="menuitem"
+              >
+                <ng-icon
+                  name="heroMegaphone"
+                  class="size-5 text-gray-400 dark:text-gray-500"
+                />
+                <span class="flex-1 truncate">What's New</span>
+                @if (unreadCount() > 0) {
+                  <span
+                    class="rounded-full bg-primary-600 px-1.5 py-0.5 text-xs/4 font-medium text-white"
+                    [attr.aria-label]="unreadLabel()"
+                  >
+                    {{ unreadCount() }}
+                  </span>
+                }
+              </button>
             </div>
 
             <!-- Admin-managed custom links -->
@@ -245,7 +284,17 @@ export interface User {
 export class UserDropdownComponent {
   private readonly themeService = inject(ThemeService);
   private readonly userMenuLinksService = inject(UserMenuLinksService);
+  private readonly announcements = inject(AnnouncementsService);
   private readonly dialog = inject(Dialog);
+
+  // Unread announcements. The service loads its feed on first read, which is
+  // here — the topnav only renders this dropdown once the session has
+  // resolved, so the request goes out post-auth with the user's roles known.
+  protected readonly unreadCount = this.announcements.unreadCount;
+  protected readonly unreadLabel = computed(() => {
+    const count = this.unreadCount();
+    return `${count} unread ${count === 1 ? 'announcement' : 'announcements'}`;
+  });
 
   // Inputs
   user = input.required<User>();
@@ -255,6 +304,13 @@ export class UserDropdownComponent {
   protected readonly customLinks = computed<UserMenuLink[]>(
     () => this.userMenuLinksService.enabledLinksResource.value()?.links ?? [],
   );
+
+  protected openWhatsNew(): void {
+    this.dialog.open<void>(WhatsNewPanelComponent, {
+      hasBackdrop: false, // the dialog component owns its own backdrop
+      panelClass: 'whats-new-panel',
+    });
+  }
 
   protected openLinkModal(link: UserMenuLink): void {
     this.dialog.open<void, UserMenuLinkModalData>(UserMenuLinkModalComponent, {

--- a/frontend/ai.client/src/app/components/topnav/components/whats-new-panel/whats-new-panel.component.spec.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/whats-new-panel/whats-new-panel.component.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { DialogRef } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { AnnouncementsService } from '../../../../services/announcements/announcements.service';
+import { Announcement } from '../../../../services/announcements/announcement.model';
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    announcement_id: 'a1',
+    title: 'Skills are here',
+    body_markdown: '# Skills',
+    summary: null,
+    surfaces: ['panel'],
+    severity: 'info',
+    publish_at: '2026-01-01T00:00:00Z',
+    expires_at: null,
+    requires_ack: false,
+    cta_label: null,
+    cta_url: null,
+    revision: 1,
+    is_unread: true,
+    is_updated: false,
+    ...overrides,
+  };
+}
+
+describe('WhatsNewPanelComponent', () => {
+  let panelItems: ReturnType<typeof signal<Announcement[]>>;
+  let readIds: Set<string>;
+  let mockAnnouncements: any;
+  let mockDialogRef: any;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    panelItems = signal<Announcement[]>([]);
+    readIds = new Set<string>();
+    mockAnnouncements = {
+      panelItems,
+      // Mirrors the real service: `markPanelSeen` clears unread immediately.
+      isUnread: (a: Announcement) => a.is_unread && !readIds.has(a.announcement_id),
+      markPanelSeen: vi.fn(async () => {
+        for (const a of panelItems()) readIds.add(a.announcement_id);
+      }),
+    };
+    mockDialogRef = { close: vi.fn() };
+
+    // DI-token overrides rather than vi.mock, per house convention.
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AnnouncementsService, useValue: mockAnnouncements },
+        { provide: DialogRef, useValue: mockDialogRef },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function createComponent() {
+    const { WhatsNewPanelComponent } = await import('./whats-new-panel.component');
+    return TestBed.runInInjectionContext(() => new WhatsNewPanelComponent());
+  }
+
+  function itemsOf(component: any) {
+    return component.items() as Array<{ announcement: Announcement; pill: string | null }>;
+  }
+
+  it('marks the panel seen on open — that is what clears the unread dot', async () => {
+    panelItems.set([makeAnnouncement()]);
+    await createComponent();
+
+    expect(mockAnnouncements.markPanelSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the pills visible after marking seen', async () => {
+    // The unread state is snapshotted at open. Reading it live would make
+    // every pill vanish the instant the dialog appeared, so the user would
+    // never learn which entries were new to them.
+    panelItems.set([makeAnnouncement({ is_unread: true })]);
+    const component = await createComponent();
+
+    expect(mockAnnouncements.isUnread(panelItems()[0])).toBe(false);
+    expect(itemsOf(component)[0].pill).toBe('New');
+  });
+
+  it('says "Updated" when the admin bumped the revision on something already read', async () => {
+    panelItems.set([makeAnnouncement({ is_unread: true, is_updated: true, revision: 2 })]);
+    const component = await createComponent();
+
+    expect(itemsOf(component)[0].pill).toBe('Updated');
+  });
+
+  it('shows no pill on an announcement that was already read', async () => {
+    panelItems.set([makeAnnouncement({ is_unread: false })]);
+    const component = await createComponent();
+
+    expect(itemsOf(component)[0].pill).toBeNull();
+  });
+
+  it('renders an empty list without calling the ack path', async () => {
+    panelItems.set([]);
+    const component = await createComponent();
+
+    expect(itemsOf(component)).toEqual([]);
+    expect(mockAnnouncements.markPanelSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes through the DialogRef', async () => {
+    const component = await createComponent();
+    (component as any).onClose();
+
+    expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+
+  describe('published label', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-10T12:00:00Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    async function labelFor(publishAt: string): Promise<string> {
+      panelItems.set([makeAnnouncement({ publish_at: publishAt })]);
+      const component = await createComponent();
+      return (component as any).items()[0].publishedLabel;
+    }
+
+    it('reads "Today" for something published hours ago', async () => {
+      expect(await labelFor('2026-06-10T09:00:00Z')).toBe('Today');
+    });
+
+    it('reads "Yesterday" for the day before', async () => {
+      expect(await labelFor('2026-06-09T09:00:00Z')).toBe('Yesterday');
+    });
+
+    it('counts days inside the last week', async () => {
+      expect(await labelFor('2026-06-07T12:00:00Z')).toBe('3 days ago');
+    });
+
+    it('falls back to a date beyond a week', async () => {
+      expect(await labelFor('2026-05-01T12:00:00Z')).toBe('May 1');
+    });
+
+    it('tolerates the legacy `+00:00Z` timestamp spelling', async () => {
+      // Rows written before the timestamp fix keep that spelling forever;
+      // `new Date()` returns Invalid Date for it, so the label would be blank.
+      expect(await labelFor('2026-06-09T09:00:00+00:00Z')).toBe('Yesterday');
+    });
+
+    it('renders nothing rather than "Invalid Date" for junk', async () => {
+      expect(await labelFor('not a date')).toBe('');
+    });
+  });
+});

--- a/frontend/ai.client/src/app/components/topnav/components/whats-new-panel/whats-new-panel.component.ts
+++ b/frontend/ai.client/src/app/components/topnav/components/whats-new-panel/whats-new-panel.component.ts
@@ -1,0 +1,218 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
+import { DialogRef } from '@angular/cdk/dialog';
+import { MarkdownComponent } from 'ngx-markdown';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroMegaphone } from '@ng-icons/heroicons/outline';
+import { DialogDismissDirective } from '../../../dialog/dialog-dismiss.directive';
+import { AnnouncementsService } from '../../../../services/announcements/announcements.service';
+import { Announcement } from '../../../../services/announcements/announcement.model';
+import { parseIso } from '../../../../utils/date';
+
+/**
+ * "What's New" — the durable announcement surface (§D1).
+ *
+ * Pull-based and uninterruptive by construction: it opens from the user menu,
+ * lists everything this user is eligible for newest-first, and never appears
+ * on its own. The banner (PR-4) and modal (PR-5) are the loud surfaces; this
+ * one is the record, which is why `panel` is forced onto every announcement
+ * server-side — dismissing a loud surface can never destroy the information.
+ *
+ * Markdown renders through `ngx-markdown` **with sanitization on**. Do not add
+ * `[disableSanitizer]` here: `admin.announcements` is a delegable scope, so
+ * this body may be authored by someone who is not a platform admin, and it is
+ * broadcast to every user (§D10).
+ *
+ * Opening the panel marks everything in it `seen`, which is what clears the
+ * unread dot.
+ */
+@Component({
+  selector: 'app-whats-new-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogDismissDirective, MarkdownComponent, NgIcon],
+  providers: [provideIcons({ heroXMark, heroMegaphone })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'onClose()',
+  },
+  template: `
+    <div
+      class="dialog-backdrop fixed inset-0 bg-gray-900/40 dark:bg-gray-900/70"
+      aria-hidden="true"
+    ></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+      appDialogDismiss
+      (dismissed)="onClose()"
+    >
+      <div
+        class="dialog-panel relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-xl sm:my-8 sm:max-w-2xl dark:border-gray-700 dark:bg-gray-800"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="titleId"
+      >
+        <div class="flex items-start justify-between gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <h2 [id]="titleId" class="text-lg/7 font-semibold text-gray-900 dark:text-white">
+            What's New
+          </h2>
+          <button
+            type="button"
+            (click)="onClose()"
+            aria-label="Close What's New"
+            class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="max-h-[70vh] overflow-y-auto px-6 py-5">
+          @if (items().length === 0) {
+            <div class="flex flex-col items-center gap-3 py-10 text-center">
+              <ng-icon
+                name="heroMegaphone"
+                class="size-8 text-gray-300 dark:text-gray-600"
+                aria-hidden="true"
+              />
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                No announcements yet. New features will show up here.
+              </p>
+            </div>
+          } @else {
+            <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+              @for (item of items(); track item.announcement.announcement_id) {
+                <li class="py-4 first:pt-0 last:pb-0">
+                  <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+                      {{ item.announcement.title }}
+                    </h3>
+                    @if (item.pill) {
+                      <span
+                        class="rounded-full bg-primary-600 px-2 py-0.5 text-xs/5 font-medium text-white"
+                      >
+                        {{ item.pill }}
+                      </span>
+                    }
+                    <span class="ml-auto text-xs/5 text-gray-500 dark:text-gray-400">
+                      {{ item.publishedLabel }}
+                    </span>
+                  </div>
+
+                  <!-- message-block is the app's markdown stylesheet
+                       (styles.css) — headings, lists, tables, code, links.
+                       Reusing it is what makes an announcement body read like
+                       an assistant message, per §D10. Note the prose classes
+                       are NOT an option: the Tailwind typography plugin is
+                       not installed, so they are inert and preflight strips
+                       list markers. -->
+                  <div class="message-block mt-2 text-sm/6 text-gray-700 dark:text-gray-300">
+                    <markdown [data]="item.announcement.body_markdown" />
+                  </div>
+
+                  @if (item.announcement.cta_url && item.announcement.cta_label) {
+                    <a
+                      [href]="item.announcement.cta_url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="mt-2 inline-flex text-sm/6 font-medium text-primary-accessible hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-accessible-dark"
+                    >
+                      {{ item.announcement.cta_label }}
+                    </a>
+                  }
+                </li>
+              }
+            </ul>
+          }
+        </div>
+
+        <div class="flex justify-end border-t border-gray-200 px-6 py-3 dark:border-gray-700">
+          <button
+            type="button"
+            (click)="onClose()"
+            class="rounded-2xl bg-blue-600 px-3 py-2 text-sm/6 font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @reference "../../../../../styles/theme.css";
+
+    .dialog-backdrop {
+      animation: backdrop-fade-in 200ms ease-out;
+    }
+    @keyframes backdrop-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    .dialog-panel {
+      animation: dialog-fade-in-up 200ms ease-out;
+    }
+    @keyframes dialog-fade-in-up {
+      from { opacity: 0; transform: translateY(1rem) scale(0.98); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+  `,
+})
+export class WhatsNewPanelComponent {
+  private readonly dialogRef = inject(DialogRef<void>);
+  private readonly announcements = inject(AnnouncementsService);
+
+  protected readonly titleId = `whats-new-title-${crypto.randomUUID()}`;
+
+  /**
+   * The unread state is snapshotted when the panel opens.
+   *
+   * `markPanelSeen()` clears it immediately, so reading `isUnread` live would
+   * make every pill vanish the instant the dialog appeared — the user would
+   * never see which entries were new to them. The dot on the avatar *should*
+   * clear right away; the pills in the list should not.
+   */
+  private readonly unreadAtOpen = new Set(
+    this.announcements
+      .panelItems()
+      .filter(a => this.announcements.isUnread(a))
+      .map(a => a.announcement_id),
+  );
+
+  protected readonly items = computed(() =>
+    this.announcements.panelItems().map(announcement => ({
+      announcement,
+      pill: this.pillFor(announcement),
+      publishedLabel: this.formatPublished(announcement.publish_at),
+    })),
+  );
+
+  constructor() {
+    // Opening the panel is the acknowledgement that these were seen.
+    void this.announcements.markPanelSeen();
+  }
+
+  protected onClose(): void {
+    this.dialogRef.close();
+  }
+
+  /** "Updated" when the admin bumped the revision on something already read. */
+  private pillFor(announcement: Announcement): string | null {
+    if (!this.unreadAtOpen.has(announcement.announcement_id)) return null;
+    return announcement.is_updated ? 'Updated' : 'New';
+  }
+
+  private formatPublished(publishAt: string): string {
+    const date = parseIso(publishAt);
+    if (Number.isNaN(date.getTime())) return '';
+
+    const diffMs = Date.now() - date.getTime();
+    const diffDays = Math.floor(diffMs / 86_400_000);
+    if (diffDays < 1) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+}

--- a/frontend/ai.client/src/app/services/announcements/announcement.model.ts
+++ b/frontend/ai.client/src/app/services/announcements/announcement.model.ts
@@ -1,0 +1,53 @@
+/**
+ * Feature announcements — the client mirror of
+ * `apis/shared/announcements/models.py` (`UserAnnouncement`).
+ *
+ * Deliberately narrower than the admin model: the server never sends
+ * `targetRoles`, `state`, or `createdBy` to a user, so there is nothing here
+ * to accidentally render.
+ *
+ * See `docs/specs/feature-announcements.md`.
+ */
+
+export type AnnouncementSurface = 'panel' | 'banner' | 'modal';
+export type AnnouncementSeverity = 'info' | 'success' | 'warning';
+
+/** What the user records about an announcement. Monotonic server-side (§D2). */
+export type AnnouncementAckAction = 'seen' | 'dismissed' | 'acknowledged';
+
+export interface Announcement {
+  announcement_id: string;
+  title: string;
+  body_markdown: string;
+  summary?: string | null;
+  surfaces: AnnouncementSurface[];
+  severity: AnnouncementSeverity;
+  publish_at: string;
+  expires_at?: string | null;
+  requires_ack: boolean;
+  cta_label?: string | null;
+  cta_url?: string | null;
+  revision: number;
+  /** No acknowledgement at this revision — drives the unread dot. */
+  is_unread: boolean;
+  /** Acked an earlier revision, so the panel says "Updated" not "New" (§D4). */
+  is_updated: boolean;
+}
+
+/**
+ * `GET /announcements` — already filtered and capped by the server (§D5/§D7).
+ *
+ * `banner` and `modal` are populated from the backend today; no SPA surface
+ * consumes them until PR-4 / PR-5.
+ */
+export interface AnnouncementFeed {
+  panel: Announcement[];
+  banner: Announcement | null;
+  modal: Announcement | null;
+  unread_count: number;
+}
+
+export interface AnnouncementAckRequest {
+  action: AnnouncementAckAction;
+  surface: AnnouncementSurface;
+}

--- a/frontend/ai.client/src/app/services/announcements/announcements.service.spec.ts
+++ b/frontend/ai.client/src/app/services/announcements/announcements.service.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { AnnouncementsService } from './announcements.service';
+import { Announcement, AnnouncementFeed } from './announcement.model';
+import { ConfigService } from '../config.service';
+
+const API = 'http://localhost:8000';
+const FEED_URL = `${API}/announcements/`;
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    announcement_id: 'a1',
+    title: 'Skills are here',
+    body_markdown: '# Skills',
+    summary: null,
+    surfaces: ['panel'],
+    severity: 'info',
+    publish_at: '2026-01-01T00:00:00Z',
+    expires_at: null,
+    requires_ack: false,
+    cta_label: null,
+    cta_url: null,
+    revision: 1,
+    is_unread: true,
+    is_updated: false,
+    ...overrides,
+  };
+}
+
+function makeFeed(overrides: Partial<AnnouncementFeed> = {}): AnnouncementFeed {
+  return {
+    panel: [makeAnnouncement()],
+    banner: null,
+    modal: null,
+    unread_count: 1,
+    ...overrides,
+  };
+}
+
+describe('AnnouncementsService', () => {
+  let service: AnnouncementsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        AnnouncementsService,
+        // DI-token override rather than vi.mock, per house convention —
+        // vi.mock pollutes across spec files.
+        { provide: ConfigService, useValue: { appApiUrl: signal(API) } },
+      ],
+    });
+    service = TestBed.inject(AnnouncementsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true).forEach(req => {
+      if (!req.cancelled) req.flush({});
+    });
+    TestBed.resetTestingModule();
+  });
+
+  /** Trigger the resource loader and settle its request. */
+  async function loadFeed(feed: AnnouncementFeed | 'error' = makeFeed()) {
+    service.feedResource.reload();
+    service.panelItems();
+    await vi.waitFor(() => {
+      const req = httpMock.expectOne(FEED_URL);
+      if (feed === 'error') {
+        req.flush('nope', { status: 500, statusText: 'Server Error' });
+      } else {
+        req.flush(feed);
+      }
+    });
+    await vi.waitFor(() => {
+      expect(service.feedResource.isLoading()).toBe(false);
+    });
+  }
+
+  describe('feed', () => {
+    it('exposes what the server sent', async () => {
+      await loadFeed(
+        makeFeed({
+          panel: [makeAnnouncement({ announcement_id: 'a1' })],
+          banner: makeAnnouncement({ announcement_id: 'a2', surfaces: ['panel', 'banner'] }),
+          modal: makeAnnouncement({ announcement_id: 'a3', surfaces: ['panel', 'modal'] }),
+          unread_count: 1,
+        }),
+      );
+
+      expect(service.panelItems().map(a => a.announcement_id)).toEqual(['a1']);
+      expect(service.bannerItem()?.announcement_id).toBe('a2');
+      expect(service.modalItem()?.announcement_id).toBe('a3');
+    });
+
+    it('does not re-derive the caps client-side', async () => {
+      // Five panel items, one banner — the server already capped it, and the
+      // service must not second-guess that (§D5).
+      const panel = ['a1', 'a2', 'a3', 'a4', 'a5'].map(id =>
+        makeAnnouncement({ announcement_id: id, surfaces: ['panel', 'banner'] }),
+      );
+      await loadFeed(makeFeed({ panel, banner: panel[0], unread_count: 5 }));
+
+      expect(service.panelItems()).toHaveLength(5);
+      expect(service.bannerItem()?.announcement_id).toBe('a1');
+    });
+
+    it('degrades to an empty feed when the endpoint fails', async () => {
+      // A 404 is the kill switch; a 500 is a bad day. Neither is worth an
+      // error in front of the user for an ambient surface.
+      await loadFeed('error');
+
+      expect(service.panelItems()).toEqual([]);
+      expect(service.unreadCount()).toBe(0);
+      expect(service.hasUnread()).toBe(false);
+    });
+  });
+
+  describe('unread count', () => {
+    it('counts unread panel items', async () => {
+      await loadFeed(
+        makeFeed({
+          panel: [
+            makeAnnouncement({ announcement_id: 'a1', is_unread: true }),
+            makeAnnouncement({ announcement_id: 'a2', is_unread: false }),
+            makeAnnouncement({ announcement_id: 'a3', is_unread: true }),
+          ],
+        }),
+      );
+
+      expect(service.unreadCount()).toBe(2);
+      expect(service.hasUnread()).toBe(true);
+    });
+
+    it('clears when the panel is marked seen, without waiting for the server', async () => {
+      await loadFeed(
+        makeFeed({
+          panel: [
+            makeAnnouncement({ announcement_id: 'a1' }),
+            makeAnnouncement({ announcement_id: 'a2' }),
+          ],
+          unread_count: 2,
+        }),
+      );
+
+      const done = service.markPanelSeen();
+      // The dot is already gone; the POSTs are still in flight.
+      expect(service.unreadCount()).toBe(0);
+
+      // `match()` *consumes* what it returns, so take the pending requests
+      // once and flush that same list — matching twice drains the queue and
+      // leaves the promise hanging.
+      const acks = httpMock.match(req => req.url.endsWith('/ack'));
+      expect(acks).toHaveLength(2);
+      acks.forEach(r => r.flush(null));
+      await done;
+    });
+
+    it('sends no request when everything is already read', async () => {
+      await loadFeed(
+        makeFeed({
+          panel: [makeAnnouncement({ is_unread: false })],
+          unread_count: 0,
+        }),
+      );
+
+      await service.markPanelSeen();
+      httpMock.expectNone(req => req.url.endsWith('/ack'));
+    });
+  });
+
+  describe('ack', () => {
+    it('posts the action and surface', async () => {
+      await loadFeed();
+
+      const done = service.ack('a1', 'dismissed', 'banner');
+      await vi.waitFor(() => {
+        const req = httpMock.expectOne(`${API}/announcements/a1/ack`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({ action: 'dismissed', surface: 'banner' });
+        req.flush(null);
+      });
+
+      expect(await done).toBe(true);
+    });
+
+    it('hides the item even when the ack fails — fail-open dismissal (§D7)', async () => {
+      // A user trapped under a banner they cannot dismiss because of a
+      // transient 500 is a worse outcome than one that comes back tomorrow.
+      await loadFeed(
+        makeFeed({
+          banner: makeAnnouncement({ announcement_id: 'a1', surfaces: ['panel', 'banner'] }),
+        }),
+      );
+      expect(service.bannerItem()).not.toBeNull();
+
+      const done = service.ack('a1', 'dismissed', 'banner');
+      await vi.waitFor(() => {
+        httpMock
+          .expectOne(`${API}/announcements/a1/ack`)
+          .flush('nope', { status: 500, statusText: 'Server Error' });
+      });
+
+      expect(await done).toBe(false);
+      expect(service.bannerItem()).toBeNull();
+    });
+
+    it('does not reject when the ack fails', async () => {
+      await loadFeed();
+
+      const done = service.ack('a1', 'dismissed', 'banner');
+      await vi.waitFor(() => {
+        httpMock
+          .expectOne(`${API}/announcements/a1/ack`)
+          .flush('nope', { status: 500, statusText: 'Server Error' });
+      });
+
+      // No caller should have to remember to catch this.
+      await expect(done).resolves.toBe(false);
+    });
+
+    it('a local dismissal hides the modal too', async () => {
+      await loadFeed(
+        makeFeed({
+          modal: makeAnnouncement({ announcement_id: 'a1', surfaces: ['panel', 'modal'] }),
+        }),
+      );
+
+      const done = service.ack('a1', 'acknowledged', 'modal');
+      await vi.waitFor(() => {
+        httpMock.expectOne(`${API}/announcements/a1/ack`).flush(null);
+      });
+      await done;
+
+      expect(service.modalItem()).toBeNull();
+    });
+
+    it('keeps the panel entry after a dismissal — the panel is the record (§D1)', async () => {
+      await loadFeed(
+        makeFeed({
+          panel: [makeAnnouncement({ announcement_id: 'a1', surfaces: ['panel', 'banner'] })],
+          banner: makeAnnouncement({ announcement_id: 'a1', surfaces: ['panel', 'banner'] }),
+        }),
+      );
+
+      const done = service.ack('a1', 'dismissed', 'banner');
+      await vi.waitFor(() => {
+        httpMock.expectOne(`${API}/announcements/a1/ack`).flush(null);
+      });
+      await done;
+
+      expect(service.bannerItem()).toBeNull();
+      expect(service.panelItems()).toHaveLength(1);
+    });
+
+    it('a `seen` ack does not hide anything', async () => {
+      await loadFeed(
+        makeFeed({
+          banner: makeAnnouncement({ announcement_id: 'a1', surfaces: ['panel', 'banner'] }),
+        }),
+      );
+
+      const done = service.ack('a1', 'seen', 'banner');
+      await vi.waitFor(() => {
+        httpMock.expectOne(`${API}/announcements/a1/ack`).flush(null);
+      });
+      await done;
+
+      // `seen` clears the dot and suppresses nothing (§D2).
+      expect(service.bannerItem()).not.toBeNull();
+      expect(service.unreadCount()).toBe(0);
+    });
+  });
+
+  describe('isUnread', () => {
+    it('reflects the server flag until acked locally', async () => {
+      await loadFeed();
+      const item = service.panelItems()[0];
+      expect(service.isUnread(item)).toBe(true);
+
+      const done = service.ack(item.announcement_id, 'seen', 'panel');
+      expect(service.isUnread(item)).toBe(false);
+
+      await vi.waitFor(() => {
+        httpMock.expectOne(`${API}/announcements/a1/ack`).flush(null);
+      });
+      await done;
+    });
+  });
+});

--- a/frontend/ai.client/src/app/services/announcements/announcements.service.ts
+++ b/frontend/ai.client/src/app/services/announcements/announcements.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, computed, inject, resource, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../config.service';
+import {
+  Announcement,
+  AnnouncementAckAction,
+  AnnouncementAckRequest,
+  AnnouncementFeed,
+  AnnouncementSurface,
+} from './announcement.model';
+
+const EMPTY_FEED: AnnouncementFeed = {
+  panel: [],
+  banner: null,
+  modal: null,
+  unread_count: 0,
+};
+
+/**
+ * Feature announcements — the read side and the acknowledgement side.
+ *
+ * **The server decides what is visible; this service renders what it is
+ * handed** (§D5). There is deliberately no targeting, date, or ack filtering
+ * here: those rules exist once, in `apis/shared/announcements/visibility.py`.
+ *
+ * Two pieces of local state exist on top of the server's answer, and both are
+ * conveniences rather than truth:
+ *
+ * - `locallyHidden` implements the **fail-open dismissal** from §D7. If the
+ *   ack POST fails, the item is hidden for this tab anyway. A user trapped
+ *   under a banner they cannot dismiss because of a transient 500 is a worse
+ *   outcome than an announcement that comes back tomorrow.
+ * - `locallyRead` clears the unread dot the moment the panel opens, without
+ *   waiting for the round trip. The server is still told, and the next fetch
+ *   agrees.
+ *
+ * Neither is ever the source of truth — that is the whole point of §D3.
+ */
+@Injectable({ providedIn: 'root' })
+export class AnnouncementsService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  private readonly baseUrl = computed(
+    () => `${this.config.appApiUrl()}/announcements`,
+  );
+
+  /**
+   * Loads on first read. The topnav only renders the user dropdown once the
+   * session bootstrap has resolved, so the loader fires post-auth with the
+   * user's roles known — which the server needs to evaluate targeting.
+   */
+  readonly feedResource = resource({
+    loader: async () => this.fetchFeed(),
+  });
+
+  /** Dismissed in this tab, whether or not the server agreed. */
+  private readonly locallyHidden = signal<ReadonlySet<string>>(new Set());
+  /** Read in this tab, so the dot clears before the round trip lands. */
+  private readonly locallyRead = signal<ReadonlySet<string>>(new Set());
+
+  private readonly feed = computed<AnnouncementFeed>(
+    () => this.feedResource.value() ?? EMPTY_FEED,
+  );
+
+  /** Every announcement this user may browse, newest first. Uncapped. */
+  readonly panelItems = computed<Announcement[]>(() => this.feed().panel);
+
+  /** At most one, chosen by the server. Consumed by PR-4. */
+  readonly bannerItem = computed<Announcement | null>(() =>
+    this.visibleOrNull(this.feed().banner),
+  );
+
+  /** At most one, chosen by the server. Consumed by PR-5. */
+  readonly modalItem = computed<Announcement | null>(() =>
+    this.visibleOrNull(this.feed().modal),
+  );
+
+  readonly unreadCount = computed<number>(() => {
+    const read = this.locallyRead();
+    return this.panelItems().filter(a => a.is_unread && !read.has(a.announcement_id))
+      .length;
+  });
+
+  readonly hasUnread = computed<boolean>(() => this.unreadCount() > 0);
+
+  /** Whether an item should render with a "New" / "Updated" pill. */
+  isUnread(announcement: Announcement): boolean {
+    return announcement.is_unread && !this.locallyRead().has(announcement.announcement_id);
+  }
+
+  /**
+   * Record an acknowledgement.
+   *
+   * Fails open (§D7): a rejected POST still hides the item locally and
+   * resolves rather than throwing, so no caller has to remember to catch.
+   * Returns whether the server accepted it, for tests and for a future retry.
+   */
+  async ack(
+    announcementId: string,
+    action: AnnouncementAckAction,
+    surface: AnnouncementSurface,
+  ): Promise<boolean> {
+    if (action !== 'seen') {
+      this.locallyHidden.update(prev => new Set(prev).add(announcementId));
+    }
+    this.locallyRead.update(prev => new Set(prev).add(announcementId));
+
+    const body: AnnouncementAckRequest = { action, surface };
+    try {
+      await firstValueFrom(
+        this.http.post<void>(`${this.baseUrl()}/${announcementId}/ack`, body),
+      );
+      return true;
+    } catch {
+      // Deliberately swallowed. The local hide already happened, and the next
+      // fetch re-derives the truth from the server.
+      return false;
+    }
+  }
+
+  /**
+   * Mark every unread panel item `seen` — what opening the What's-New panel
+   * means. Fire-and-forget per item, since each `ack` already fails open.
+   */
+  async markPanelSeen(): Promise<void> {
+    const unread = this.panelItems().filter(a => this.isUnread(a));
+    if (unread.length === 0) return;
+    await Promise.all(
+      unread.map(a => this.ack(a.announcement_id, 'seen', 'panel')),
+    );
+  }
+
+  /** Re-read the server's answer. */
+  reload(): void {
+    this.feedResource.reload();
+  }
+
+  private visibleOrNull(item: Announcement | null): Announcement | null {
+    if (!item) return null;
+    return this.locallyHidden().has(item.announcement_id) ? null : item;
+  }
+
+  private async fetchFeed(): Promise<AnnouncementFeed> {
+    try {
+      return await firstValueFrom(
+        this.http.get<AnnouncementFeed>(`${this.baseUrl()}/`),
+      );
+    } catch {
+      // The surface is kill-switched off (404) or the backend is unhappy.
+      // Announcements are ambient; none of this is worth an error to the user.
+      return EMPTY_FEED;
+    }
+  }
+}


### PR DESCRIPTION
PR-2 of [`docs/specs/feature-announcements.md`](docs/specs/feature-announcements.md), following [#966](https://github.com/Boise-State-Development/agentcore-public-stack/pull/966). This is the **durable surface**: users can see and acknowledge announcements, and nothing interrupts anyone.

The banner (PR-4) and modal (PR-5) are still unbuilt, but `GET /announcements` already returns their slots — so those PRs are pure frontend work against a contract that exists today.

## What's here

**Backend**

- **[`visibility.py`](backend/src/apis/shared/announcements/visibility.py)** — the entire filter chain as one pure function. No DynamoDB, no FastAPI, no clock of its own. The server computes visibility and the client renders what it is handed (§D5), so the rules live in one language instead of drifting across two — and they're table-testable without moto.
- `GET /announcements` → panel list + capped banner/modal slots + unread count. `POST /announcements/{id}/ack` → 204. Cookie session auth on both, per CLAUDE.md's app_api rule.
- `UserAnnouncement` is deliberately **not** a subset alias of the admin model. It omits `state`, `targetRoles`, `showToNewUsers` and `createdBy`, so adding an admin field later can't widen the user payload by accident.

**Frontend**

- **[`announcements.service.ts`](frontend/ai.client/src/app/services/announcements/announcements.service.ts)** — signal-based, loads on first read from the user dropdown (which the topnav renders only after the session resolves, so the request carries the roles the server needs for targeting).
- **[What's-New panel](frontend/ai.client/src/app/components/topnav/components/whats-new-panel/whats-new-panel.component.ts)** in the user menu, with the unread dot on the avatar and a count badge on the row.

## Three things worth a close read

**1. I diverged from the spec's filter chain, on purpose.** §D5 lists the ack check as step 5, *before* the caps. But D1 and D2 are explicit that dismissing a loud surface leaves the entry in the panel — so applied literally, step 5 deletes the durable record the whole design is built around. Eligibility (steps 1–4) produces the panel; ack suppression applies **only** when choosing the banner and the modal. Commented at the call site and pinned by a test.

**2. Browser verification caught a bug that every unit test passed.** The panel's markdown rendered lists without bullets and tables unstyled. The cause: the `prose` classes copied from `user-menu-link-modal` are **inert** — the Tailwind typography plugin isn't installed — so Tailwind's preflight `list-style: none` wins. The app's real markdown stylesheet is scoped under `.message-block` in `styles.css`. Switching to it fixed lists, tables, code and links at once, and it's what §D10 asks for anyway ("styling matches assistant messages").

> ⚠️ **`user-menu-link-modal` has this same latent bug today.** Any admin-authored modal link containing a list or table renders unstyled. Left alone here as out of scope, but it's a one-line fix worth doing.

**3. Fail-open dismissal (§D7).** A rejected ack still hides the item for the tab session and *resolves* rather than throwing, so no caller has to remember to catch. A user trapped under an undismissable banner by a transient 500 is a worse outcome than one that reappears tomorrow. `localStorage` is not used at all — server state is the truth (§D3).

Also: the ack endpoint returns **404, not 403**, for an id this user can't see. 403 would confirm that an announcement targeted at another role exists.

## Verification

Beyond the unit tests, I ran this against real dev data on a local stack (app-api on :8010, SPA on :4300, so nothing touched the running services on :4200/:8000) and confirmed the full loop:

- **New / Updated / already-read pills** all render correctly side by side.
- **Revision bump lapses suppression** — acked at R1, bumped to R2, the entry returns as *Updated* rather than plain *New*, exactly as §D4 intends.
- **Acks persist**: opening the panel cleared the dot, wrote the rows, and `unread_count` was 0 on the next fetch.
- Markdown (ordered lists, nested bullets, tables, inline code, links) renders identically to assistant messages.

The three seeded announcements and four ack rows were **deleted afterwards — the dev table is back to zero rows.** Temporary launch/env config and the dev server's regenerated favicons were all reverted.

**Test results**

- New backend tests: **44 visibility cases + 22 route cases**, covering state/date/role/new-user filtering, ack suppression scoped to loud surfaces, the caps and their ordering (`requiresAck` first, then severity, then oldest), the 404-not-403 path, unread/updated derivation, and the flag-off 404.
- New SPA tests: **26**, using DI-token overrides rather than `vi.mock` per house convention — service caps, fail-open dismissal, unread clearing without waiting on the server, and the pill snapshot.
- SPA suite: **2348 of 2349 pass**. The single failure is `shared-view.page.spec.ts > should create the component`, a load-sensitive timeout — I confirmed it fails on **clean `develop`** too (where this machine produced 9 failures across 5 files), so it is pre-existing and not from this change.
- `npx tsc --noEmit`: clean.
- The full backend suite was still running when this PR was opened; every announcements-related test and the architecture/rbac suites pass. I'll confirm the full run in a comment.

No infrastructure change in this PR — the table and IAM grant shipped with #966, so this deploys through `backend.yml` + `frontend-deploy.yml` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
