### PR TITLE
fix(mcp-apps): keep tool-result content on app-initiated tools/call

### DIFF
--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -56,6 +56,12 @@ def _serialize_content(result: Any) -> List[Dict[str, Any]]:
     block so a quirky server response still round-trips.
     """
     content = getattr(result, "content", None)
+    if content is None and isinstance(result, dict):
+        # Strands' MCPToolResult extends ToolResult, a TypedDict — so a result
+        # is a plain dict at runtime and `getattr` finds nothing. Without this
+        # every app-initiated tools/call returned `content: []`, leaving the
+        # App with no data to render. Mirrors `_is_error`'s dict handling.
+        content = result.get("content")
     blocks: List[Dict[str, Any]] = []
     if isinstance(content, list):
         for item in content:

--- a/backend/tests/apis/inference_api/test_app_tool_dispatch.py
+++ b/backend/tests/apis/inference_api/test_app_tool_dispatch.py
@@ -165,3 +165,31 @@ async def test_success_returns_result_and_publishes_thread_events(monkeypatch):
     assert events[0]["data"]["tool_use"]["name"] == "widget_tool"
     assert events[0]["data"]["tool_use"]["origin"] == "mcp_app"
     assert events[1]["data"]["tool_result"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_dict_shaped_result_keeps_its_content(monkeypatch):
+    """A dict-shaped tool result must round-trip its content blocks.
+
+    Strands' `MCPToolResult` extends `ToolResult`, a TypedDict — so what
+    `call_tool_sync` returns is a plain dict at runtime, and the `getattr`
+    lookup in `_serialize_content` finds nothing on it. That regression sent
+    `content: []` back for every app-initiated tools/call, leaving embedded
+    Apps with no data to render while every layer still reported 200/success.
+
+    The other fakes in this module are objects with a `.content` attribute,
+    which is why the attribute path alone looked correct.
+    """
+    result = {
+        "toolUseId": "mcp-1",
+        "status": "success",
+        # Strands content blocks are untagged: `text`/`json`, no `type`.
+        "content": [{"text": '{"lists": []}'}],
+    }
+    client = _FakeClient(result)
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+
+    payload = await _call(session_id="disp-dict")
+
+    assert payload["result"]["content"] == [{"text": '{"lists": []}'}]
+    assert payload["result"]["isError"] is False


### PR DESCRIPTION
## Problem

Every app-initiated `tools/call` relayed `content: []` back to the embedded App, so an MCP App had nothing to render after any edit.

`_serialize_content` reads the result with `getattr`:

```python
content = getattr(result, "content", None)
```

Strands' `MCPToolResult` extends `ToolResult`, which is a **`TypedDict`** — so `call_tool_sync` returns a plain `dict` at runtime and the attribute lookup finds nothing:

```
runtime type      : dict
getattr(.content) : None
r["content"]      : [{'text': '{"lists": []}'}]
```

`content` is then `None`, `isinstance(content, list)` is `False`, and `blocks` stays empty.

## Why it went unnoticed

The failure is silent at every layer: app-api returns 200, inference-api returns 200, and the MCP server really did run the tool. A write takes effect but the App receives nothing back, so it looks frozen — a task added from an App board is created in the upstream service and never appears in the UI, even on an explicit refresh.

The existing fakes in `test_app_tool_dispatch.py` are objects with a `.content` attribute, so the attribute-only path looked correct under test.

## Fix

Handle the dict shape alongside the attribute one, mirroring the `isinstance(result, dict)` branch `_is_error` already has a few lines below.

## Test

Adds `test_dict_shaped_result_keeps_its_content`, using the dict shape the client really returns with untagged Strands content blocks (`text`/`json`, no `type`). Verified it fails without the fix:

```
FAILED tests/apis/inference_api/test_app_tool_dispatch.py::test_dict_shaped_result_keeps_its_content
Right contains one more item: {'text': '{"lists": []}'}
```

and the file passes with it (7 passed).

## Verification

Found while building an MCP App board against a local stack. Captured off the wire before the fix:

```json
{"toolUseId":"tooluse_ErGfS0Gj1Ww87fS4sjW1Fl","result":{"content":[],"isError":false}}
```

After the fix, add / rename / notes / complete / un-complete / delete / refresh all render correctly in the App.

## Follow-ups (not in this PR)

Two related gaps in the same path, left alone to keep this focused:

- `MCPToolResult` also carries `structuredContent`, which the proxy drops. Apps that follow the spec path get nothing and must fall back to parsing the text block.
- `toCallToolResult` in the SPA normalizes blocks to `{type: 'text'}` for the initial `tool-result`, but the proxy path relays raw untagged Strands blocks. An App that filters on `type === "text"` handles one and not the other.

Happy to open an issue for either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)