### PR TITLE
fix(sidenav): show the skeleton, not "No Chats Yet", while sessions load

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.spec.ts
@@ -31,7 +31,7 @@ describe('SessionList', () => {
       mergedSessionsResource: signal({ sessions: [mockSession], nextToken: null }),
       currentSession: signal(mockSession),
       deleteSession: vi.fn().mockResolvedValue(undefined),
-      sessionsResource: { value: vi.fn().mockReturnValue(null), error: vi.fn().mockReturnValue(null), isPending: vi.fn().mockReturnValue(false) },
+      sessionsResource: { value: vi.fn().mockReturnValue({ sessions: [mockSession], nextToken: null }), error: vi.fn().mockReturnValue(null), isPending: vi.fn().mockReturnValue(false) },
       isLocallyRead: vi.fn().mockReturnValue(false),
       markSessionRead: vi.fn().mockResolvedValue(undefined),
       markSessionUnread: vi.fn().mockResolvedValue(undefined),
@@ -61,6 +61,53 @@ describe('SessionList', () => {
     const { SessionList } = await import('./session-list');
     return TestBed.runInInjectionContext(() => new SessionList());
   }
+
+  describe('isLoading', () => {
+    it('stays loading while the resource has not produced a response', async () => {
+      // Cold start: the loader short-circuits to `null` because sessions
+      // loading is not enabled until the BFF bootstrap resolves — and
+      // `reload()` keeps that `null` for the whole real fetch. With nothing
+      // cached to draw, that must read as loading (skeleton), never as
+      // "no conversations".
+      mockSessionService.mergedSessionsResource.set({ sessions: [], nextToken: null });
+      mockSessionService.sessionsResource.value.mockReturnValue(null);
+      const component = await createComponent();
+
+      expect(component.isLoading()).toBe(true);
+
+      // Before the first load resolves at all.
+      mockSessionService.sessionsResource.value.mockReturnValue(undefined);
+      expect(component.isLoading()).toBe(true);
+    });
+
+    it('is not loading once the API answers, even with zero sessions', async () => {
+      mockSessionService.mergedSessionsResource.set({ sessions: [], nextToken: null });
+      mockSessionService.sessionsResource.value.mockReturnValue({ sessions: [], nextToken: null });
+      const component = await createComponent();
+
+      // A real empty response is the empty state, not a skeleton.
+      expect(component.isLoading()).toBe(false);
+    });
+
+    it('renders locally cached sessions instead of a skeleton', async () => {
+      mockSessionService.sessionsResource.value.mockReturnValue(null);
+      const component = await createComponent();
+
+      expect(component.isLoading()).toBe(false);
+    });
+
+    it('defers to the error state without reading the resource value', async () => {
+      mockSessionService.mergedSessionsResource.set({ sessions: [], nextToken: null });
+      mockSessionService.sessionsResource.error.mockReturnValue(new Error('boom'));
+      // Angular's resource throws from `value()` when the load errored.
+      mockSessionService.sessionsResource.value.mockImplementation(() => {
+        throw new Error('should not be read');
+      });
+      const component = await createComponent();
+
+      expect(component.isLoading()).toBe(false);
+    });
+  });
 
   it('should compute sessions from merged resource', async () => {
     const component = await createComponent();

--- a/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
+++ b/frontend/ai.client/src/app/components/sidenav/components/session-list/session-list.ts
@@ -132,11 +132,32 @@ export class SessionList {
   });
 
   /**
-   * Computed signal for loading state.
+   * Computed signal for loading state — i.e. "we have nothing to draw yet".
+   *
+   * `value()` alone is not enough. The loader short-circuits to `null` while
+   * `sessionsRequest` is still false, and that is the ordinary cold-start path:
+   * `SessionService` is constructed during the APP_INITIALIZER pass (via
+   * `AnnouncementModalService` -> `MessageMapService`), and Angular runs every
+   * initializer synchronously before awaiting any of them — so the BFF
+   * `bootstrap()` promise is still in flight and `isAuthenticated()` is false.
+   * The eager-fetch branch in the constructor is skipped, the resource resolves
+   * `null`, and the auth effect only enables loading afterwards. `reload()`
+   * keeps the previous value, so `null` survives the entire real fetch: testing
+   * `=== undefined` reported "loaded, no sessions" and the sidebar rendered the
+   * "No Chats Yet" empty state instead of the skeleton.
+   *
+   * So: no API response yet (`undefined` before the first load resolves, `null`
+   * while it is short-circuited) means loading. An empty `sessions` array is a
+   * real response and must fall through to the empty state.
+   *
+   * `error()` is read first — reading `value()` on an errored resource throws.
    */
   readonly isLoading = computed(() => {
-    const value = this.sessionsResource.value();
-    return value === undefined;
+    if (this.sessionsResource.error()) return false;
+    if (this.sessionsResource.value() != null) return false;
+    // Locally created sessions can exist before the API answers; draw those
+    // rather than covering them with a skeleton.
+    return this.groupedSessions().length === 0;
   });
 
   /**


### PR DESCRIPTION
## The regression

On a cold load the sidebar rendered the **"No Chats Yet"** empty state for the whole duration of the sessions fetch, then popped the list in. It should have shown the loading skeleton.

## Root cause

`isLoading()` in `session-list.ts` tested `sessionsResource.value() === undefined`. That stopped being true during the fetch, for two reasons that compound:

1. **The loader short-circuits to `null`.** `sessionsResource`'s loader returns `null` when `sessionsRequest` is false, so the resource *resolves* — `undefined` → `null` — before a single session is fetched.

2. **`SessionService` is constructed before the BFF bootstrap resolves.** Its constructor only calls `enableSessionsLoading()` if `bffSession.isAuthenticated()` is already true, and the comment there assumes the service is instantiated post-bootstrap. That no longer holds: `provideAppInitializer(() => { inject(AnnouncementModalService); })` pulls in `MessageMapService`, which injects `SessionService`. Angular's `runInitializers` invokes every initializer **synchronously in registration order**, collecting promises and only `Promise.all`-ing them afterwards — so that initializer runs while `SessionService.bootstrap()` is still in flight, `isAuthenticated()` is false, and the eager-fetch branch is skipped.

The auth effect then enables loading and calls `reload()` — but Angular's resource **preserves the previous value across a reload** (status projects to `reloading`, the stream is kept). So `value()` stayed `null` for the entire real fetch: `isLoading()` read false, `groupedSessions()` was empty, and the template fell to the empty-state branch.

## The fix

`isLoading()` now means *"we have nothing to draw yet"*:

- No API response — `undefined` before the first load resolves, **or** the short-circuit `null` — and no rows from the local cache.
- An empty `sessions` array is a real response and still falls through to the empty state.
- `error()` is checked **first**: reading `value()` on an errored resource throws, which the old ordering walked straight into.

Deliberately **not** keyed on `status() === 'reloading'` — `refreshSessions()` reloads after send/rename/mark-unread, and that would have flashed the whole list to a skeleton every time.

## Testing

Four new specs covering the short-circuit `null`, the genuinely-empty response, the locally-cached rows case, and the error path. Verified they are not vacuous: reverting the implementation makes 2 of them fail.

- `ng test` — 2500 passed, 221 files
- `tsc --noEmit -p tsconfig.app.json` — clean

## Follow-up, not in this PR

The underlying fragility is that `SessionService`'s constructor gates on auth state that may not exist yet. This fix makes the UI correct under any construction order, but the service would be more honest with a `params` gate on the resource (`undefined` → `idle`) instead of a loader that resolves `null`. That changes logout/idle semantics, so it doesn't belong in a regression fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)