### PR TITLE
fix(mcp-apps): revive a torn-down MCP session for app-initiated calls

### DIFF
--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -24,7 +24,9 @@ rejected as not app-visible.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import threading
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -87,6 +89,77 @@ def _is_error(result: Any) -> bool:
     return bool(val)
 
 
+# Guards the start/stop refcount below. Sessions are cheap to hold but must
+# not be torn down under a concurrent call, so overlapping app calls against
+# the same client share one revived session.
+_revive_lock = threading.Lock()
+_revived_users: Dict[int, int] = {}
+
+
+def _session_is_active(client: Any) -> bool:
+    """Whether `client` currently has a live MCP session.
+
+    Strands exposes this only as a private predicate; treat an unexpected
+    client shape as "active" so we never start a session we cannot own.
+    """
+    probe = getattr(client, "_is_session_active", None)
+    if not callable(probe):
+        return True
+    try:
+        return bool(probe())
+    except Exception:  # noqa: BLE001 - a broken probe must not block the call
+        return True
+
+
+@contextlib.contextmanager
+def _active_session(client: Any):
+    """Ensure `client` can serve one out-of-band tools/call, then restore it.
+
+    An app-initiated call arrives *between* turns: the agent it belongs to is
+    served from cache, and Strands tore that agent's MCP client sessions down
+    when the turn that built them ended. The catalog still holds the client
+    object, so calling straight through raises
+    `MCPClientInitializationError("the client session is not running")` and the
+    App sees a 502.
+
+    Reconnect for the duration of the call and leave the client as we found
+    it. A session that is already live — the mid-stream case, where the turn
+    is still running — is used as-is and never stopped here, because it
+    belongs to that turn.
+    """
+    key = id(client)
+    started_here = False
+
+    with _revive_lock:
+        if _revived_users.get(key):
+            # Another app call already revived it; join that session.
+            _revived_users[key] += 1
+        elif _session_is_active(client):
+            pass  # Live session owned by an in-flight turn — use, don't touch.
+        else:
+            client.start()
+            _revived_users[key] = 1
+            started_here = True
+
+    try:
+        yield client
+    finally:
+        if started_here or _revived_users.get(key):
+            with _revive_lock:
+                remaining = _revived_users.get(key, 0) - 1
+                if remaining > 0:
+                    _revived_users[key] = remaining
+                else:
+                    _revived_users.pop(key, None)
+                    try:
+                        client.stop(None, None, None)
+                    except Exception:  # noqa: BLE001 - best-effort teardown
+                        logger.warning(
+                            "failed to stop a revived MCP client session",
+                            exc_info=True,
+                        )
+
+
 def _resolve_client(agent: Any, tool_name: str):
     """The MCP client that surfaced `tool_name`.
 
@@ -142,10 +215,14 @@ async def dispatch_app_tool_call(
     synth_id = f"app-{tool_use_id}-{uuid.uuid4().hex[:8]}"
     args = dict(arguments or {})
 
+    def _invoke() -> Any:
+        # `start()` blocks on the handshake, so revive inside the worker
+        # thread rather than on the event loop.
+        with _active_session(client):
+            return client.call_tool_sync(synth_id, tool_name, args)
+
     try:
-        result = await asyncio.to_thread(
-            client.call_tool_sync, synth_id, tool_name, args
-        )
+        result = await asyncio.to_thread(_invoke)
     except Exception as exc:  # noqa: BLE001 - surfaced to the App as an error
         logger.warning(
             "app tools/call dispatch failed (tool=%s session=%s): %s",

--- a/backend/tests/apis/inference_api/test_app_tool_dispatch.py
+++ b/backend/tests/apis/inference_api/test_app_tool_dispatch.py
@@ -193,3 +193,71 @@ async def test_dict_shaped_result_keeps_its_content(monkeypatch):
 
     assert payload["result"]["content"] == [{"text": '{"lists": []}'}]
     assert payload["result"]["isError"] is False
+
+
+class _SessionClient(_FakeClient):
+    """Client that tracks its MCP session the way Strands' MCPClient does.
+
+    `start()` raises if the session is already running, matching upstream, so
+    a test fails loudly if the dispatch tries to revive a live session.
+    """
+
+    def __init__(self, active: bool, result=None) -> None:
+        super().__init__(result)
+        self.active = active
+        self.starts = 0
+        self.stops = 0
+        self.active_during_call: bool | None = None
+
+    def _is_session_active(self) -> bool:
+        return self.active
+
+    def start(self):
+        if self.active:
+            raise AssertionError("start() on an already-running session")
+        self.active = True
+        self.starts += 1
+        return self
+
+    def stop(self, exc_type, exc_val, exc_tb) -> None:
+        self.active = False
+        self.stops += 1
+
+    def call_tool_sync(self, tool_use_id, name, arguments=None):
+        self.active_during_call = self.active
+        return super().call_tool_sync(tool_use_id, name, arguments)
+
+
+@pytest.mark.asyncio
+async def test_revives_a_torn_down_client_session(monkeypatch):
+    """An app call between turns must reconnect rather than 502.
+
+    The agent is served from cache, so Strands has already torn down its MCP
+    client sessions; the catalog still holds the client. Calling straight
+    through raised MCPClientInitializationError, which surfaced to the App as
+    a 502 Bad Gateway.
+    """
+    client = _SessionClient(active=False)
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+
+    payload = await _call(session_id="disp-revive")
+
+    assert payload["result"]["isError"] is False
+    assert client.starts == 1
+    assert client.active_during_call is True
+    # Restored to how we found it — the revival is scoped to this one call.
+    assert client.stops == 1
+    assert client.active is False
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_live_client_session_alone(monkeypatch):
+    """Mid-stream the session belongs to the running turn — don't touch it."""
+    client = _SessionClient(active=True)
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+
+    await _call(session_id="disp-live")
+
+    assert client.starts == 0
+    assert client.stops == 0
+    assert client.active is True


### PR DESCRIPTION
> **Draft — stacked on #993, and not yet verified end to end.** See *Verification* below.

## Problem

An app-initiated `tools/call` fails with **502 Bad Gateway**:

```
app tools/call dispatch failed (tool=board_snapshot session=…):
the client session is not running. Ensure the agent is used within the MCP client context manager.
```

An MCP App calling any tool after its turn has ended hits this — for a board that re-reads state after each edit, that is every refresh.

## Cause

The call arrives *between* turns:

1. `routes.py` rebuilds the agent first, but with `cache_write=False` — *"Read the slot; never seed it."* — so it gets a **cached** agent.
2. Strands tore that agent's MCP client sessions down when the turn that built them ended.
3. `_resolve_client` returns the client the `UIToolCatalog` recorded at some earlier build, whose session is now dead.
4. `call_tool_sync` raises `MCPClientInitializationError` → `AppToolCallError(502)`.

It presents as intermittent because a call made while the turn is still streaming finds the session alive — which matches the note in `UIToolCatalog`'s docstring:

> The client's session stays alive for the agent's lifetime … so it is still active when a tool result arrives mid-stream.

True mid-stream; not true out of band.

## Fix

Reconnect the client for the duration of the call and leave it as found:

- A session that is **already live** belongs to an in-flight turn — used as-is, never stopped here.
- A **dead** session is started for the call and stopped afterwards.
- **Overlapping** app calls against the same client share one revived session via a refcount, so no call has the connection closed underneath it.

`_session_is_active` reads Strands' private `_is_session_active` and treats an unexpected client shape as active, so we never start a session we cannot own.

## Trade-offs, deliberately

- **The deeper fix is elsewhere.** `_resolve_client` accepts `agent` and never uses it; resolving the live client from the freshly built agent would be more correct, but it reaches into how tool providers are held and cached. This keeps the blast radius at the dispatch boundary. Happy to go the other way if you prefer.
- **Reconnect cost.** One connect/disconnect per out-of-band call. Fresh auth is a side benefit (the token provider is lazy), but it is not free.
- **The revival lock is held across `start()`**, so concurrent revivals serialize — including for different clients. Fine at app-call volume; worth a per-client lock if that changes.

## Tests

Two added:

- `test_revives_a_torn_down_client_session` — start called once, session live during the call, stopped after. **Fails without the fix** (`assert 0 == 1` on `starts`).
- `test_leaves_a_live_client_session_alone` — no start, no stop, session untouched.

The new `_SessionClient` fake raises from `start()` if already running, matching upstream, so reviving a live session fails loudly. Suite: 9 passed.

## Verification

Unit-tested only. I could **not** confirm it end to end: my local stack got into a bad state while testing (one restart collided with a still-running process on `:8001`, and the SPA then stopped bootstrapping), so the browser-level repro is outstanding. The diagnosis above is from the inference-api logs and the captured 502, not from watching the fix succeed in the UI.

Worth someone reproducing before this leaves draft: open an MCP App board, let the turn finish, then trigger an app-initiated tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)