### PR TITLE
feat(artifacts): render a shared conversation's artifacts for its recipient

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -68,6 +68,28 @@
       </section>
     }
 
+    <!-- The same anchoring for a shared conversation's snapshot, through
+         the recipient card: it opens a read-only dialog and mints via the
+         conversation share, where the owner card opens the docked panel
+         and mints as the owner. -->
+    @let sharedMessageArtifacts = sharedArtifactsForMessageId(message.id);
+    @if (sharedMessageArtifacts.length > 0 && sharedArtifactShareId(); as shareId) {
+      <section
+        class="flex flex-col gap-2"
+        aria-label="Artifacts from this response"
+      >
+        @for (
+          artifact of sharedMessageArtifacts;
+          track artifact.artifactId + '#' + artifact.version
+        ) {
+          <app-shared-artifact-card
+            [artifact]="artifact"
+            [shareId]="shareId"
+          />
+        }
+      </section>
+    }
+
   }
 
   <!-- End-of-conversation sections render INSIDE the last turn's reserved
@@ -108,6 +130,23 @@
         track artifact.artifactId + '#' + artifact.version
       ) {
         <app-artifact-card [artifact]="artifact" />
+      }
+    </section>
+  }
+
+  <!-- Shared artifacts with no usable anchor. Same reasoning as the
+       owner's orphan strip: an artifact that silently disappears is
+       worse than one shown at the end. -->
+  @if (orphanSharedArtifacts().length > 0 && sharedArtifactShareId(); as shareId) {
+    <section
+      class="mt-4 flex flex-col gap-2"
+      aria-label="Artifacts from this conversation"
+    >
+      @for (
+        artifact of orphanSharedArtifacts();
+        track artifact.artifactId + '#' + artifact.version
+      ) {
+        <app-shared-artifact-card [artifact]="artifact" [shareId]="shareId" />
       }
     </section>
   }

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -14,6 +14,8 @@ import { CompactionSummaryComponent } from './components/compaction-summary/comp
 import { ArtifactCardComponent } from './components/artifact/artifact-card.component';
 import { ArtifactPanelComponent } from './components/artifact/artifact-panel.component';
 import { ArtifactStateService } from '../../services/artifacts/artifact-state.service';
+import { SharedArtifactCardComponent } from '../../../shared/artifact/shared-artifact-card.component';
+import type { SharedConversationArtifact } from '../../services/share/share.service';
 import { McpAppCardComponent } from './components/mcp-app-card/mcp-app-card.component';
 import { AgentFeedbackLinkComponent } from '../../../agents/components/agent-feedback-link.component';
 import { McpAppCardStateService } from '../../services/mcp-apps/mcp-app-card-state.service';
@@ -44,6 +46,7 @@ import { StreamParserService } from '../../services/chat/stream-parser.service';
     CompactionSummaryComponent,
     ArtifactCardComponent,
     ArtifactPanelComponent,
+    SharedArtifactCardComponent,
     McpAppCardComponent,
     AgentFeedbackLinkComponent,
   ],
@@ -83,6 +86,21 @@ export class MessageListComponent {
   isChatLoading = input<boolean>(false);
   streamingMessageId = input<string | null>(null);
   embeddedMode = input<boolean>(false);
+  /**
+   * Artifacts pinned into a shared conversation's snapshot, plus the
+   * share that grants them — set only by the shared view.
+   *
+   * An input rather than a second read of `ArtifactStateService`,
+   * because that service is the *owner's* session state: it is
+   * populated by live SSE events and owner-scoped hydration, neither of
+   * which a recipient has. Feeding it recipient rows would put another
+   * user's artifacts into the signal the real session view reads.
+   *
+   * When set, these render in place of the owner cards. Null is the
+   * normal session view.
+   */
+  sharedArtifacts = input<SharedConversationArtifact[] | null>(null);
+  sharedArtifactShareId = input<string | null>(null);
 
   /**
    * The published marketplace agent behind this conversation, when there is one — the
@@ -312,6 +330,51 @@ export class MessageListComponent {
     const n = this.parseMessageIndex(id);
     if (n === null) return [];
     return this.artifactsByMessageIndex().get(n) ?? [];
+  }
+
+  // ----------------------------------------------------------------
+  // Shared-conversation artifacts (recipient view)
+  // ----------------------------------------------------------------
+
+  /** Shared artifacts grouped by the turn that produced them. Uses only
+   *  `producedByMessageIndex` — a snapshot has no live producing message
+   *  id, because nothing streamed into it. */
+  private readonly sharedArtifactsByMessageIndex = computed<
+    ReadonlyMap<number, SharedConversationArtifact[]>
+  >(() => {
+    const loaded = this.loadedMessageIndices();
+    const map = new Map<number, SharedConversationArtifact[]>();
+    for (const a of this.sharedArtifacts() ?? []) {
+      const idx = a.producedByMessageIndex;
+      if (idx == null || !loaded.has(idx)) continue;
+      const list = map.get(idx);
+      if (list) list.push(a);
+      else map.set(idx, [a]);
+    }
+    return map;
+  });
+
+  /** Shared artifacts with no usable anchor — kept visible in the
+   *  end-of-conversation strip, for the same reason the owner's orphans
+   *  are: an artifact that silently vanishes is worse than one in the
+   *  wrong place. */
+  protected readonly orphanSharedArtifacts = computed<
+    SharedConversationArtifact[]
+  >(() => {
+    const loaded = this.loadedMessageIndices();
+    return (this.sharedArtifacts() ?? []).filter(
+      (a) =>
+        a.producedByMessageIndex == null ||
+        !loaded.has(a.producedByMessageIndex),
+    );
+  });
+
+  protected sharedArtifactsForMessageId(
+    id: string,
+  ): SharedConversationArtifact[] {
+    const n = this.parseMessageIndex(id);
+    if (n === null) return [];
+    return this.sharedArtifactsByMessageIndex().get(n) ?? [];
   }
 
   /** Single end-of-conversation compaction summary inputs. Sourced from

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.shared-artifacts.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.shared-artifacts.spec.ts
@@ -1,0 +1,181 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideMarkdown } from 'ngx-markdown';
+
+import { MessageListComponent } from './message-list.component';
+import type { Message } from '../../services/models/message.model';
+import type { SharedConversationArtifact } from '../../services/share/share.service';
+
+/**
+ * Anchoring for artifacts inside a shared conversation.
+ *
+ * The owner's equivalent (`artifactsByMessageIndex`) has no component
+ * spec, so this covers the branch it was modelled on as well as the new
+ * one: an artifact whose index is outside the loaded page must fall back
+ * to the end strip rather than disappear, which is the failure the
+ * whole feature exists to fix.
+ */
+describe('MessageListComponent — shared conversation artifacts', () => {
+  let fixture: ComponentFixture<MessageListComponent>;
+
+  /**
+   * Fixtures are user-role messages throughout.
+   *
+   * Artifacts anchor to assistant turns in production, but the grouping
+   * under test keys on the message *id* and is role-agnostic (the
+   * template renders the artifact section per message, outside the role
+   * branch). Assistant messages render markdown, which pulls ngx-markdown
+   * into a KaTeX dependency this suite has no reason to carry — and its
+   * async render rejects after teardown, which under `isolate: false`
+   * leaks into unrelated spec files.
+   */
+  function message(index: number, role: 'user' | 'assistant' = 'user'): Message {
+    return {
+      id: `msg-sess1-${index}`,
+      role,
+      content: [{ type: 'text', text: 'hi' }],
+      createdAt: '2026-01-01T00:00:00Z',
+    } as unknown as Message;
+  }
+
+  function artifact(
+    overrides: Partial<SharedConversationArtifact> = {},
+  ): SharedConversationArtifact {
+    return {
+      artifactId: 'art-1',
+      version: 1,
+      title: 'Deck',
+      contentType: 'text/html',
+      producedByMessageIndex: 1,
+      ...overrides,
+    };
+  }
+
+  /** Reaching the grouping the template reaches. */
+  function api() {
+    return fixture.componentInstance as unknown as {
+      sharedArtifactsForMessageId: (
+        id: string,
+      ) => SharedConversationArtifact[];
+      orphanSharedArtifacts: () => SharedConversationArtifact[];
+    };
+  }
+
+  function render(
+    messages: Message[],
+    shared: SharedConversationArtifact[] | null,
+  ): void {
+    fixture = TestBed.createComponent(MessageListComponent);
+    fixture.componentRef.setInput('messages', messages);
+    fixture.componentRef.setInput('embeddedMode', true);
+    fixture.componentRef.setInput('sharedArtifacts', shared);
+    fixture.componentRef.setInput('sharedArtifactShareId', 'conv-share-1');
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    // jsdom has no ResizeObserver, and UserMessageComponent constructs one
+    // unguarded in ngAfterViewInit — so rendering any message list needs
+    // this stub. Same convention as user-message.component.spec.ts.
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    TestBed.configureTestingModule({
+      imports: [MessageListComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        // Assistant messages render markdown; the real component tree is
+        // used deliberately here so the template's branching is under
+        // test, not a mock of it.
+        provideMarkdown(),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('anchors an artifact under the turn that produced it', () => {
+    render(
+      [message(0), message(1)],
+      [artifact({ producedByMessageIndex: 1 })],
+    );
+
+    expect(
+      api().sharedArtifactsForMessageId('msg-sess1-1'),
+    ).toHaveLength(1);
+    expect(api().sharedArtifactsForMessageId('msg-sess1-0')).toEqual([]);
+    expect(api().orphanSharedArtifacts()).toEqual([]);
+  });
+
+  it('falls back to the end strip when the anchor is missing', () => {
+    // Written before the linkage existed. It must still be visible —
+    // an artifact that silently disappears is the bug this feature
+    // exists to fix.
+    render(
+      [message(0), message(1)],
+      [artifact({ producedByMessageIndex: null })],
+    );
+
+    expect(api().orphanSharedArtifacts()).toHaveLength(1);
+  });
+
+  it('falls back to the end strip when the turn is not loaded', () => {
+    // The index points outside the loaded (paginated) message list.
+    render([message(0)], [artifact({ producedByMessageIndex: 42 })]);
+
+    expect(api().sharedArtifactsForMessageId('msg-sess1-0')).toEqual([]);
+    expect(api().orphanSharedArtifacts()).toHaveLength(1);
+  });
+
+  it('groups several artifacts from one turn', () => {
+    render(
+      [message(0), message(1)],
+      [
+        artifact({ artifactId: 'a', producedByMessageIndex: 1 }),
+        artifact({ artifactId: 'b', producedByMessageIndex: 1 }),
+      ],
+    );
+
+    expect(api().sharedArtifactsForMessageId('msg-sess1-1')).toHaveLength(2);
+  });
+
+  it('renders nothing in a normal session view', () => {
+    // Null is the ordinary case: the session view reads the owner's
+    // ArtifactStateService instead, and must not gain a second source.
+    render([message(0), message(1)], null);
+
+    expect(api().sharedArtifactsForMessageId('msg-sess1-1')).toEqual([]);
+    expect(api().orphanSharedArtifacts()).toEqual([]);
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector(
+        'app-shared-artifact-card',
+      ),
+    ).toBeNull();
+  });
+
+  it('renders a recipient card, never the owner card', () => {
+    render(
+      [message(0), message(1)],
+      [artifact({ producedByMessageIndex: 1 })],
+    );
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('app-shared-artifact-card')).not.toBeNull();
+    // The owner card opens the docked panel and carries owner-only
+    // actions; it must never render for a recipient.
+    expect(el.querySelector('app-artifact-card')).toBeNull();
+  });
+});

--- a/frontend/ai.client/src/app/session/services/share/share.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/share/share.service.spec.ts
@@ -99,6 +99,7 @@ describe('ShareService', () => {
   describe('getSharedConversation', () => {
     it('should GET /shared/{shareId}', async () => {
       const mockResponse: SharedConversationResponse = {
+    artifacts: [],
         shareId: 'share-001',
         title: 'Test Conversation',
         accessLevel: 'public',

--- a/frontend/ai.client/src/app/session/services/share/share.service.ts
+++ b/frontend/ai.client/src/app/session/services/share/share.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
 import { Message } from '../models/message.model';
+import type { RenderToken } from '../artifacts/artifact-http.service';
 
 // ------------------------------------------------------------------
 // Interfaces
@@ -32,6 +33,26 @@ export interface ShareListResponse {
   shares: ShareResponse[];
 }
 
+/**
+ * One artifact pinned into a shared conversation's snapshot.
+ *
+ * The recipient shape — no artifact-level share id, because there is no
+ * artifact share: the CONVERSATION share is the grant, and the pair
+ * (conversation shareId, artifactId) is the whole handle a recipient
+ * has. `version` is the version the artifact stood at when the
+ * conversation was shared, matching the frozen transcript around it
+ * rather than whatever the owner has edited it into since.
+ */
+export interface SharedConversationArtifact {
+  artifactId: string;
+  version: number;
+  title: string;
+  contentType: string;
+  /** Anchors the card under the same turn the owner sees it under.
+   *  Null for artifacts written before that linkage existed. */
+  producedByMessageIndex: number | null;
+}
+
 export interface SharedConversationResponse {
   shareId: string;
   title: string;
@@ -39,6 +60,10 @@ export interface SharedConversationResponse {
   createdAt: string;
   ownerId: string;
   messages: Message[];
+  /** Empty for shares created before artifacts were captured, and for
+   *  conversations that produced none — indistinguishable, and neither
+   *  is an error. */
+  artifacts: SharedConversationArtifact[];
 }
 
 export interface ExportResponse {
@@ -79,6 +104,33 @@ export class ShareService {
     return firstValueFrom(
       this.http.get<SharedConversationResponse>(`${this.sharedUrl()}/${shareId}`)
     );
+  }
+
+  /**
+   * Mint a render URL for one artifact inside a shared conversation.
+   *
+   * The grant is the conversation share, so this is addressed by
+   * (shareId, artifactId) and never by an artifact share id — there
+   * isn't one. The backend serves only artifacts the snapshot pinned,
+   * at the version it pinned, so a 404 here means "not part of this
+   * share" as much as "gone".
+   *
+   * The returned URL embeds a short-lived (~120s) bearer credential:
+   * set it as an iframe `src` and re-mint on each open rather than
+   * caching it.
+   */
+  async mintConversationArtifactToken(
+    shareId: string,
+    artifactId: string,
+  ): Promise<RenderToken> {
+    const res = await firstValueFrom(
+      this.http.post<{ url: string; expires_at: string }>(
+        `${this.sharedUrl()}/${encodeURIComponent(shareId)}/artifacts/` +
+          `${encodeURIComponent(artifactId)}/render-token`,
+        {},
+      ),
+    );
+    return { url: res.url, expiresAt: res.expires_at };
   }
 
   async updateShare(shareId: string, accessLevel?: string, allowedEmails?: string[]): Promise<ShareResponse> {

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-card.component.spec.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-card.component.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Dialog } from '@angular/cdk/dialog';
+
+import { SharedArtifactCardComponent } from './shared-artifact-card.component';
+import { SharedArtifactDialogComponent } from './shared-artifact-dialog.component';
+import type { SharedConversationArtifact } from '../../session/services/share/share.service';
+
+function stubArtifact(
+  overrides: Partial<SharedConversationArtifact> = {},
+): SharedConversationArtifact {
+  return {
+    artifactId: 'art-1',
+    version: 2,
+    title: 'Quarterly Deck',
+    contentType: 'text/html; charset=utf-8',
+    producedByMessageIndex: 2,
+    ...overrides,
+  };
+}
+
+describe('SharedArtifactCardComponent', () => {
+  let fixture: ComponentFixture<SharedArtifactCardComponent>;
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  const button = () => el().querySelector('button')!;
+
+  function render(
+    artifact: SharedConversationArtifact = stubArtifact(),
+    shareId = 'conv-share-1',
+  ): void {
+    fixture = TestBed.createComponent(SharedArtifactCardComponent);
+    fixture.componentRef.setInput('artifact', artifact);
+    fixture.componentRef.setInput('shareId', shareId);
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockDialog = { open: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [SharedArtifactCardComponent],
+      providers: [{ provide: Dialog, useValue: mockDialog }],
+    });
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('opens the read-only dialog with the conversation share as the grant', () => {
+    render(stubArtifact({ artifactId: 'art-9' }), 'conv-share-7');
+    button().click();
+
+    expect(mockDialog.open).toHaveBeenCalledTimes(1);
+    const [component, config] = mockDialog.open.mock.calls[0];
+    expect(component).toBe(SharedArtifactDialogComponent);
+    // There is no artifact share here — the pair (conversation shareId,
+    // artifactId) is the whole handle a recipient has.
+    expect(config.data.shareId).toBe('conv-share-7');
+    expect(config.data.artifact.artifactId).toBe('art-9');
+  });
+
+  it('offers opening and nothing else', () => {
+    render();
+
+    // Download, share, rename and delete are all owner endpoints a
+    // conversation-share recipient has no handle for. A visible control
+    // that 403s is worse than an absent one.
+    expect(el().querySelectorAll('button')).toHaveLength(1);
+    expect(el().textContent).not.toContain('Download');
+    expect(el().textContent).not.toContain('Delete');
+    expect(el().textContent).not.toContain('Share');
+  });
+
+  it('names the artifact for screen readers', () => {
+    render(stubArtifact({ title: 'Budget model', version: 3 }));
+    const label = button().getAttribute('aria-label')!;
+    expect(label).toContain('Budget model');
+    expect(label).toContain('version 3');
+  });
+
+  it('falls back to a placeholder title', () => {
+    render(stubArtifact({ title: '' }));
+    expect(el().textContent).toContain('Untitled artifact');
+  });
+
+  it('labels the type from the content type, charset and all', () => {
+    render(stubArtifact({ contentType: 'text/markdown' }));
+    expect(el().textContent).toContain('Markdown');
+
+    // The writer stores HTML with a charset suffix; a lookup keyed on
+    // the raw string would fall through to the generic label.
+    render(stubArtifact({ contentType: 'text/html; charset=utf-8' }));
+    expect(el().textContent).toContain('Web page');
+  });
+
+  it('shows the version only when there is more than one', () => {
+    render(stubArtifact({ version: 1 }));
+    expect(el().textContent).not.toContain('v1');
+
+    render(stubArtifact({ version: 4 }));
+    expect(el().textContent).toContain('v4');
+  });
+});

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-card.component.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-card.component.ts
@@ -1,0 +1,165 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroCodeBracket,
+  heroDocument,
+  heroDocumentText,
+  heroPhoto,
+  heroTableCells,
+} from '@ng-icons/heroicons/outline';
+
+import type { SharedConversationArtifact } from '../../session/services/share/share.service';
+import {
+  SharedArtifactDialogComponent,
+  type SharedArtifactDialogData,
+} from './shared-artifact-dialog.component';
+
+interface TypeStyle {
+  readonly label: string;
+  readonly icon: string;
+  readonly bg: string;
+  readonly text: string;
+}
+
+/** Same `filetype-*` identity tokens the library and attachment cards
+ *  use, so one artifact reads as the same kind of thing everywhere. */
+const TYPE_STYLES: Record<string, TypeStyle> = {
+  'text/markdown': {
+    label: 'Markdown',
+    icon: 'heroDocumentText',
+    bg: 'bg-filetype-markdown-100 dark:bg-filetype-markdown-900/60',
+    text: 'text-filetype-markdown-600 dark:text-filetype-markdown-300',
+  },
+  'text/x-markdown': {
+    label: 'Markdown',
+    icon: 'heroDocumentText',
+    bg: 'bg-filetype-markdown-100 dark:bg-filetype-markdown-900/60',
+    text: 'text-filetype-markdown-600 dark:text-filetype-markdown-300',
+  },
+  'text/html': {
+    label: 'Web page',
+    icon: 'heroCodeBracket',
+    bg: 'bg-filetype-code-100 dark:bg-filetype-code-900/60',
+    text: 'text-filetype-code-600 dark:text-filetype-code-300',
+  },
+  'application/xhtml+xml': {
+    label: 'Web page',
+    icon: 'heroCodeBracket',
+    bg: 'bg-filetype-code-100 dark:bg-filetype-code-900/60',
+    text: 'text-filetype-code-600 dark:text-filetype-code-300',
+  },
+  'text/csv': {
+    label: 'CSV',
+    icon: 'heroTableCells',
+    bg: 'bg-filetype-sheet-100 dark:bg-filetype-sheet-900/60',
+    text: 'text-filetype-sheet-600 dark:text-filetype-sheet-300',
+  },
+  'image/svg+xml': {
+    label: 'SVG',
+    icon: 'heroPhoto',
+    bg: 'bg-filetype-image-100 dark:bg-filetype-image-900/60',
+    text: 'text-filetype-image-600 dark:text-filetype-image-300',
+  },
+};
+
+const DEFAULT_TYPE_STYLE: TypeStyle = {
+  label: 'Text',
+  icon: 'heroDocument',
+  bg: 'bg-gray-100 dark:bg-gray-700',
+  text: 'text-gray-600 dark:text-gray-300',
+};
+
+/**
+ * An artifact inside a shared conversation, as its recipient sees it.
+ *
+ * Deliberately a separate component from `ArtifactCardComponent` rather
+ * than a mode of it. That one opens the docked owner panel and carries
+ * download, share and rename/delete — all keyed on endpoints a
+ * conversation-share recipient has no handle for. Sharing the markup
+ * would mean guarding every one of those on a flag, and the failure
+ * mode of a missed guard is a visible button that 403s.
+ *
+ * What is shared instead is the *viewer* underneath the dialog, which is
+ * presentational and already serves three mint paths.
+ */
+@Component({
+  selector: 'app-shared-artifact-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  viewProviders: [
+    provideIcons({
+      heroCodeBracket,
+      heroDocument,
+      heroDocumentText,
+      heroPhoto,
+      heroTableCells,
+    }),
+  ],
+  template: `
+    <button
+      type="button"
+      (click)="open()"
+      [attr.aria-label]="ariaLabel()"
+      class="flex w-full items-center gap-3 rounded-2xl border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+    >
+      <span
+        class="grid size-9 shrink-0 place-items-center rounded-2xl"
+        [class]="style().bg"
+        aria-hidden="true"
+      >
+        <ng-icon [name]="style().icon" class="size-5" [class]="style().text" />
+      </span>
+
+      <span class="min-w-0 flex-1">
+        <span
+          class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+        >
+          {{ artifact().title || 'Untitled artifact' }}
+        </span>
+        <span class="block text-xs/5 text-gray-500 dark:text-gray-400">
+          {{ style().label }}
+          @if (artifact().version > 1) {
+            <span aria-hidden="true"> · </span>v{{ artifact().version }}
+          }
+        </span>
+      </span>
+    </button>
+  `,
+})
+export class SharedArtifactCardComponent {
+  readonly artifact = input.required<SharedConversationArtifact>();
+  /** The CONVERSATION share this came in on — the grant, and half the
+   *  address the mint needs. */
+  readonly shareId = input.required<string>();
+
+  private readonly dialog = inject(Dialog);
+
+  protected readonly style = computed<TypeStyle>(
+    () =>
+      TYPE_STYLES[
+        this.artifact().contentType.split(';')[0].trim().toLowerCase()
+      ] ?? DEFAULT_TYPE_STYLE,
+  );
+
+  protected readonly ariaLabel = computed(
+    () =>
+      `Open ${this.style().label} artifact ${
+        this.artifact().title || 'Untitled'
+      }, version ${this.artifact().version}`,
+  );
+
+  protected open(): void {
+    const data: SharedArtifactDialogData = {
+      shareId: this.shareId(),
+      artifact: this.artifact(),
+    };
+    this.dialog.open<void>(SharedArtifactDialogComponent, { data });
+  }
+}

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-dialog.component.spec.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-dialog.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+import { SharedArtifactDialogComponent } from './shared-artifact-dialog.component';
+import { ShareService } from '../../session/services/share/share.service';
+
+describe('SharedArtifactDialogComponent', () => {
+  let fixture: ComponentFixture<SharedArtifactDialogComponent>;
+  let mockShares: { mintConversationArtifactToken: ReturnType<typeof vi.fn> };
+  let mockRef: { close: ReturnType<typeof vi.fn> };
+
+  const el = () => fixture.nativeElement as HTMLElement;
+  const iframe = () => el().querySelector('iframe');
+
+  async function render(): Promise<void> {
+    fixture = TestBed.createComponent(SharedArtifactDialogComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockShares = {
+      mintConversationArtifactToken: vi.fn().mockResolvedValue({
+        url: 'https://artifacts.example/?t=jwt',
+        expiresAt: '2026-09-05T00:02:00+00:00',
+      }),
+    };
+    mockRef = { close: vi.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [SharedArtifactDialogComponent],
+      providers: [
+        { provide: ShareService, useValue: mockShares },
+        { provide: DialogRef, useValue: mockRef },
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            shareId: 'conv-share-1',
+            artifact: {
+              artifactId: 'art-1',
+              version: 2,
+              title: 'Quarterly Deck',
+              contentType: 'text/html; charset=utf-8',
+              producedByMessageIndex: 2,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    // isolate:false shares one DOM, so a fixture left mounted keeps its
+    // loading skeleton animating for the rest of the suite.
+    fixture?.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('mints through the conversation share, not an artifact share', async () => {
+    await render();
+
+    expect(mockShares.mintConversationArtifactToken).toHaveBeenCalledWith(
+      'conv-share-1',
+      'art-1',
+    );
+    expect(iframe()).not.toBeNull();
+  });
+
+  it('sandboxes the iframe without allow-same-origin', async () => {
+    await render();
+
+    // Same isolation the owner panel and the standalone recipient page
+    // rely on — a third mint path must not weaken it.
+    const sandbox = iframe()!.getAttribute('sandbox');
+    expect(sandbox).toBe('allow-scripts');
+    expect(sandbox).not.toContain('allow-same-origin');
+    expect(iframe()!.getAttribute('referrerpolicy')).toBe('no-referrer');
+  });
+
+  it('gives one message for a refused and a missing artifact alike', async () => {
+    mockShares.mintConversationArtifactToken.mockRejectedValue(
+      new Error('404'),
+    );
+    await render();
+
+    // "Not in this share" and "you may not open this share" are the same
+    // fact to a recipient; telling them apart would describe what the
+    // owner has.
+    expect(el().textContent).toContain("couldn't be loaded");
+    expect(iframe()).toBeNull();
+  });
+
+  it('offers no owner actions', async () => {
+    await render();
+
+    const text = el().textContent ?? '';
+    expect(text).not.toContain('Download');
+    expect(text).not.toContain('Rename');
+    expect(text).not.toContain('Delete');
+    // No source toggle either: the content endpoint is keyed on an
+    // artifact share id, which a conversation share does not have, so
+    // the control is absent rather than permanently failing.
+    expect(text).not.toContain('Source');
+    expect(text).toContain('Shared read-only');
+  });
+
+  it('closes on the close button', async () => {
+    await render();
+    const close = [...el().querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Close'),
+    )!;
+    close.click();
+
+    expect(mockRef.close).toHaveBeenCalled();
+  });
+
+  it('drops a mint that resolves after a retry', async () => {
+    let resolveFirst: (v: unknown) => void = () => undefined;
+    mockShares.mintConversationArtifactToken
+      .mockImplementationOnce(
+        () => new Promise((r) => (resolveFirst = r)),
+      )
+      .mockResolvedValueOnce({
+        url: 'https://artifacts.example/?t=second',
+        expiresAt: '',
+      });
+
+    fixture = TestBed.createComponent(SharedArtifactDialogComponent);
+    fixture.detectChanges();
+
+    // Retry supersedes the in-flight first mint.
+    (fixture.componentInstance as unknown as { retry: () => void }).retry();
+    await fixture.whenStable();
+
+    resolveFirst({ url: 'https://artifacts.example/?t=stale', expiresAt: '' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // The stale response must not overwrite the newer URL.
+    expect(iframe()!.getAttribute('src')).toContain('t=second');
+  });
+});

--- a/frontend/ai.client/src/app/shared/artifact/shared-artifact-dialog.component.ts
+++ b/frontend/ai.client/src/app/shared/artifact/shared-artifact-dialog.component.ts
@@ -1,0 +1,172 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
+
+import { ArtifactViewerComponent } from '../../session/components/message-list/components/artifact/artifact-viewer.component';
+import {
+  ShareService,
+  type SharedConversationArtifact,
+} from '../../session/services/share/share.service';
+
+export interface SharedArtifactDialogData {
+  /** The CONVERSATION share this artifact came in on — the grant. */
+  readonly shareId: string;
+  readonly artifact: SharedConversationArtifact;
+}
+
+/**
+ * Read-only viewer for one artifact inside a shared conversation.
+ *
+ * A dialog rather than the owner's docked panel, and deliberately not a
+ * variant of it. `ArtifactPanelComponent` carries rename, delete, share,
+ * a version picker, a code view and a download — every one of them an
+ * endpoint keyed on something a recipient of a CONVERSATION share does
+ * not have (an owned artifact, or an artifact share id). Bending it into a
+ * "read-only mode" would mean a component whose every action is
+ * conditional on a mode flag, which is how a missed condition becomes a
+ * button that 403s.
+ *
+ * The body is `ArtifactViewerComponent`, which is purely presentational
+ * and already serves the owner panel and the standalone recipient page
+ * through two different mint endpoints. This is the third, and it needed
+ * no change to that component — which is the sign the split was drawn in
+ * the right place.
+ *
+ * Minting goes through the conversation share: there is no artifact
+ * share record here, so the pair (shareId, artifactId) is the whole
+ * handle, and the version served is the one the snapshot pinned.
+ */
+@Component({
+  selector: 'app-shared-artifact-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, ArtifactViewerComponent],
+  providers: [provideIcons({ heroXMark })],
+  host: { '(keydown.escape)': 'close()' },
+  template: `
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      (click)="close()"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-label]="'Artifact: ' + (data.artifact.title || 'Untitled')"
+        class="flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-800"
+        (click)="$event.stopPropagation()"
+      >
+        <div
+          class="flex shrink-0 items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700"
+        >
+          <div class="min-w-0 flex-1">
+            <h2 class="truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+              {{ data.artifact.title || 'Untitled artifact' }}
+            </h2>
+            <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+              Shared read-only
+              @if (data.artifact.version > 1) {
+                <span aria-hidden="true"> · </span>v{{ data.artifact.version }}
+              }
+            </p>
+          </div>
+
+          <button
+            type="button"
+            (click)="close()"
+            class="grid size-8 shrink-0 place-items-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <ng-icon name="heroXMark" class="size-4" aria-hidden="true" />
+            <span class="sr-only">Close</span>
+          </button>
+        </div>
+
+        <div class="flex min-h-0 flex-1 flex-col">
+          <!-- Preview only. The code view reads a content endpoint keyed
+               on an artifact share id, and a conversation share does not
+               have one — so the toggle is absent rather than present and
+               permanently failing. Adding it is a backend change. -->
+          <app-artifact-viewer
+            [safeUrl]="safeUrl()"
+            [title]="data.artifact.title"
+            [error]="error()"
+            [previewReady]="previewReady()"
+            (iframeLoad)="onIframeLoad()"
+            (retry)="retry()"
+          />
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class SharedArtifactDialogComponent {
+  protected readonly data = inject<SharedArtifactDialogData>(DIALOG_DATA);
+  private readonly dialogRef = inject<DialogRef<void>>(DialogRef);
+  private readonly shares = inject(ShareService);
+  private readonly sanitizer = inject(DomSanitizer);
+
+  protected readonly safeUrl = signal<SafeResourceUrl | null>(null);
+  protected readonly error = signal<string | null>(null);
+
+  private readonly iframeLoaded = signal(false);
+  protected readonly previewReady = computed(
+    () => !!this.safeUrl() && this.iframeLoaded(),
+  );
+
+  /** Bumped per mint so a slow response resolving after a retry is
+   *  dropped rather than overwriting the newer one. */
+  private requestSeq = 0;
+
+  constructor() {
+    void this.mint();
+  }
+
+  protected close(): void {
+    this.dialogRef.close();
+  }
+
+  protected onIframeLoad(): void {
+    this.iframeLoaded.set(true);
+  }
+
+  protected retry(): void {
+    void this.mint();
+  }
+
+  private async mint(): Promise<void> {
+    const seq = ++this.requestSeq;
+    this.error.set(null);
+    this.safeUrl.set(null);
+    this.iframeLoaded.set(false);
+    try {
+      const token = await this.shares.mintConversationArtifactToken(
+        this.data.shareId,
+        this.data.artifact.artifactId,
+      );
+      if (seq !== this.requestSeq) {
+        return;
+      }
+      this.safeUrl.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(token.url),
+      );
+    } catch {
+      if (seq !== this.requestSeq) {
+        return;
+      }
+      // Deliberately one message for 404 and 403 alike. "Not part of
+      // this share" and "you may not open this share" are the same fact
+      // to a recipient, and distinguishing them would describe what the
+      // owner has.
+      this.error.set(
+        "This artifact couldn't be loaded. It may have been removed, or " +
+          'the conversation may no longer be shared with you.',
+      );
+    }
+  }
+}

--- a/frontend/ai.client/src/app/shared/shared-view.page.spec.ts
+++ b/frontend/ai.client/src/app/shared/shared-view.page.spec.ts
@@ -34,6 +34,7 @@ describe('SharedViewPage', () => {
   let mockRouter: any;
 
   const mockConversation: SharedConversationResponse = {
+    artifacts: [],
     shareId: 'share-001',
     title: 'Test Shared Conversation',
     accessLevel: 'public',

--- a/frontend/ai.client/src/app/shared/shared-view.page.ts
+++ b/frontend/ai.client/src/app/shared/shared-view.page.ts
@@ -70,9 +70,16 @@ import { SpinnerComponent } from '../components/spinner/spinner.component';
 
         <!-- Messages -->
         <div class="mx-auto max-w-4xl px-4 pb-32">
+          <!-- Artifacts ride in on the conversation payload, pinned at
+               the versions the snapshot froze, and anchor under the same
+               turns the owner sees them under. They are passed in rather
+               than read from ArtifactStateService, which holds the
+               OWNER's live session state and has nothing to say here. -->
           <app-message-list
             [messages]="messages()"
             [embeddedMode]="true"
+            [sharedArtifacts]="conversation()!.artifacts"
+            [sharedArtifactShareId]="conversation()!.shareId"
           />
         </div>
 


### PR DESCRIPTION
PR-2 of the pair. [#971](https://github.com/Boise-State-Development/agentcore-public-stack/pull/971) made the artifacts reachable; this makes them visible. A recipient now sees artifact cards anchored under the same turns the owner sees them under, and opens them read-only.

Frontend only. Depends on #971 for the endpoint — until that merges, the payload carries no `artifacts` and this renders nothing, which is the current behaviour.

## A separate recipient component, not a mode of the owner's

`ArtifactCardComponent` opens the docked panel and carries download, share, rename and delete. `ArtifactPanelComponent` adds a version picker and a code view. **Every one of those is keyed on something a conversation-share recipient does not have** — an owned artifact, or an artifact share id. Bending either into a "read-only mode" means a component whose every action is conditional on a flag, and the failure mode of a missed condition is a visible button that 403s.

So the card and dialog are their own components. What *is* shared is the layer that should be: `ArtifactViewerComponent`, which is purely presentational and already served the owner panel and the standalone recipient page through two different mint endpoints. This is the third, **and it needed no change to that component** — which is the sign the split was drawn in the right place.

## Artifacts arrive as an input, not through the state service

`MessageListComponent` reads artifacts from `ArtifactStateService` — the *owner's* live session state, populated by SSE events and owner-scoped hydration, neither of which a recipient has. Feeding it recipient rows would put another user's artifacts into the signal the real session view reads.

So the shared view passes them down, and the list groups them with the same index-anchoring the owner path uses, including the **orphan fallback**: an artifact with no usable anchor lands in the end strip rather than disappearing. That matters here more than anywhere, since silently disappearing artifacts is the exact failure this whole feature exists to fix.

## No code view, deliberately

The source endpoint is keyed on an artifact share id, which a conversation share doesn't have. The toggle is **absent rather than present and permanently failing** — adding it is a backend change, not a UI one. I built it with the toggle first, then removed it rather than ship a control that can only ever error.

A refused artifact and a missing one get one message: "not part of this share" and "you may not open this share" are the same fact to a recipient, and distinguishing them would describe what the owner has.

## Tests

**2367 passed** (+26). 20 new: the card, the dialog (including the sandbox isolation this third mint path must not weaken, and the superseded-mint race), and the message-list anchoring.

That last one is worth calling out — `MessageListComponent` had **no component spec at all**, so the orphan-fallback branch the *owner* path also depends on was untested until now. It's covered for both.

## A verification correction worth recording

Browser-verified at 1080px in both themes — but getting light mode right took two attempts. This app drives dark mode with a **`.dark` class on `<html>`** *and* honours `prefers-color-scheme`. The Browser pane's `colorScheme` emulation only moves the second, so with the class still set the "light" screenshot was the app still fully in dark mode. Cards looked broken; they weren't.

Correct check is both levers: clear the class *and* emulate light. Once done, cards are white with dark text as intended (verified against computed styles, not just the screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)