### PR TITLE
feat(artifacts): All / Yours / Shared with you tabs on the library

### DIFF
--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -12,7 +12,7 @@
         </p>
       </div>
 
-      @if (items().length > 0) {
+      @if (totalCount() > 0) {
         <!-- One setting with two values, so a radiogroup rather than two
              independent toggle buttons. Mirrors the Agents page.
 
@@ -80,8 +80,44 @@
       </div>
     }
 
+    <!-- Tabs. Rendered only where the share inbox exists: while
+         ARTIFACT_SHARE_INBOX_ENABLED is off the endpoint 404s, the page
+         has one list, and a lone "Yours" tab would be chrome around
+         nothing. -->
+    @if (sharedAvailable() && !loading()) {
+      <!-- A filled pill, not an underline. Matches the model-catalog tabs
+           and the view toggle in this page's own header, and an underline
+           in brand blue is close to invisible on the dark surface — the
+           token is a fixed brand colour with no dark variant. -->
+      <div
+        role="tablist"
+        aria-label="Which artifacts to show"
+        class="mt-6 flex flex-wrap items-center gap-1 rounded-2xl border border-gray-200 bg-white p-1 dark:border-gray-700 dark:bg-gray-800"
+      >
+        @for (option of tabOptions; track option.value) {
+          <button
+            type="button"
+            role="tab"
+            [id]="'artifact-tab-' + option.value"
+            [attr.aria-selected]="tab() === option.value"
+            aria-controls="artifact-tabpanel"
+            [tabindex]="tab() === option.value ? 0 : -1"
+            (click)="setTab(option.value)"
+            class="rounded-2xl px-4 py-1.5 text-sm/6 font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            [class]="
+              tab() === option.value
+                ? 'bg-primary-accessible text-white'
+                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'
+            "
+          >
+            {{ option.label }}
+          </button>
+        }
+      </div>
+    }
+
     <!-- Filters. Hidden until there is enough to be worth filtering. -->
-    @if (items().length > 0) {
+    @if (totalCount() > 0) {
       <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
         <div class="relative flex-1 sm:max-w-xs">
           <ng-icon
@@ -125,7 +161,7 @@
         }
 
         <p class="text-xs/5 text-gray-500 sm:ml-auto dark:text-gray-400" aria-live="polite">
-          {{ filtered().length }} of {{ items().length }}
+          {{ filtered().length }} of {{ tabCount() }}
         </p>
       </div>
     }
@@ -185,6 +221,14 @@
       </div>
     }
 
+    <!-- The region the tabs control. Present even with no tabs, so the
+         results have one stable container either way; `aria-labelledby`
+         is only meaningful once a tab is naming it. -->
+    <div
+      id="artifact-tabpanel"
+      [attr.role]="sharedAvailable() ? 'tabpanel' : null"
+      [attr.aria-labelledby]="sharedAvailable() ? 'artifact-tab-' + tab() : null"
+    >
     <!-- Empty: the filters excluded everything -->
     @if (isFilteredEmpty()) {
       <div
@@ -202,37 +246,44 @@
         role="list"
         class="mt-6 divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
       >
-        @for (item of filtered(); track item.artifactId) {
+        @for (row of filtered(); track row.key) {
           <li class="flex items-center gap-3 px-3 py-3 sm:px-4">
             <span
               class="grid size-9 shrink-0 place-items-center rounded-2xl"
-              [class]="styleFor(item.contentType).bg"
+              [class]="styleFor(row.contentType).bg"
               aria-hidden="true"
             >
               <ng-icon
-                [name]="styleFor(item.contentType).icon"
+                [name]="styleFor(row.contentType).icon"
                 class="size-5"
-                [class]="styleFor(item.contentType).text"
+                [class]="styleFor(row.contentType).text"
               />
             </span>
 
             <div class="min-w-0 flex-1">
               <button
                 type="button"
-                (click)="open(item)"
+                (click)="open(row)"
                 class="block max-w-full truncate text-left text-sm/6 font-semibold text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-white"
               >
-                {{ item.title || 'Untitled artifact' }}
+                {{ row.title || 'Untitled artifact' }}
               </button>
               <p class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs/5 text-gray-500 dark:text-gray-400">
-                <span>{{ styleFor(item.contentType).label }}</span>
-                @if (item.version > 1) {
+                <span>{{ styleFor(row.contentType).label }}</span>
+                @if (row.version > 1) {
                   <span aria-hidden="true">·</span>
-                  <span>{{ versionLabel(item.version) }}</span>
+                  <span>{{ versionLabel(row.version) }}</span>
+                }
+                @if (row.ownerEmail) {
+                  <span aria-hidden="true">·</span>
+                  <span class="truncate">Shared by {{ row.ownerEmail }}</span>
                 }
                 <span aria-hidden="true">·</span>
-                @if (item.updatedAt) {
-                  <span>Updated {{ item.updatedAt | date: 'mediumDate' }}</span>
+                @if (row.timestamp) {
+                  <span
+                    >{{ row.timestampLabel }}
+                    {{ row.timestamp | date: 'mediumDate' }}</span
+                  >
                 } @else {
                   <span>Date unknown</span>
                 }
@@ -240,47 +291,52 @@
             </div>
 
             <div class="flex shrink-0 items-center gap-1">
-              @if (item.sessionId) {
+              <!-- Owner-only actions. A received artifact is someone
+                   else's record: you can open it and nothing more, which
+                   is what the recipient page enforces server-side too. -->
+              @if (row.kind === 'owned' && row.sessionId) {
                 <a
-                  [routerLink]="['/s', item.sessionId]"
+                  [routerLink]="['/s', row.sessionId]"
                   [appTooltip]="'Open the conversation'"
                   appTooltipPosition="top"
                   class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                 >
                   <ng-icon name="heroChatBubbleLeftRight" class="size-4" aria-hidden="true" />
-                  <span class="sr-only">Open the conversation for {{ item.title }}</span>
+                  <span class="sr-only">Open the conversation for {{ row.title }}</span>
                 </a>
               }
               <button
                 type="button"
-                (click)="open(item)"
+                (click)="open(row)"
                 class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
               >
                 <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
-                <span class="sr-only">Open {{ item.title }}</span>
+                <span class="sr-only">Open {{ row.title }}</span>
               </button>
-              <button
-                type="button"
-                (click)="rename(item)"
-                [disabled]="busy() === item.artifactId"
-                [appTooltip]="'Rename'"
-                appTooltipPosition="top"
-                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-              >
-                <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
-                <span class="sr-only">Rename {{ item.title }}</span>
-              </button>
-              <button
-                type="button"
-                (click)="confirmDelete(item)"
-                [disabled]="busy() === item.artifactId"
-                [appTooltip]="'Delete'"
-                appTooltipPosition="top"
-                class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
-              >
-                <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
-                <span class="sr-only">Delete {{ item.title }}</span>
-              </button>
+              @if (row.owned; as item) {
+                <button
+                  type="button"
+                  (click)="rename(item)"
+                  [disabled]="busy() === item.artifactId"
+                  [appTooltip]="'Rename'"
+                  appTooltipPosition="top"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                >
+                  <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                  <span class="sr-only">Rename {{ item.title }}</span>
+                </button>
+                <button
+                  type="button"
+                  (click)="confirmDelete(item)"
+                  [disabled]="busy() === item.artifactId"
+                  [appTooltip]="'Delete'"
+                  appTooltipPosition="top"
+                  class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                >
+                  <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                  <span class="sr-only">Delete {{ item.title }}</span>
+                </button>
+              }
             </div>
           </li>
         }
@@ -290,7 +346,7 @@
     <!-- Grid view -->
     @if (!loading() && filtered().length > 0 && viewMode() === 'grid') {
       <ul role="list" class="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-        @for (item of filtered(); track item.artifactId) {
+        @for (row of filtered(); track row.key) {
           <li
             class="flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
           >
@@ -303,16 +359,11 @@
                  times, so the picture stays a picture and the mouse
                  affordance rides along with it. -->
             <div
-              (click)="open(item)"
+              (click)="open(row)"
               aria-hidden="true"
               class="cursor-pointer border-b border-gray-200 dark:border-gray-700"
             >
-              <app-artifact-thumbnail
-                [artifactId]="item.artifactId"
-                [version]="item.version"
-                [sessionId]="item.sessionId"
-                [contentType]="item.contentType"
-              />
+              <app-artifact-thumbnail [source]="row.thumbnail" />
             </div>
 
             <!-- @container on the padded body rather than on the <li>: the
@@ -325,23 +376,26 @@
               <h2 class="text-sm/6 font-semibold text-gray-900 dark:text-white">
                 <button
                   type="button"
-                  (click)="open(item)"
+                  (click)="open(row)"
                   class="block max-w-full text-left line-clamp-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
                 >
-                  {{ item.title || 'Untitled artifact' }}
+                  {{ row.title || 'Untitled artifact' }}
                 </button>
               </h2>
 
               <p class="mt-1 grow text-xs/5 text-gray-500 dark:text-gray-400">
-                {{ styleFor(item.contentType).label }}
-                @if (item.version > 1) {
-                  <span aria-hidden="true"> · </span>{{ versionLabel(item.version) }}
+                {{ styleFor(row.contentType).label }}
+                @if (row.version > 1) {
+                  <span aria-hidden="true"> · </span>{{ versionLabel(row.version) }}
                 }
                 <span aria-hidden="true"> · </span>
-                @if (item.updatedAt) {
-                  Updated {{ item.updatedAt | date: 'mediumDate' }}
+                @if (row.timestamp) {
+                  {{ row.timestampLabel }} {{ row.timestamp | date: 'mediumDate' }}
                 } @else {
                   Date unknown
+                }
+                @if (row.ownerEmail) {
+                  <span class="mt-1 block truncate">Shared by {{ row.ownerEmail }}</span>
                 }
               </p>
 
@@ -365,7 +419,7 @@
               >
                 <button
                   type="button"
-                  (click)="open(item)"
+                  (click)="open(row)"
                   [appTooltip]="'Open'"
                   appTooltipPosition="top"
                   class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
@@ -373,9 +427,9 @@
                   <ng-icon name="heroEye" class="size-4" aria-hidden="true" />
                   <span class="@max-[19rem]:sr-only">Open</span>
                 </button>
-                @if (item.sessionId) {
+                @if (row.kind === 'owned' && row.sessionId) {
                   <a
-                    [routerLink]="['/s', item.sessionId]"
+                    [routerLink]="['/s', row.sessionId]"
                     [appTooltip]="'Open the conversation'"
                     appTooltipPosition="top"
                     class="inline-flex items-center gap-1.5 rounded-2xl px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-300 dark:hover:bg-gray-700"
@@ -384,35 +438,57 @@
                     <span class="@max-[19rem]:sr-only">Conversation</span>
                   </a>
                 }
-                <div class="ml-auto flex items-center gap-1">
-                  <button
-                    type="button"
-                    (click)="rename(item)"
-                    [disabled]="busy() === item.artifactId"
-                    [appTooltip]="'Rename'"
-                    appTooltipPosition="top"
-                    class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-                  >
-                    <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
-                    <span class="sr-only">Rename {{ item.title }}</span>
-                  </button>
-                  <button
-                    type="button"
-                    (click)="confirmDelete(item)"
-                    [disabled]="busy() === item.artifactId"
-                    [appTooltip]="'Delete'"
-                    appTooltipPosition="top"
-                    class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
-                  >
-                    <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
-                    <span class="sr-only">Delete {{ item.title }}</span>
-                  </button>
-                </div>
+                @if (row.owned; as item) {
+                  <div class="ml-auto flex items-center gap-1">
+                    <button
+                      type="button"
+                      (click)="rename(item)"
+                      [disabled]="busy() === item.artifactId"
+                      [appTooltip]="'Rename'"
+                      appTooltipPosition="top"
+                      class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                    >
+                      <ng-icon name="heroPencilSquare" class="size-4" aria-hidden="true" />
+                      <span class="sr-only">Rename {{ item.title }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      (click)="confirmDelete(item)"
+                      [disabled]="busy() === item.artifactId"
+                      [appTooltip]="'Delete'"
+                      appTooltipPosition="top"
+                      class="grid size-8 place-items-center rounded-2xl text-gray-400 hover:bg-state-danger-50 hover:text-state-danger-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-state-danger-500 dark:text-gray-500 dark:hover:bg-state-danger-500/10 dark:hover:text-state-danger-400"
+                    >
+                      <ng-icon name="heroTrash" class="size-4" aria-hidden="true" />
+                      <span class="sr-only">Delete {{ item.title }}</span>
+                    </button>
+                  </div>
+                }
               </div>
             </div>
           </li>
         }
       </ul>
     }
+
+    <!-- The inbox is paged; your own library is not. So this is an
+         inbox-only control, and it stays visible on the All tab too —
+         the merged list is only as complete as what has been loaded, and
+         hiding the control there would present a partial merge as the
+         whole thing. -->
+    @if (!loading() && receivedCursor() && tab() !== 'yours') {
+      <div class="mt-6 flex justify-center">
+        <button
+          type="button"
+          (click)="loadMoreShared()"
+          [disabled]="loadingMore()"
+          class="rounded-2xl border border-gray-300 px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          {{ loadingMore() ? 'Loading…' : 'Load more' }}
+        </button>
+      </div>
+    }
+
+    </div>
   </div>
 </div>

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.spec.ts
@@ -10,8 +10,27 @@ import {
   ArtifactHttpService,
   type LibraryArtifact,
 } from '../session/services/artifacts/artifact-http.service';
+import {
+  ArtifactShareService,
+  type SharedWithMeArtifact,
+} from '../session/services/artifacts/artifact-share.service';
 import { LocalSettingsService, type ViewMode } from '../services/local-settings.service';
 import { ToastService } from '../services/toast/toast.service';
+
+function stubShared(
+  overrides: Partial<SharedWithMeArtifact> = {},
+): SharedWithMeArtifact {
+  return {
+    shareId: 'sh-1',
+    title: 'Their deck',
+    contentType: 'text/html',
+    version: 1,
+    ownerEmail: 'ada@x.com',
+    sharedAt: '2026-06-01T10:00:00+00:00',
+    shareUrl: '/shared-artifact/sh-1',
+    ...overrides,
+  };
+}
 
 function stubArtifact(overrides: Partial<LibraryArtifact> = {}): LibraryArtifact {
   return {
@@ -35,6 +54,7 @@ describe('ArtifactLibraryPage', () => {
   };
   /** Stands in for the CDK dialog. `closed` is what the page awaits, so
    *  each test sets the value the user "chose" before acting. */
+  let mockShares: { listSharedWithMe: ReturnType<typeof vi.fn> };
   let mockDialog: { open: ReturnType<typeof vi.fn> };
   let dialogResult: unknown;
   let mockSettings: {
@@ -54,6 +74,9 @@ describe('ArtifactLibraryPage', () => {
       renameArtifact: vi.fn(),
       deleteArtifact: vi.fn().mockResolvedValue(undefined),
     };
+    // Default: the inbox does not exist in this environment (the flag is
+    // off), which is what every pre-existing test in this file assumes.
+    mockShares = { listSharedWithMe: vi.fn().mockResolvedValue(null) };
     dialogResult = undefined;
     mockDialog = {
       open: vi.fn(() => ({ closed: of(dialogResult) })),
@@ -74,6 +97,7 @@ describe('ArtifactLibraryPage', () => {
           { path: 'artifacts/:artifactId', children: [] },
         ]),
         { provide: ArtifactHttpService, useValue: mockHttp },
+        { provide: ArtifactShareService, useValue: mockShares },
         { provide: LocalSettingsService, useValue: mockSettings },
         { provide: ToastService, useValue: mockToast },
         { provide: Dialog, useValue: mockDialog },
@@ -100,7 +124,14 @@ describe('ArtifactLibraryPage', () => {
   function api(fixture: Awaited<ReturnType<typeof createComponent>>) {
     return fixture.componentInstance as unknown as {
       items: () => LibraryArtifact[];
-      filtered: () => LibraryArtifact[];
+      filtered: () => Array<{
+        key: string;
+        kind: 'owned' | 'shared';
+        title: string;
+        route: readonly string[];
+        ownerEmail?: string;
+        timestampLabel: string;
+      }>;
       typeOptions: () => Array<{ value: string; label: string }>;
       isEmpty: () => boolean;
       isFilteredEmpty: () => boolean;
@@ -110,7 +141,15 @@ describe('ArtifactLibraryPage', () => {
       typeFilter: { set: (v: string) => void };
       styleFor: (t: string) => { label: string };
       setViewMode: (m: ViewMode) => void;
-      open: (item: LibraryArtifact) => void;
+      open: (row: { route: readonly string[] }) => void;
+      tab: () => 'all' | 'yours' | 'shared';
+      setTab: (t: 'all' | 'yours' | 'shared') => void;
+      sharedAvailable: () => boolean;
+      received: () => SharedWithMeArtifact[] | null;
+      receivedCursor: () => string | null;
+      loadMoreShared: () => Promise<void>;
+      totalCount: () => number;
+      tabCount: () => number;
       load: () => Promise<void>;
       rename: (item: LibraryArtifact) => Promise<void>;
       confirmDelete: (item: LibraryArtifact) => Promise<void>;
@@ -131,7 +170,9 @@ describe('ArtifactLibraryPage', () => {
       stubArtifact({ artifactId: 'a', updatedAt: '2026-09-01T00:00:00+00:00' }),
     ]);
     const c = api(await createComponent());
-    expect(c.filtered().map((i) => i.artifactId)).toEqual(['b', 'a']);
+    // Keys are prefixed by provenance — an artifact id and a share id
+    // come from different key spaces and could otherwise collide.
+    expect(c.filtered().map((r) => r.key)).toEqual(['owned:b', 'owned:a']);
   });
 
   it('surfaces a retryable message when the load fails', async () => {
@@ -148,7 +189,7 @@ describe('ArtifactLibraryPage', () => {
     ]);
     const c = api(await createComponent());
     c.search.set('BUDGET');
-    expect(c.filtered().map((i) => i.artifactId)).toEqual(['a']);
+    expect(c.filtered().map((r) => r.key)).toEqual(['owned:a']);
   });
 
   it('filters by type with the charset suffix normalized away', async () => {
@@ -160,7 +201,7 @@ describe('ArtifactLibraryPage', () => {
     ]);
     const c = api(await createComponent());
     c.typeFilter.set('text/html');
-    expect(c.filtered().map((i) => i.artifactId)).toEqual(['a']);
+    expect(c.filtered().map((r) => r.key)).toEqual(['owned:a']);
   });
 
   it('offers only the types the user actually has, deduped', async () => {
@@ -221,8 +262,13 @@ describe('ArtifactLibraryPage', () => {
         .spyOn(TestBed.inject(Router), 'navigate')
         .mockResolvedValue(true);
 
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ artifactId: 'a1' }),
+      ]);
       const c = api(await createComponent());
-      c.open(stubArtifact({ artifactId: 'a1' }));
+      // Opened through the row the page actually built, so the route
+      // under test is the projection's, not the spec's.
+      c.open(c.filtered()[0]);
 
       expect(navigate).toHaveBeenCalledWith(['/artifacts', 'a1']);
       expect(openSpy).not.toHaveBeenCalled();
@@ -230,8 +276,9 @@ describe('ArtifactLibraryPage', () => {
 
     it('does not mint a render token — the viewer owns that', async () => {
       vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
       const c = api(await createComponent());
-      c.open(stubArtifact());
+      c.open(c.filtered()[0]);
 
       expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
     });
@@ -240,10 +287,191 @@ describe('ArtifactLibraryPage', () => {
       // A route change has no blocked/failed path to report, so the old
       // "Pop-up blocked" and "Could not open artifact" toasts are gone.
       vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
       const c = api(await createComponent());
-      c.open(stubArtifact());
+      c.open(c.filtered()[0]);
 
       expect(mockToast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shared with you', () => {
+    /** Turn the inbox on with the given rows. */
+    function withInbox(
+      artifacts: SharedWithMeArtifact[],
+      nextCursor: string | null = null,
+    ): void {
+      mockShares.listSharedWithMe.mockResolvedValue({
+        artifacts,
+        nextCursor,
+      });
+    }
+
+    it('hides the tabs entirely when the inbox does not exist', async () => {
+      // `null` is the backend saying the endpoint 404'd — the feature is
+      // off in this environment. A lone "Yours" tab would be chrome
+      // around nothing.
+      mockShares.listSharedWithMe.mockResolvedValue(null);
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const c = api(await createComponent());
+
+      expect(c.sharedAvailable()).toBe(false);
+      expect(c.filtered()).toHaveLength(1);
+    });
+
+    it('distinguishes an absent inbox from an empty one', async () => {
+      // Collapsing these would either show a permanently empty tab
+      // wherever the feature is off, or hide a real empty state.
+      withInbox([]);
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const c = api(await createComponent());
+
+      expect(c.sharedAvailable()).toBe(true);
+      expect(c.received()).toEqual([]);
+    });
+
+    it('merges both lists newest-first on the All tab', async () => {
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({
+          artifactId: 'mine',
+          updatedAt: '2026-06-05T10:00:00+00:00',
+        }),
+      ]);
+      withInbox([
+        stubShared({ shareId: 'theirs', sharedAt: '2026-06-10T10:00:00+00:00' }),
+      ]);
+      const c = api(await createComponent());
+
+      // Two independently server-ordered lists can only be shown as one
+      // by interleaving them here; the tabs that show one list each do
+      // not sort at all.
+      expect(c.filtered().map((r) => r.key)).toEqual([
+        'shared:theirs',
+        'owned:mine',
+      ]);
+    });
+
+    it('scopes each tab to its own list', async () => {
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact({ artifactId: 'mine' })]);
+      withInbox([stubShared({ shareId: 'theirs' })]);
+      const c = api(await createComponent());
+
+      c.setTab('yours');
+      expect(c.filtered().map((r) => r.key)).toEqual(['owned:mine']);
+
+      c.setTab('shared');
+      expect(c.filtered().map((r) => r.key)).toEqual(['shared:theirs']);
+    });
+
+    it('routes a received artifact to the recipient page', async () => {
+      // A recipient has no artifact id and no owner route — the share id
+      // is the only handle they have on it.
+      mockHttp.listLibrary.mockResolvedValue([]);
+      withInbox([stubShared({ shareId: 'sh-9' })]);
+      const c = api(await createComponent());
+
+      const row = c.filtered()[0];
+      expect(row.kind).toBe('shared');
+      expect(row.route).toEqual(['/shared-artifact', 'sh-9']);
+      expect(row.ownerEmail).toBe('ada@x.com');
+      // "Updated" is the owner's clock and means nothing to a recipient.
+      expect(row.timestampLabel).toBe('Shared');
+    });
+
+    it('searches received artifacts by sender as well as title', async () => {
+      mockHttp.listLibrary.mockResolvedValue([]);
+      withInbox([
+        stubShared({ shareId: 'a', title: 'Deck', ownerEmail: 'ada@x.com' }),
+        stubShared({ shareId: 'b', title: 'Notes', ownerEmail: 'bob@x.com' }),
+      ]);
+      const c = api(await createComponent());
+
+      // "Who sent me that thing" is at least as likely a starting point
+      // as remembering what it was called.
+      c.search.set('ada');
+      expect(c.filtered().map((r) => r.key)).toEqual(['shared:a']);
+    });
+
+    it('keeps your library when the inbox request fails', async () => {
+      // The library is the page's reason to exist; a 503 on the inbox
+      // must not blank it. The tabs simply do not appear.
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      mockShares.listSharedWithMe.mockRejectedValue(new Error('503'));
+      const c = api(await createComponent());
+
+      expect(c.error()).toBeNull();
+      expect(c.filtered()).toHaveLength(1);
+      expect(c.sharedAvailable()).toBe(false);
+    });
+
+    it('still fails the page when your own library fails', async () => {
+      mockHttp.listLibrary.mockRejectedValue(new Error('503'));
+      withInbox([stubShared()]);
+      const c = api(await createComponent());
+
+      expect(c.error()).toContain("couldn't load");
+    });
+
+    it('appends the next page rather than replacing it', async () => {
+      mockHttp.listLibrary.mockResolvedValue([]);
+      withInbox([stubShared({ shareId: 'first' })], 'cursor-1');
+      const c = api(await createComponent());
+
+      expect(c.receivedCursor()).toBe('cursor-1');
+
+      mockShares.listSharedWithMe.mockResolvedValue({
+        artifacts: [stubShared({ shareId: 'second' })],
+        nextCursor: null,
+      });
+      await c.loadMoreShared();
+
+      expect(mockShares.listSharedWithMe).toHaveBeenLastCalledWith('cursor-1');
+      expect(c.filtered().map((r) => r.key)).toEqual([
+        'shared:first',
+        'shared:second',
+      ]);
+      expect(c.receivedCursor()).toBeNull();
+    });
+
+    it('drops the tabs if the inbox disappears while paging', async () => {
+      // A deploy or a flag flip mid-session. Leaving a "Load more"
+      // button that does nothing is worse than losing the tab.
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      withInbox([stubShared()], 'cursor-1');
+      const c = api(await createComponent());
+
+      mockShares.listSharedWithMe.mockResolvedValue(null);
+      await c.loadMoreShared();
+
+      expect(c.sharedAvailable()).toBe(false);
+      expect(c.receivedCursor()).toBeNull();
+    });
+
+    it('falls back to All when the selected tab stops existing', async () => {
+      withInbox([stubShared()]);
+      mockHttp.listLibrary.mockResolvedValue([stubArtifact()]);
+      const c = api(await createComponent());
+      c.setTab('shared');
+
+      mockShares.listSharedWithMe.mockResolvedValue(null);
+      await c.load();
+
+      expect(c.tab()).toBe('all');
+      expect(c.filtered()).toHaveLength(1);
+    });
+
+    it('counts against the tab, not the whole library', async () => {
+      mockHttp.listLibrary.mockResolvedValue([
+        stubArtifact({ artifactId: 'a' }),
+        stubArtifact({ artifactId: 'b' }),
+      ]);
+      withInbox([stubShared()]);
+      const c = api(await createComponent());
+
+      expect(c.totalCount()).toBe(3);
+      c.setTab('shared');
+      // "n of m" has to follow the tab or it reads as a bug.
+      expect(c.tabCount()).toBe(1);
     });
   });
 

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.ts
@@ -37,7 +37,14 @@ import {
   ConfirmationDialogComponent,
   type ConfirmationDialogData,
 } from '../components/confirmation-dialog';
-import { ArtifactThumbnailComponent } from './components/artifact-thumbnail.component';
+import {
+  ArtifactThumbnailComponent,
+  type ArtifactThumbnailSource,
+} from './components/artifact-thumbnail.component';
+import {
+  ArtifactShareService,
+  type SharedWithMeArtifact,
+} from '../session/services/artifacts/artifact-share.service';
 import {
   RenameArtifactDialogComponent,
   type RenameArtifactDialogData,
@@ -106,6 +113,46 @@ const DEFAULT_TYPE_STYLE: TypeStyle = {
   text: 'text-gray-600 dark:text-gray-300',
 };
 
+/** Which slice of the library is on screen. */
+export type LibraryTab = 'all' | 'yours' | 'shared';
+
+/**
+ * One card, whichever list it came from.
+ *
+ * The two sources are genuinely different records — a received artifact
+ * has no artifact id, no session to go back to, and no `updatedAt` that
+ * means anything to the viewer — so they are normalized into one row
+ * shape here rather than the template branching on which fields happen
+ * to be present. `kind` is what the template branches on, and it is the
+ * only thing it needs to branch on: everything else is already resolved.
+ */
+interface LibraryRow {
+  /** Stable `@for` key. Ids come from different key spaces, so they are
+   *  prefixed — an artifact id and a share id could otherwise collide
+   *  and make Angular reuse one row's DOM for the other. */
+  readonly key: string;
+  readonly kind: 'owned' | 'shared';
+  readonly title: string;
+  readonly contentType: string;
+  readonly version: number;
+  /** What the card mints its preview through — the two kinds are two
+   *  different credentials for the same bytes. */
+  readonly thumbnail: ArtifactThumbnailSource;
+  /** ISO timestamp this row is ordered and labelled by. */
+  readonly timestamp: string;
+  /** "Updated" for your own, "Shared" for one you received — the words
+   *  are not interchangeable and neither are the clocks they read. */
+  readonly timestampLabel: string;
+  /** Where clicking the card goes. Owner and recipient routes are
+   *  different pages, not one page with a mode. */
+  readonly route: readonly string[];
+  /** Present only on owned rows — the record rename/delete act on. */
+  readonly owned?: LibraryArtifact;
+  /** Present only on received rows. */
+  readonly ownerEmail?: string;
+  readonly sessionId?: string;
+}
+
 /**
  * The artifact library at `/artifacts` — every artifact the user has ever
  * produced, across every conversation.
@@ -156,12 +203,30 @@ const DEFAULT_TYPE_STYLE: TypeStyle = {
 })
 export class ArtifactLibraryPage {
   private readonly artifacts = inject(ArtifactHttpService);
+  private readonly shares = inject(ArtifactShareService);
   private readonly localSettings = inject(LocalSettingsService);
   private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
   private readonly dialog = inject(Dialog);
 
   protected readonly items = signal<LibraryArtifact[]>([]);
+
+  /**
+   * Artifacts shared with the caller — or `null` when the inbox does not
+   * exist in this environment.
+   *
+   * The distinction is the whole feature flag. `null` means the backend
+   * 404'd the endpoint (`ARTIFACT_SHARE_INBOX_ENABLED` off) and the tabs
+   * are not rendered at all; `[]` means the inbox is real and empty, and
+   * says so. Collapsing the two would either show a permanently empty
+   * tab everywhere the feature is off, or hide a real empty state.
+   */
+  protected readonly received = signal<SharedWithMeArtifact[] | null>(null);
+  /** Continuation for the inbox; non-null means there is more to load. */
+  protected readonly receivedCursor = signal<string | null>(null);
+  protected readonly loadingMore = signal(false);
+
+  protected readonly tab = signal<LibraryTab>('all');
   protected readonly loading = signal(true);
   protected readonly error = signal<string | null>(null);
   protected readonly search = signal('');
@@ -178,10 +243,13 @@ export class ArtifactLibraryPage {
    */
   protected readonly typeOptions = computed(() => {
     const seen = new Map<string, string>();
-    for (const item of this.items()) {
-      const key = this.normalizeType(item.contentType);
+    // Both lists: the filter sits above the tabs and applies to whatever
+    // is on screen, so offering only the types you happen to own would
+    // make it look broken on the "Shared with you" tab.
+    for (const row of this.allRows()) {
+      const key = this.normalizeType(row.contentType);
       if (!seen.has(key)) {
-        seen.set(key, this.styleFor(item.contentType).label);
+        seen.set(key, this.styleFor(row.contentType).label);
       }
     }
     return [...seen.entries()]
@@ -189,20 +257,129 @@ export class ArtifactLibraryPage {
       .sort((a, b) => a.label.localeCompare(b.label));
   });
 
-  protected readonly filtered = computed(() => {
+  /** True once the backend has confirmed the inbox exists here. */
+  protected readonly sharedAvailable = computed(
+    () => this.received() !== null,
+  );
+
+  /**
+   * "All" leads, because the page's job is to be the one place your
+   * artifacts are — splitting them by provenance is a filter on that,
+   * not the default reading of it.
+   */
+  protected readonly tabOptions: ReadonlyArray<{
+    value: LibraryTab;
+    label: string;
+  }> = [
+    { value: 'all', label: 'All' },
+    { value: 'yours', label: 'Yours' },
+    { value: 'shared', label: 'Shared with you' },
+  ];
+
+  /** Rows in the current tab before filtering — the denominator in
+   *  "n of m", which has to follow the tab or it reads as a bug. */
+  protected readonly tabCount = computed(() => this.tabRows().length);
+
+  private readonly ownedRows = computed<LibraryRow[]>(() =>
+    this.items().map((item) => ({
+      key: `owned:${item.artifactId}`,
+      kind: 'owned' as const,
+      title: item.title,
+      contentType: item.contentType,
+      version: item.version,
+      thumbnail: {
+        kind: 'owned' as const,
+        artifactId: item.artifactId,
+        version: item.version,
+        sessionId: item.sessionId,
+        contentType: item.contentType,
+      },
+      timestamp: item.updatedAt,
+      timestampLabel: 'Updated',
+      route: ['/artifacts', item.artifactId],
+      owned: item,
+      sessionId: item.sessionId,
+    })),
+  );
+
+  private readonly sharedRows = computed<LibraryRow[]>(() =>
+    (this.received() ?? []).map((item) => ({
+      key: `shared:${item.shareId}`,
+      kind: 'shared' as const,
+      title: item.title,
+      contentType: item.contentType,
+      version: item.version,
+      thumbnail: {
+        kind: 'shared' as const,
+        shareId: item.shareId,
+        contentType: item.contentType,
+      },
+      timestamp: item.sharedAt,
+      timestampLabel: 'Shared',
+      route: ['/shared-artifact', item.shareId],
+      ownerEmail: item.ownerEmail,
+    })),
+  );
+
+  /**
+   * Both lists interleaved, newest first.
+   *
+   * This is the one place the page sorts, and it is a deliberate
+   * exception to the rule below: two independently server-ordered lists
+   * cannot be shown as one without interleaving them on the client,
+   * because there is no single server ordering to preserve. Each list is
+   * still consumed in the order the server gave it; only the merge is
+   * ours. The tabs that show one list each do not sort at all.
+   */
+  private readonly allRows = computed<LibraryRow[]>(() =>
+    [...this.ownedRows(), ...this.sharedRows()].sort((a, b) =>
+      b.timestamp.localeCompare(a.timestamp),
+    ),
+  );
+
+  /** The rows for the selected tab, before search and type filtering. */
+  private readonly tabRows = computed<LibraryRow[]>(() => {
+    if (!this.sharedAvailable()) {
+      // No inbox here, so there are no tabs and "everything" is yours.
+      return this.ownedRows();
+    }
+    switch (this.tab()) {
+      case 'yours':
+        return this.ownedRows();
+      case 'shared':
+        return this.sharedRows();
+      default:
+        return this.allRows();
+    }
+  });
+
+  protected readonly filtered = computed<LibraryRow[]>(() => {
     const term = this.search().trim().toLowerCase();
     const type = this.typeFilter();
-    return this.items().filter((item) => {
-      if (type !== 'all' && this.normalizeType(item.contentType) !== type) {
+    return this.tabRows().filter((row) => {
+      if (type !== 'all' && this.normalizeType(row.contentType) !== type) {
         return false;
       }
-      return term === '' || item.title.toLowerCase().includes(term);
+      if (term === '') {
+        return true;
+      }
+      // Sender is searchable on a received row: "who sent me that thing"
+      // is at least as likely a starting point as remembering its title.
+      return (
+        row.title.toLowerCase().includes(term) ||
+        (row.ownerEmail ?? '').toLowerCase().includes(term)
+      );
     });
   });
 
+  /** Everything the page holds, for the empty-state distinction below. */
+  protected readonly totalCount = computed(
+    () => this.items().length + (this.received()?.length ?? 0),
+  );
+
   /** True only once loading has resolved, so the empty state can't flash. */
   protected readonly isEmpty = computed(
-    () => !this.loading() && !this.error() && this.items().length === 0,
+    () => !this.loading() && !this.error() && this.totalCount() === 0,
   );
 
   /**
@@ -212,7 +389,7 @@ export class ArtifactLibraryPage {
   protected readonly isFilteredEmpty = computed(
     () =>
       !this.loading() &&
-      this.items().length > 0 &&
+      this.totalCount() > 0 &&
       this.filtered().length === 0,
   );
 
@@ -224,11 +401,74 @@ export class ArtifactLibraryPage {
     this.loading.set(true);
     this.error.set(null);
     try {
-      this.items.set(await this.artifacts.listLibrary());
+      // Both in parallel, and the inbox is allowed to fail on its own:
+      // `allSettled`, not `all`. Your own library is the page's reason to
+      // exist, so an inbox that 503s must not blank it — the tabs simply
+      // do not appear, exactly as when the feature is off. The reverse is
+      // not true: if your library fails there is nothing to show.
+      const [owned, inbox] = await Promise.allSettled([
+        this.artifacts.listLibrary(),
+        this.shares.listSharedWithMe(),
+      ]);
+
+      if (owned.status === 'rejected') {
+        throw owned.reason;
+      }
+      this.items.set(owned.value);
+
+      const page = inbox.status === 'fulfilled' ? inbox.value : null;
+      this.received.set(page?.artifacts ?? null);
+      this.receivedCursor.set(page?.nextCursor ?? null);
+      if (!page && this.tab() === 'shared') {
+        // The tab that was selected no longer exists.
+        this.tab.set('all');
+      }
     } catch {
       this.error.set("We couldn't load your artifacts. Try again in a moment.");
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  protected setTab(next: LibraryTab): void {
+    this.tab.set(next);
+  }
+
+  /**
+   * Fetch the next page of the inbox and append it.
+   *
+   * The owned library arrives whole (its endpoint is unpaginated), but
+   * the inbox is paged, because a share partition grows by one row per
+   * share received and has no ceiling this app controls. So "Load more"
+   * is an inbox-only affordance, and it stays visible on the All tab
+   * too — the merged list is only as complete as what has been loaded,
+   * and hiding the control there would quietly present a partial merge
+   * as the whole thing.
+   */
+  protected async loadMoreShared(): Promise<void> {
+    const cursor = this.receivedCursor();
+    if (!cursor || this.loadingMore()) {
+      return;
+    }
+    this.loadingMore.set(true);
+    try {
+      const page = await this.shares.listSharedWithMe(cursor);
+      if (!page) {
+        // The feature went away under us (a deploy, a flag flip). Drop
+        // the tabs rather than leaving a control that does nothing.
+        this.received.set(null);
+        this.receivedCursor.set(null);
+        return;
+      }
+      this.received.update((rows) => [...(rows ?? []), ...page.artifacts]);
+      this.receivedCursor.set(page.nextCursor);
+    } catch {
+      this.toast.error(
+        'Could not load more',
+        'The rest of your shared artifacts did not load. Try again in a moment.',
+      );
+    } finally {
+      this.loadingMore.set(false);
     }
   }
 
@@ -268,8 +508,8 @@ export class ArtifactLibraryPage {
    * moved into that page, where a refusal is harmless because the
    * artifact is already on screen beside it.
    */
-  protected open(item: LibraryArtifact): void {
-    void this.router.navigate(['/artifacts', item.artifactId]);
+  protected open(row: LibraryRow): void {
+    void this.router.navigate([...row.route]);
   }
 
   /**

--- a/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.spec.ts
+++ b/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.spec.ts
@@ -1,12 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { ArtifactThumbnailComponent } from './artifact-thumbnail.component';
+import {
+  ArtifactThumbnailComponent,
+  type ArtifactThumbnailSource,
+} from './artifact-thumbnail.component';
 import { ArtifactHttpService } from '../../session/services/artifacts/artifact-http.service';
+import { ArtifactShareService } from '../../session/services/artifacts/artifact-share.service';
+
+const OWNED: ArtifactThumbnailSource = {
+  kind: 'owned',
+  artifactId: 'a1',
+  version: 2,
+  sessionId: 'sess-9',
+  contentType: 'text/html',
+};
 
 describe('ArtifactThumbnailComponent', () => {
   let fixture: ComponentFixture<ArtifactThumbnailComponent>;
   let mockHttp: { mintRenderToken: ReturnType<typeof vi.fn> };
+  let mockShares: { mintSharedRenderToken: ReturnType<typeof vi.fn> };
 
   /** Fires the observed element into view. Null until one is observed. */
   let intersect: (() => void) | null;
@@ -61,16 +74,10 @@ describe('ArtifactThumbnailComponent', () => {
   }
 
   async function create(
-    inputs: Record<string, unknown> = {},
+    source: ArtifactThumbnailSource = OWNED,
   ): Promise<ComponentFixture<ArtifactThumbnailComponent>> {
     fixture = TestBed.createComponent(ArtifactThumbnailComponent);
-    fixture.componentRef.setInput('artifactId', 'a1');
-    fixture.componentRef.setInput('version', 2);
-    fixture.componentRef.setInput('sessionId', 'sess-9');
-    fixture.componentRef.setInput('contentType', 'text/html');
-    for (const [k, v] of Object.entries(inputs)) {
-      fixture.componentRef.setInput(k, v);
-    }
+    fixture.componentRef.setInput('source', source);
     setHostWidth(512);
     fixture.detectChanges(); // runs ngAfterViewInit → wires the observers
     return fixture;
@@ -88,10 +95,19 @@ describe('ArtifactThumbnailComponent', () => {
         expiresAt: '2026-09-05T00:02:00+00:00',
       }),
     };
+    mockShares = {
+      mintSharedRenderToken: vi.fn().mockResolvedValue({
+        url: 'https://artifacts.example/shared?t=jwt',
+        expiresAt: '2026-09-05T00:02:00+00:00',
+      }),
+    };
 
     TestBed.configureTestingModule({
       imports: [ArtifactThumbnailComponent],
-      providers: [{ provide: ArtifactHttpService, useValue: mockHttp }],
+      providers: [
+        { provide: ArtifactHttpService, useValue: mockHttp },
+        { provide: ArtifactShareService, useValue: mockShares },
+      ],
     });
   });
 
@@ -224,7 +240,7 @@ describe('ArtifactThumbnailComponent', () => {
 
   it('falls back to the type glyph when minting fails', async () => {
     mockHttp.mintRenderToken.mockRejectedValue(new Error('503'));
-    await create({ contentType: 'text/csv' });
+    await create({ ...OWNED, contentType: 'text/csv' });
     intersect!();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -234,5 +250,36 @@ describe('ArtifactThumbnailComponent', () => {
     expect(iframe()).toBeNull();
     expect(el().querySelector('ng-icon')).not.toBeNull();
     expect(el().textContent).not.toContain('Try again');
+  });
+
+  // ----------------------------------------------------------------
+  // The two access paths
+  // ----------------------------------------------------------------
+
+  it('mints a received artifact through the share endpoint', async () => {
+    // A recipient has no artifact id, and the owner endpoint builds its
+    // key from the authenticated session — calling it would 404. The
+    // two kinds are two different credentials for the same bytes.
+    await create({
+      kind: 'shared',
+      shareId: 'share-7',
+      contentType: 'text/html',
+    });
+    intersect!();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockShares.mintSharedRenderToken).toHaveBeenCalledWith('share-7');
+    expect(mockHttp.mintRenderToken).not.toHaveBeenCalled();
+    expect(iframe()).not.toBeNull();
+  });
+
+  it('mints an owned artifact through the owner endpoint', async () => {
+    await create();
+    intersect!();
+    await fixture.whenStable();
+
+    expect(mockHttp.mintRenderToken).toHaveBeenCalledWith('a1', 2, 'sess-9');
+    expect(mockShares.mintSharedRenderToken).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.ts
+++ b/frontend/ai.client/src/app/artifacts/components/artifact-thumbnail.component.ts
@@ -20,6 +20,35 @@ import {
 } from '@ng-icons/heroicons/outline';
 
 import { ArtifactHttpService } from '../../session/services/artifacts/artifact-http.service';
+import { ArtifactShareService } from '../../session/services/artifacts/artifact-share.service';
+
+/**
+ * Which access path this thumbnail mints through.
+ *
+ * A recipient cannot mint against an artifact id — the owner endpoint
+ * builds its DynamoDB key from the authenticated session, so it would
+ * 404 — and an owner has no share id. The two are genuinely different
+ * credentials for the same bytes, so the source says which one it is
+ * rather than the component guessing from which fields are populated.
+ *
+ * This mirrors `ArtifactViewerComponent`, which serves the owner panel
+ * and the recipient page through two mint endpoints; that one takes the
+ * URL pre-minted from its parent, which this cannot do because it mints
+ * lazily, on intersection, long after the parent rendered it.
+ */
+export type ArtifactThumbnailSource =
+  | {
+      readonly kind: 'owned';
+      readonly artifactId: string;
+      readonly version: number;
+      readonly sessionId: string;
+      readonly contentType: string;
+    }
+  | {
+      readonly kind: 'shared';
+      readonly shareId: string;
+      readonly contentType: string;
+    };
 
 /**
  * The virtual viewport an artifact is rendered at before being scaled
@@ -170,13 +199,11 @@ const TYPE_ICONS: Record<string, string> = {
 })
 export class ArtifactThumbnailComponent implements AfterViewInit, OnDestroy {
   private readonly artifacts = inject(ArtifactHttpService);
+  private readonly shares = inject(ArtifactShareService);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  readonly artifactId = input.required<string>();
-  readonly version = input.required<number>();
-  readonly sessionId = input<string>('');
-  readonly contentType = input<string>('');
+  readonly source = input.required<ArtifactThumbnailSource>();
 
   protected readonly virtualWidth = VIRTUAL_WIDTH;
   protected readonly virtualHeight = VIRTUAL_HEIGHT;
@@ -197,7 +224,10 @@ export class ArtifactThumbnailComponent implements AfterViewInit, OnDestroy {
   protected readonly scale = computed(() => this.boxWidth() / VIRTUAL_WIDTH);
 
   protected readonly fallbackIcon = computed(
-    () => TYPE_ICONS[this.contentType().split(';')[0].trim().toLowerCase()] ?? 'heroDocument',
+    () =>
+      TYPE_ICONS[
+        this.source().contentType.split(';')[0].trim().toLowerCase()
+      ] ?? 'heroDocument',
   );
 
   private intersectionObserver?: IntersectionObserver;
@@ -281,12 +311,16 @@ export class ArtifactThumbnailComponent implements AfterViewInit, OnDestroy {
       return;
     }
     this.requested = true;
+    const source = this.source();
     try {
-      const token = await this.artifacts.mintRenderToken(
-        this.artifactId(),
-        this.version(),
-        this.sessionId(),
-      );
+      const token =
+        source.kind === 'owned'
+          ? await this.artifacts.mintRenderToken(
+              source.artifactId,
+              source.version,
+              source.sessionId,
+            )
+          : await this.shares.mintSharedRenderToken(source.shareId);
       if (this.destroyed) {
         return;
       }

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.spec.ts
@@ -223,6 +223,45 @@ describe('ArtifactShareService', () => {
     }
   });
 
+  describe('listSharedWithMe', () => {
+    it('returns null when the inbox does not exist in this environment', async () => {
+      // A 404 is the backend saying ARTIFACT_SHARE_INBOX_ENABLED is off.
+      // Null and an empty page are different facts and the library page
+      // renders them differently — null hides the tabs, [] says
+      // "nothing yet".
+      const p = service.listSharedWithMe();
+      httpMock
+        .expectOne((r) => r.url === `${API}/shared-artifacts`)
+        .flush(null, { status: 404, statusText: 'Not Found' });
+
+      await expect(p).resolves.toBeNull();
+    });
+
+    it('rethrows anything that is not a 404', async () => {
+      // "We could not load your inbox" is not "you do not have one" —
+      // swallowing a 503 would silently hide a tab that exists.
+      const p = service.listSharedWithMe();
+      httpMock
+        .expectOne((r) => r.url === `${API}/shared-artifacts`)
+        .flush(null, { status: 503, statusText: 'Service Unavailable' });
+
+      await expect(p).rejects.toBeTruthy();
+    });
+
+    it('passes the cursor through and normalizes a missing one', async () => {
+      const p = service.listSharedWithMe('cursor-1');
+      const req = httpMock.expectOne(
+        (r) => r.url === `${API}/shared-artifacts`,
+      );
+      expect(req.request.params.get('cursor')).toBe('cursor-1');
+      req.flush({ artifacts: [] });
+
+      // The backend omits `nextCursor` on the last page; the client
+      // normalizes it so callers can page until it is null.
+      await expect(p).resolves.toEqual({ artifacts: [], nextCursor: null });
+    });
+  });
+
   it('leaves the toast on for the share list, which degrades silently', async () => {
     // listShares has no inline error UI — the dialog still opens and can
     // create a link — so the toast is the only signal the list is stale.

--- a/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
+++ b/frontend/ai.client/src/app/session/services/artifacts/artifact-share.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpContext } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse,
+} from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import { SUPPRESS_ERROR_TOAST } from '../../../auth/error.interceptor';
@@ -31,6 +35,48 @@ export interface ArtifactShare {
 
 interface ArtifactShareListResponse {
   shares: ArtifactShare[];
+}
+
+/**
+ * One artifact somebody else shared with you, as the library's
+ * "Shared with you" tab sees it.
+ *
+ * Deliberately *not* `LibraryArtifact` with extra fields. A received
+ * artifact has no `artifactId` and no `sessionId` you can reach — the
+ * share id is the only handle you have on it — and no `updatedAt` that
+ * means anything to you, because that is the owner's clock. Modelling
+ * the two as one type would invite a template to reach for a field that
+ * is structurally absent on half its rows.
+ */
+export interface SharedWithMeArtifact {
+  shareId: string;
+  title: string;
+  contentType: string;
+  version: number;
+  /** Who shared it. */
+  ownerEmail: string;
+  /** When it was shared with you — not when it was made or last edited. */
+  sharedAt: string;
+  /** SPA-relative recipient route, e.g. `/shared-artifact/{id}`. */
+  shareUrl: string;
+}
+
+interface SharedWithMeResponseDto {
+  artifacts: SharedWithMeArtifact[];
+  nextCursor: string | null;
+}
+
+/**
+ * A page of the share inbox, plus where to continue from.
+ *
+ * `nextCursor` terminates the listing, not the page length: the backend
+ * drops rows after its underlying query (a share revoked since it was
+ * fanned out, an allowlist edited), so a short page can still have more
+ * behind it. Page until the cursor is null.
+ */
+export interface SharedWithMePage {
+  artifacts: SharedWithMeArtifact[];
+  nextCursor: string | null;
 }
 
 /** Recipient-facing share metadata. Never carries artifact content. */
@@ -169,6 +215,43 @@ export class ArtifactShareService {
   // ----------------------------------------------------------------
   // Recipient
   // ----------------------------------------------------------------
+
+  /**
+   * One page of the artifacts other people have shared with the caller.
+   *
+   * Returns `null` — not an empty page — when the endpoint 404s, which
+   * is how the backend says the inbox does not exist in this
+   * environment (`ARTIFACT_SHARE_INBOX_ENABLED` off). The two are
+   * different facts and the library page renders them differently: null
+   * hides the tabs entirely, an empty page shows "Nothing yet". Any
+   * other failure rethrows, because "we could not load your inbox" is
+   * not the same as "you do not have one".
+   *
+   * Scoped by the session cookie; there is no parameter that could ask
+   * about anybody else.
+   */
+  async listSharedWithMe(
+    cursor?: string,
+    limit = 100,
+  ): Promise<SharedWithMePage | null> {
+    try {
+      const res = await firstValueFrom(
+        this.http.get<SharedWithMeResponseDto>(this.sharedUrl(), {
+          ...this.inlineErrors(),
+          params: cursor ? { cursor, limit } : { limit },
+        }),
+      );
+      return {
+        artifacts: res.artifacts ?? [],
+        nextCursor: res.nextCursor ?? null,
+      };
+    } catch (err: unknown) {
+      if (err instanceof HttpErrorResponse && err.status === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
 
   /** Metadata for a shared artifact. Never returns content. */
   async getSharedArtifact(shareId: string): Promise<SharedArtifact> {


### PR DESCRIPTION
PR-2 of the share-inbox pair. [#968](https://github.com/Boise-State-Development/agentcore-public-stack/pull/968) gave recipients somewhere to be listed; this is the surface that lists them. Frontend only.

Still dark: with `ARTIFACT_SHARE_INBOX_ENABLED` off the endpoint 404s, no tabs render, and the library is exactly what it is today.

## One row shape, two records

A received artifact is **not** a `LibraryArtifact` with extra fields. It has no artifact id and no session to go back to — the share id is the only handle a recipient has on it — and no `updatedAt` that means anything to them, because that's the owner's clock. Modelling both as one type would invite a template to reach for a field that's structurally absent on half its rows.

So both lists normalize into a `LibraryRow` carrying a `kind` discriminator, and the template branches on that and nothing else:

| | Owned | Received |
|---|---|---|
| Opens | `/artifacts/{id}` | `/shared-artifact/{shareId}` |
| Timestamp | "Updated" (owner's clock) | "Shared" (when you got it) |
| Actions | Open, Conversation, Rename, Delete | Open |
| Attribution | — | "Shared by ada@…" |

`ArtifactThumbnailComponent` gains the same discrimination. A recipient can't mint against an artifact id — the owner endpoint builds its DynamoDB key from the session and would 404 — so the source says which credential it is rather than the component inferring it from which fields are populated. Two mint paths, one component, mirroring how `ArtifactViewerComponent` already serves the owner panel and the recipient page.

## The flag reaches the SPA with no new plumbing

`listSharedWithMe` returns **null** on 404 — the backend saying the inbox doesn't exist here. Null hides the tabs; `[]` is a real, empty inbox and says "nothing yet". Collapsing those would either show a permanently empty tab wherever the feature is off, or hide a genuine empty state. Anything that isn't a 404 rethrows: *"we couldn't load your inbox"* is not *"you don't have one"*.

The two lists load with `allSettled`, not `all`. Your own library is the page's reason to exist, so an inbox that 503s must not blank it — the tabs just don't appear, same as when the feature is off. The reverse isn't true, and isn't treated as such.

## Smaller calls

- **"All" interleaves both lists newest-first.** The one place this page sorts, and a deliberate exception to its own no-re-sorting rule: two independently server-ordered lists can't be shown as one without merging on the client. The single-list tabs don't sort at all.
- **Search matches the sender** on a received row — "who sent me that thing" is at least as likely a starting point as remembering its title.
- **"Load more" is inbox-only** (the owned endpoint is unpaginated) and stays visible on the All tab, since the merged list is only as complete as what's loaded and hiding the control there would present a partial merge as the whole thing.
- Row keys are prefixed by provenance — an artifact id and a share id come from different key spaces and could otherwise collide into shared DOM.

## A contrast defect caught by verifying

I first built the tabs as an underline in `primary-accessible`. That's a fixed brand colour with no dark variant, so a 2px `#0033A0` rule on the `#101828` dark surface is nearly invisible — and it passed every unit test. Switched to the filled pill that `model-catalog.page.html` and this page's own view toggle already use: **10.6:1** on the active pill, and one fewer idiom in the app.

Browser-verified against the compiled stylesheet at 1080px in both themes — tabs, received-card variant, no horizontal overflow.

## Tests

**2341 passed**, +17 from this change (12 tab-behaviour, 3 service contract, 2 mint-path). `tsc --noEmit` clean.

The one failure in a full run — `shared-view.page.spec.ts`, a parallel-load timeout its own comment already documents — **reproduces on clean develop with these changes stashed**, so it's pre-existing and unrelated.

## To turn it on

Set `CDK_ARTIFACT_SHARE_INBOX_ENABLED=true` for the environment and deploy `platform.yml`. Existing dev shares predate the fan-out and won't appear until re-created; prod has no shares at all, so it's correct from its first one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)