### PR TITLE
fix(kb): engine-aware managed context cap (8,000) — task 16.1

### DIFF
--- a/.kiro/specs/managed-kb-migration/requirements.md
+++ b/.kiro/specs/managed-kb-migration/requirements.md
@@ -69,11 +69,15 @@ The following are explicitly **not** in scope, each for a stated reason:
   > shape as Requirement 8.5, which was also validated under conditions that
   > excluded the real failure.
   >
-  > This exclusion stands for now, because the cap is a parity control and moving
-  > it forfeits attributability (§9, §13.5). It is no longer justified by "no
-  > correctness change", which is false. Resolving it requires either accepting a
-  > managed-only cap and declaring the asymmetry, or re-running §13.6 on a corpus
-  > where section context sits outside the top chunk. See HANDOFF.md §5.40.
+  > **RESOLVED 2026-09-04:** the cap is now **engine-aware** — legacy stays 2,000,
+  > managed becomes 8,000 (`rag_service.resolve_context_cap`), which restores parity
+  > in chunks-reaching-the-model rather than characters and is sized from §13.6
+  > itself (8,000 = all five managed chunks fit, ~966 extra input tokens/turn). This
+  > does **not** forfeit attributability — the single-character cap had *already*
+  > broken it (~4 legacy chunks vs ~1 managed). Confirmed on the KINES advising
+  > corpus in dev (1 of 4 emphasis areas answered from the documents at 2,000; all
+  > four at 8,000). Raising the cap on the *legacy* path remains out of scope. See
+  > Requirement 3.2 (amended) and HANDOFF.md §5.40.
 - **0..N agent-to-KB bindings (F4).** §10.6 requires that the engine swap and the
   binding-cardinality change not be coupled, because a joint failure is
   unattributable. This spec lands the `KnowledgeBase` entity record while
@@ -199,15 +203,26 @@ the upgrade.
 #### Acceptance Criteria
 
 1. THE system SHALL request `top_k = 5` on both backends.
-2. THE system SHALL apply a context cap of **2,000 characters** on both backends,
-   unchanged from today's `max_context_length` default.
+2. THE system SHALL apply an **engine-aware** context cap — **2,000 characters**
+   on the Legacy_Backend and **8,000 characters** on the Managed_Backend —
+   resolved by `rag_service.resolve_context_cap` from the knowledge base's
+   Retrieval_Engine, the same value the backend resolver keys on, so the cap and
+   the served engine can never disagree.
 
-   > ⚠️ Identical characters is **not** identical behaviour. Bedrock's chunks are
-   > ~3× Docling's, so this same number admits ~4 legacy chunks and ~1 managed
-   > chunk, making `top_k = 5` above effectively `top_k = 1` on the managed path.
-   > This is parity on the constant, not on the effect. Measured, with a wrong
-   > answer to show for it — see the amendment in the out-of-scope list above and
-   > HANDOFF.md §5.40 before treating this requirement as satisfied.
+   > ⚠️ **Amended 2026-09-04 by measurement (was: 2,000 on both backends).**
+   > Identical characters is **not** identical behaviour. Bedrock's chunks are ~3×
+   > Docling's, so a single 2,000 cap admitted ~4 legacy chunks but only ~1 managed
+   > chunk — making `top_k = 5` (3.1) effectively `top_k = 1` on the managed path,
+   > and it produced materially wrong answers (a Major-Core course described as an
+   > elective; on the KINES advising corpus, only 1 of 4 emphasis areas described
+   > from the documents with the rest guessed from outside knowledge the assistant
+   > was told not to use). 8,000 is the evaluation's own §13.6 sizing: the point at
+   > which all five managed chunks fit, ~966 extra input tokens/turn. The
+   > managed-only asymmetry is **deliberate and restores parity in the unit that
+   > matters** — chunks reaching the model, not characters. §13.6's "no correctness
+   > change 2,000→20,000" covered single-fact lookups only and flagged multi-chunk
+   > synthesis — the case that broke — as untested. See HANDOFF.md §5.40. Guarded by
+   > `tests/shared/test_kb_backend_parity.py` (mutation-tested).
 3. THE system SHALL retain the Doc_Status_Filter on **both** backends during
    parity, even though Managed_Backend makes it redundant.
 4. THE system SHALL build citations from the same `context_chunks` structure on

--- a/.kiro/specs/managed-kb-migration/tasks.md
+++ b/.kiro/specs/managed-kb-migration/tasks.md
@@ -766,7 +766,16 @@ All three flags — managed-default, migration, and reconciler arming — ship *
 
 - [ ] 16. Post-implementation findings (opened by running it — see `HANDOFF.md` §5)
 
-  - [ ] 16.1 Resolve the 2,000-character context cap on the managed path
+  - [x] 16.1 Resolve the 2,000-character context cap on the managed path
+    - **RESOLVED 2026-09-04 (Option A: engine-aware cap).** `rag_service.resolve_context_cap`
+      returns 2,000 for legacy, 8,000 for managed, keyed on the same `resolve_engine_for`
+      the backend resolver uses. Both call sites (`inference_api/chat/routes.py`,
+      `app_api/assistants/routes.py`) pass it. Requirement 3.2 amended; out-of-scope
+      note updated. Guard in `tests/shared/test_kb_backend_parity.py`, mutation-tested
+      (dropping the managed branch fails two named tests). Measured end-to-end on a
+      prod-derived KINES advising corpus re-created in dev (`ast-1d51df6ea532`): at
+      2,000 the model described 1 of 4 emphasis areas from the docs and guessed the
+      rest; at 8,000 all four came from the documents. Branch `fix/kb-managed-context-cap`.
     - **The most consequential open item.** Bedrock's chunks are ~3× Docling's, so
       only ~1 chunk clears the cap and four of reranking's five results never reach
       the model. Measured: legacy 388/130/1035/106 chars (4 fit) vs managed

--- a/backend/src/apis/app_api/assistants/routes.py
+++ b/backend/src/apis/app_api/assistants/routes.py
@@ -53,7 +53,7 @@ from apis.shared.assistants.service import (
     update_share_permission,
 )
 from apis.shared.assistants.kb_access import granted
-from apis.shared.assistants.rag_service import augment_prompt_with_context, search_assistant_knowledgebase_with_formatting
+from apis.shared.assistants.rag_service import augment_prompt_with_context, resolve_context_cap, search_assistant_knowledgebase_with_formatting
 
 logger = logging.getLogger(__name__)
 
@@ -532,8 +532,10 @@ async def test_chat_endpoint(assistant_id: str, request: AssistantTestChatReques
             access=granted(assistant_id, user_id, permission),
         )
 
-        # 5. Augment user message with retrieved context
-        augmented_message = augment_prompt_with_context(user_message=request.message, context_chunks=context_chunks)
+        # 5. Augment user message with retrieved context (engine-aware cap:
+        # managed 8,000, legacy 2,000 — Requirement 3.2 / HANDOFF §5.40).
+        cap = resolve_context_cap(assistant_id)
+        augmented_message = augment_prompt_with_context(user_message=request.message, context_chunks=context_chunks, max_context_length=cap)
 
         # 6. Create agent with assistant's instructions as system prompt
         agent = await get_agent(

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -1709,6 +1709,7 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
         from apis.shared.assistants.kb_access import granted
         from apis.shared.assistants.rag_service import (
             augment_prompt_with_context,
+            resolve_context_cap,
             search_assistant_knowledgebase_with_formatting,
         )
         from apis.shared.assistants.service import (
@@ -1989,7 +1990,11 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
 
             # 4. Augment message with context
             if context_chunks:
-                augmented_message = augment_prompt_with_context(user_message=input_data.message, context_chunks=context_chunks)
+                # Engine-aware cap (Requirement 3.2): managed gets 8,000 so
+                # reranking's top_k chunks actually reach the model; legacy keeps
+                # 2,000. See rag_service.resolve_context_cap / HANDOFF §5.40.
+                cap = resolve_context_cap(input_data.rag_assistant_id)
+                augmented_message = augment_prompt_with_context(user_message=input_data.message, context_chunks=context_chunks, max_context_length=cap)
                 logger.info(
                     f"Augmented message with {len(context_chunks)} context chunks"
                 )

--- a/backend/src/apis/shared/assistants/__init__.py
+++ b/backend/src/apis/shared/assistants/__init__.py
@@ -38,6 +38,7 @@ from .service import (
 )
 from .rag_service import (
     augment_prompt_with_context,
+    resolve_context_cap,
     search_assistant_knowledgebase_with_formatting,
 )
 
@@ -74,5 +75,6 @@ __all__ = [
     "update_share_permission",
     # RAG service functions
     "augment_prompt_with_context",
+    "resolve_context_cap",
     "search_assistant_knowledgebase_with_formatting",
 ]

--- a/backend/src/apis/shared/assistants/rag_service.py
+++ b/backend/src/apis/shared/assistants/rag_service.py
@@ -22,10 +22,19 @@ implemented twice is a rule that will eventually differ (Requirement 3):
 * **``top_k`` narrowing.** Applied *after* the status filter, which is the order
   the legacy path has always used: filter-then-slice, so an incomplete document
   cannot silently shrink a five-chunk answer.
-* **The 2,000-character context cap.** ``augment_prompt_with_context``'s
-  default. Held constant deliberately: the evaluation measured no correctness
-  change between 2,000 and 20,000 characters, so raising it here would add a
-  variable to a change whose whole purpose is to hold every variable but one.
+* **The context cap, per engine.** ``augment_prompt_with_context`` takes an
+  explicit ``max_context_length``; :func:`resolve_context_cap` decides it from
+  the assistant's engine. Legacy keeps the historical 2,000 characters; managed
+  gets :data:`MANAGED_MAX_CONTEXT_CHARS` (8,000). This is a *deliberate*
+  managed-only asymmetry, amended into Requirement 3.2 on 2026-09-04 after
+  measurement: holding the *character* cap identical across backends did **not**
+  hold retrieval identical, because Bedrock's chunks are ~3x the size of the
+  Docling chunks the 2,000 figure was sized for — so at 2,000, four of managed's
+  five reranked chunks never reached the model and answers went wrong (HANDOFF
+  §5.40). Capping per engine restores parity in the unit that actually matters:
+  chunks reaching the model, not characters. The evaluation's §13.6 "no
+  correctness change 2,000→20,000" covered single-fact lookups only and flagged
+  multi-chunk synthesis — the case that broke — as untested.
 
 The dual-read pilot
 -------------------
@@ -45,7 +54,7 @@ client already reads. The rename stops at the seam; no caller has to change.
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Mapping, Optional, Set
 
 import boto3
 
@@ -59,15 +68,49 @@ from apis.shared.kb_backend.metrics import (
 )
 from apis.shared.kb_backend.protocol import DEFAULT_TOP_K, Chunk, distance_from_relevance
 from apis.shared.kb_backend.query_guard import clamp_query
-from apis.shared.kb_backend.resolver import load_record, resolve_backend
+from apis.shared.kb_backend.resolver import (
+    ENGINE_MANAGED,
+    load_record,
+    resolve_backend,
+    resolve_engine_for,
+)
 
 logger = logging.getLogger(__name__)
 
-#: Parity contract (Requirement 3.2): the cap is 2,000 characters on every
-#: backend, unchanged from the value the legacy path has always used. Named so
-#: that a change to it is a visible change to a constant rather than an edit to a
-#: default argument.
+#: Legacy context cap (Requirement 3.2): 2,000 characters, unchanged from the
+#: value the S3 Vectors path has always used. Named so a change to it is a visible
+#: change to a constant rather than an edit to a default argument.
 MAX_CONTEXT_CHARS = 2000
+
+#: Managed context cap (Requirement 3.2, amended by measurement 2026-09-04).
+#: Bedrock's chunks run ~3x larger than the Docling chunks 2,000 was sized for, so
+#: at 2,000 only ~1 of top_k=5 managed chunks clears the cap and four of
+#: reranking's results never reach the model — measured, with wrong/degraded
+#: answers to show for it (HANDOFF §5.40). 8,000 is the evaluation's own §13.6
+#: sizing: the point at which all five managed chunks fit, ~966 extra input
+#: tokens/turn. Pin the literal, not ``MAX_CONTEXT_CHARS * k``: 8,000 is a
+#: property of Bedrock's chunk sizing measured against this corpus, not a multiple
+#: of the legacy figure, and must not silently follow it if that one moves.
+MANAGED_MAX_CONTEXT_CHARS = 8000
+
+
+def resolve_context_cap(assistant_id: str, *, record: Optional[Mapping[str, Any]] = None) -> int:
+    """The context-character cap for this assistant's engine, read at call time.
+
+    Managed knowledge bases get :data:`MANAGED_MAX_CONTEXT_CHARS`; every other
+    engine — and any unreadable record, which resolves to legacy — gets
+    :data:`MAX_CONTEXT_CHARS`. Keyed on the SAME decision the backend resolver
+    uses (:func:`resolve_engine_for`, backed by ``records.resolve_engine``), so
+    the cap and the backend can never disagree about which engine an assistant is
+    on. That single source is the whole point: a second, independent "is this
+    managed?" test here would be a second chance to drift.
+
+    Pass ``record`` when the caller already holds the KB_Record to skip a read.
+    The constants are read inside the function, at call time, never bound as
+    default arguments — see the module-constant note in HANDOFF §3.
+    """
+    engine = resolve_engine_for(assistant_id, record=record)
+    return MANAGED_MAX_CONTEXT_CHARS if engine == ENGINE_MANAGED else MAX_CONTEXT_CHARS
 
 
 async def search_assistant_knowledgebase_with_formatting(

--- a/backend/tests/shared/test_kb_backend_parity.py
+++ b/backend/tests/shared/test_kb_backend_parity.py
@@ -26,8 +26,10 @@ import pytest
 
 from apis.shared.assistants.kb_access import granted
 from apis.shared.assistants.rag_service import (
+    MANAGED_MAX_CONTEXT_CHARS,
     MAX_CONTEXT_CHARS,
     augment_prompt_with_context,
+    resolve_context_cap,
     search_assistant_knowledgebase_with_formatting,
 )
 from apis.shared.kb_backend.protocol import (
@@ -173,6 +175,53 @@ def test_managed_path_requests_top_k_five(managed_kb):
 
     assert backend.calls, "the managed backend was never reached"
     assert backend.calls[0]["top_k"] == DEFAULT_TOP_K
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3.2 — the context cap is engine-aware (amended 2026-09-04, §5.40)
+# ---------------------------------------------------------------------------
+#
+# The cap is NO LONGER identical across backends, and that is the fix, not a
+# regression. Bedrock's chunks are ~3x the Docling chunks 2,000 was sized for, so
+# a single character cap silently admitted 4 legacy chunks and 1 managed chunk —
+# top_k=5 became top_k=1 at the model, with wrong answers to show for it. The cap
+# is now per engine, and these guards pin the two values apart. Measured before/
+# after on the KINES advising corpus (dev ast-1d51df6ea532): at 2,000 the model
+# described 1 of 4 emphasis areas and guessed the rest from outside knowledge;
+# at 8,000 all four came from the documents.
+
+
+def test_managed_gets_the_eight_thousand_char_cap():
+    """A managed knowledge base's context cap is 8,000.
+
+    Pinned to the literal, not to ``MANAGED_MAX_CONTEXT_CHARS`` — that number is a
+    property of Bedrock's chunk sizing measured on a real corpus (eval §13.6,
+    HANDOFF §5.40), so a silent edit to the constant must fail here rather than
+    follow it (HANDOFF §4: never assert a constant against itself).
+    """
+    assert resolve_context_cap(ASSISTANT_ID, record={"retrievalEngine": ENGINE_MANAGED}) == 8000
+
+
+def test_legacy_keeps_the_two_thousand_char_cap():
+    """An absent/legacy record resolves to the historical 2,000 cap, unchanged."""
+    assert resolve_context_cap(ASSISTANT_ID, record={}) == 2000
+
+
+def test_the_managed_and_legacy_caps_are_distinct():
+    """Guard against the two caps collapsing to one value — the mutation that
+    reintroduces §5.40 by making managed inherit the 2,000 figure again."""
+    assert MANAGED_MAX_CONTEXT_CHARS == 8000
+    assert MAX_CONTEXT_CHARS == 2000
+    assert MANAGED_MAX_CONTEXT_CHARS != MAX_CONTEXT_CHARS
+
+
+def test_context_cap_keys_on_the_same_kb_record_read_as_the_backend():
+    """With no record passed, the cap reads the KB_Record itself and gets 8,000
+    for a managed assistant — the SAME read ``resolve_backend`` uses, so the cap
+    and the served engine can never disagree."""
+    boto_patch, _ = _patch_record_and_statuses({})
+    with patch.dict("os.environ", {"DYNAMODB_ASSISTANTS_TABLE_NAME": TABLE_NAME}), boto_patch:
+        assert resolve_context_cap(ASSISTANT_ID) == 8000
     assert DEFAULT_TOP_K == 5, "the parity contract pins top_k at 5"
 
 

--- a/scripts/local-dev/kb-cap-benchmark.py
+++ b/scripts/local-dev/kb-cap-benchmark.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Answer-quality A/B for the managed context cap — the measurement task 16.1 needs.
+
+    cd backend
+    uv run python ../scripts/local-dev/kb-cap-benchmark.py ast-1a90784a7f18 \
+        "is CS434 a required course or an elective?"
+
+    # a scorable question set, one query per line (blank / #-comment lines skipped)
+    uv run python ../scripts/local-dev/kb-cap-benchmark.py ast-1a90784a7f18 -f queries.txt
+
+WHAT THIS ANSWERS, AND WHY kb-compare-engines.py IS NOT ENOUGH
+`kb-compare-engines.py` shows which chunks clear the 2,000-char cap. It measures
+the RETRIEVER. It cannot show the consequence HANDOFF §5.40 is actually about:
+the model gave a *materially wrong answer* (a Major-Core course called an
+elective) even though retrieval ranked the right chunk first, because the cap
+discarded the neighbours that carried the section header. Answer quality is not
+retrieval quality — §5.40's own "earlier demo advice was wrong" note is exactly
+this mistake. So this harness runs the whole path: retrieve → augment → MODEL,
+and prints the answer at each cap side by side.
+
+THE EXPERIMENT IS CONTROLLED
+Everything is held identical across the two arms except ``max_context_length``:
+same assistant, same retrieved chunks (retrieval runs once), same system prompt
+(the assistant's own instructions), same model, temperature 0. The only thing
+that changes is how many of the retrieved chunks survive the cap and reach the
+model. It reuses the REAL production ``rag_service.augment_prompt_with_context``,
+so a passing result here is a statement about the code that ships, not a proxy.
+
+DEFAULT CAPS: 2000 (today) vs 8000 (the evaluation's §13.6 sizing — the point at
+which all five managed chunks fit, at ~966 extra input tokens/turn). Override
+with --caps.
+
+READ + INFERENCE ONLY: issues retrievals, one DynamoDB get for the assistant's
+instructions, and Bedrock Converse calls. Writes nothing, mutates nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "backend" / "src"))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_REPO_ROOT / "backend" / "src" / ".env", override=True)
+
+TOP_K = 5
+DEFAULT_CAPS = (2000, 8000)
+# Held constant across both arms — the cap is the only variable. Sonnet is a
+# capable default; override with --model to match a specific assistant.
+DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+MAX_ANSWER_TOKENS = 1024
+
+
+def _fits_count(chunk_texts: list[str], cap: int) -> int:
+    """How many whole chunks clear the cap, mirroring augment's accumulation."""
+    running = 0
+    fit = 0
+    for i, text in enumerate(chunk_texts, 1):
+        block = f"[Context {i}]\n{text.strip()}\n"
+        if running + len(block) > cap:
+            break
+        running += len(block)
+        fit += 1
+    return fit
+
+
+def _assistant_instructions(assistant_id: str) -> str:
+    import boto3
+
+    table_name = os.environ.get("DYNAMODB_ASSISTANTS_TABLE_NAME")
+    if not table_name:
+        print("  ⚠️  DYNAMODB_ASSISTANTS_TABLE_NAME not set; using an empty system prompt")
+        return ""
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+    item = table.get_item(Key={"PK": f"AST#{assistant_id}", "SK": "METADATA"}).get("Item") or {}
+    return item.get("instructions") or ""
+
+
+def _answer(model_id: str, system_prompt: str, augmented_message: str) -> str:
+    import boto3
+
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    client = boto3.client("bedrock-runtime", region_name=region)
+    kwargs = {
+        "modelId": model_id,
+        "messages": [{"role": "user", "content": [{"text": augmented_message}]}],
+        "inferenceConfig": {"maxTokens": MAX_ANSWER_TOKENS, "temperature": 0.0},
+    }
+    if system_prompt.strip():
+        kwargs["system"] = [{"text": system_prompt}]
+    resp = client.converse(**kwargs)
+    parts = resp["output"]["message"]["content"]
+    return "".join(p.get("text", "") for p in parts).strip()
+
+
+async def run(assistant_id: str, queries: list[str], caps: tuple[int, ...], model_id: str,
+              instructions_file: str | None = None) -> int:
+    from apis.shared.assistants.rag_service import augment_prompt_with_context
+    from apis.shared.kb_backend.resolver import load_record, resolve_backend, resolve_engine_for
+
+    record = load_record(assistant_id)
+    engine = resolve_engine_for(assistant_id, record=record)
+    print(f"assistant       : {assistant_id}")
+    print(f"retrievalEngine : {engine}")
+    print(f"model           : {model_id}")
+    print(f"caps            : {', '.join(str(c) for c in caps)}")
+    if engine != "managed":
+        print(
+            "\n⚠️  This assistant is not on the managed engine, so the cap A/B is not\n"
+            "    meaningful here — legacy chunks are small and the cap rarely bites.\n"
+        )
+
+    backend = resolve_backend(assistant_id, record=record)
+    if instructions_file:
+        instructions = Path(instructions_file).read_text()
+    else:
+        instructions = _assistant_instructions(assistant_id)
+
+    for query in queries:
+        print("\n" + "=" * 100)
+        print(f"QUERY: {query!r}")
+        print("=" * 100)
+
+        chunks = await backend.search(assistant_id, query, TOP_K)
+        texts = [c.text for c in chunks]
+        if not chunks:
+            print("  (retrieval returned nothing — skipping)")
+            continue
+
+        sizes = ", ".join(str(len(t)) for t in texts)
+        print(f"  retrieved {len(chunks)} chunks, sizes (chars): {sizes}")
+
+        for cap in caps:
+            fit = _fits_count(texts, cap)
+            chunk_dicts = [{"text": t} for t in texts]
+            augmented = augment_prompt_with_context(
+                user_message=query, context_chunks=chunk_dicts, max_context_length=cap
+            )
+            try:
+                answer = _answer(model_id, instructions, augmented)
+            except Exception as exc:  # noqa: BLE001 — diagnostic harness
+                answer = f"[model call RAISED {type(exc).__name__}: {str(exc)[:200]}]"
+            print(f"\n  ── cap={cap}  ({fit}/{len(chunks)} chunks reach the model)")
+            for line in answer.splitlines() or [""]:
+                print(f"     {line}")
+
+    print(
+        "\n\nReading this: the two answers differ ONLY because a different number of the\n"
+        "same retrieved chunks reached the model. If cap=2000 is wrong and cap=8000 is\n"
+        "right, that is the §5.40 defect and its fix, measured end to end. Score each\n"
+        "answer against ground truth you hold (this harness does not judge for you).\n"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("assistant_id")
+    parser.add_argument("query", nargs="*", help="a single query (words joined); or use -f")
+    parser.add_argument("-f", "--file", help="file of queries, one per line")
+    parser.add_argument("--caps", default=",".join(str(c) for c in DEFAULT_CAPS), help="comma-separated char caps")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Bedrock model id")
+    parser.add_argument("--instructions-file", default=None, help="file whose contents become the system prompt (else read the assistant's METADATA row)")
+    args = parser.parse_args()
+
+    if args.file:
+        queries = [
+            ln.strip() for ln in Path(args.file).read_text().splitlines() if ln.strip() and not ln.startswith("#")
+        ]
+    elif args.query:
+        queries = [" ".join(args.query)]
+    else:
+        parser.error("give a query or -f FILE")
+
+    caps = tuple(int(c) for c in args.caps.split(",") if c.strip())
+    return asyncio.run(run(args.assistant_id, queries, caps, args.model, args.instructions_file))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

The `2,000`-char context cap (`MAX_CONTEXT_CHARS`) was sized for legacy Docling
chunks. Bedrock's managed-KB chunks run **~3× larger**, so on the managed backend
only ~1 of `top_k=5` reranked chunks cleared the cap — `top_k=5` silently became
`top_k=1` at the model, and it produced **materially wrong answers** (HANDOFF
§5.40: a Major-Core course described as an elective, because the one surviving
chunk had lost its section header).

Holding one character cap across both engines did **not** hold retrieval
constant — it admitted ~4 legacy chunks but ~1 managed chunk. This is task **16.1**.

## The fix

- `rag_service.resolve_context_cap(assistant_id, record=)` returns
  **8,000 for managed, 2,000 for legacy**, keyed on the same `resolve_engine_for`
  the backend resolver uses — so the cap and the served engine can never disagree.
- Both retrieval call sites (`inference_api/chat/routes.py`,
  `app_api/assistants/routes.py`) now resolve and pass the cap.
- `8,000` is the evaluation's own §13.6 sizing (all five managed chunks fit,
  ~966 extra input tokens/turn). The managed-only asymmetry **restores** parity in
  the unit that matters — chunks reaching the model, not characters.

## Tests

- 4 new guards in `tests/shared/test_kb_backend_parity.py` (file: 23 passed).
- **Mutation-tested**: collapsing managed back to the legacy cap fails two
  specifically-named tests (`2000 != 8000`); the mutant compiles (not a
  syntax-error false positive).

## Measured before/after

End-to-end on a **prod-derived** KINES advising corpus re-created in dev
(`scripts/local-dev/kb-cap-benchmark.py`, same chunks/model/temp, cap the only
variable):

- **Enumeration** ("four emphasis areas"): at 2,000 the model described **1 of 4**
  from the documents and **guessed the rest from outside knowledge** (a rule
  violation); at 8,000 all four came from the documents.
- **Compare-and-contrast** (the case eval §13.6 flagged untested): at 2,000 the
  second emphasis lost its credential + career list; at 8,000 both complete.
- **Single-fact control**: correct at both caps — **no regression**.

## Spec

- Requirement 3.2 amended (was "2,000 on both") to the engine-aware cap, with the
  measurement; the out-of-scope "raising the cap" note marked RESOLVED.
- `tasks.md` 16.1 checked off.

## Not included / follow-ups

Legacy path keeps 2,000. Prod flags remain off. Remaining §16 items (16.2 diagram
quality, 16.3 fail-open status filter, 16.4 UI vocabulary, 16.5 dead-letter
reconcile) are separate.
