### PR TITLE
fix: retain MCP App UI resources per conversation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,28 +4,39 @@
     {
       "name": "frontend",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start"],
+      "runtimeArgs": [
+        "run",
+        "start"
+      ],
       "port": 4200,
-      "cwd": "frontend/ai.client"
+      "cwd": "frontend/ai.client",
+      "autoPort": false
     },
     {
       "name": "app-api",
       "runtimeExecutable": "/Users/philmerrell/Repos/agentcore-public-stack/backend/.venv/bin/python",
-      "runtimeArgs": ["main.py"],
+      "runtimeArgs": [
+        "main.py"
+      ],
       "port": 8000,
       "cwd": "backend/src/apis/app_api"
     },
     {
       "name": "inference-api",
       "runtimeExecutable": "/Users/philmerrell/Repos/agentcore-public-stack/backend/.venv/bin/python",
-      "runtimeArgs": ["main.py"],
+      "runtimeArgs": [
+        "main.py"
+      ],
       "port": 8001,
       "cwd": "backend/src/apis/inference_api"
     },
     {
       "name": "docs-site",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
       "port": 4321,
       "cwd": "docs-site"
     }

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -4,6 +4,7 @@ import { provideMarkdown, MarkdownService } from 'ngx-markdown';
 import { AssistantMessageComponent } from './assistant-message.component';
 import { Message, ContentBlock } from '../../../services/models/message.model';
 import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
+import { ChatStateService } from '../../../services/chat/chat-state.service';
 import { UiResourceEvent } from '../../../../shared/utils/stream-parser/stream-parser-types';
 
 function makeMessage(content: ContentBlock[]): Message {
@@ -52,6 +53,8 @@ function makePromotedVisualToolBlock(name: string): ContentBlock {
     },
   };
 }
+
+const VIEWED_SESSION = 'sess-viewed';
 
 describe('AssistantMessageComponent', () => {
   let fixture: ComponentFixture<AssistantMessageComponent>;
@@ -254,7 +257,9 @@ describe('AssistantMessageComponent', () => {
         toolUseId: 'tooluse_mcp_app_1',
         result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
       });
-      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_1'));
+      // Resources are held per conversation and read against the viewed one.
+      TestBed.inject(ChatStateService).setViewedSession(VIEWED_SESSION);
+      mcpAppState.recordLive(VIEWED_SESSION, makeUiResource('tooluse_mcp_app_1'));
 
       fixture.componentRef.setInput('message', makeMessage([tool]));
       fixture.detectChanges();
@@ -281,6 +286,8 @@ describe('AssistantMessageComponent', () => {
         result: { status: 'success', content: [{ text: 'Diagram displayed!' }] },
       });
 
+      TestBed.inject(ChatStateService).setViewedSession(VIEWED_SESSION);
+
       // Initial render: ui_resource hasn't arrived yet → tool folded into group.
       fixture.componentRef.setInput('message', makeMessage([tool]));
       fixture.detectChanges();
@@ -289,7 +296,7 @@ describe('AssistantMessageComponent', () => {
       // ui_resource arrives ~40ms after tool_result on the wire. The
       // displayBlocks computed must re-run on the McpAppStateService signal
       // update, or the tool stays folded forever.
-      mcpAppState.recordLive(makeUiResource('tooluse_mcp_app_2'));
+      mcpAppState.recordLive(VIEWED_SESSION, makeUiResource('tooluse_mcp_app_2'));
       fixture.detectChanges();
 
       const blocks = component.displayBlocks();

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.ts
@@ -13,6 +13,7 @@ import {
   OAuthConsentService,
 } from '../../../../services/oauth-consent/oauth-consent.service';
 import { McpAppStateService } from '../../../services/mcp-apps/mcp-app-state.service';
+import { ChatStateService } from '../../../services/chat/chat-state.service';
 import type { ToolResultData } from './tool-use/tool-renderer-registry.service';
 
 // ──────────────────────────────────────────────────────────────
@@ -306,6 +307,7 @@ export class AssistantMessageComponent {
 
   private consentService = inject(OAuthConsentService);
   private mcpAppState = inject(McpAppStateService);
+  private chatState = inject(ChatStateService);
 
   /**
    * Transforms content blocks into display blocks.
@@ -386,8 +388,12 @@ export class AssistantMessageComponent {
         // signal here keeps `displayBlocks` reactive to a late-arriving
         // `ui_resource` — the computed re-runs when McpAppStateService
         // updates and the tool gets promoted retroactively (vs. staying
-        // folded into the group forever).
-        const hasMcpAppResource = this.mcpAppState.has(toolUse.toolUseId);
+        // folded into the group forever). Resources are held per
+        // conversation, so the lookup is scoped to the viewed one.
+        const hasMcpAppResource = this.mcpAppState.has(
+          this.chatState.viewedSessionId(),
+          toolUse.toolUseId,
+        );
 
         if (promotedVisual || hasMcpAppResource) {
           // Promoted visuals and MCP Apps both need their own first-class

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -440,7 +440,9 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   /** The UI resource for this tool invocation (undefined ⇒ render nothing). */
   protected readonly resource = computed(() => {
     const id = this.toolUseId();
-    return id ? this.mcpAppState.get(id) : undefined;
+    return id
+      ? this.mcpAppState.get(this.chatState.viewedSessionId(), id)
+      : undefined;
   });
 
   /** Whether the header's server icon `<img>` failed to load (→ glyph). */
@@ -534,7 +536,9 @@ export class McpAppFrameComponent implements ToolResultRenderer {
    */
   protected readonly partialInput = computed(() => {
     const id = this.toolUseId();
-    return id ? this.mcpAppState.getPartialInput(id) : undefined;
+    return id
+      ? this.mcpAppState.getPartialInput(this.chatState.viewedSessionId(), id)
+      : undefined;
   });
 
   /**

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -594,13 +594,15 @@ export class StreamParserService {
       onUiResource: (data: UiResourceEvent) => {
         // Inline event (arrives right after its tool_result, mid-stream),
         // unlike the post-message_stop side channels above — just record
-        // it keyed by toolUseId. The tool-use renderer picks it up
-        // reactively and swaps in the MCP App frame. Viewed-session only:
-        // McpAppStateService is reset on route change, so recording for a
-        // background conversation would be wiped before it could render.
-        if (this.isViewedSession(state)) {
-          this.mcpAppState.recordLive(data);
-        }
+        // it under this stream's own session, keyed by toolUseId. The
+        // tool-use renderer picks it up reactively and swaps in the MCP App
+        // frame. Deliberately NOT viewed-session-scoped: McpAppStateService
+        // retains per conversation rather than resetting on route change, so
+        // a background conversation's App is there when the user navigates
+        // to it. Dropping it here would lose it for good — the inline event
+        // never re-streams and the persisted replay rides on a `GET
+        // /messages` that navigate-back skips.
+        this.mcpAppState.recordLive(state.sessionId, data);
       },
 
       onToolInputPartial: (data: ToolInputPartialEvent) => {
@@ -608,10 +610,13 @@ export class StreamParserService {
         // UI tool's args are still streaming (after early frame mount). Record
         // the latest healed prefix keyed by toolUseId; the frame relays it to
         // the App as `ui/notifications/tool-input-partial` for progressive
-        // rendering (e.g. Excalidraw's guided camera tour).
-        if (this.isViewedSession(state)) {
-          this.mcpAppState.recordPartialInput(data.toolUseId, data.arguments);
-        }
+        // rendering (e.g. Excalidraw's guided camera tour). Recorded under
+        // this stream's own session, same as the resource above.
+        this.mcpAppState.recordPartialInput(
+          state.sessionId,
+          data.toolUseId,
+          data.arguments,
+        );
       },
 
       onSessionTitle: (data: SessionTitleEvent) => {

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.spec.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { McpAppStateService } from './mcp-app-state.service';
 import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
 
+const SESSION_A = 'sess-a';
+const SESSION_B = 'sess-b';
+
 function ev(toolUseId: string, html = '<h1>hi</h1>'): UiResourceEvent {
   return {
     type: 'ui_resource',
@@ -26,87 +29,136 @@ describe('McpAppStateService', () => {
   });
 
   it('starts empty', () => {
-    expect(svc.hasApps()).toBe(false);
-    expect(svc.has('tu-1')).toBe(false);
-    expect(svc.get('tu-1')).toBeUndefined();
+    expect(svc.has(SESSION_A, 'tu-1')).toBe(false);
+    expect(svc.get(SESSION_A, 'tu-1')).toBeUndefined();
   });
 
   it('records and retrieves a resource by toolUseId', () => {
     const e = ev('tu-1');
-    svc.recordLive(e);
-    expect(svc.has('tu-1')).toBe(true);
-    expect(svc.get('tu-1')).toEqual(e);
-    expect(svc.hasApps()).toBe(true);
+    svc.recordLive(SESSION_A, e);
+    expect(svc.has(SESSION_A, 'tu-1')).toBe(true);
+    expect(svc.get(SESSION_A, 'tu-1')).toEqual(e);
   });
 
   it('last write wins for the same toolUseId', () => {
-    svc.recordLive(ev('tu-1', '<old>'));
-    svc.recordLive(ev('tu-1', '<new>'));
-    expect(svc.get('tu-1')?.html).toBe('<new>');
+    svc.recordLive(SESSION_A, ev('tu-1', '<old>'));
+    svc.recordLive(SESSION_A, ev('tu-1', '<new>'));
+    expect(svc.get(SESSION_A, 'tu-1')?.html).toBe('<new>');
   });
 
   it('keeps distinct invocations separate', () => {
-    svc.recordLive(ev('tu-1'));
-    svc.recordLive(ev('tu-2'));
-    expect(svc.get('tu-1')?.resourceUri).toBe('ui://srv/tu-1');
-    expect(svc.get('tu-2')?.resourceUri).toBe('ui://srv/tu-2');
+    svc.recordLive(SESSION_A, ev('tu-1'));
+    svc.recordLive(SESSION_A, ev('tu-2'));
+    expect(svc.get(SESSION_A, 'tu-1')?.resourceUri).toBe('ui://srv/tu-1');
+    expect(svc.get(SESSION_A, 'tu-2')?.resourceUri).toBe('ui://srv/tu-2');
   });
 
-  it('reset() drops everything (conversation teardown)', () => {
-    svc.recordLive(ev('tu-1'));
-    svc.recordPartialInput('tu-1', { elements: [] });
+  it('reset() drops everything (full teardown)', () => {
+    svc.recordLive(SESSION_A, ev('tu-1'));
+    svc.recordPartialInput(SESSION_A, 'tu-1', { elements: [] });
     svc.reset();
-    expect(svc.hasApps()).toBe(false);
-    expect(svc.has('tu-1')).toBe(false);
-    expect(svc.getPartialInput('tu-1')).toBeUndefined();
+    expect(svc.has(SESSION_A, 'tu-1')).toBe(false);
+    expect(svc.getPartialInput(SESSION_A, 'tu-1')).toBeUndefined();
+  });
+
+  it('treats a null session id as empty (no viewed conversation)', () => {
+    svc.recordLive(SESSION_A, ev('tu-1'));
+    expect(svc.has(null, 'tu-1')).toBe(false);
+    expect(svc.get(null, 'tu-1')).toBeUndefined();
+    expect(svc.getPartialInput(null, 'tu-1')).toBeUndefined();
+  });
+
+  describe('per-conversation retention', () => {
+    // The regression this shape exists to prevent: leaving a conversation
+    // and coming back dropped every App frame to a plain tool card, because
+    // the registry was reset on navigation while `loadMessagesForSession`
+    // skips the `GET /messages` (and its `uiResources` sidecar) for a
+    // conversation whose messages are already cached.
+    it('keeps a conversation\'s resources across a visit to another one', () => {
+      svc.seedFromHydration(SESSION_A, [ev('tu-1')]);
+      svc.recordLive(SESSION_A, ev('tu-2'));
+
+      // User navigates to B (which has its own App), then back to A.
+      svc.recordLive(SESSION_B, ev('tu-3'));
+
+      expect(svc.has(SESSION_A, 'tu-1')).toBe(true);
+      expect(svc.has(SESSION_A, 'tu-2')).toBe(true);
+    });
+
+    it('scopes lookups to their own conversation', () => {
+      svc.recordLive(SESSION_A, ev('tu-1'));
+      expect(svc.has(SESSION_B, 'tu-1')).toBe(false);
+      expect(svc.get(SESSION_B, 'tu-1')).toBeUndefined();
+    });
+
+    it('retains a background stream\'s resource for when the user opens it', () => {
+      // recordLive is no longer viewed-session-gated: a conversation
+      // streaming in the background records into its own bucket.
+      svc.recordLive(SESSION_B, ev('tu-9'));
+      expect(svc.get(SESSION_B, 'tu-9')?.resourceUri).toBe('ui://srv/tu-9');
+    });
   });
 
   describe('recordPartialInput', () => {
     it('records and retrieves the latest streamed partial input', () => {
-      expect(svc.getPartialInput('tu-1')).toBeUndefined();
-      svc.recordPartialInput('tu-1', { elements: [{ type: 'rect' }] });
-      expect(svc.getPartialInput('tu-1')).toEqual({
+      expect(svc.getPartialInput(SESSION_A, 'tu-1')).toBeUndefined();
+      svc.recordPartialInput(SESSION_A, 'tu-1', {
+        elements: [{ type: 'rect' }],
+      });
+      expect(svc.getPartialInput(SESSION_A, 'tu-1')).toEqual({
         elements: [{ type: 'rect' }],
       });
     });
 
     it('last write wins (the backend streams a growing healed prefix)', () => {
-      svc.recordPartialInput('tu-1', { elements: [{ type: 'rect' }] });
-      svc.recordPartialInput('tu-1', {
+      svc.recordPartialInput(SESSION_A, 'tu-1', {
+        elements: [{ type: 'rect' }],
+      });
+      svc.recordPartialInput(SESSION_A, 'tu-1', {
         elements: [{ type: 'rect' }, { type: 'cameraUpdate' }],
       });
       expect(
-        (svc.getPartialInput('tu-1')?.['elements'] as unknown[]).length,
+        (svc.getPartialInput(SESSION_A, 'tu-1')?.['elements'] as unknown[])
+          .length,
       ).toBe(2);
     });
 
     it('keeps partial input separate per toolUseId', () => {
-      svc.recordPartialInput('tu-1', { a: 1 });
-      svc.recordPartialInput('tu-2', { b: 2 });
-      expect(svc.getPartialInput('tu-1')).toEqual({ a: 1 });
-      expect(svc.getPartialInput('tu-2')).toEqual({ b: 2 });
+      svc.recordPartialInput(SESSION_A, 'tu-1', { a: 1 });
+      svc.recordPartialInput(SESSION_A, 'tu-2', { b: 2 });
+      expect(svc.getPartialInput(SESSION_A, 'tu-1')).toEqual({ a: 1 });
+      expect(svc.getPartialInput(SESSION_A, 'tu-2')).toEqual({ b: 2 });
+    });
+
+    it('keeps partial input separate per conversation', () => {
+      svc.recordPartialInput(SESSION_A, 'tu-1', { a: 1 });
+      expect(svc.getPartialInput(SESSION_B, 'tu-1')).toBeUndefined();
     });
   });
 
   describe('seedFromHydration', () => {
     it('seeds persisted resources so the frame re-renders on reload', () => {
-      svc.seedFromHydration([ev('tu-1'), ev('tu-2')]);
-      expect(svc.has('tu-1')).toBe(true);
-      expect(svc.get('tu-2')?.resourceUri).toBe('ui://srv/tu-2');
-      expect(svc.hasApps()).toBe(true);
+      svc.seedFromHydration(SESSION_A, [ev('tu-1'), ev('tu-2')]);
+      expect(svc.has(SESSION_A, 'tu-1')).toBe(true);
+      expect(svc.get(SESSION_A, 'tu-2')?.resourceUri).toBe('ui://srv/tu-2');
     });
 
     it('is a no-op for an empty list', () => {
-      svc.seedFromHydration([]);
-      expect(svc.hasApps()).toBe(false);
+      svc.seedFromHydration(SESSION_A, []);
+      expect(svc.has(SESSION_A, 'tu-1')).toBe(false);
     });
 
     it('does not clobber a live recordLive entry (non-clobbering)', () => {
-      svc.recordLive(ev('tu-1', '<live>'));
+      svc.recordLive(SESSION_A, ev('tu-1', '<live>'));
       // A slow hydration response arriving after the live event must not
       // overwrite the fresher live resource.
-      svc.seedFromHydration([ev('tu-1', '<stale>')]);
-      expect(svc.get('tu-1')?.html).toBe('<live>');
+      svc.seedFromHydration(SESSION_A, [ev('tu-1', '<stale>')]);
+      expect(svc.get(SESSION_A, 'tu-1')?.html).toBe('<live>');
+    });
+
+    it('seeds into the named conversation only', () => {
+      svc.seedFromHydration(SESSION_A, [ev('tu-1')]);
+      expect(svc.has(SESSION_B, 'tu-1')).toBe(false);
     });
   });
 });

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-state.service.ts
@@ -1,52 +1,61 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import type { UiResourceEvent } from '../../../shared/utils/stream-parser';
 
 /**
- * Per-conversation registry of MCP App UI resources (SEP-1865), keyed by the
- * originating `toolUseId`. Structural sibling of `ArtifactStateService` /
- * `CompactionSummaryService`: a live SSE path (`recordLive`) and a `reset()`
- * the session page calls on conversation change.
+ * Registry of MCP App UI resources (SEP-1865), keyed by conversation and then
+ * by the originating `toolUseId`.
  *
- * The `ui_resource` event is INLINE (it arrives right after its
- * `tool_result`), so a refreshed conversation re-streams nothing. To survive
- * a reload, app-api persists each resource and replays it on the
- * `GET /messages` response's `uiResources` sidecar; `seedFromHydration`
- * re-seeds this registry from that list so the `mcp-app-frame` re-renders.
- * Iframes otherwise persist for the lifetime of the conversation per the
- * scoping doc; teardown is on `reset()`.
+ * Unlike `ArtifactStateService` / `CompactionSummaryService` — which are
+ * viewed-session-scoped and reset on conversation change — this registry
+ * RETAINS every conversation it has seen for the lifetime of the SPA session,
+ * mirroring the message cache in `MessageMapService`. That retention is the
+ * whole point: the `ui_resource` event is inline (it arrives at the tool's
+ * `content_block_start`, mid-stream) and never re-streams, and the only
+ * server-side replay is the `uiResources` sidecar on `GET /messages` — a
+ * request `loadMessagesForSession` deliberately skips when the conversation's
+ * messages are already in memory. A registry that reset on navigation
+ * therefore had no way back: leaving a conversation and returning to it
+ * dropped every App frame to a plain tool card until a hard refresh.
+ *
+ * Reads are scoped to a conversation so a `toolUseId` can only ever resolve
+ * inside the conversation that produced it. Writes carry their own session id
+ * (the streaming session, which is not necessarily the viewed one — a
+ * background conversation's Apps are recorded too, and are there when the user
+ * navigates back).
+ *
+ * Iframe teardown is not this registry's job: a frame unmounts when its
+ * message-list component is destroyed on conversation change.
  *
  * The whole surface is dark until the backend `AGENTCORE_MCP_APPS_HOST_ENABLED`
  * flag is flipped, so when it's off nothing is recorded or hydrated.
  */
 @Injectable({ providedIn: 'root' })
 export class McpAppStateService {
-  private readonly byToolUseId = signal<ReadonlyMap<string, UiResourceEvent>>(
-    new Map(),
-  );
-
-  /**
-   * Latest streamed partial tool input per `toolUseId` (SEP-1865
-   * `tool-input-partial`). Populated while a UI tool's arguments are still
-   * streaming, after the frame mounts early; the frame relays each healed
-   * prefix to the App for progressive rendering. Last write wins (the backend
-   * sends the growing healed prefix). Cleared on `reset()`.
-   */
-  private readonly partialInputByToolUseId = signal<
-    ReadonlyMap<string, Record<string, unknown>>
+  private readonly bySession = signal<
+    ReadonlyMap<string, ReadonlyMap<string, UiResourceEvent>>
   >(new Map());
 
-  /** True once any MCP App resource has been recorded this conversation. */
-  readonly hasApps = computed(() => this.byToolUseId().size > 0);
+  /**
+   * Latest streamed partial tool input per conversation and `toolUseId`
+   * (SEP-1865 `tool-input-partial`). Populated while a UI tool's arguments are
+   * still streaming, after the frame mounts early; the frame relays each
+   * healed prefix to the App for progressive rendering. Last write wins (the
+   * backend sends the growing healed prefix). Retained alongside the
+   * resources.
+   */
+  private readonly partialInputBySession = signal<
+    ReadonlyMap<string, ReadonlyMap<string, Record<string, unknown>>>
+  >(new Map());
 
   /**
    * Record the UI resource for a tool invocation. Last write wins — a tool
    * that re-emits for the same `toolUseId` replaces the prior resource
    * (the iframe rebinds to the new HTML). New invocations get new ids.
    */
-  recordLive(event: UiResourceEvent): void {
-    const next = new Map(this.byToolUseId());
-    next.set(event.toolUseId, event);
-    this.byToolUseId.set(next);
+  recordLive(sessionId: string, event: UiResourceEvent): void {
+    this.bySession.update(map =>
+      writeEntry(map, sessionId, event.toolUseId, event),
+    );
   }
 
   /**
@@ -55,13 +64,20 @@ export class McpAppStateService {
    * `toolUseId` so a slow response can't undo a live `recordLive` entry
    * (matches `ArtifactStateService.seedFromHydration` semantics).
    */
-  seedFromHydration(list: readonly UiResourceEvent[]): void {
+  seedFromHydration(
+    sessionId: string,
+    list: readonly UiResourceEvent[],
+  ): void {
     if (!list.length) return;
-    const next = new Map(this.byToolUseId());
-    for (const event of list) {
-      if (!next.has(event.toolUseId)) next.set(event.toolUseId, event);
-    }
-    this.byToolUseId.set(next);
+    this.bySession.update(map => {
+      const existing = map.get(sessionId);
+      const next = new Map(existing ?? []);
+      for (const event of list) {
+        if (!next.has(event.toolUseId)) next.set(event.toolUseId, event);
+      }
+      if (existing && next.size === existing.size) return map;
+      return new Map(map).set(sessionId, next);
+    });
   }
 
   /**
@@ -70,22 +86,31 @@ export class McpAppStateService {
    * growing, server-healed prefix of the arguments object.
    */
   recordPartialInput(
+    sessionId: string,
     toolUseId: string,
     args: Record<string, unknown>,
   ): void {
-    const next = new Map(this.partialInputByToolUseId());
-    next.set(toolUseId, args);
-    this.partialInputByToolUseId.set(next);
+    this.partialInputBySession.update(map =>
+      writeEntry(map, sessionId, toolUseId, args),
+    );
   }
 
   /** Latest streamed partial tool input for a tool invocation, or undefined. */
-  getPartialInput(toolUseId: string): Record<string, unknown> | undefined {
-    return this.partialInputByToolUseId().get(toolUseId);
+  getPartialInput(
+    sessionId: string | null,
+    toolUseId: string,
+  ): Record<string, unknown> | undefined {
+    if (!sessionId) return undefined;
+    return this.partialInputBySession().get(sessionId)?.get(toolUseId);
   }
 
   /** The UI resource for a tool invocation, or undefined. */
-  get(toolUseId: string): UiResourceEvent | undefined {
-    return this.byToolUseId().get(toolUseId);
+  get(
+    sessionId: string | null,
+    toolUseId: string,
+  ): UiResourceEvent | undefined {
+    if (!sessionId) return undefined;
+    return this.bySession().get(sessionId)?.get(toolUseId);
   }
 
   /**
@@ -93,13 +118,26 @@ export class McpAppStateService {
    * so a `computed()` that calls it stays reactive to the `ui_resource`
    * event arriving after the tool-use block first renders.
    */
-  has(toolUseId: string): boolean {
-    return this.byToolUseId().has(toolUseId);
+  has(sessionId: string | null, toolUseId: string): boolean {
+    if (!sessionId) return false;
+    return this.bySession().get(sessionId)?.has(toolUseId) ?? false;
   }
 
-  /** Drop all resources — called on conversation change (teardown). */
+  /** Drop everything — full teardown (e.g. sign-out). */
   reset(): void {
-    this.byToolUseId.set(new Map());
-    this.partialInputByToolUseId.set(new Map());
+    this.bySession.set(new Map());
+    this.partialInputBySession.set(new Map());
   }
+}
+
+/** Immutably set `sessionId → toolUseId → value`, last write wins. */
+function writeEntry<T>(
+  map: ReadonlyMap<string, ReadonlyMap<string, T>>,
+  sessionId: string,
+  toolUseId: string,
+  value: T,
+): ReadonlyMap<string, ReadonlyMap<string, T>> {
+  const next = new Map(map.get(sessionId) ?? []);
+  next.set(toolUseId, value);
+  return new Map(map).set(sessionId, next);
 }

--- a/frontend/ai.client/src/app/session/services/session/message-map.service.ts
+++ b/frontend/ai.client/src/app/session/services/session/message-map.service.ts
@@ -436,9 +436,15 @@ export class MessageMapService {
       // resources the backend replays on this response. The inline
       // `ui_resource` event never re-streams, so without this the
       // `mcp-app-frame` falls back to a plain tool card after a refresh.
-      // session.page resets McpAppStateService before this load, so the
-      // non-clobbering seed lands cleanly.
-      this.mcpAppState.seedFromHydration(messagesResponse.uiResources ?? []);
+      // Only reached on a real fetch — `loadMessagesForSession` skips this
+      // whole path once a conversation's messages are cached, which is why
+      // McpAppStateService retains per conversation instead of resetting on
+      // navigation. The seed is non-clobbering, so it can't undo a live
+      // `recordLive` entry for the same invocation.
+      this.mcpAppState.seedFromHydration(
+        sessionId,
+        messagesResponse.uiResources ?? [],
+      );
     } finally {
       if (showLoading) {
         this._isLoadingSession.set(null);

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -20,7 +20,6 @@ import { CompactionSummaryService } from './services/chat/compaction-summary.ser
 import { SteeringService } from './services/chat/steering.service';
 import { ArtifactStateService } from './services/artifacts/artifact-state.service';
 import { ArtifactHttpService } from './services/artifacts/artifact-http.service';
-import { McpAppStateService } from './services/mcp-apps/mcp-app-state.service';
 import { McpAppCardStateService } from './services/mcp-apps/mcp-app-card-state.service';
 import { McpAppCardHttpService } from './services/mcp-apps/mcp-app-card-http.service';
 import { McpAppConsentService } from './services/mcp-apps/mcp-app-consent.service';
@@ -62,7 +61,6 @@ export class ConversationPage implements OnDestroy {
   private compactionSummary = inject(CompactionSummaryService);
   private steering = inject(SteeringService);
   private artifactState = inject(ArtifactStateService);
-  private mcpAppState = inject(McpAppStateService);
   private mcpAppCardState = inject(McpAppCardStateService);
   private mcpAppCardHttp = inject(McpAppCardHttpService);
   private mcpAppConsent = inject(McpAppConsentService);
@@ -419,12 +417,15 @@ export class ConversationPage implements OnDestroy {
       // from the app-api list endpoint below.
       this.artifactState.reset();
 
-      // MCP App frames persist for the conversation's lifetime per the
-      // scoping doc; teardown is on conversation change. Clear before the
-      // next load — loadMessagesForSession re-seeds from the persisted
-      // `uiResources` sidecar on the messages response so frames survive a
-      // refresh (the inline `ui_resource` event itself only arrives live).
-      this.mcpAppState.reset();
+      // MCP App UI resources are deliberately NOT cleared here. They are
+      // held per conversation in McpAppStateService and retained for the
+      // SPA session, mirroring the message cache: the only server-side
+      // replay is the `uiResources` sidecar on `GET /messages`, and
+      // loadMessagesForSession skips that request once a conversation's
+      // messages are already in memory — so a reset on navigation had no
+      // way back and dropped every frame to a plain tool card until a hard
+      // refresh. The iframes themselves still tear down with the message
+      // list components on conversation change.
 
       // Option A (PR #6): app-initiated tool cards DO re-hydrate (the
       // broker is in-memory). Any open consent prompt for the prior


### PR DESCRIPTION
## The bug

A conversation containing an MCP App (e.g. the Google Tasks server) renders its App frame fine on load and after a hard refresh — but navigating away to another conversation and back dropped the frame to a plain tool card. Only a refresh brought it back.

## Root cause

Two things collided:

1. **`session.page` reset `McpAppStateService` on every route change** — [session.page.ts:427](https://github.com/Boise-State-Development/agentcore-public-stack/blob/develop/frontend/ai.client/src/app/session/session.page.ts#L427).
2. **The only thing that re-seeds it is the `uiResources` sidecar on `GET /messages`** — and `loadMessagesForSession` deliberately skips that request once a conversation's messages are cached. `MessageMapService` never evicts, so the *second* visit to any conversation always hits that short-circuit.

The inline `ui_resource` event never re-streams, so with the sidecar skipped and the registry cleared, there was no way back. A refresh worked only because it destroyed the message cache and forced a real fetch.

Artifacts and app-initiated cards don't break the same way because they hydrate from their own endpoints, called unconditionally on every route change. App UI resources were the odd one out.

## The fix

Re-key the registry `sessionId → toolUseId → resource` and **retain every conversation for the SPA session**, mirroring the message cache. Reads are scoped to the viewed conversation, so a `toolUseId` can only resolve inside the conversation that produced it. Iframe teardown is unaffected — frames unmount with their message-list components, not with the registry.

This also removes the `isViewedSession` gate on `onUiResource` / `onToolInputPartial`. That gate existed *only* because of the reset; with retention it became actively harmful — an App produced by a conversation streaming in the background would have been discarded permanently.

A narrower fix (caching the last sidecar per session and re-seeding on the short-circuit) was considered and rejected: it fixes the reported repro but still loses any App that mounted from a *live* event this tab session.

## Verification

Browser-verified against the dev backend, navigating via sidebar clicks (a URL load re-fetches and hides the bug):

| Check | Result |
|---|---|
| Fresh load | 1 frame, iframe on the sandbox origin |
| **Navigate away → back** | **1 frame, iframe intact, 0 fallback cards** |
| Hard refresh | Still hydrates |
| Two App conversations, A→B→A→B | Each retains its own frame, no cross-contamination |
| Live turn (`recordLive`) | Frame mounts, header-shell → iframe promotion as documented |
| App produced while conversation streamed **in the background** | Present on return (previously discarded) |

**The mechanism is proven, not just the symptom:** on the return trip the SPA re-fetched `/metadata`, `/artifacts` and `/mcp-apps/cards`, but `/messages` fired only once, on the initial load.

**No regressions** in adjacent features: ordinary tool grouping (1 rail, no false promotion), artifacts (2 cards, survive navigate-back), and app-initiated "RAN BY APP" cards (16 before and after, coexisting with the App frame). Console clean apart from pre-existing COOP warnings.

`ng test`: **2524 passed, 221 files.** The service spec is reworked around the retention contract, including a test that walks the exact repro.

## Notes for review

- **The second commit (`chore:`) is independent and easy to drop.** It sets `autoPort: false` on the frontend preview. The local app-api's CORS allowlist is explicit (`allow_credentials=True` forbids a wildcard) and the Cognito localhost callback is registered for `:4200`, so a preview relocated to another port has every API call blocked and cannot log in. `autoPort: false` fails loudly instead. It does affect anyone running a preview from another worktree, so it's a judgement call.
- Nothing evicts a conversation's resources, matching how `MessageMapService` already retains messages unboundedly. A `releaseSession()` for the delete path was drafted and dropped — `deleteSession` doesn't purge the message cache either, so purging only App HTML would be inconsistent.
- Two pre-existing issues surfaced during verification and are **not** addressed here: the top-nav conversation title lags a navigation behind the URL (reproduced between two conversations with no MCP Apps involved), and live turns render the raw `google_tasks` authority as the server name where persisted rows render `Google Tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
