### PR TITLE
feat(announcements): admin list and form pages (PR-3)

### DIFF
--- a/frontend/ai.client/src/app/admin/admin.layout.ts
+++ b/frontend/ai.client/src/app/admin/admin.layout.ts
@@ -25,6 +25,7 @@ import {
   heroFingerPrint,
   heroClipboardDocumentList,
   heroBars3,
+  heroMegaphone,
   heroSparkles,
   heroInbox,
   heroFlag,
@@ -77,6 +78,7 @@ interface NavGroup {
       heroFingerPrint,
       heroClipboardDocumentList,
       heroBars3,
+      heroMegaphone,
       heroSparkles,
       heroInbox,
       heroFlag,
@@ -246,6 +248,7 @@ export class AdminLayout implements OnInit {
     {
       label: 'Customization',
       items: [
+        { label: 'Announcements', icon: 'heroMegaphone', route: '/admin/manage-announcements', scope: 'admin.announcements' },
         { label: 'User Menu Links', icon: 'heroBars3', route: '/admin/manage-user-menu-links', scope: 'admin.user_menu_links' },
         { label: 'Conversation Modes', icon: 'heroSparkles', route: '/admin/system-prompts', scope: 'admin.system_prompts' },
       ],

--- a/frontend/ai.client/src/app/admin/admin.routes.ts
+++ b/frontend/ai.client/src/app/admin/admin.routes.ts
@@ -306,6 +306,24 @@ export const adminRoutes: Routes = [
     loadComponent: () => import('./manage-user-menu-links/user-menu-link-form.page').then(m => m.UserMenuLinkFormPage),
   },
   {
+    path: 'manage-announcements',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.announcements' } satisfies AdminScopeRouteData,
+    loadComponent: () => import('./manage-announcements/manage-announcements.page').then(m => m.ManageAnnouncementsPage),
+  },
+  {
+    path: 'manage-announcements/new',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.announcements' } satisfies AdminScopeRouteData,
+    loadComponent: () => import('./manage-announcements/announcement-form.page').then(m => m.AnnouncementFormPage),
+  },
+  {
+    path: 'manage-announcements/edit/:id',
+    canActivate: [adminScopeGuard],
+    data: { scope: 'admin.announcements' } satisfies AdminScopeRouteData,
+    loadComponent: () => import('./manage-announcements/announcement-form.page').then(m => m.AnnouncementFormPage),
+  },
+  {
     path: 'system-prompts',
     canActivate: [adminScopeGuard],
     data: { scope: 'admin.system_prompts' } satisfies AdminScopeRouteData,

--- a/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.spec.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AnnouncementFormPage } from './announcement-form.page';
+import { AnnouncementsAdminService } from './services/announcements-admin.service';
+import { AppRolesService } from '../roles/services/app-roles.service';
+import { Announcement } from './models/announcement.model';
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    announcement_id: 'a1',
+    title: 'Skills are here',
+    body_markdown: '# Skills',
+    summary: null,
+    surfaces: ['panel'],
+    severity: 'info',
+    state: 'draft',
+    publish_at: '2026-01-01T00:00:00Z',
+    expires_at: null,
+    target_roles: ['*'],
+    show_to_new_users: false,
+    requires_ack: false,
+    cta_label: null,
+    cta_url: null,
+    revision: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: 'admin@example.com',
+    ...overrides,
+  };
+}
+
+describe('AnnouncementFormPage', () => {
+  let service: {
+    get: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  let router: { navigate: ReturnType<typeof vi.fn> };
+  let paramId: string | null;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    paramId = null;
+    service = {
+      get: vi.fn(async () => makeAnnouncement()),
+      create: vi.fn(async () => makeAnnouncement()),
+      update: vi.fn(async () => makeAnnouncement()),
+    };
+    router = { navigate: vi.fn() };
+
+    // DI-token overrides rather than vi.mock, per house convention.
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AnnouncementsAdminService, useValue: service },
+        { provide: AppRolesService, useValue: { getRoles: () => [
+          { roleId: 'faculty', displayName: 'Faculty' },
+          { roleId: 'student', displayName: 'Student' },
+        ] } },
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => paramId } } },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  async function createPage() {
+    const page = TestBed.runInInjectionContext(() => new AnnouncementFormPage());
+    await page.ngOnInit();
+    return page as any;
+  }
+
+  function fill(page: any, values: Record<string, unknown>) {
+    page.form.patchValue({
+      title: 'Skills are here',
+      body_markdown: '# Skills',
+      ...values,
+    });
+  }
+
+  describe('surfaces', () => {
+    it('always sends panel, even though the form has no panel checkbox', async () => {
+      // The server forces it too (§D1), but sending it keeps the payload
+      // honest about what was chosen.
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ surfaces: ['panel'] }),
+      );
+    });
+
+    it('adds banner and modal when selected', async () => {
+      const page = await createPage();
+      fill(page, { banner: true, modal: true, expires_at: '2099-01-01T00:00' });
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ surfaces: ['panel', 'banner', 'modal'] }),
+      );
+    });
+
+    it('clears requiresAck when the modal is unchecked', async () => {
+      // Otherwise unchecking modal leaves a stale flag on the record.
+      const page = await createPage();
+      fill(page, { modal: true, expires_at: '2099-01-01T00:00', requires_ack: true });
+      expect(page.form.controls.requires_ack.value).toBe(true);
+
+      page.form.patchValue({ modal: false });
+      expect(page.form.controls.requires_ack.value).toBe(false);
+    });
+  });
+
+  describe('expiry rule (§5)', () => {
+    it('blocks submit when a banner has no expiry', async () => {
+      const page = await createPage();
+      fill(page, { banner: true });
+
+      expect(page.expiryMissing()).toBe(true);
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('blocks submit when a modal has no expiry', async () => {
+      const page = await createPage();
+      fill(page, { modal: true });
+
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('allows a panel-only announcement with no expiry', async () => {
+      const page = await createPage();
+      fill(page, {});
+
+      expect(page.expiryMissing()).toBe(false);
+      expect(page.canSubmit()).toBe(true);
+    });
+
+    it('rejects an expiry that precedes the publish date', async () => {
+      const page = await createPage();
+      fill(page, {
+        banner: true,
+        publish_at: '2099-06-01T00:00',
+        expires_at: '2099-01-01T00:00',
+      });
+
+      expect(page.expiryBeforePublish()).toBe(true);
+      expect(page.canSubmit()).toBe(false);
+    });
+  });
+
+  describe('call to action', () => {
+    it('rejects a label with no URL', async () => {
+      const page = await createPage();
+      fill(page, { cta_label: 'Read more' });
+      expect(page.ctaIncomplete()).toBe(true);
+    });
+
+    it('rejects a URL with no label', async () => {
+      const page = await createPage();
+      fill(page, { cta_url: 'https://example.test' });
+      expect(page.ctaIncomplete()).toBe(true);
+    });
+
+    it('rejects a javascript: URL before it reaches the API', async () => {
+      // The server rejects it too — this just saves a round trip.
+      const page = await createPage();
+      fill(page, { cta_label: 'Click', cta_url: 'javascript:alert(1)' });
+
+      expect(page.ctaIncomplete()).toBe(true);
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('accepts both together', async () => {
+      const page = await createPage();
+      fill(page, { cta_label: 'Read more', cta_url: 'https://example.test' });
+      expect(page.ctaIncomplete()).toBe(false);
+    });
+
+    it('sends nulls rather than empty strings when blank', async () => {
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ cta_label: null, cta_url: null, summary: null }),
+      );
+    });
+  });
+
+  describe('audience', () => {
+    it('sends the wildcard when Everyone is checked', async () => {
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ target_roles: ['*'] }),
+      );
+    });
+
+    it('sends the picked roles when Everyone is unchecked', async () => {
+      const page = await createPage();
+      fill(page, { all_roles: false });
+      page.toggleRole('faculty');
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ target_roles: ['faculty'] }),
+      );
+    });
+
+    it('blocks submit when Everyone is off and no role is picked', async () => {
+      const page = await createPage();
+      fill(page, { all_roles: false });
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('defaults showToNewUsers off (§D6)', async () => {
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ show_to_new_users: false }),
+      );
+    });
+  });
+
+  describe('body size', () => {
+    it('blocks submit past 16 KB', async () => {
+      const page = await createPage();
+      fill(page, { body_markdown: 'x'.repeat(16 * 1024 + 1) });
+      expect(page.bodyOverLimit()).toBe(true);
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('counts bytes, not characters', async () => {
+      const page = await createPage();
+      fill(page, { body_markdown: '✅'.repeat(6000) }); // 3 bytes each
+      expect(page.bodyBytes()).toBe(18000);
+      expect(page.bodyOverLimit()).toBe(true);
+    });
+  });
+
+  describe('create vs edit', () => {
+    it('creates as a draft — publishing is a separate action', async () => {
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'draft' }),
+      );
+    });
+
+    it('never sends state on an edit', async () => {
+      // state is owned by publish/archive. Sending it from an edit form would
+      // be a route around the lifecycle guard.
+      paramId = 'a1';
+      const page = await createPage();
+      await page.onSubmit();
+
+      expect(service.update).toHaveBeenCalledTimes(1);
+      const [, payload] = service.update.mock.calls[0];
+      expect(payload).not.toHaveProperty('state');
+      expect(payload).not.toHaveProperty('revision');
+    });
+
+    it('loads an existing announcement into the form', async () => {
+      paramId = 'a1';
+      service.get = vi.fn(async () =>
+        makeAnnouncement({
+          title: 'Loaded',
+          surfaces: ['panel', 'banner'],
+          expires_at: '2099-01-01T00:00:00Z',
+          target_roles: ['faculty'],
+          severity: 'warning',
+        }),
+      );
+      const page = await createPage();
+
+      expect(page.form.controls.title.value).toBe('Loaded');
+      expect(page.form.controls.banner.value).toBe(true);
+      expect(page.form.controls.all_roles.value).toBe(false);
+      expect(page.selectedRoles()).toEqual(['faculty']);
+      expect(page.form.controls.severity.value).toBe('warning');
+    });
+
+    it('treats an empty target list as Everyone', async () => {
+      paramId = 'a1';
+      service.get = vi.fn(async () => makeAnnouncement({ target_roles: [] }));
+      const page = await createPage();
+
+      expect(page.form.controls.all_roles.value).toBe(true);
+    });
+
+    it('surfaces the server detail when a save fails', async () => {
+      const page = await createPage();
+      fill(page, {});
+      service.create = vi.fn(async () => {
+        throw { error: { detail: 'expiresAt is required when surfaces include banner' } };
+      });
+      await page.onSubmit();
+
+      expect(page.submitError()).toContain('expiresAt is required');
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('returns to the list on success', async () => {
+      const page = await createPage();
+      fill(page, {});
+      await page.onSubmit();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/admin/manage-announcements']);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.ts
@@ -1,0 +1,674 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MarkdownComponent } from 'ngx-markdown';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowLeft } from '@ng-icons/heroicons/outline';
+import { AnnouncementsAdminService } from './services/announcements-admin.service';
+import {
+  AnnouncementCreateRequest,
+  AnnouncementSeverity,
+  AnnouncementSurface,
+} from './models/announcement.model';
+import { AppRolesService } from '../roles/services/app-roles.service';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+
+const URL_PATTERN = /^https?:\/\/.+/i;
+const TITLE_MAX = 140;
+const BODY_MAX_BYTES = 16 * 1024;
+
+/** Bytes, not characters — the server caps `body_markdown` at 16 KB of UTF-8. */
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+/**
+ * Author or edit one announcement.
+ *
+ * Two rules the server enforces are mirrored here so the admin finds out
+ * before submitting rather than via a 422:
+ *  - `expires_at` is required when a banner or modal is selected (§5). An
+ *    unbounded loud surface is announcement fatigue with no backstop.
+ *  - `cta_label` and `cta_url` travel together, and the URL must be http(s).
+ *
+ * The panel checkbox is deliberately fixed on: the server forces it anyway
+ * (§D1), and showing it as a disabled, checked box explains *why* far better
+ * than silently adding it after save.
+ */
+@Component({
+  selector: 'app-announcement-form-page',
+  imports: [RouterLink, ReactiveFormsModule, MarkdownComponent, NgIcon, SpinnerComponent],
+  providers: [provideIcons({ heroArrowLeft })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="max-w-4xl">
+      <a
+        routerLink="/admin/manage-announcements"
+        class="mb-6 inline-flex items-center gap-2 text-sm/6 font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+      >
+        <ng-icon name="heroArrowLeft" class="size-4" />
+        Back to Announcements
+      </a>
+
+      <h1 class="mb-6 text-3xl/9 font-bold text-gray-900 dark:text-white">
+        {{ isEdit() ? 'Edit announcement' : 'New announcement' }}
+      </h1>
+
+      @if (loadError()) {
+        <div class="mb-4 rounded-sm border border-state-danger-300 bg-state-danger-50 p-4 text-sm/6 text-state-danger-700 dark:border-state-danger-700 dark:bg-state-danger-900/20 dark:text-state-danger-300">
+          {{ loadError() }}
+        </div>
+      }
+
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="space-y-6">
+        <!-- Content -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <div class="grid grid-cols-1 gap-4">
+            <div>
+              <label for="title" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Title <span class="text-state-danger-600">*</span>
+              </label>
+              <input
+                id="title"
+                type="text"
+                formControlName="title"
+                [maxlength]="TITLE_MAX"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g. Mid-turn steering is here"
+              />
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Used as the banner line and the What's New heading. {{ titleRemaining() }} characters left.
+              </p>
+              @if (showError('title')) {
+                <p class="mt-1 text-xs text-state-danger-600 dark:text-state-danger-400">Title is required.</p>
+              }
+            </div>
+
+            <div>
+              <label for="summary" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Banner summary
+              </label>
+              <input
+                id="summary"
+                type="text"
+                formControlName="summary"
+                maxlength="280"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+                placeholder="Optional one-liner, used when the title is too long for a banner"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Body + live preview -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <label for="body_markdown" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+            Body (Markdown) <span class="text-state-danger-600">*</span>
+          </label>
+          <p class="mt-1 mb-3 text-xs text-gray-500 dark:text-gray-400">
+            Shown in What's New and in the modal. Supports CommonMark: headings, lists,
+            tables, links, code, emphasis. Markdown is sanitized on render.
+          </p>
+          <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <textarea
+              id="body_markdown"
+              formControlName="body_markdown"
+              rows="14"
+              class="block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Say what changed, and what the user can now do.&#10;&#10;- One&#10;- Two"
+            ></textarea>
+            <div class="rounded-sm border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+              <p class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Preview</p>
+              <!-- message-block is the app's markdown stylesheet, so this
+                   preview matches what the panel actually renders. The prose
+                   classes would be inert: the Tailwind typography plugin is
+                   not installed. -->
+              <div class="message-block text-sm/6 text-gray-700 dark:text-gray-300">
+                <markdown [data]="previewMarkdown()" />
+              </div>
+            </div>
+          </div>
+          <p class="mt-1 text-xs" [class]="bodyOverLimit() ? 'text-state-danger-600 dark:text-state-danger-400' : 'text-gray-500 dark:text-gray-400'">
+            {{ bodyBytes() }} / {{ BODY_MAX_BYTES }} bytes
+          </p>
+          @if (showError('body_markdown')) {
+            <p class="mt-1 text-xs text-state-danger-600 dark:text-state-danger-400">Body is required.</p>
+          }
+        </div>
+
+        <!-- Surfaces + severity -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <fieldset>
+            <legend class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">How loudly?</legend>
+            <p class="mt-1 mb-3 text-xs text-gray-500 dark:text-gray-400">
+              Users see at most one banner and one modal at a time, whichever is most
+              severe and oldest.
+            </p>
+
+            <div class="space-y-3">
+              <div class="flex items-start gap-2">
+                <input
+                  id="surface-panel"
+                  type="checkbox"
+                  checked
+                  disabled
+                  class="mt-1 size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                />
+                <label for="surface-panel" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                  <span class="font-medium">What's New panel</span> — always on
+                  <span class="block text-xs text-gray-500 dark:text-gray-400">
+                    Every announcement is browsable from the user menu, so dismissing a
+                    banner or modal never destroys the information.
+                  </span>
+                </label>
+              </div>
+
+              <div class="flex items-start gap-2">
+                <input
+                  id="surface-banner"
+                  type="checkbox"
+                  formControlName="banner"
+                  class="mt-1 size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                />
+                <label for="surface-banner" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                  <span class="font-medium">Banner</span> — a strip below the top nav
+                  <span class="block text-xs text-gray-500 dark:text-gray-400">
+                    Ambient. Dismissible with a ✕.
+                  </span>
+                </label>
+              </div>
+
+              <div class="flex items-start gap-2">
+                <input
+                  id="surface-modal"
+                  type="checkbox"
+                  formControlName="modal"
+                  class="mt-1 size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                />
+                <label for="surface-modal" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                  <span class="font-medium">Modal</span> — a dialog on next load
+                  <span class="block text-xs text-gray-500 dark:text-gray-400">
+                    Interruptive. Reserve it for policy changes. It never opens over an
+                    in-progress response.
+                  </span>
+                </label>
+              </div>
+
+              @if (modalSelected()) {
+                <div class="ml-6 flex items-start gap-2">
+                  <input
+                    id="requires_ack"
+                    type="checkbox"
+                    formControlName="requires_ack"
+                    class="mt-1 size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                  />
+                  <label for="requires_ack" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                    Require an explicit acknowledgement
+                    <span class="block text-xs text-gray-500 dark:text-gray-400">
+                      The modal cannot be dismissed by clicking away or pressing Escape,
+                      and the acknowledgement is kept as a durable record.
+                    </span>
+                  </label>
+                </div>
+              }
+            </div>
+          </fieldset>
+
+          <div class="mt-5">
+            <label for="severity" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+              Severity
+            </label>
+            <select
+              id="severity"
+              formControlName="severity"
+              class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 md:w-64 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+            >
+              <option value="info">Info</option>
+              <option value="success">Success</option>
+              <option value="warning">Warning</option>
+            </select>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Sets the banner colour, and breaks the tie when more than one wants the slot.
+            </p>
+          </div>
+        </div>
+
+        <!-- Schedule -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label for="publish_at" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Publish at
+              </label>
+              <input
+                id="publish_at"
+                type="datetime-local"
+                formControlName="publish_at"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              />
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Leave blank for now. Nothing is visible until you press Publish, whatever
+                this says.
+              </p>
+            </div>
+
+            <div>
+              <label for="expires_at" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Expires at
+                @if (loudSurfaceSelected()) {
+                  <span class="text-state-danger-600">*</span>
+                }
+              </label>
+              <input
+                id="expires_at"
+                type="datetime-local"
+                formControlName="expires_at"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              />
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                @if (loudSurfaceSelected()) {
+                  Required for a banner or modal — a loud surface has to say when it stops.
+                } @else {
+                  Optional. The panel entry stays browsable either way.
+                }
+              </p>
+              @if (expiryMissing()) {
+                <p class="mt-1 text-xs text-state-danger-600 dark:text-state-danger-400">
+                  An expiry is required when a banner or modal is selected.
+                </p>
+              }
+              @if (expiryBeforePublish()) {
+                <p class="mt-1 text-xs text-state-danger-600 dark:text-state-danger-400">
+                  The expiry must be after the publish date.
+                </p>
+              }
+            </div>
+          </div>
+        </div>
+
+        <!-- Audience -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <fieldset>
+            <legend class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">Who sees it?</legend>
+            <p class="mt-1 mb-3 text-xs text-gray-500 dark:text-gray-400">
+              This filters who the announcement is shown to. It grants nothing and
+              changes no permissions.
+            </p>
+
+            <div class="flex items-center gap-2">
+              <input
+                id="all_roles"
+                type="checkbox"
+                formControlName="all_roles"
+                class="size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <label for="all_roles" class="text-sm/6 text-gray-700 dark:text-gray-300">Everyone</label>
+            </div>
+
+            @if (!allRolesSelected()) {
+              <div class="mt-3">
+                @if (roles().length === 0) {
+                  <p class="text-xs text-state-warning-600 dark:text-state-warning-400">
+                    No roles available. Everyone will see this announcement.
+                  </p>
+                } @else {
+                  <div class="flex flex-wrap gap-2">
+                    @for (role of roles(); track role.roleId) {
+                      <button
+                        type="button"
+                        (click)="toggleRole(role.roleId)"
+                        [attr.aria-pressed]="isRoleSelected(role.roleId)"
+                        class="rounded-sm border px-2.5 py-1 text-xs/5 font-medium focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        [class]="roleChipClass(role.roleId)"
+                      >
+                        {{ role.displayName || role.roleId }}
+                      </button>
+                    }
+                  </div>
+                  @if (selectedRoles().length === 0) {
+                    <p class="mt-2 text-xs text-state-danger-600 dark:text-state-danger-400">
+                      Pick at least one role, or choose Everyone.
+                    </p>
+                  }
+                }
+              </div>
+            }
+
+            <div class="mt-5 flex items-start gap-2">
+              <input
+                id="show_to_new_users"
+                type="checkbox"
+                formControlName="show_to_new_users"
+                class="mt-1 size-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <label for="show_to_new_users" class="text-sm/6 text-gray-700 dark:text-gray-300">
+                Also show to people who join later
+                <span class="block text-xs text-gray-500 dark:text-gray-400">
+                  Off by default, and usually right to leave off. Someone who signs up next
+                  year should not be met with a queue of notices about features that, to
+                  them, have always existed. Turn it on only for a standing notice that
+                  genuinely applies to everyone who ever joins — an acceptable-use policy,
+                  not a feature launch.
+                </span>
+              </label>
+            </div>
+          </fieldset>
+        </div>
+
+        <!-- Call to action -->
+        <div class="rounded-sm border border-gray-300 bg-white p-6 dark:border-gray-600 dark:bg-gray-800">
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label for="cta_label" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Link label
+              </label>
+              <input
+                id="cta_label"
+                type="text"
+                formControlName="cta_label"
+                maxlength="64"
+                placeholder="e.g. Read the docs"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            <div>
+              <label for="cta_url" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Link URL
+              </label>
+              <input
+                id="cta_url"
+                type="url"
+                formControlName="cta_url"
+                maxlength="2048"
+                placeholder="https://example.com/whats-new"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-700 dark:text-white"
+              />
+              @if (ctaIncomplete()) {
+                <p class="mt-1 text-xs text-state-danger-600 dark:text-state-danger-400">
+                  A label and an http(s) URL must be given together, or both left blank.
+                </p>
+              }
+            </div>
+          </div>
+        </div>
+
+        @if (submitError()) {
+          <div class="rounded-sm border border-state-danger-300 bg-state-danger-50 p-4 text-sm/6 text-state-danger-700 dark:border-state-danger-700 dark:bg-state-danger-900/20 dark:text-state-danger-300">
+            {{ submitError() }}
+          </div>
+        }
+
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            @if (isEdit()) {
+              Editing does not re-show this to anyone who already dismissed it. Use
+              <strong>Show again</strong> on the list for that.
+            } @else {
+              Saved as a draft. Publish it from the list when you are ready.
+            }
+          </p>
+          <div class="flex justify-end gap-3">
+            <a
+              routerLink="/admin/manage-announcements"
+              class="rounded-sm border border-gray-300 bg-white px-4 py-2 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Cancel
+            </a>
+            <button
+              type="submit"
+              [disabled]="!canSubmit()"
+              class="inline-flex items-center gap-2 rounded-sm bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              @if (isSubmitting()) {
+                <app-spinner size="sm" variant="on-solid" label="Saving" />
+              }
+              {{ isEdit() ? 'Save changes' : 'Create draft' }}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  `,
+})
+export class AnnouncementFormPage implements OnInit {
+  private readonly service = inject(AnnouncementsAdminService);
+  private readonly rolesService = inject(AppRolesService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  protected readonly TITLE_MAX = TITLE_MAX;
+  protected readonly BODY_MAX_BYTES = BODY_MAX_BYTES;
+
+  protected readonly form = new FormGroup({
+    title: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(TITLE_MAX)],
+    }),
+    summary: new FormControl<string>('', { nonNullable: true }),
+    body_markdown: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    banner: new FormControl<boolean>(false, { nonNullable: true }),
+    modal: new FormControl<boolean>(false, { nonNullable: true }),
+    requires_ack: new FormControl<boolean>(false, { nonNullable: true }),
+    severity: new FormControl<AnnouncementSeverity>('info', { nonNullable: true }),
+    publish_at: new FormControl<string>('', { nonNullable: true }),
+    expires_at: new FormControl<string>('', { nonNullable: true }),
+    all_roles: new FormControl<boolean>(true, { nonNullable: true }),
+    show_to_new_users: new FormControl<boolean>(false, { nonNullable: true }),
+    cta_label: new FormControl<string>('', { nonNullable: true }),
+    cta_url: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  protected readonly isSubmitting = signal(false);
+  protected readonly submitError = signal<string | null>(null);
+  protected readonly loadError = signal<string | null>(null);
+  private readonly editingId = signal<string | null>(null);
+  protected readonly isEdit = computed(() => this.editingId() !== null);
+  protected readonly selectedRoles = signal<string[]>([]);
+
+  // FormControl.valueChanges is rxjs, so mirror what the template reacts to.
+  private readonly titleSig = signal('');
+  private readonly bodySig = signal('');
+  private readonly bannerSig = signal(false);
+  private readonly modalSig = signal(false);
+  private readonly allRolesSig = signal(true);
+  private readonly publishAtSig = signal('');
+  private readonly expiresAtSig = signal('');
+  private readonly ctaLabelSig = signal('');
+  private readonly ctaUrlSig = signal('');
+
+  protected readonly modalSelected = this.modalSig.asReadonly();
+  protected readonly allRolesSelected = this.allRolesSig.asReadonly();
+
+  protected readonly previewMarkdown = computed(
+    () => this.bodySig() || '*(nothing to preview yet)*',
+  );
+  protected readonly titleRemaining = computed(() =>
+    Math.max(0, TITLE_MAX - this.titleSig().length),
+  );
+  protected readonly bodyBytes = computed(() => byteLength(this.bodySig()));
+  protected readonly bodyOverLimit = computed(() => this.bodyBytes() > BODY_MAX_BYTES);
+  protected readonly loudSurfaceSelected = computed(
+    () => this.bannerSig() || this.modalSig(),
+  );
+  protected readonly expiryMissing = computed(
+    () => this.loudSurfaceSelected() && !this.expiresAtSig(),
+  );
+  protected readonly expiryBeforePublish = computed(() => {
+    const publish = this.publishAtSig();
+    const expires = this.expiresAtSig();
+    if (!publish || !expires) return false;
+    return new Date(expires).getTime() <= new Date(publish).getTime();
+  });
+  protected readonly ctaIncomplete = computed(() => {
+    const label = this.ctaLabelSig().trim();
+    const url = this.ctaUrlSig().trim();
+    if (!label && !url) return false;
+    if (!label || !url) return true;
+    return !URL_PATTERN.test(url);
+  });
+
+  protected readonly roles = computed(() => this.rolesService.getRoles());
+
+  protected readonly canSubmit = computed(() => {
+    if (this.isSubmitting()) return false;
+    if (this.form.invalid) return false;
+    if (this.bodyOverLimit()) return false;
+    if (this.expiryMissing() || this.expiryBeforePublish()) return false;
+    if (this.ctaIncomplete()) return false;
+    if (!this.allRolesSig() && this.roles().length > 0 && this.selectedRoles().length === 0) {
+      return false;
+    }
+    return true;
+  });
+
+  async ngOnInit(): Promise<void> {
+    const c = this.form.controls;
+    c.title.valueChanges.subscribe(v => this.titleSig.set(v));
+    c.body_markdown.valueChanges.subscribe(v => this.bodySig.set(v));
+    c.banner.valueChanges.subscribe(v => this.bannerSig.set(v));
+    c.modal.valueChanges.subscribe(v => {
+      this.modalSig.set(v);
+      // requiresAck is modal-only; clear it so an unchecked modal cannot leave
+      // a stale flag on the record.
+      if (!v) c.requires_ack.setValue(false, { emitEvent: false });
+    });
+    c.all_roles.valueChanges.subscribe(v => this.allRolesSig.set(v));
+    c.publish_at.valueChanges.subscribe(v => this.publishAtSig.set(v));
+    c.expires_at.valueChanges.subscribe(v => this.expiresAtSig.set(v));
+    c.cta_label.valueChanges.subscribe(v => this.ctaLabelSig.set(v));
+    c.cta_url.valueChanges.subscribe(v => this.ctaUrlSig.set(v));
+
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) return;
+
+    this.editingId.set(id);
+    try {
+      const a = await this.service.get(id);
+      const targeted = (a.target_roles ?? []).filter(r => r !== '*');
+      const everyone = (a.target_roles ?? []).includes('*') || targeted.length === 0;
+
+      this.form.patchValue({
+        title: a.title,
+        summary: a.summary ?? '',
+        body_markdown: a.body_markdown,
+        banner: a.surfaces.includes('banner'),
+        modal: a.surfaces.includes('modal'),
+        requires_ack: a.requires_ack,
+        severity: a.severity,
+        publish_at: toLocalInput(a.publish_at),
+        expires_at: toLocalInput(a.expires_at),
+        all_roles: everyone,
+        show_to_new_users: a.show_to_new_users,
+        cta_label: a.cta_label ?? '',
+        cta_url: a.cta_url ?? '',
+      });
+      this.selectedRoles.set(targeted);
+    } catch (err) {
+      this.loadError.set(
+        err instanceof Error ? err.message : 'Failed to load the announcement.',
+      );
+    }
+  }
+
+  protected isRoleSelected(roleId: string): boolean {
+    return this.selectedRoles().includes(roleId);
+  }
+
+  protected toggleRole(roleId: string): void {
+    this.selectedRoles.update(prev =>
+      prev.includes(roleId) ? prev.filter(r => r !== roleId) : [...prev, roleId],
+    );
+  }
+
+  protected roleChipClass(roleId: string): string {
+    return this.isRoleSelected(roleId)
+      ? 'border-primary-600 bg-primary-600 text-white'
+      : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-100 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600';
+  }
+
+  protected showError(name: 'title' | 'body_markdown'): boolean {
+    const c = this.form.get(name);
+    return !!c && c.invalid && (c.touched || c.dirty);
+  }
+
+  protected async onSubmit(): Promise<void> {
+    if (!this.canSubmit()) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+
+    const raw = this.form.getRawValue();
+    const surfaces: AnnouncementSurface[] = ['panel'];
+    if (raw.banner) surfaces.push('banner');
+    if (raw.modal) surfaces.push('modal');
+
+    const label = raw.cta_label.trim();
+    const url = raw.cta_url.trim();
+
+    const payload: AnnouncementCreateRequest = {
+      title: raw.title.trim(),
+      body_markdown: raw.body_markdown,
+      summary: raw.summary.trim() || null,
+      surfaces,
+      severity: raw.severity,
+      state: 'draft',
+      publish_at: toIsoOrNull(raw.publish_at),
+      expires_at: toIsoOrNull(raw.expires_at),
+      target_roles: raw.all_roles ? ['*'] : this.selectedRoles(),
+      show_to_new_users: raw.show_to_new_users,
+      requires_ack: raw.modal && raw.requires_ack,
+      cta_label: label || null,
+      cta_url: url || null,
+    };
+
+    try {
+      const id = this.editingId();
+      if (id) {
+        // `state` is not sent on an edit — publish/archive own that transition.
+        const { state: _state, ...updates } = payload;
+        await this.service.update(id, updates);
+      } else {
+        await this.service.create(payload);
+      }
+      this.router.navigate(['/admin/manage-announcements']);
+    } catch (err: unknown) {
+      const detail =
+        (err as { error?: { detail?: string }; message?: string })?.error?.detail ??
+        (err as Error)?.message ??
+        'Failed to save the announcement.';
+      this.submitError.set(
+        typeof detail === 'string' ? detail : 'Failed to save the announcement.',
+      );
+    } finally {
+      this.isSubmitting.set(false);
+    }
+  }
+}
+
+/** ISO-8601 → the `datetime-local` shape, in the admin's own timezone. */
+function toLocalInput(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const date = new Date(iso.replace('+00:00Z', 'Z'));
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** `datetime-local` → ISO-8601 UTC, which is what the server stores. */
+function toIsoOrNull(local: string): string | null {
+  if (!local) return null;
+  const date = new Date(local);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}

--- a/frontend/ai.client/src/app/admin/manage-announcements/manage-announcements.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/manage-announcements.page.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { ManageAnnouncementsPage } from './manage-announcements.page';
+import { AnnouncementsAdminService } from './services/announcements-admin.service';
+import { Announcement, AnnouncementState } from './models/announcement.model';
+
+function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
+  return {
+    announcement_id: 'a1',
+    title: 'Skills are here',
+    body_markdown: '# Skills',
+    summary: null,
+    surfaces: ['panel'],
+    severity: 'info',
+    state: 'draft',
+    publish_at: '2026-01-01T00:00:00Z',
+    expires_at: null,
+    target_roles: ['*'],
+    show_to_new_users: false,
+    requires_ack: false,
+    cta_label: null,
+    cta_url: null,
+    revision: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: 'admin@example.com',
+    ...overrides,
+  };
+}
+
+describe('ManageAnnouncementsPage', () => {
+  let items: ReturnType<typeof signal<Announcement[]>>;
+  let service: any;
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    items = signal<Announcement[]>([]);
+    service = {
+      ensureLoaded: vi.fn(),
+      announcements: items,
+      announcementsResource: { isLoading: () => false, error: () => null },
+      publish: vi.fn(async () => makeAnnouncement({ state: 'published' })),
+      archive: vi.fn(async () => makeAnnouncement({ state: 'archived' })),
+      revise: vi.fn(async () => makeAnnouncement({ revision: 2 })),
+      remove: vi.fn(async () => undefined),
+    };
+    TestBed.configureTestingModule({
+      providers: [{ provide: AnnouncementsAdminService, useValue: service }],
+    });
+    confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    TestBed.resetTestingModule();
+  });
+
+  function createPage() {
+    return TestBed.runInInjectionContext(() => new ManageAnnouncementsPage()) as any;
+  }
+
+  it('loads the admin list on construction', () => {
+    createPage();
+    expect(service.ensureLoaded).toHaveBeenCalled();
+  });
+
+  describe('publish affordance', () => {
+    it.each<[AnnouncementState, boolean]>([
+      ['draft', true],
+      ['scheduled', true],
+      ['published', false],
+      // Archived is terminal — the server 400s, so do not offer the button.
+      ['archived', false],
+    ])('state %s → publishable: %s', (state, expected) => {
+      const page = createPage();
+      expect(page.canPublish(makeAnnouncement({ state }))).toBe(expected);
+    });
+  });
+
+  describe('destructive actions confirm first', () => {
+    it('asks before bumping the revision, and says what it does', async () => {
+      // "Show again" re-surfaces the announcement for everyone who dismissed
+      // it — the one thing an admin fixing a typo must not trigger by accident.
+      const page = createPage();
+      await page.onRevise(makeAnnouncement());
+
+      expect(confirmSpy).toHaveBeenCalledOnce();
+      expect(confirmSpy.mock.calls[0][0]).toContain('dismissed it will see it once more');
+      expect(service.revise).toHaveBeenCalledWith('a1');
+    });
+
+    it('does not revise when the confirm is declined', async () => {
+      confirmSpy.mockReturnValue(false);
+      const page = createPage();
+      await page.onRevise(makeAnnouncement());
+
+      expect(service.revise).not.toHaveBeenCalled();
+    });
+
+    it('asks before archiving and mentions acks are kept', async () => {
+      const page = createPage();
+      await page.onArchive(makeAnnouncement());
+
+      expect(confirmSpy.mock.calls[0][0]).toContain('acknowledgements are kept');
+      expect(service.archive).toHaveBeenCalledWith('a1');
+    });
+
+    it('asks before deleting and points at archive instead', async () => {
+      const page = createPage();
+      await page.onDelete(makeAnnouncement());
+
+      expect(confirmSpy.mock.calls[0][0]).toContain('Archive instead');
+      expect(service.remove).toHaveBeenCalledWith('a1');
+    });
+
+    it('publishes without a confirm — it is reversible by archiving', async () => {
+      const page = createPage();
+      await page.onPublish(makeAnnouncement());
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(service.publish).toHaveBeenCalledWith('a1');
+    });
+  });
+
+  it('surfaces the server detail when an action fails', async () => {
+    service.publish = vi.fn(async () => {
+      throw { error: { detail: "cannot publish an announcement in state 'archived'" } };
+    });
+    const page = createPage();
+    await page.onPublish(makeAnnouncement());
+
+    expect(page.actionError()).toContain('cannot publish');
+    expect(page.busyId()).toBeNull();
+  });
+
+  describe('row summary', () => {
+    it('describes an untargeted announcement as Everyone', () => {
+      items.set([makeAnnouncement()]);
+      const page = createPage();
+      expect(page.rows()[0].audience).toBe('Everyone');
+    });
+
+    it('lists the roles when targeted', () => {
+      items.set([makeAnnouncement({ target_roles: ['faculty', 'staff'] })]);
+      const page = createPage();
+      expect(page.rows()[0].audience).toBe('faculty, staff');
+    });
+
+    it('calls out showToNewUsers, since it is the surprising setting', () => {
+      items.set([makeAnnouncement({ show_to_new_users: true })]);
+      const page = createPage();
+      expect(page.rows()[0].audience).toContain('including users who join later');
+    });
+
+    it('says "Live since" for a published announcement and "Publishes" otherwise', () => {
+      items.set([
+        makeAnnouncement({ announcement_id: 'live', state: 'published' }),
+        makeAnnouncement({ announcement_id: 'draft', state: 'draft' }),
+      ]);
+      const page = createPage();
+      expect(page.rows()[0].timing).toContain('Live since');
+      expect(page.rows()[1].timing).toContain('Publishes');
+    });
+
+    it('mentions the expiry when there is one', () => {
+      items.set([makeAnnouncement({ expires_at: '2099-01-01T00:00:00Z' })]);
+      const page = createPage();
+      expect(page.rows()[0].timing).toContain('expires');
+    });
+
+    it('renders a dash rather than "Invalid Date" for junk', () => {
+      items.set([makeAnnouncement({ publish_at: 'not a date' })]);
+      const page = createPage();
+      expect(page.rows()[0].timing).toContain('—');
+    });
+
+    it('tolerates the legacy +00:00Z timestamp spelling', () => {
+      items.set([makeAnnouncement({ publish_at: '2026-03-04T00:00:00+00:00Z' })]);
+      const page = createPage();
+      expect(page.rows()[0].timing).not.toContain('—');
+    });
+  });
+
+  describe('surface chips', () => {
+    it('maps each surface to its own icon', () => {
+      const page = createPage();
+      expect(page.surfaceIcon('panel')).toBe('heroWindow');
+      expect(page.surfaceIcon('banner')).toBe('heroRectangleGroup');
+      expect(page.surfaceIcon('modal')).toBe('heroBellAlert');
+    });
+
+    it('gives every state a distinct chip style', () => {
+      const page = createPage();
+      const states: AnnouncementState[] = ['draft', 'scheduled', 'published', 'archived'];
+      const classes = states.map(s => page.stateChipClass(s));
+      expect(new Set(classes).size).toBe(states.length);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/admin/manage-announcements/manage-announcements.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/manage-announcements.page.ts
@@ -1,0 +1,357 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroPencil,
+  heroTrash,
+  heroPlus,
+  heroMegaphone,
+  heroPaperAirplane,
+  heroArchiveBox,
+  heroArrowPath,
+  heroWindow,
+  heroRectangleGroup,
+  heroBellAlert,
+} from '@ng-icons/heroicons/outline';
+import { AnnouncementsAdminService } from './services/announcements-admin.service';
+import { Announcement, AnnouncementState } from './models/announcement.model';
+import { parseIso } from '../../utils/date';
+
+/**
+ * Admin list of feature announcements.
+ *
+ * Mirrors `manage-user-menu-links`, plus the lifecycle actions an
+ * announcement has and a link does not: publish, archive, and "Show again"
+ * (the revision bump, §D4).
+ */
+@Component({
+  selector: 'app-manage-announcements-page',
+  imports: [RouterLink, NgIcon],
+  providers: [
+    provideIcons({
+      heroPencil,
+      heroTrash,
+      heroPlus,
+      heroMegaphone,
+      heroPaperAirplane,
+      heroArchiveBox,
+      heroArrowPath,
+      heroWindow,
+      heroRectangleGroup,
+      heroBellAlert,
+    }),
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div>
+      <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 class="text-3xl/9 font-bold text-gray-900 dark:text-white">Announcements</h1>
+          <p class="mt-1 text-gray-600 dark:text-gray-400">
+            Tell users what changed. Everything published appears in What's New; a
+            banner or modal additionally puts it in front of them.
+          </p>
+        </div>
+        <a
+          routerLink="/admin/manage-announcements/new"
+          class="inline-flex items-center gap-2 rounded-sm bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        >
+          <ng-icon name="heroPlus" class="size-5" />
+          New announcement
+        </a>
+      </div>
+
+      <!-- The norm this feature lives or dies by (§11). A control cannot
+           enforce it, so say it where announcements are written. -->
+      <div class="mb-6 rounded-sm border border-state-info-300 bg-state-info-50 p-4 text-sm/6 text-state-info-800 dark:border-state-info-700 dark:bg-state-info-900/20 dark:text-state-info-200">
+        <strong class="font-semibold">Panel by default, banner when it matters, modal when it is a policy change.</strong>
+        Every extra interruption costs attention on the next one. Users only ever
+        see one banner and one modal at a time, no matter how many are eligible.
+      </div>
+
+      @if (loadError()) {
+        <div class="mb-4 rounded-sm border border-state-danger-300 bg-state-danger-50 p-4 text-sm/6 text-state-danger-700 dark:border-state-danger-700 dark:bg-state-danger-900/20 dark:text-state-danger-300">
+          Failed to load announcements. {{ loadError() }}
+        </div>
+      }
+
+      @if (actionError()) {
+        <div class="mb-4 rounded-sm border border-state-danger-300 bg-state-danger-50 p-4 text-sm/6 text-state-danger-700 dark:border-state-danger-700 dark:bg-state-danger-900/20 dark:text-state-danger-300">
+          {{ actionError() }}
+        </div>
+      }
+
+      @if (announcements().length === 0 && !isLoading()) {
+        <div class="rounded-sm border border-gray-300 bg-white p-12 text-center dark:border-gray-600 dark:bg-gray-800">
+          <ng-icon name="heroMegaphone" class="mx-auto size-8 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+          <p class="mt-3 text-base/7 text-gray-500 dark:text-gray-400">No announcements yet.</p>
+          <a
+            routerLink="/admin/manage-announcements/new"
+            class="mt-4 inline-flex items-center gap-2 text-sm/6 font-medium text-primary-accessible hover:underline dark:text-primary-accessible-dark"
+          >
+            Write the first one →
+          </a>
+        </div>
+      } @else {
+        <div class="space-y-3">
+          @for (item of rows(); track item.announcement.announcement_id) {
+            <div class="rounded-sm border border-gray-300 bg-white p-4 dark:border-gray-600 dark:bg-gray-800">
+              <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div class="min-w-0 flex-1">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                      {{ item.announcement.title }}
+                    </span>
+
+                    <span
+                      class="shrink-0 rounded-sm px-2 py-0.5 text-xs/5 font-medium"
+                      [class]="stateChipClass(item.announcement.state)"
+                    >
+                      {{ stateLabel(item.announcement.state) }}
+                    </span>
+
+                    @for (surface of item.announcement.surfaces; track surface) {
+                      <span
+                        class="inline-flex shrink-0 items-center gap-1 rounded-sm bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                        [title]="surfaceHint(surface)"
+                      >
+                        <ng-icon [name]="surfaceIcon(surface)" class="size-3.5" aria-hidden="true" />
+                        {{ surface }}
+                      </span>
+                    }
+
+                    @if (item.announcement.requires_ack) {
+                      <span class="shrink-0 rounded-sm bg-state-warning-100 px-2 py-0.5 text-xs/5 font-medium text-state-warning-800 dark:bg-state-warning-900/40 dark:text-state-warning-300">
+                        Requires acknowledgement
+                      </span>
+                    }
+
+                    @if (item.announcement.revision > 1) {
+                      <span
+                        class="shrink-0 rounded-sm bg-gray-100 px-2 py-0.5 text-xs/5 font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                        title="Each bump re-shows this to everyone who had dismissed it"
+                      >
+                        rev {{ item.announcement.revision }}
+                      </span>
+                    }
+                  </div>
+
+                  <p class="mt-1 truncate text-xs/5 text-gray-500 dark:text-gray-400">
+                    {{ summarize(item.announcement.body_markdown) }}
+                  </p>
+
+                  <p class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+                    {{ item.timing }}
+                    @if (item.audience) {
+                      · {{ item.audience }}
+                    }
+                  </p>
+                </div>
+
+                <div class="flex shrink-0 flex-wrap items-center gap-2">
+                  @if (canPublish(item.announcement)) {
+                    <button
+                      type="button"
+                      (click)="onPublish(item.announcement)"
+                      [disabled]="busyId() !== null"
+                      class="inline-flex items-center gap-1 rounded-sm border border-gray-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                      [attr.aria-label]="'Publish ' + item.announcement.title"
+                    >
+                      <ng-icon name="heroPaperAirplane" class="size-4" />
+                      Publish
+                    </button>
+                  }
+
+                  @if (item.announcement.state === 'published') {
+                    <button
+                      type="button"
+                      (click)="onRevise(item.announcement)"
+                      [disabled]="busyId() !== null"
+                      class="inline-flex items-center gap-1 rounded-sm border border-gray-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                      title="Bump the revision so everyone sees this again"
+                      [attr.aria-label]="'Show ' + item.announcement.title + ' again'"
+                    >
+                      <ng-icon name="heroArrowPath" class="size-4" />
+                      Show again
+                    </button>
+                    <button
+                      type="button"
+                      (click)="onArchive(item.announcement)"
+                      [disabled]="busyId() !== null"
+                      class="inline-flex items-center gap-1 rounded-sm border border-gray-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                      [attr.aria-label]="'Archive ' + item.announcement.title"
+                    >
+                      <ng-icon name="heroArchiveBox" class="size-4" />
+                      Archive
+                    </button>
+                  }
+
+                  <a
+                    [routerLink]="['/admin/manage-announcements/edit', item.announcement.announcement_id]"
+                    class="inline-flex items-center gap-1 rounded-sm border border-gray-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                    [attr.aria-label]="'Edit ' + item.announcement.title"
+                  >
+                    <ng-icon name="heroPencil" class="size-4" />
+                    <span class="sr-only sm:not-sr-only">Edit</span>
+                  </a>
+
+                  <button
+                    type="button"
+                    (click)="onDelete(item.announcement)"
+                    [disabled]="busyId() !== null"
+                    class="inline-flex items-center gap-1 rounded-sm border border-state-danger-300 bg-white px-2.5 py-1.5 text-sm/6 font-medium text-state-danger-700 hover:bg-state-danger-50 focus:outline-none focus:ring-2 focus:ring-state-danger-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-state-danger-500 dark:bg-gray-700 dark:text-state-danger-400 dark:hover:bg-state-danger-900/20"
+                    [attr.aria-label]="'Delete ' + item.announcement.title"
+                  >
+                    <ng-icon name="heroTrash" class="size-4" />
+                    <span class="sr-only sm:not-sr-only">Delete</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class ManageAnnouncementsPage {
+  private readonly service = inject(AnnouncementsAdminService);
+
+  constructor() {
+    this.service.ensureLoaded();
+  }
+
+  protected readonly announcements = this.service.announcements;
+  protected readonly isLoading = computed(() =>
+    this.service.announcementsResource.isLoading(),
+  );
+  protected readonly loadError = computed(() => {
+    const err = this.service.announcementsResource.error();
+    if (!err) return null;
+    return err instanceof Error ? err.message : String(err);
+  });
+
+  protected readonly busyId = signal<string | null>(null);
+  protected readonly actionError = signal<string | null>(null);
+
+  protected readonly rows = computed(() =>
+    this.announcements().map(announcement => ({
+      announcement,
+      timing: this.describeTiming(announcement),
+      audience: this.describeAudience(announcement),
+    })),
+  );
+
+  protected canPublish(a: Announcement): boolean {
+    // Archived is terminal; the server refuses to publish out of it, so do not
+    // offer a button that returns a 400.
+    return a.state === 'draft' || a.state === 'scheduled';
+  }
+
+  protected stateLabel(state: AnnouncementState): string {
+    return state.charAt(0).toUpperCase() + state.slice(1);
+  }
+
+  protected stateChipClass(state: AnnouncementState): string {
+    switch (state) {
+      case 'published':
+        return 'bg-state-success-100 text-state-success-800 dark:bg-state-success-900/40 dark:text-state-success-300';
+      case 'scheduled':
+        return 'bg-state-info-100 text-state-info-700 dark:bg-state-info-900/40 dark:text-state-info-300';
+      case 'archived':
+        return 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400';
+      default:
+        return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
+    }
+  }
+
+  protected surfaceIcon(surface: string): string {
+    if (surface === 'banner') return 'heroRectangleGroup';
+    if (surface === 'modal') return 'heroBellAlert';
+    return 'heroWindow';
+  }
+
+  protected surfaceHint(surface: string): string {
+    if (surface === 'banner') return 'A strip below the top nav. At most one at a time.';
+    if (surface === 'modal') return 'A dialog on next load. At most one at a time.';
+    return "Always on. The What's New entry in the user menu.";
+  }
+
+  protected summarize(markdown: string | null | undefined): string {
+    if (!markdown) return '(empty)';
+    const stripped = markdown.replace(/[#*_`>\-]/g, '').replace(/\s+/g, ' ').trim();
+    return stripped.length > 140 ? stripped.slice(0, 140) + '…' : stripped;
+  }
+
+  private describeTiming(a: Announcement): string {
+    const published = this.formatDate(a.publish_at);
+    const verb = a.state === 'published' ? 'Live since' : 'Publishes';
+    const base = `${verb} ${published}`;
+    return a.expires_at ? `${base} · expires ${this.formatDate(a.expires_at)}` : base;
+  }
+
+  private describeAudience(a: Announcement): string | null {
+    const roles = a.target_roles ?? [];
+    const audience = roles.includes('*') || roles.length === 0
+      ? 'Everyone'
+      : roles.join(', ');
+    return a.show_to_new_users
+      ? `${audience} (including users who join later)`
+      : audience;
+  }
+
+  private formatDate(value: string | null | undefined): string {
+    if (!value) return '—';
+    const date = parseIso(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  protected async onPublish(a: Announcement): Promise<void> {
+    await this.run(a, () => this.service.publish(a.announcement_id));
+  }
+
+  protected async onArchive(a: Announcement): Promise<void> {
+    if (!confirm(`Archive "${a.title}"? It stops showing, but acknowledgements are kept.`)) return;
+    await this.run(a, () => this.service.archive(a.announcement_id));
+  }
+
+  protected async onRevise(a: Announcement): Promise<void> {
+    // Worth a confirm: this re-surfaces the announcement for everyone who had
+    // already dismissed it, which is exactly what an admin fixing a typo does
+    // NOT want (that is what Edit is for).
+    if (
+      !confirm(
+        `Show "${a.title}" again?\n\nThis bumps the revision, so everyone who dismissed it will see it once more. Editing the text does not do this.`,
+      )
+    ) {
+      return;
+    }
+    await this.run(a, () => this.service.revise(a.announcement_id));
+  }
+
+  protected async onDelete(a: Announcement): Promise<void> {
+    if (!confirm(`Delete "${a.title}"? This cannot be undone. Archive instead to keep the record.`)) return;
+    await this.run(a, () => this.service.remove(a.announcement_id));
+  }
+
+  private async run(a: Announcement, action: () => Promise<unknown>): Promise<void> {
+    this.busyId.set(a.announcement_id);
+    this.actionError.set(null);
+    try {
+      await action();
+    } catch (err: unknown) {
+      const detail =
+        (err as { error?: { detail?: string }; message?: string })?.error?.detail ??
+        (err as Error)?.message ??
+        'The action failed. Please try again.';
+      this.actionError.set(detail);
+    } finally {
+      this.busyId.set(null);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/admin/manage-announcements/models/announcement.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/models/announcement.model.ts
@@ -1,0 +1,74 @@
+/**
+ * Admin-side announcement types — the client mirror of
+ * `apis/shared/announcements/models.py` (`AnnouncementResponse`).
+ *
+ * Wider than the user-facing model in
+ * `services/announcements/announcement.model.ts`, which deliberately omits
+ * `state`, `target_roles`, `show_to_new_users` and `created_by`. Keep them
+ * separate: collapsing them into one type is how admin-only fields end up
+ * being served to users.
+ *
+ * See `docs/specs/feature-announcements.md`.
+ */
+
+export type AnnouncementSurface = 'panel' | 'banner' | 'modal';
+export type AnnouncementSeverity = 'info' | 'success' | 'warning';
+export type AnnouncementState = 'draft' | 'scheduled' | 'published' | 'archived';
+
+export interface Announcement {
+  announcement_id: string;
+  title: string;
+  body_markdown: string;
+  summary?: string | null;
+  surfaces: AnnouncementSurface[];
+  severity: AnnouncementSeverity;
+  state: AnnouncementState;
+  publish_at: string;
+  expires_at?: string | null;
+  /**
+   * A **display filter, not an RBAC grant** (spec §D9). This list is written
+   * only to the announcement; it is never mirrored into a role's `granted*`
+   * arrays, and `apis/shared/rbac/` knows nothing about it. Visibility of a
+   * notice is not access control.
+   */
+  target_roles: string[];
+  show_to_new_users: boolean;
+  requires_ack: boolean;
+  cta_label?: string | null;
+  cta_url?: string | null;
+  revision: number;
+  created_at: string;
+  updated_at: string;
+  created_by?: string | null;
+}
+
+export interface AnnouncementListResponse {
+  announcements: Announcement[];
+  total: number;
+}
+
+/** POST body. The server always creates as a draft or scheduled — never live. */
+export interface AnnouncementCreateRequest {
+  title: string;
+  body_markdown: string;
+  summary?: string | null;
+  surfaces: AnnouncementSurface[];
+  severity: AnnouncementSeverity;
+  state: 'draft' | 'scheduled';
+  publish_at?: string | null;
+  expires_at?: string | null;
+  target_roles: string[];
+  show_to_new_users: boolean;
+  requires_ack: boolean;
+  cta_label?: string | null;
+  cta_url?: string | null;
+}
+
+/**
+ * PATCH body. `state` and `revision` are absent by design — both are
+ * transitions, owned by the publish / archive / revise endpoints, not by an
+ * edit that looks like a body change.
+ */
+export type AnnouncementUpdateRequest = Partial<
+  Omit<AnnouncementCreateRequest, 'state'>
+>;

--- a/frontend/ai.client/src/app/admin/manage-announcements/services/announcements-admin.service.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/services/announcements-admin.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, computed, inject, resource, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../../../services/config.service';
+import { AnnouncementsService } from '../../../services/announcements/announcements.service';
+import {
+  Announcement,
+  AnnouncementCreateRequest,
+  AnnouncementListResponse,
+  AnnouncementUpdateRequest,
+} from '../models/announcement.model';
+
+/**
+ * Admin CRUD for feature announcements (`/admin/announcements`).
+ *
+ * Separate from the root-provided `AnnouncementsService`, which owns the
+ * *user* surface — that one is injected by the always-rendered user dropdown,
+ * so putting an admin loader on it would fire `GET /admin/announcements/` for
+ * every user on every app load. Same reasoning as `UserMenuLinksService`'s
+ * gated admin resource, but split into its own service because the admin
+ * surface here is much larger than a second resource.
+ *
+ * Every mutation reloads the admin list **and** the user-facing feed, so an
+ * admin who publishes something sees their own What's-New entry appear
+ * without a refresh.
+ */
+@Injectable({ providedIn: 'root' })
+export class AnnouncementsAdminService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+  private readonly userFeed = inject(AnnouncementsService);
+
+  private readonly baseUrl = computed(
+    () => `${this.config.appApiUrl()}/admin/announcements`,
+  );
+
+  // Gated so the loader only fires once an admin page asks for it.
+  private readonly requested = signal(false);
+
+  readonly announcementsResource = resource({
+    params: () => (this.requested() ? {} : undefined),
+    loader: async () => this.fetchAll(),
+  });
+
+  /** Activates the resource. Called by the admin list page. */
+  ensureLoaded(): void {
+    this.requested.set(true);
+  }
+
+  readonly announcements = computed<Announcement[]>(
+    () => this.announcementsResource.value()?.announcements ?? [],
+  );
+
+  async fetchAll(): Promise<AnnouncementListResponse> {
+    return await firstValueFrom(
+      this.http.get<AnnouncementListResponse>(`${this.baseUrl()}/`),
+    );
+  }
+
+  async get(id: string): Promise<Announcement> {
+    return await firstValueFrom(
+      this.http.get<Announcement>(`${this.baseUrl()}/${id}`),
+    );
+  }
+
+  async create(data: AnnouncementCreateRequest): Promise<Announcement> {
+    const created = await firstValueFrom(
+      this.http.post<Announcement>(`${this.baseUrl()}/`, data),
+    );
+    this.refresh();
+    return created;
+  }
+
+  async update(
+    id: string,
+    updates: AnnouncementUpdateRequest,
+  ): Promise<Announcement> {
+    const updated = await firstValueFrom(
+      this.http.patch<Announcement>(`${this.baseUrl()}/${id}`, updates),
+    );
+    this.refresh();
+    return updated;
+  }
+
+  /** draft | scheduled → published. */
+  async publish(id: string): Promise<Announcement> {
+    const result = await firstValueFrom(
+      this.http.post<Announcement>(`${this.baseUrl()}/${id}/publish`, {}),
+    );
+    this.refresh();
+    return result;
+  }
+
+  /** Stops it showing. Acknowledgements are kept. */
+  async archive(id: string): Promise<Announcement> {
+    const result = await firstValueFrom(
+      this.http.post<Announcement>(`${this.baseUrl()}/${id}/archive`, {}),
+    );
+    this.refresh();
+    return result;
+  }
+
+  /**
+   * "Show again" — increments `revision`, so everyone's suppression lapses at
+   * once (§D4). This is the destructive-feeling one: it re-surfaces the
+   * announcement for every targeted user, which is why it is a separate
+   * action from editing and why the UI confirms first.
+   */
+  async revise(id: string): Promise<Announcement> {
+    const result = await firstValueFrom(
+      this.http.post<Announcement>(`${this.baseUrl()}/${id}/revise`, {}),
+    );
+    this.refresh();
+    return result;
+  }
+
+  async remove(id: string): Promise<void> {
+    await firstValueFrom(this.http.delete<void>(`${this.baseUrl()}/${id}`));
+    this.refresh();
+  }
+
+  private refresh(): void {
+    this.announcementsResource.reload();
+    // The admin is also a user: keep their own What's-New in step.
+    this.userFeed.reload();
+  }
+}


### PR DESCRIPTION
PR-3 of [`docs/specs/feature-announcements.md`](docs/specs/feature-announcements.md), following [#966](https://github.com/Boise-State-Development/agentcore-public-stack/pull/966) and [#969](https://github.com/Boise-State-Development/agentcore-public-stack/pull/969).

This removes the "author by curl" step. Until now the feature was **live for users but only authorable by engineers** — the API shipped in PR-1 and the user surface in PR-2, but there was no page in the admin console and no nav entry.

## What's here

- **[List page](frontend/ai.client/src/app/admin/manage-announcements/manage-announcements.page.ts)** — state chips, surface icons, audience and schedule summary, and the lifecycle actions an announcement has and a user-menu link does not: **Publish**, **Show again**, **Archive**.
- **[Form page](frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.ts)** — title, markdown body with live preview, surface checkboxes, severity, schedule, role picker, `showToNewUsers`, `requiresAck`, CTA.
- Nav entry under **Customization**, `data: { scope: 'admin.announcements' }`.

## Decisions worth reviewing

**Server rules are mirrored in the form**, so an admin finds out before submitting rather than through a 422: `expiresAt` becomes required the moment a banner or modal is ticked; `ctaLabel`/`ctaUrl` must travel together and be http(s); and the body cap counts **bytes**, not characters — the server's limit is 16 KB of UTF-8, so a 3-byte character costs three. A `javascript:` CTA is rejected client-side too, which just saves the round trip; the server still rejects it.

**The panel checkbox is rendered checked-and-disabled rather than omitted.** The server forces `panel` on regardless (§D1). Showing it explains *why* dismissing a banner never destroys the information; silently adding it after save would not.

**Two lifecycle guards are carried into the UI, not left to the API:**

- Edit never sends `state`, and **"Show again" is a separate action from editing** — a typo fix must not re-fire a modal at everyone who already dismissed it (§D4). The confirm text says exactly that, because it is the one action here whose blast radius is every targeted user.
- **Publish is not offered on an archived announcement.** Archived is terminal and the server 400s; a button that returns an error is worse than no button.

**The markdown preview uses `message-block`**, the app's real markdown stylesheet, so what the admin previews is what the panel renders. The `prose` classes would be inert — the Tailwind typography plugin is not installed (this is the bug found by browser-verifying PR-2).

**Help text carries the norm, because no control can.** §11 is explicit that announcement fatigue is the real failure mode and that the mitigation is a norm, not a mechanism. So the list page says it where announcements are written: *panel by default, banner when it matters, modal when it is a policy change.* The `showToNewUsers` checkbox gets the §D6 warning next to it — that someone who signs up next year should not meet a queue of notices about features that, to them, have always existed.

## ⚠️ Rollout note: delegated admins will not get this automatically

`admin.announcements` is a new entry in a closed registry, so **existing roles do not pick it up**. In dev the `developer` role currently holds 13 delegated scopes and not this one — which is exactly why it 403s today. `system_admin` is unaffected (it satisfies every scope implicitly).

Whoever should be able to author announcements needs `admin.announcements` added to their role explicitly, or the nav entry simply will not appear for them.

## Testing

- `npm test`: **214 files, 2393 tests pass** — 44 of them new, using DI-token overrides rather than `vi.mock` per house convention. They cover the surface payload (`panel` always sent, `requiresAck` cleared when the modal is unticked), the expiry rule, CTA pairing including the `javascript:` case, byte-counted body limits, role targeting, create-as-draft, and that an edit never sends `state` or `revision`.
- `npx tsc --noEmit`: clean.
- No backend change in this PR, so no Python tests were affected.

### Browser verification is NOT done — and here is why

I verified PR-2 in a browser and it caught a real bug that every unit test passed. I intended to do the same here and **could not**: the `dev-ai` SSO token expired partway through this session, so a fresh boto3 process cannot authenticate, RBAC resolution fails, and the guard correctly fails closed — every admin route 403s locally regardless of role.

That needs an interactive `aws sso login --profile dev-ai`, which I cannot run. So treat the layout of these two pages as **unverified against a real browser**; the logic is covered by the 44 specs, the rendering is not. Happy to complete that pass once the session is refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
