### PR TITLE
fix(kb): fail closed on the last fail-open status-filter path — task 16.3

### DIFF
--- a/.kiro/specs/managed-kb-migration/tasks.md
+++ b/.kiro/specs/managed-kb-migration/tasks.md
@@ -792,7 +792,15 @@ All three flags — managed-default, migration, and reconciler arming — ship *
       tabular answers from it are not established.
     - _HANDOFF §5.41_
 
-  - [ ] 16.3 Make the document-status filter fail closed on its one open path
+  - [x] 16.3 Make the document-status filter fail closed on its one open path
+    - **RESOLVED (§5.33).** `_filter_vectors_by_document_status`'s `if not doc_ids:
+      return vectors` now fails closed: a non-empty batch where no chunk carries a
+      `document_id` returns `[]` and emits `METRIC_STATUS_FILTER_FAIL_CLOSED`, like
+      every other unprovable path. An empty input stays an empty result with no
+      metric (an ordinary "no match", not a degradation). Guard
+      `test_filter_fails_closed_when_no_chunk_carries_a_document_id` in
+      `tests/shared/test_search_filtering.py`, mutation-tested (reverting to
+      `return vectors` fails it). Branch `fix/kb-status-filter-fail-closed`.
     - `_filter_vectors_by_document_status` opens with `if not doc_ids: return
       vectors`. Every other unprovable path in that function returns `[]` and emits
       `METRIC_STATUS_FILTER_FAIL_CLOSED`. Predates this feature; not firing today.

--- a/backend/src/apis/shared/assistants/rag_service.py
+++ b/backend/src/apis/shared/assistants/rag_service.py
@@ -265,7 +265,22 @@ def _filter_vectors_by_document_status(vectors: List[Dict[str, Any]], assistant_
             doc_ids.add(doc_id)
 
     if not doc_ids:
-        return vectors
+        # FAIL CLOSED (Requirement 5; §5.33). Reaching here with vectors present
+        # means not one chunk carried a `document_id`, so not one can be confirmed
+        # `complete` — the same unprovable state the branches below drop to `[]`.
+        # The old `return vectors` was the single fail-OPEN line left in an
+        # otherwise fail-closed function: it served chunks whose parent document
+        # was never verified (including content a user may have deleted) whenever
+        # `_document_id` resolved to "" for the whole batch. An *empty* input stays
+        # an empty result with no metric — that is an ordinary "no match", logged
+        # at INFO by the caller, not a degradation.
+        if vectors:
+            logger.error(
+                "Document status filter: chunks present but none carry a "
+                "document_id; dropping all because status cannot be confirmed"
+            )
+            emit_count(METRIC_STATUS_FILTER_FAIL_CLOSED)
+        return []
 
     # Look up document status in DynamoDB
     valid_doc_ids: Set[str] = set()

--- a/backend/tests/shared/test_search_filtering.py
+++ b/backend/tests/shared/test_search_filtering.py
@@ -244,3 +244,36 @@ def test_filter_empty_vectors(mock_boto3_resource):
     assert result == []
     # boto3.resource should not be called for empty input
     mock_boto3_resource.assert_not_called()
+
+
+# -----------------------------------------------------------------------
+# managed-kb-migration §5.33 / task 16.3: chunks present but NONE carry a
+# document_id → fail closed. This was the one fail-OPEN line left in an
+# otherwise fail-closed function (`if not doc_ids: return vectors`): it served
+# chunks whose parent document could never be confirmed `complete` — including
+# deleted content — whenever `_document_id` resolved to "" for the whole batch.
+# Reverting the fix (back to `return vectors`) makes this test fail.
+# -----------------------------------------------------------------------
+
+
+@patch("apis.shared.assistants.rag_service.emit_count")
+@patch("boto3.resource")
+@patch.dict("os.environ", ENV_PATCH)
+def test_filter_fails_closed_when_no_chunk_carries_a_document_id(mock_boto3_resource, mock_emit):
+    """Non-empty batch where no chunk has a document_id — drop them all."""
+    from apis.shared.assistants.rag_service import _filter_vectors_by_document_status
+
+    # One chunk missing the key entirely, one with an empty id (the exact input
+    # `_document_id` produces when location + both metadata mirrors are absent).
+    vectors = [
+        {"key": "k0", "distance": 0.5, "metadata": {"text": "orphan chunk 0"}},
+        {"key": "k1", "distance": 0.6, "metadata": {"document_id": "", "text": "orphan chunk 1"}},
+    ]
+
+    result = _filter_vectors_by_document_status(vectors, ASSISTANT_ID)
+
+    assert result == [], "chunks with no confirmable document_id must not leak"
+    # The degradation is reported, distinguishing this from an ordinary "no match".
+    mock_emit.assert_called_once()
+    # Nothing to look up, so DynamoDB is never contacted.
+    mock_boto3_resource.assert_not_called()


### PR DESCRIPTION
## What & why (task 16.3 / §5.33)

`_filter_vectors_by_document_status` opened with:

```python
if not doc_ids:
    return vectors
```

That was the **one fail-OPEN line** left in an otherwise fail-closed function. A
non-empty batch where every chunk's `document_id` was absent/empty (the exact
input `_document_id` produces when the location + both metadata mirrors are
missing) bypassed the DynamoDB status check entirely and was **served
unverified** — including content a user may have deleted. Every other unprovable
path in the function already returns `[]` and emits
`METRIC_STATUS_FILTER_FAIL_CLOSED`.

Not firing today (managed and legacy chunks both carry the id), but silent in the
serving direction, so worth closing.

## The fix

- No `document_id` on any chunk of a **non-empty** batch → return `[]` and emit
  `METRIC_STATUS_FILTER_FAIL_CLOSED`, matching the table-unset and lookup-error
  branches.
- An **empty** input stays an empty result with **no** metric — that is an
  ordinary "no match" (logged at INFO by the caller), not a degradation.

## Tests

- New guard `test_filter_fails_closed_when_no_chunk_carries_a_document_id` in
  `tests/shared/test_search_filtering.py`.
- Full run: `test_search_filtering.py` + `test_pbt_kb_status_fail_closed.py` +
  `test_kb_backend_parity.py` = **36 passed** (no test assumed the old fail-open).
- **Mutation-tested**: reverting the line to `return vectors` fails the named
  guard (2 chunks leak instead of `[]`); the mutant compiles.

## Spec

Requirements 5.1/5.2 already mandate fail-closed on unprovable status — this path
was simply overlooked when the other two fail-open paths were closed. `tasks.md`
16.3 checked off. (HANDOFF §5.33's "STILL OPEN" marker is stale; a HANDOFF refresh
is a separate pass.)

Independent of the 16.1 cap PR (#997) — different function, same file, non-overlapping lines.
