### PR TITLE
fix(announcements): submit button could never enable on the new-announcement form

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.spec.ts
@@ -82,6 +82,52 @@ describe('AnnouncementFormPage', () => {
     });
   }
 
+  describe('submit gate reactivity', () => {
+    /**
+     * The regression that browser verification caught and the original specs
+     * missed: they only ever read `canSubmit()` *after* filling the form, so
+     * its first evaluation saw a valid form, tracked every signal, and stayed
+     * reactive. In the real page the first read happens while the form is
+     * empty — and an early `return` on the non-signal `form.invalid` shortened
+     * the computed's dependency set to `isSubmitting` alone. Nothing could
+     * re-enable the button afterwards.
+     *
+     * Reading it empty FIRST is the whole point of these tests.
+     */
+    it('enables once the form is filled, having first been read while empty', async () => {
+      const page = await createPage();
+
+      expect(page.canSubmit()).toBe(false); // first evaluation, empty form
+
+      fill(page, {});
+
+      expect(page.canSubmit()).toBe(true);
+    });
+
+    it('stays reactive to a later invalidation', async () => {
+      const page = await createPage();
+      expect(page.canSubmit()).toBe(false);
+
+      fill(page, {});
+      expect(page.canSubmit()).toBe(true);
+
+      // Clearing a required field must disable it again.
+      page.form.patchValue({ title: '' });
+      expect(page.canSubmit()).toBe(false);
+    });
+
+    it('re-enables after a blocking rule is satisfied, read empty first', async () => {
+      const page = await createPage();
+      expect(page.canSubmit()).toBe(false);
+
+      fill(page, { banner: true });
+      expect(page.canSubmit()).toBe(false); // banner with no expiry
+
+      page.form.patchValue({ expires_at: '2099-01-01T00:00' });
+      expect(page.canSubmit()).toBe(true);
+    });
+  });
+
   describe('surfaces', () => {
     it('always sends panel, even though the form has no panel checkbox', async () => {
       // The server forces it too (§D1), but sending it keeps the payload

--- a/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-announcements/announcement-form.page.ts
@@ -485,6 +485,8 @@ export class AnnouncementFormPage implements OnInit {
   private readonly expiresAtSig = signal('');
   private readonly ctaLabelSig = signal('');
   private readonly ctaUrlSig = signal('');
+  // Form validity is not a signal on FormGroup, so mirror it like the rest.
+  private readonly formValid = signal(false);
 
   protected readonly modalSelected = this.modalSig.asReadonly();
   protected readonly allRolesSelected = this.allRolesSig.asReadonly();
@@ -519,16 +521,39 @@ export class AnnouncementFormPage implements OnInit {
 
   protected readonly roles = computed(() => this.rolesService.getRoles());
 
+  /**
+   * Whether the form can be submitted.
+   *
+   * ⚠️ **Every dependency is read unconditionally, and form validity comes from
+   * a signal.** Both details are load-bearing, and getting either wrong
+   * deadlocks the button.
+   *
+   * A `computed` tracks the signals actually read during its *last* execution,
+   * so an early `return` shortens its dependency set. This began as a chain of
+   * guard clauses with `if (this.form.invalid) return false` near the top —
+   * and `FormGroup.invalid` is a plain getter, not a signal. On the first
+   * evaluation the form was empty, so it returned there having read only
+   * `isSubmitting()`; nothing else was tracked, no later edit could schedule a
+   * recompute, and `isSubmitting` only changes inside `onSubmit`, which the
+   * disabled button prevented. The submit button could never enable.
+   *
+   * So: mirror validity into `formValid` (fed by `statusChanges`), read every
+   * input before combining them, and never guard-clause out of this computed.
+   */
   protected readonly canSubmit = computed(() => {
-    if (this.isSubmitting()) return false;
-    if (this.form.invalid) return false;
-    if (this.bodyOverLimit()) return false;
-    if (this.expiryMissing() || this.expiryBeforePublish()) return false;
-    if (this.ctaIncomplete()) return false;
-    if (!this.allRolesSig() && this.roles().length > 0 && this.selectedRoles().length === 0) {
-      return false;
-    }
-    return true;
+    const submitting = this.isSubmitting();
+    const formValid = this.formValid();
+    const overLimit = this.bodyOverLimit();
+    const missingExpiry = this.expiryMissing();
+    const badExpiry = this.expiryBeforePublish();
+    const badCta = this.ctaIncomplete();
+    const rolesChosen =
+      this.allRolesSig() || this.roles().length === 0 || this.selectedRoles().length > 0;
+
+    return (
+      !submitting && formValid && !overLimit && !missingExpiry && !badExpiry &&
+      !badCta && rolesChosen
+    );
   });
 
   async ngOnInit(): Promise<void> {
@@ -547,6 +572,8 @@ export class AnnouncementFormPage implements OnInit {
     c.expires_at.valueChanges.subscribe(v => this.expiresAtSig.set(v));
     c.cta_label.valueChanges.subscribe(v => this.ctaLabelSig.set(v));
     c.cta_url.valueChanges.subscribe(v => this.ctaUrlSig.set(v));
+    this.form.statusChanges.subscribe(status => this.formValid.set(status === 'VALID'));
+    this.formValid.set(this.form.valid);
 
     const id = this.route.snapshot.paramMap.get('id');
     if (!id) return;


### PR DESCRIPTION
Follow-up to [#972](https://github.com/Boise-State-Development/agentcore-public-stack/pull/972). **The admin form shipped unable to create anything** — this fixes that.

## The bug

Browser-verifying the page in dev: every field filled, the form reporting `ng-valid` on every control, and **"Create draft" still disabled.** No announcement could be authored from the UI at all, which was the entire point of PR-3.

`canSubmit` is a `computed`, and a computed tracks the signals read during its **last execution** — so an early `return` shortens its dependency set:

```ts
protected readonly canSubmit = computed(() => {
  if (this.isSubmitting()) return false;   // signal — tracked
  if (this.form.invalid) return false;     // ⚠️ plain getter, NOT a signal — returns here
  if (this.bodyOverLimit()) return false;  // never reached on first run
  …
});
```

On the first evaluation the form was empty, so it returned at line 2 having tracked only `isSubmitting`. Nothing else was a dependency, so no later edit could schedule a recompute — and `isSubmitting` only changes inside `onSubmit`, which the disabled button prevented. A deadlock.

## The fix

Two changes, both load-bearing:

1. Form validity is mirrored into a signal fed by `statusChanges`, exactly like the `valueChanges` mirrors this component already keeps for the template.
2. Every input is read unconditionally before being combined, so no branch can shrink the tracked dependency set again. The comment on `canSubmit` explains why, because the guard-clause version reads as the more natural style and someone will want to refactor back to it.

## Why the existing tests missed it

They only ever read `canSubmit()` **after** filling the form. In that order the computed's first evaluation sees a valid form, reads past the `form.invalid` check, tracks every signal, and stays reactive — so the bug is invisible. In the real page the first read happens while the form is still empty.

The three new tests read `canSubmit()` while empty **first**, then fill. That ordering is the entire test.

I verified they actually catch it rather than assuming: reverting the fix makes the 3 new tests fail while **all 24 original specs still pass**.

## Testing

- `npm test`: **217 files, 2431 tests pass**.
- `npx tsc --noEmit`: clean.
- Reverted-fix check: 3 failed / 24 passed, as described above.

Backend untouched.

## Note for the epic

This is the second bug in this feature that unit tests passed and a browser caught (the first was PR-2's markdown rendering with inert `prose` classes). Both were in the SPA, and both were invisible to specs that exercised the logic without rendering it. Worth remembering when PR-4 (banner) and PR-5 (modal) land — those are the surfaces where a silent failure is most costly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
