### PR TITLE
feat(artifacts): share a conversation's artifacts with the conversation

### DIFF
--- a/backend/src/apis/app_api/artifacts/service.py
+++ b/backend/src/apis/app_api/artifacts/service.py
@@ -321,6 +321,76 @@ class RenderTokenService:
         return f"{origin}/?t={token}", exp
 
 
+    def mint_for_conversation_share(
+        self,
+        *,
+        owner_id: str,
+        artifact_id: str,
+        version: int,
+        conversation_share_id: str,
+        viewer: User,
+    ) -> tuple[str, int]:
+        """Mint a render token for an artifact inside a *shared conversation*.
+
+        Returns (render_url, exp_unix). Raises ArtifactNotFoundError or
+        RenderTokenConfigError.
+
+        ############################################################
+        # SECURITY — this method performs NO access control.
+        #
+        # Unlike `mint_for_share`, which resolves and checks its own
+        # share record, this one is handed an owner id and an artifact
+        # id by its caller. Both the conversation-share ACL check and
+        # the "is this artifact actually in that share's snapshot"
+        # check happen in `shares/service.py`, because the grant lives
+        # in the shared-conversations table, which this module does not
+        # read.
+        #
+        # So the ONLY safe caller is one that has already done both. Do
+        # not expose this on a route, do not call it with an
+        # artifact id taken from a request, and do not add a default
+        # for `owner_id`. Given `sub` is a partition address (see
+        # `mint_for_share`), an unchecked call here is "read any
+        # artifact by id" with extra steps.
+        ############################################################
+        """
+        origin = _origin()
+        # The snapshot is denormalized metadata; the version row is the
+        # truth. Re-assert it so an artifact deleted since the
+        # conversation was shared 404s here rather than minting a token
+        # that renders the Lambda's error page in the recipient's frame.
+        _assert_version_exists(owner_id, artifact_id, version)
+
+        now = int(time.time())
+        exp = now + _TTL_SECONDS
+        claims = {
+            "iss": _ISS,
+            "aud": _AUD,
+            "sub": owner_id,  # DynamoDB partition — NOT an identity claim.
+            "aid": artifact_id,
+            "ver": version,
+            "sid": "",
+            "vwr": viewer.user_id,  # who actually looked (audit)
+            # The grant is a CONVERSATION share, not an artifact share.
+            # Prefixed so a log or a later Lambda can tell the two apart
+            # rather than silently reading it as an artifact share id.
+            "shr": f"conv:{conversation_share_id}",
+            "iat": now,
+            "exp": exp,
+        }
+        token = jwt.encode(claims, _signing_key(), algorithm="HS256")
+        logger.info(
+            "minted conversation-share render token share=%s owner=%s "
+            "viewer=%s artifact=%s v=%s",
+            scrub_log(conversation_share_id),
+            scrub_log(owner_id),
+            scrub_log(viewer.user_id),
+            scrub_log(artifact_id),
+            scrub_log(version),
+        )
+        return f"{origin}/?t={token}", exp
+
+
 def get_render_token_service() -> RenderTokenService:
     return RenderTokenService()
 
@@ -393,6 +463,71 @@ class ArtifactListService:
                 self._versions_for_artifact(user_id, artifact_id)
             )
         return summaries
+
+    def heads_for_session(
+        self, *, user_id: str, session_id: str
+    ) -> list[dict]:
+        """Each artifact the session produced, at HEAD, newest-first.
+
+        One row per *artifact*, unlike `list_for_session`, which returns
+        one per version so the session view can anchor a card under the
+        turn that made it. This is the shape a point-in-time snapshot
+        wants: the version each artifact stood at when the conversation
+        was shared.
+
+        Only HEAD rows carry `GSI1PK`, so the index query alone is the
+        answer — no per-artifact expansion, and no base-table read.
+
+        `user_id` filters rather than keys, because `SessionIndex` is
+        partitioned by session and is NOT user-scoped. Dropping that
+        filter would let a borrowed session id enumerate somebody else's
+        artifacts, which is the same reason `list_for_session` re-checks
+        it per row.
+        """
+        table = _table()
+        items: list[dict] = []
+        kwargs: dict = {
+            "IndexName": _SESSION_INDEX,
+            "KeyConditionExpression": Key("GSI1PK").eq(
+                f"SESSION#{session_id}"
+            ),
+            "ScanIndexForward": False,  # GSI1SK embeds updated_at → newest first
+        }
+        try:
+            while True:
+                resp = table.query(**kwargs)
+                items.extend(resp.get("Items", []))
+                last = resp.get("LastEvaluatedKey")
+                if not last:
+                    break
+                kwargs["ExclusiveStartKey"] = last
+        except ClientError as exc:
+            raise ArtifactQueryError("artifact head query failed") from exc
+
+        heads: list[dict] = []
+        seen: set = set()
+        for item in items:
+            artifact_id = str(item.get("artifact_id", ""))
+            if not artifact_id or item.get("user_id") != user_id:
+                continue
+            if artifact_id in seen:
+                continue
+            seen.add(artifact_id)
+            produced_by = item.get("produced_by_message_index")
+            heads.append(
+                {
+                    "artifact_id": artifact_id,
+                    "version": int(item.get("version", 1)),
+                    "title": str(item.get("title", "")),
+                    "content_type": str(
+                        item.get("content_type", "text/html; charset=utf-8")
+                    ),
+                    "produced_by_message_index": (
+                        int(produced_by) if produced_by is not None else None
+                    ),
+                }
+            )
+        return heads
 
     def list_for_user(self, *, user_id: str) -> list[dict]:
         """Every artifact the user owns, at HEAD, newest-first.

--- a/backend/src/apis/app_api/shares/models.py
+++ b/backend/src/apis/app_api/shares/models.py
@@ -89,6 +89,35 @@ class ShareListResponse(BaseModel):
     shares: List[ShareResponse] = Field(..., description="List of shares for the session")
 
 
+class SharedConversationArtifact(BaseModel):
+    """One artifact pinned into a conversation share's snapshot.
+
+    The recipient shape: no owner id, and no session id to go back to.
+    A recipient reaches this artifact only through the conversation
+    share that carries it, so the pair (share id, artifact id) is the
+    whole of their handle on it.
+
+    `version` is the version the artifact stood at when the conversation
+    was shared, not its current HEAD — the same point-in-time promise
+    the messages make.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    artifact_id: str = Field(..., alias="artifactId")
+    version: int
+    title: str = Field(default="")
+    content_type: str = Field(default="", alias="contentType")
+    produced_by_message_index: Optional[int] = Field(
+        default=None,
+        alias="producedByMessageIndex",
+        description="0-based index of the assistant message that produced "
+        "this artifact, so the shared view can anchor its card under the "
+        "same turn the owner sees it under. Null for artifacts written "
+        "before that linkage existed.",
+    )
+
+
 class SharedConversationResponse(BaseModel):
     """Response model for retrieving a shared conversation"""
 
@@ -102,3 +131,11 @@ class SharedConversationResponse(BaseModel):
     created_at: str = Field(..., alias="createdAt", description="ISO 8601 timestamp of share creation")
     owner_id: str = Field(..., alias="ownerId", description="User ID of the share creator")
     messages: List[MessageResponse] = Field(..., description="Snapshot of conversation messages")
+    artifacts: List[SharedConversationArtifact] = Field(
+        default_factory=list,
+        description="Artifacts the conversation produced, pinned at the "
+        "versions they stood at when it was shared. Empty for shares "
+        "created before artifacts were captured, and for conversations "
+        "that produced none — the two are indistinguishable and neither "
+        "is an error.",
+    )

--- a/backend/src/apis/app_api/shares/routes.py
+++ b/backend/src/apis/app_api/shares/routes.py
@@ -8,11 +8,22 @@ Three routers:
 """
 
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
+
+# The artifacts domain owns render-token minting; this module owns the
+# grant that authorizes it. Both live under app_api, so this is a
+# same-package import, not a service boundary crossing.
+from apis.app_api.artifacts.models import RenderTokenResponse
+from apis.app_api.artifacts.service import (
+    ArtifactNotFoundError,
+    RenderTokenConfigError,
+    get_render_token_service,
+)
 
 from .models import (
     CreateShareRequest,
@@ -211,3 +222,72 @@ async def get_shared_conversation(
         sanitized_share_id = share_id.replace("\r", "").replace("\n", "")
         logger.error(f"Error retrieving shared conversation {sanitized_share_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve shared conversation")
+
+
+@shared_view_router.post(
+    "/{share_id}/artifacts/{artifact_id}/render-token",
+    response_model=RenderTokenResponse,
+)
+async def mint_shared_conversation_artifact_token(
+    share_id: str,
+    artifact_id: str,
+    current_user: User = Depends(get_current_user_from_session),
+):
+    """Mint a render URL for an artifact inside a shared conversation.
+
+    The grant is the CONVERSATION share — there is no separate artifact
+    share record, and none is created. Sharing a conversation shares the
+    artifacts it produced, so the conversation share is the single thing
+    that grants, updates and revokes them: change its allowlist and the
+    artifacts follow in the same write, revoke it and they die with it.
+    Parallel artifact-share rows would each need cascading, and a missed
+    cascade is an artifact still readable after its conversation was
+    locked down.
+
+    The version served is the one pinned in the snapshot, so a recipient
+    sees the artifact the transcript around it describes rather than
+    whatever the owner has edited it into since.
+
+    `resolve_shared_artifact` is the access boundary and does both
+    checks — may this viewer open this share, and is this artifact one
+    the snapshot pinned. The mint it feeds performs none of its own.
+    """
+    try:
+        owner_id, version = get_share_service().resolve_shared_artifact(
+            share_id=share_id,
+            artifact_id=artifact_id,
+            requester=current_user,
+        )
+        url, exp = get_render_token_service().mint_for_conversation_share(
+            owner_id=owner_id,
+            artifact_id=artifact_id,
+            version=version,
+            conversation_share_id=share_id,
+            viewer=current_user,
+        )
+    except ShareNotFoundError:
+        # Also the "not in this snapshot" case, deliberately: an artifact
+        # the share does not carry is indistinguishable from one that
+        # does not exist, so this reveals nothing about what the owner has.
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    except AccessDeniedError:
+        raise HTTPException(status_code=403, detail="Access denied")
+    except ArtifactNotFoundError:
+        # Pinned by the snapshot but gone from the table — deleted since
+        # the conversation was shared.
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    except ShareTableNotFoundError:
+        raise HTTPException(
+            status_code=503,
+            detail="Share feature unavailable - table not deployed",
+        )
+    except RenderTokenConfigError:
+        logger.error("artifact render token service misconfigured", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="Artifact rendering is unavailable"
+        )
+
+    return RenderTokenResponse(
+        url=url,
+        expires_at=datetime.fromtimestamp(exp, tz=timezone.utc).isoformat(),
+    )

--- a/backend/src/apis/app_api/shares/service.py
+++ b/backend/src/apis/app_api/shares/service.py
@@ -25,6 +25,7 @@ from .models import (
     CreateShareRequest,
     ShareListResponse,
     ShareResponse,
+    SharedConversationArtifact,
     SharedConversationResponse,
     UpdateShareRequest,
 )
@@ -106,8 +107,25 @@ class ShareService:
         if not self._snapshot_store.enabled:
             raise ShareStorageUnavailableError()
 
+        # Artifacts the conversation produced, pinned at the version each
+        # stood at right now.
+        #
+        # They belong in the snapshot for the same reason the messages
+        # do: this share is a point-in-time copy, and an artifact
+        # resolved live would drift under a recipient who is reading a
+        # frozen conversation — they would see a chart the transcript
+        # around it never describes. Pinning also makes the snapshot the
+        # ALLOWLIST: the mint route will serve an (artifact, version)
+        # pair only if it appears here, so a recipient cannot name an
+        # arbitrary artifact of the owner's.
+        artifacts_snapshot = self._snapshot_artifacts(session_id, user)
+
         body_bytes = json.dumps(
-            {"metadata": metadata_snapshot, "messages": messages_snapshot}
+            {
+                "metadata": metadata_snapshot,
+                "messages": messages_snapshot,
+                "artifacts": artifacts_snapshot,
+            }
         ).encode("utf-8")
 
         try:
@@ -566,6 +584,16 @@ class ShareService:
     def _load_snapshot_body(self, item: dict) -> Tuple[dict, list]:
         """Return ``(metadata, messages)`` for a share item.
 
+        A narrowing of :meth:`_load_snapshot_raw` kept because it is what
+        every existing caller wants; anything needing another key of the
+        body (the pinned artifact list) reads the raw dict instead.
+        """
+        body = self._load_snapshot_raw(item)
+        return body.get("metadata", {}) or {}, body.get("messages", []) or []
+
+    def _load_snapshot_raw(self, item: dict) -> dict:
+        """Return the whole snapshot body for a share item.
+
         Handles three item shapes for backward compatibility:
 
           - **New** (``body_ref`` present): fetch the JSON body from S3.
@@ -574,6 +602,10 @@ class ShareService:
             offload. Existing shares predate the offload and stay readable
             with no migration.
           - **Malformed** (neither): unreadable → ``ShareNotFoundError``.
+
+        Callers must treat every key as optional. Bodies written before a
+        key existed simply do not have it, and there is no migration —
+        conversation sharing is in production.
         """
         body_ref = item.get("body_ref")
         if body_ref:
@@ -588,14 +620,22 @@ class ShareService:
                     f"key={key}: {e}"
                 )
                 raise ShareNotFoundError() from e
-            return body.get("metadata", {}) or {}, body.get("messages", []) or []
+            return body if isinstance(body, dict) else {}
 
         if item.get("messages") is not None:
             # Legacy inline share — DynamoDB stored floats as Decimal; convert
             # back so downstream JSON/Pydantic handling matches the S3 path.
-            metadata = self._convert_decimals_to_float(item.get("metadata", {}) or {})
-            messages = self._convert_decimals_to_float(item.get("messages", []))
-            return metadata, messages
+            # Legacy inline shares predate artifacts entirely, so there
+            # is no `artifacts` key to recover here — the caller's
+            # tolerance for a missing one is what covers them.
+            return {
+                "metadata": self._convert_decimals_to_float(
+                    item.get("metadata", {}) or {}
+                ),
+                "messages": self._convert_decimals_to_float(
+                    item.get("messages", [])
+                ),
+            }
 
         logger.warning(
             f"Share {self._sanitize_id(str(item.get('share_id', '')))} has neither "
@@ -617,6 +657,99 @@ class ShareService:
         if key:
             self._snapshot_store.delete(key)
 
+    @staticmethod
+    def _snapshot_artifacts(session_id: str, user: User) -> list[dict]:
+        """The session's artifacts at HEAD, for the snapshot body.
+
+        Best-effort and never raising. Sharing a conversation must not
+        fail because the artifacts feature is off in this environment,
+        or because its table hiccuped — a share with no artifacts is the
+        behaviour every share had before this existed, and it degrades
+        to exactly that. The alternative, failing the share, would trade
+        a missing picture for a missing conversation.
+        """
+        try:
+            from apis.app_api.artifacts.service import (
+                get_artifact_list_service,
+            )
+
+            return get_artifact_list_service().heads_for_session(
+                user_id=user.user_id, session_id=session_id
+            )
+        except Exception:
+            logger.warning(
+                "could not snapshot artifacts for session %s — sharing "
+                "the conversation without them",
+                ShareService._sanitize_id(session_id),
+                exc_info=True,
+            )
+            return []
+
+    def resolve_shared_artifact(
+        self, *, share_id: str, artifact_id: str, requester: User
+    ) -> tuple[str, int]:
+        """Authorize one artifact inside a shared conversation.
+
+        Returns (owner_id, pinned_version) for a caller that is about to
+        mint. Raises ShareNotFoundError when the share is gone or does
+        not carry that artifact, and AccessDeniedError when the viewer
+        may not open the share.
+
+        ############################################################
+        # This is the access-control boundary for artifacts in shared
+        # conversations, and it is the whole of it — the mint it feeds
+        # (`mint_for_conversation_share`) performs no checks of its
+        # own, by design and by the comment on it.
+        #
+        # Two things have to hold, and both are here:
+        #   1. the viewer may open this conversation share, and
+        #   2. the artifact is one the SNAPSHOT pinned.
+        #
+        # (2) is what stops a recipient swapping in another artifact id
+        # belonging to the same owner. `sub` on the minted token is a
+        # partition address, so without it any valid share id would be
+        # a read primitive over the owner's whole artifact partition.
+        # An unknown artifact is a 404 rather than a 403, so it also
+        # reveals nothing about what the owner has.
+        ############################################################
+        """
+        self._ensure_enabled()
+
+        item = self._get_share_item(share_id)
+        if not item:
+            raise ShareNotFoundError()
+
+        self._check_access(item, requester)
+
+        for entry in self._load_snapshot_artifacts(item):
+            if str(entry.get("artifact_id", "")) == artifact_id:
+                return str(item["owner_id"]), int(entry.get("version", 0))
+
+        raise ShareNotFoundError()
+
+    def _load_snapshot_artifacts(self, item: dict) -> list[dict]:
+        """The pinned artifact list from a share's snapshot body.
+
+        Absent on every share created before this feature, and on any
+        share whose owner had no artifacts — both are a normal empty
+        list, not an error. Conversation sharing is already in
+        production, so this MUST stay tolerant of a body with no
+        `artifacts` key; there is no migration and none is needed.
+        """
+        try:
+            body = self._load_snapshot_raw(item)
+        except ShareNotFoundError:
+            raise
+        except Exception:
+            logger.warning(
+                "could not read snapshot artifacts for share %s",
+                self._sanitize_id(str(item.get("share_id", ""))),
+                exc_info=True,
+            )
+            return []
+        raw = body.get("artifacts")
+        return raw if isinstance(raw, list) else []
+
     def _build_shared_conversation_response(self, item: dict) -> SharedConversationResponse:
         from apis.shared.sessions.models import MessageResponse
 
@@ -629,6 +762,20 @@ class ShareService:
             except Exception as e:
                 logger.warning(f"Skipping malformed message in share {item['share_id']}: {e}")
 
+        artifacts = []
+        for entry in self._load_snapshot_artifacts(item):
+            try:
+                artifacts.append(
+                    SharedConversationArtifact.model_validate(entry)
+                )
+            except Exception as e:
+                # One malformed entry must not cost the recipient the
+                # conversation, the same way a malformed message does not.
+                logger.warning(
+                    f"Skipping malformed artifact in share "
+                    f"{self._sanitize_id(str(item.get('share_id', '')))}: {e}"
+                )
+
         return SharedConversationResponse(
             share_id=item["share_id"],
             title=metadata.get("title", "Untitled Conversation"),
@@ -636,6 +783,7 @@ class ShareService:
             created_at=item["created_at"],
             owner_id=item["owner_id"],
             messages=messages,
+            artifacts=artifacts,
         )
 
 

--- a/backend/tests/apis/app_api/shares/test_shared_conversation_artifacts.py
+++ b/backend/tests/apis/app_api/shares/test_shared_conversation_artifacts.py
@@ -1,0 +1,488 @@
+"""Tests for artifacts inside a shared conversation.
+
+Sharing a conversation shares the artifacts it produced. The mechanism
+is that the **conversation share is the grant** — there is no parallel
+artifact-share record — and the snapshot pins the versions.
+
+Two things carry the weight here:
+
+* `resolve_shared_artifact` is the *whole* access boundary. The mint it
+  feeds does no checking of its own, and the token's `sub` is a
+  DynamoDB partition address, so a gap here is "read any artifact by
+  id" against the owner's partition.
+* The snapshot's artifact list is the allowlist. A recipient must not be
+  able to name an artifact the share does not carry.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.shares.models import CreateShareRequest
+from apis.app_api.shares.service import (
+    AccessDeniedError,
+    ShareNotFoundError,
+    ShareService,
+)
+from apis.app_api.shares.snapshot_store import ShareSnapshotStore
+from apis.shared.auth.models import User
+
+AWS_REGION = "us-east-1"
+BUCKET = "test-shared-conversations"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", AWS_REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def s3_client(aws_env):
+    client = boto3.client("s3", region_name=AWS_REGION)
+    client.create_bucket(Bucket=BUCKET)
+    return client
+
+
+@pytest.fixture()
+def service(s3_client, monkeypatch):
+    monkeypatch.setenv("SHARED_CONVERSATIONS_TABLE_NAME", "shares-table")
+    store = ShareSnapshotStore(bucket_name=BUCKET, s3_client=s3_client)
+    with patch("boto3.resource"):
+        svc = ShareService(snapshot_store=store)
+    svc._table = MagicMock()
+    return svc
+
+
+def _owner() -> User:
+    return User(
+        email="owner@example.com", user_id="owner-1", name="Owner", roles=[]
+    )
+
+
+def _viewer(email: str = "friend@example.com") -> User:
+    return User(email=email, user_id="friend-1", name="Friend", roles=[])
+
+
+def _patch_sources(heads: list[dict] | Exception):
+    """Patch the three things `create_share` reads."""
+    meta = MagicMock()
+    meta.model_dump.return_value = {"title": "Chat"}
+    messages = MagicMock(
+        messages=[
+            MagicMock(
+                model_dump=MagicMock(
+                    return_value={
+                        "id": "m0",
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hi"}],
+                        "createdAt": "2026-01-01T00:00:00Z",
+                    }
+                )
+            )
+        ]
+    )
+
+    list_service = MagicMock()
+    if isinstance(heads, Exception):
+        list_service.heads_for_session.side_effect = heads
+    else:
+        list_service.heads_for_session.return_value = heads
+
+    return (
+        patch(
+            "apis.app_api.shares.service.get_session_metadata",
+            new=AsyncMock(return_value=meta),
+        ),
+        patch(
+            "apis.app_api.shares.service.get_messages",
+            new=AsyncMock(return_value=messages),
+        ),
+        patch(
+            "apis.app_api.artifacts.service.get_artifact_list_service",
+            return_value=list_service,
+        ),
+    )
+
+
+def _head(artifact_id: str = "art-1", version: int = 3) -> dict:
+    return {
+        "artifact_id": artifact_id,
+        "version": version,
+        "title": "Quarterly Deck",
+        "content_type": "text/html; charset=utf-8",
+        "produced_by_message_index": 2,
+    }
+
+
+async def _create(service, heads, *, access="public", emails=None):
+    meta_p, msgs_p, arts_p = _patch_sources(heads)
+    with meta_p, msgs_p, arts_p:
+        return await service.create_share(
+            "sess-1",
+            _owner(),
+            CreateShareRequest(accessLevel=access, allowedEmails=emails),
+        )
+
+
+def _written_item(service) -> dict:
+    """The DynamoDB item create_share wrote, as the read path sees it."""
+    return service._table.put_item.call_args[1]["Item"]
+
+
+def _snapshot_body(service, s3_client) -> dict:
+    key = _written_item(service)["body_ref"]["bucket_key"]
+    obj = s3_client.get_object(Bucket=BUCKET, Key=key)
+    return json.loads(obj["Body"].read())
+
+
+# ------------------------------------------------------------------
+# Capture
+# ------------------------------------------------------------------
+
+
+class TestSnapshotCapture:
+    @pytest.mark.asyncio
+    async def test_pins_each_artifact_at_its_current_version(
+        self, service, s3_client
+    ):
+        await _create(service, [_head(version=3)])
+
+        artifacts = _snapshot_body(service, s3_client)["artifacts"]
+        assert len(artifacts) == 1
+        # The version at share time, not a moving HEAD pointer: a
+        # recipient reading a frozen conversation must not be shown an
+        # artifact the transcript around it never describes.
+        assert artifacts[0]["version"] == 3
+        assert artifacts[0]["artifact_id"] == "art-1"
+        assert artifacts[0]["produced_by_message_index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_conversation_with_no_artifacts_shares_fine(
+        self, service, s3_client
+    ):
+        await _create(service, [])
+        assert _snapshot_body(service, s3_client)["artifacts"] == []
+
+    @pytest.mark.asyncio
+    async def test_artifact_failure_does_not_fail_the_share(
+        self, service, s3_client
+    ):
+        """Sharing a conversation must not break because the artifacts
+        feature is off here, or because its table hiccuped. A share with
+        no artifacts is what every share was before this existed."""
+        await _create(service, RuntimeError("artifacts table is gone"))
+
+        body = _snapshot_body(service, s3_client)
+        assert body["artifacts"] == []
+        # The conversation itself still made it.
+        assert body["messages"][0]["content"][0]["text"] == "hi"
+
+
+# ------------------------------------------------------------------
+# Read
+# ------------------------------------------------------------------
+
+
+class TestSharedConversationResponse:
+    @pytest.mark.asyncio
+    async def test_returns_artifacts_with_the_conversation(self, service):
+        await _create(service, [_head()])
+        service._get_share_item = MagicMock(return_value=_written_item(service))
+
+        resp = await service.get_shared_conversation(
+            share_id=_written_item(service)["share_id"], requester=_viewer()
+        )
+
+        assert len(resp.artifacts) == 1
+        assert resp.artifacts[0].artifact_id == "art-1"
+        assert resp.artifacts[0].version == 3
+        # Anchoring data, so the shared view can place the card under the
+        # same turn the owner sees it under.
+        assert resp.artifacts[0].produced_by_message_index == 2
+
+    @pytest.mark.asyncio
+    async def test_a_share_predating_artifacts_reads_as_empty(
+        self, service, s3_client
+    ):
+        """Conversation sharing is already in production, so a body with
+        no `artifacts` key is the common case, not an error. There is no
+        migration and none is needed."""
+        await _create(service, [_head()])
+        item = _written_item(service)
+
+        # Overwrite in place, at the key the item already points at, so
+        # this reads back through the real resolution path rather than a
+        # second object nothing references.
+        s3_client.put_object(
+            Bucket=BUCKET,
+            Key=item["body_ref"]["bucket_key"],
+            Body=json.dumps(
+                {"metadata": {"title": "Chat"}, "messages": []}
+            ).encode(),
+        )
+        service._get_share_item = MagicMock(return_value=item)
+
+        resp = await service.get_shared_conversation(
+            share_id=item["share_id"], requester=_viewer()
+        )
+        assert resp.artifacts == []
+
+    @pytest.mark.asyncio
+    async def test_a_legacy_inline_share_reads_as_empty(self, service):
+        """Inline shares predate the S3 offload entirely — and artifacts
+        by a wider margin. They must still open."""
+        item = {
+            "share_id": "s-legacy",
+            "session_id": "sess-1",
+            "owner_id": "owner-1",
+            "owner_email": "owner@example.com",
+            "access_level": "public",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {"title": "Old Chat"},
+            "messages": [],
+        }
+        service._get_share_item = MagicMock(return_value=item)
+
+        resp = await service.get_shared_conversation(
+            share_id="s-legacy", requester=_viewer()
+        )
+        assert resp.artifacts == []
+        assert resp.title == "Old Chat"
+
+
+# ------------------------------------------------------------------
+# The access boundary
+# ------------------------------------------------------------------
+
+
+class TestResolveSharedArtifact:
+    @pytest.mark.asyncio
+    async def test_returns_the_owner_and_the_pinned_version(self, service):
+        await _create(service, [_head(version=3)])
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        owner_id, version = service.resolve_shared_artifact(
+            share_id=item["share_id"],
+            artifact_id="art-1",
+            requester=_viewer(),
+        )
+
+        # The owner id is a DynamoDB partition address for the mint, not
+        # an identity assertion. See mint_for_conversation_share.
+        assert owner_id == "owner-1"
+        assert version == 3
+
+    @pytest.mark.asyncio
+    async def test_an_artifact_outside_the_snapshot_is_404(self, service):
+        """The load-bearing test.
+
+        The snapshot list is the allowlist. Without this check, any valid
+        share id plus a guessed artifact id would read the owner's whole
+        artifact partition, because `sub` on the minted token is an
+        address rather than an identity. 404 rather than 403, so it also
+        reveals nothing about what the owner has."""
+        await _create(service, [_head("art-1")])
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        with pytest.raises(ShareNotFoundError):
+            service.resolve_shared_artifact(
+                share_id=item["share_id"],
+                artifact_id="art-somebody-elses",
+                requester=_viewer(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_viewer_outside_the_allowlist_is_denied(self, service):
+        await _create(
+            service,
+            [_head()],
+            access="specific",
+            emails=["invited@example.com"],
+        )
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        with pytest.raises(AccessDeniedError):
+            service.resolve_shared_artifact(
+                share_id=item["share_id"],
+                artifact_id="art-1",
+                requester=_viewer("uninvited@example.com"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_access_follows_the_conversation_share(self, service):
+        """The point of having no separate artifact-share record.
+
+        Narrowing the conversation's allowlist has to lock the artifacts
+        down in the same write — with parallel artifact shares this is
+        where a missed cascade would leave them readable."""
+        await _create(
+            service,
+            [_head()],
+            access="specific",
+            emails=["friend@example.com"],
+        )
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        # Allowed while on the list.
+        assert service.resolve_shared_artifact(
+            share_id=item["share_id"],
+            artifact_id="art-1",
+            requester=_viewer(),
+        )
+
+        # Owner edits the allowlist — one write, no cascade.
+        item["allowed_emails"] = ["someone.else@example.com"]
+
+        with pytest.raises(AccessDeniedError):
+            service.resolve_shared_artifact(
+                share_id=item["share_id"],
+                artifact_id="art-1",
+                requester=_viewer(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_revoked_share_takes_its_artifacts_with_it(self, service):
+        await _create(service, [_head()])
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=None)
+
+        with pytest.raises(ShareNotFoundError):
+            service.resolve_shared_artifact(
+                share_id=item["share_id"],
+                artifact_id="art-1",
+                requester=_viewer(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_owner_can_resolve_their_own(self, service):
+        await _create(
+            service, [_head()], access="specific", emails=["a@example.com"]
+        )
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        owner_id, _ = service.resolve_shared_artifact(
+            share_id=item["share_id"],
+            artifact_id="art-1",
+            requester=_owner(),
+        )
+        assert owner_id == "owner-1"
+
+
+# ------------------------------------------------------------------
+# The route
+# ------------------------------------------------------------------
+
+
+class TestMintRoute:
+    """The HTTP surface, wired to a real ShareService.
+
+    These exist because the boundary is split across two modules: the
+    grant lives here and the minting lives in `artifacts/service.py`.
+    Unit tests on either half can both pass while the route wires them
+    together wrongly.
+    """
+
+    @pytest.fixture()
+    def client(self, service, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from apis.app_api.shares import routes as share_routes
+        from apis.shared.auth import get_current_user_from_session
+
+        monkeypatch.setenv(
+            "ARTIFACTS_RENDER_TOKEN_SECRET_ARN", "arn:aws:secret:test"
+        )
+        monkeypatch.setenv("ARTIFACTS_ORIGIN", "https://a.test.example.com")
+
+        def make(user: User):
+            app = FastAPI()
+            app.include_router(share_routes.shared_view_router)
+            app.dependency_overrides[get_current_user_from_session] = (
+                lambda: user
+            )
+            monkeypatch.setattr(
+                share_routes, "get_share_service", lambda: service
+            )
+            return TestClient(app)
+
+        return make
+
+    @pytest.mark.asyncio
+    async def test_mints_for_a_permitted_viewer(
+        self, service, client, monkeypatch
+    ):
+        await _create(service, [_head(version=3)])
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        seen = {}
+
+        def fake_mint(**kwargs):
+            seen.update(kwargs)
+            return "https://a.test.example.com/?t=jwt", 1800000000
+
+        from apis.app_api.shares import routes as share_routes
+
+        monkeypatch.setattr(
+            share_routes,
+            "get_render_token_service",
+            lambda: MagicMock(mint_for_conversation_share=fake_mint),
+        )
+
+        resp = client(_viewer()).post(
+            f"/shared/{item['share_id']}/artifacts/art-1/render-token"
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["url"].endswith("?t=jwt")
+        # The route must hand the mint the OWNER (a partition address)
+        # and the PINNED version — not the viewer, and not HEAD.
+        assert seen["owner_id"] == "owner-1"
+        assert seen["version"] == 3
+        assert seen["viewer"].user_id == "friend-1"
+        assert seen["conversation_share_id"] == item["share_id"]
+
+    @pytest.mark.asyncio
+    async def test_an_artifact_outside_the_snapshot_is_404(
+        self, service, client
+    ):
+        await _create(service, [_head("art-1")])
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        resp = client(_viewer()).post(
+            f"/shared/{item['share_id']}/artifacts/art-other/render-token"
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_a_viewer_outside_the_allowlist_is_403(
+        self, service, client
+    ):
+        await _create(
+            service,
+            [_head()],
+            access="specific",
+            emails=["invited@example.com"],
+        )
+        item = _written_item(service)
+        service._get_share_item = MagicMock(return_value=item)
+
+        resp = client(_viewer("uninvited@example.com")).post(
+            f"/shared/{item['share_id']}/artifacts/art-1/render-token"
+        )
+        assert resp.status_code == 403

--- a/docs-site/src/content/docs/features/artifacts.md
+++ b/docs-site/src/content/docs/features/artifacts.md
@@ -186,12 +186,41 @@ was off — a wrong answer rather than an empty one, and one nobody could see wa
 wrong. Writing the rows regardless makes the flip complete and instant, with no
 backfill to sequence.
 
-## Known gap: artifacts inside a shared conversation
+## Artifacts inside a shared conversation
 
-Sharing a *conversation* does not share the artifacts it produced. A recipient
-viewing a shared conversation sees nothing where the owner sees artifact cards,
-because artifact hydration filters by the requesting user.
+Sharing a conversation shares the artifacts it produced. A recipient sees the
+artifact cards where the owner sees them, anchored under the same turns.
 
-Closing that properly means deciding whether sharing a conversation should also
-share its artifacts — a consent question, not just a wiring one — so it is
-tracked as a known gap rather than treated as a bug.
+The mechanism is worth knowing before changing it: **the conversation share is
+the grant.** No artifact share records are created for this. Instead
+`create_share` pins the session's artifacts — at the version each stood at right
+then — into the conversation's snapshot body, next to the messages.
+
+That does two jobs at once. It keeps the point-in-time promise the snapshot
+already makes, so a recipient reading a frozen conversation is not shown an
+artifact the transcript around it never describes. And it makes the snapshot the
+**allowlist**: `resolve_shared_artifact` will only serve an `(artifact, version)`
+pair that appears there, which is what stops a recipient naming an arbitrary
+artifact belonging to the same owner. That check matters because the minted
+token's `sub` is a partition address rather than an identity — see
+[How access is actually enforced](#how-access-is-actually-enforced).
+
+The payoff is that access has one source of truth. Narrow a conversation's
+allowlist and its artifacts lock down in the same write; revoke the share and
+they go with it. Provisioning parallel artifact shares would instead need a
+cascade on every one of those paths, and a missed cascade leaves an artifact
+readable after its conversation was locked down.
+
+Shares created before this landed carry no artifact list and read as an empty
+one. There is no migration.
+
+## Historical note: how this used to be broken
+
+Until the section above shipped, sharing a *conversation* did not share the
+artifacts it produced. A recipient saw nothing where the owner saw artifact
+cards — silently, with no placeholder — because artifact hydration goes through
+`GET /artifacts?session_id=…`, which filters HEAD rows by the requesting user.
+
+It stayed open as long as it did because the fix needed a consent decision
+("should sharing a conversation also share its artifacts?") rather than only
+wiring. The answer was yes.

--- a/docs/specs/artifact-sharing.md
+++ b/docs/specs/artifact-sharing.md
@@ -336,7 +336,41 @@ Deliberately **not** in scope: deleting artifact content on session delete.
 That is a retention decision about the artifacts feature as a whole, not about
 sharing, and it deserves its own spec.
 
-## 8. Known gap: artifacts in shared conversations
+## 8. Artifacts in shared conversations — CLOSED
+
+**Status: implemented.** Sharing a conversation now shares the artifacts it
+produced. The rest of this section is the original gap analysis, kept because
+the reasoning still explains the shape of the fix.
+
+The mechanism differs from the sketch below in one important way: **no artifact
+share records are created.** The conversation share record *is* the grant.
+
+- `create_share` pins the session's artifacts, at the version each stood at, into
+  the snapshot body alongside the messages. That preserves the point-in-time
+  promise (a recipient reading a frozen conversation sees the artifact the
+  transcript describes) and makes the snapshot the **allowlist**.
+- `resolve_shared_artifact` is the whole access boundary: it checks the
+  conversation share's ACL *and* that the artifact is one the snapshot pinned,
+  then hands an owner id and pinned version to
+  `RenderTokenService.mint_for_conversation_share`, which checks nothing itself.
+- Access, updates and revocation are therefore free. Narrow the conversation's
+  allowlist and the artifacts follow in the same write; revoke it and they go
+  with it.
+
+Auto-provisioning parallel artifact shares (the original sketch) was rejected on
+two grounds. Each would need cascading on update, revoke, artifact delete and
+session delete — and a missed cascade leaves an artifact readable after its
+conversation was locked down, which is a security bug rather than a display one.
+It would also put N rows in the recipient's "Shared with you" inbox for one
+conversation share, when the conversation is the thing that was shared.
+
+The snapshot's artifact list is optional on read. Conversation sharing is in
+production, so bodies written before this exist and have no `artifacts` key;
+they read as an empty list, and there is no migration.
+
+### Original gap analysis
+
+
 
 `shared-view.page.ts` renders `MessageListComponent` with `embeddedMode` and has
 no artifact wiring. Artifact hydration goes through


### PR DESCRIPTION
Closes the gap §8 of `docs/specs/artifact-sharing.md` has carried since artifact sharing shipped: **a recipient of a shared conversation saw nothing where the owner sees artifact cards** — silently, no placeholder, no error, because artifact hydration filters HEAD rows by the requesting user. It stayed open because closing it needed a consent decision rather than wiring. You made it: sharing a conversation shares the artifacts it produced.

Backend only. PR-2 is the shared view rendering them.

## The conversation share *is* the grant

No artifact share records are created for this — which is where §8's original sketch pointed, and where this deliberately doesn't go.

`create_share` pins the session's artifacts, at the version each stood at right then, into the snapshot body next to the messages. That does two jobs:

- **Keeps the point-in-time promise.** The snapshot already freezes the messages; an artifact resolved live would drift under a recipient reading a frozen conversation, showing them a chart the transcript around it never describes.
- **Makes the snapshot the allowlist.** `resolve_shared_artifact` serves an `(artifact, version)` pair only if it appears there.

That second one is load-bearing. `resolve_shared_artifact` is the *entire* access boundary and does both halves — may this viewer open this share, and is this artifact one the snapshot pinned — then hands an owner id and pinned version to `mint_for_conversation_share`, which checks nothing itself and carries a comment saying so. The minted token's `sub` is a DynamoDB partition *address*, not an identity, so without the second half any valid share id plus a guessed artifact id would be a read primitive over the owner's whole artifact partition. An artifact outside the snapshot 404s rather than 403s, so it also reveals nothing about what the owner has.

## Why not auto-provision artifact shares

Two reasons, and the first is the serious one:

1. **Cascade risk.** Parallel artifact shares would each need cascading on update, revoke, artifact delete *and* session delete. A missed cascade leaves an artifact readable after its conversation was locked down — a security bug, not a display one.
2. **Inbox flooding.** Sharing one conversation with a dozen artifacts would put a dozen rows in each recipient's "Shared with you" tab. The conversation is the thing that was shared.

The payoff is one source of truth: narrow a conversation's allowlist and its artifacts lock down in the same write; revoke it and they go with it. Both are tested as such, including the "owner edits the allowlist, no cascade runs, access changes anyway" case.

## Compatibility

Conversation sharing **is in production**, so the snapshot's `artifacts` key is optional on read. Bodies written before this have no such key; legacy inline shares predate the S3 offload by a wider margin still. Both read as an empty list. No migration, no schema bump — the addition is purely additive, and there are tests for each shape.

Capture is best-effort: sharing a conversation must not fail because the artifacts feature is off in an environment or its table hiccuped. A share with no artifacts is exactly what every share was until now.

## Also in here

- `_load_snapshot_body` becomes a narrowing of a new `_load_snapshot_raw`, so a caller wanting another key of the body doesn't have to widen the tuple every existing caller destructures.
- `heads_for_session` — one row per artifact at HEAD, off `SessionIndex` alone. The shape a snapshot wants, where `list_for_session` returns one row per *version* for the session view's per-turn anchoring.

## Tests

**914 passed** across `app_api` + `architecture` (including the import-boundary checks — `shares` → `artifacts` is a same-package import, not a service-boundary crossing).

15 new tests: snapshot capture and its degradation, the three body shapes on read, the access boundary (outside-the-snapshot, outside-the-allowlist, allowlist-edited, revoked, owner), and route-level wiring. That last group exists because the boundary is split across two modules — unit tests on either half can both pass while the route wires them together wrongly.

## Not in this PR

The shared view still doesn't render them, so this is inert until PR-2. Worth flagging what I found while sizing that: `MessageListComponent` reads artifacts from the injected `ArtifactStateService` rather than an input, and the card and panel mint through the owner endpoints — so PR-2 is a real piece of work, not a one-line wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)