### PR TITLE
fix(mcp-apps): resolve the OAuth token for app-initiated tool calls

### DIFF
--- a/backend/src/agents/main_agent/session/hooks/oauth_consent.py
+++ b/backend/src/agents/main_agent/session/hooks/oauth_consent.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-import re
 from typing import Any, Awaitable, Callable, Optional, Union
 
 from strands.hooks import (
@@ -41,64 +40,9 @@ from apis.shared.oauth.agentcore_identity import (
     custom_parameters_for,
     get_agentcore_identity_client,
 )
+from apis.shared.oauth.auth_failure import looks_like_auth_failure
 
 logger = logging.getLogger(__name__)
-
-
-# Markers that indicate an OAuth-style auth failure in a tool result.
-# A false positive triggers an unnecessary OAuth popup — far more
-# disruptive than a missed match (which surfaces the underlying error to
-# the user). So we err on the side of high-confidence signals only.
-#
-# Tiers:
-#   1. HTTP 401 with negative lookarounds for path segments / adjacent
-#      digits. Bare "401" in MCP error text is almost always an HTTP
-#      status code in practice.
-#   2. "Unauthorized" only when paired with an HTTP/status/code keyword.
-#      The bare word fires on prose like "you are not authorized to view
-#      this calendar" — which is application-level, not OAuth.
-#   3. Unambiguous OAuth/token signals stand alone — `invalid_token`,
-#      `invalid_grant` (refresh-token revocation), Google API's
-#      `UNAUTHENTICATED` and `invalid authentication credentials`.
-#
-# We only run this on results whose `status == "error"`
-# (see `_looks_like_auth_failure`), so even the broader patterns above
-# are gated by an explicit failure signal from the MCP framework.
-_AUTH_FAILURE_PATTERN = re.compile(
-    r"(?<![\w/])401(?![\w/])"
-    r"|\b(?:http|status|response|code)\b[^\n]{0,20}\bunauthoriz(?:ed|e)\b"
-    r"|\bunauthoriz(?:ed|e)\b[^\n]{0,20}\b(?:http|status|response|code|401)\b"
-    r"|\binvalid[_\s-]?token\b"
-    r"|\bexpired[_\s-]?token\b"
-    r"|\btoken[_\s-]?expired\b"
-    r"|\brejected the oauth token\b"
-    r"|\boauth token (?:has )?expired\b"
-    r"|\binvalid[_\s-]?grant\b"
-    r"|\binvalid[_\s-]?authentication[_\s-]?credentials\b"
-    r"|\bUNAUTHENTICATED\b",
-    re.IGNORECASE,
-)
-
-
-def _looks_like_auth_failure(tool_result: Any) -> bool:
-    """Heuristic: does this tool result look like an OAuth 401?
-
-    Inspects the result's status and content for one of the markers above.
-    False positives here just trigger a wasted retry; false negatives
-    leave the user stuck with a stale token, so we err on the side of
-    matching.
-    """
-    if not isinstance(tool_result, dict):
-        return False
-    if tool_result.get("status") != "error":
-        return False
-    for block in tool_result.get("content", []) or []:
-        if not isinstance(block, dict):
-            continue
-        text = block.get("text") or ""
-        if isinstance(text, str) and _AUTH_FAILURE_PATTERN.search(text):
-            return True
-    return False
 
 
 # Returns provider_id for a Strands `selected_tool`, or None if the tool
@@ -331,7 +275,7 @@ class OAuthConsentHook(HookProvider):
         if not provider_id:
             return
 
-        if not _looks_like_auth_failure(event.result):
+        if not looks_like_auth_failure(event.result):
             return
 
         # Avoid both an infinite retry loop within a single tool call and a

--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -6,8 +6,14 @@ to `/invocations` with an `app_tool_call` directive. This module runs that
 single tool call WITHOUT a model turn:
 
 1. Rebuild the conversation's agent via `get_agent` (the same path resume
-   uses) so the MCP client session + auth (OAuth token cache, SigV4,
-   consent hook) are wired exactly as for a model-driven tool call.
+   uses) so the MCP client session + transport auth (SigV4, OIDC
+   forwarding, the lazy OAuth token provider) are wired exactly as for a
+   model-driven tool call.
+1a. Resolve the OAuth token this call needs. A model-driven call gets this
+   from `OAuthConsentHook`, which fires on `BeforeToolCallEvent` — an event
+   this path never raises, because it calls the MCP client directly instead
+   of running the agent's tool loop. So the warm-the-cache half of the hook
+   is repeated here explicitly (see `_ensure_oauth_token`).
 2. Re-check the tool's `_meta.ui.visibility` includes `"app"` — the spec
    MUST, enforced here as the second gate (app-api is the first).
 3. Call the tool against the MCP client that surfaced it (recorded in the
@@ -31,6 +37,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from apis.shared.mcp_apps.broker import get_app_tool_event_broker
+from apis.shared.oauth.auth_failure import looks_like_auth_failure
 
 from apis.shared.security.log_sanitize import scrub_log
 
@@ -180,6 +187,140 @@ def _resolve_client(agent: Any, tool_name: str):
     return ui_metadata, client
 
 
+def _provider_for_client(client: Any) -> Optional[str]:
+    """The OAuth provider_id backing `client`, or None when it isn't gated.
+
+    Reads the same `MCPClient -> provider_id` map `OAuthConsentHook` reaches
+    through its injected `provider_lookup`. Lazy import for the same reason
+    `_resolve_client` uses one.
+    """
+    from agents.main_agent.integrations.external_mcp_client import (
+        get_external_mcp_integration,
+    )
+
+    try:
+        return get_external_mcp_integration().provider_for_client(client)
+    except Exception:  # noqa: BLE001 - a lookup miss must not block the call
+        logger.warning(
+            "failed to resolve the OAuth provider for an MCP client",
+            exc_info=True,
+        )
+        return None
+
+
+async def _user_disconnected(user_id: str, provider_id: str) -> bool:
+    """Durable "user pressed Disconnect" intent for (user, provider).
+
+    Mirrors `OAuthConsentHook._is_disconnected`. Without it an App frame
+    left open on screen keeps working off the cached token for the rest of
+    its TTL after the user disconnects the connector.
+    """
+    from apis.shared.oauth.disconnect_repository import get_disconnect_repository
+
+    try:
+        return bool(
+            await get_disconnect_repository().is_disconnected(user_id, provider_id)
+        )
+    except Exception:  # noqa: BLE001 - fail open, same as the hook's lookup
+        logger.warning(
+            "failed to read disconnect intent for provider=%s",
+            scrub_log(provider_id),
+            exc_info=True,
+        )
+        return False
+
+
+async def _ensure_oauth_token(client: Any, user_id: str) -> Optional[str]:
+    """Guarantee an OAuth token is cached before an app-initiated call.
+
+    A model-driven tool call gets this from `OAuthConsentHook._gate`, which
+    fires on `BeforeToolCallEvent`. This path calls the MCP client directly,
+    so that event never fires and nothing warms `oauth_token_cache` — the
+    lazy token provider then resolves to `None` and the request goes out
+    with no `Authorization` header at all. Servers that allow an
+    unauthenticated `tools/list` (so the tool still registers and the App
+    still renders) answer such a call with their own "you aren't connected"
+    text, which reads to the user as the App being broken.
+
+    The cache is per-process, so it is cold on any container that has not
+    run a model-driven turn for this (user, provider) — the common case
+    after a page reload lands the call on a fresh runtime — and it expires
+    on its own TTL well before the App frame does.
+
+    Returns the provider_id when the client is OAuth-gated (whether or not
+    the cache was already warm), else None. Raises `AppToolCallError` when
+    AgentCore Identity says this user genuinely still has to consent.
+    """
+    provider_id = _provider_for_client(client)
+    if not provider_id:
+        return None
+
+    from agents.main_agent.integrations import oauth_token_cache
+    from apis.shared.oauth.token_resolution import resolve_token_or_consent_url
+
+    force_reauth = await _user_disconnected(user_id, provider_id)
+    if not force_reauth and oauth_token_cache.get(user_id, provider_id):
+        return provider_id
+    if force_reauth:
+        oauth_token_cache.clear_user_provider(user_id, provider_id)
+
+    resolved = await resolve_token_or_consent_url(
+        provider_id, user_id, force_authentication=force_reauth
+    )
+    if resolved is None:
+        # Couldn't ask AgentCore at all — that is not evidence of a consent
+        # gap, so don't tell the user to connect something they may already
+        # have connected. Let the call go out; the server's own error is a
+        # truer report than a guess.
+        logger.warning(
+            "could not resolve a %s token for an app-initiated tools/call; "
+            "calling unauthenticated",
+            scrub_log(provider_id),
+        )
+        return provider_id
+
+    if resolved["token"]:
+        oauth_token_cache.set(user_id, provider_id, resolved["token"])
+        return provider_id
+
+    # No token and a consent URL: the user has not authorized this
+    # connector. There is no turn to interrupt here, so surface it as an
+    # error the App can render — the SPA relays `message` verbatim.
+    #
+    # 409, never 401: the SPA's error interceptor treats *any* 401 as an
+    # expired BFF session and redirects to login, so answering "connect
+    # your account" with a 401 would sign the user out. 409 is already this
+    # codebase's "connector needs connecting" status (the file-source
+    # browser and the export dialog both branch on it to show Connect).
+    raise AppToolCallError(
+        f"Authorization required for '{provider_id}'. Connect the account, "
+        "then try again.",
+        code=409,
+    )
+
+
+def _invalidate_oauth_token(user_id: str, provider_id: str, tool_name: str) -> None:
+    """Drop a token the MCP server just rejected, so the next call re-asks.
+
+    Deliberately does NOT retry the call, unlike the hook's
+    `_handle_auth_failure`. An app-initiated call is whatever button the
+    user pressed — `complete_task`, `delete_event` — and re-firing a
+    mutation off a regex match could apply the side effect twice. Clearing
+    is enough: the next press misses the cache, re-resolves from the vault
+    (which refreshes transparently), and either succeeds or reports that
+    consent is required.
+    """
+    from agents.main_agent.integrations import oauth_token_cache
+
+    logger.info(
+        "app-initiated tools/call for tool=%s looks like a %s auth failure; "
+        "clearing the cached token so the next call re-resolves it",
+        scrub_log(tool_name),
+        scrub_log(provider_id),
+    )
+    oauth_token_cache.clear_user_provider(user_id, provider_id)
+
+
 async def dispatch_app_tool_call(
     agent: Any,
     *,
@@ -210,6 +351,10 @@ async def dispatch_app_tool_call(
             f"No live MCP client for tool '{tool_name}'", code=409
         )
 
+    # The consent hook can't run for this call (no BeforeToolCallEvent), so
+    # resolve the OAuth token here or the request goes out unauthenticated.
+    provider_id = await _ensure_oauth_token(client, user_id)
+
     # Distinct id for the thread card — the originating tool_use_id is the
     # one that rendered the iframe; this proxied call is its own invocation.
     synth_id = f"app-{tool_use_id}-{uuid.uuid4().hex[:8]}"
@@ -237,6 +382,11 @@ async def dispatch_app_tool_call(
     content = _serialize_content(result)
     is_error = _is_error(result)
     status = "error" if is_error else "success"
+
+    if provider_id and looks_like_auth_failure(
+        {"status": status, "content": content}
+    ):
+        _invalidate_oauth_token(user_id, provider_id, tool_name)
 
     # Surface the call in the conversation thread. Best-effort: a missing
     # listener (no active stream) buffers in the broker for the next turn;

--- a/backend/src/apis/shared/oauth/auth_failure.py
+++ b/backend/src/apis/shared/oauth/auth_failure.py
@@ -1,0 +1,74 @@
+"""Shared "does this tool result look like an OAuth 401?" heuristic.
+
+Two paths need the same answer about an MCP tool result:
+
+  * ``OAuthConsentHook._handle_auth_failure`` — the model-driven tool
+    loop, which clears the token cache and retries the call.
+  * ``dispatch_app_tool_call`` — the app-initiated ``tools/call`` path,
+    which clears the token cache but deliberately does NOT retry (an App
+    call can be a mutation, so a heuristic-driven retry could apply a side
+    effect twice).
+
+Keeping the markers in one place means the two paths can never drift into
+disagreeing about what an auth failure looks like.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Markers that indicate an OAuth-style auth failure in a tool result.
+# A false positive triggers an unnecessary OAuth popup — far more
+# disruptive than a missed match (which surfaces the underlying error to
+# the user). So we err on the side of high-confidence signals only.
+#
+# Tiers:
+#   1. HTTP 401 with negative lookarounds for path segments / adjacent
+#      digits. Bare "401" in MCP error text is almost always an HTTP
+#      status code in practice.
+#   2. "Unauthorized" only when paired with an HTTP/status/code keyword.
+#      The bare word fires on prose like "you are not authorized to view
+#      this calendar" — which is application-level, not OAuth.
+#   3. Unambiguous OAuth/token signals stand alone — `invalid_token`,
+#      `invalid_grant` (refresh-token revocation), Google API's
+#      `UNAUTHENTICATED` and `invalid authentication credentials`.
+#
+# We only run this on results whose `status == "error"`
+# (see `looks_like_auth_failure`), so even the broader patterns above
+# are gated by an explicit failure signal from the MCP framework.
+AUTH_FAILURE_PATTERN = re.compile(
+    r"(?<![\w/])401(?![\w/])"
+    r"|\b(?:http|status|response|code)\b[^\n]{0,20}\bunauthoriz(?:ed|e)\b"
+    r"|\bunauthoriz(?:ed|e)\b[^\n]{0,20}\b(?:http|status|response|code|401)\b"
+    r"|\binvalid[_\s-]?token\b"
+    r"|\bexpired[_\s-]?token\b"
+    r"|\btoken[_\s-]?expired\b"
+    r"|\brejected the oauth token\b"
+    r"|\boauth token (?:has )?expired\b"
+    r"|\binvalid[_\s-]?grant\b"
+    r"|\binvalid[_\s-]?authentication[_\s-]?credentials\b"
+    r"|\bUNAUTHENTICATED\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_auth_failure(tool_result: Any) -> bool:
+    """Heuristic: does this tool result look like an OAuth 401?
+
+    Inspects the result's status and content for one of the markers above.
+    False positives here just trigger a wasted retry; false negatives
+    leave the user stuck with a stale token, so we err on the side of
+    matching.
+    """
+    if not isinstance(tool_result, dict):
+        return False
+    if tool_result.get("status") != "error":
+        return False
+    for block in tool_result.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("text") or ""
+        if isinstance(text, str) and AUTH_FAILURE_PATTERN.search(text):
+            return True
+    return False

--- a/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
+++ b/backend/tests/agents/main_agent/session/test_oauth_consent_hook.py
@@ -19,10 +19,8 @@ from apis.shared.oauth.agentcore_identity import (
     TokenResult,
     WorkloadTokenUnavailableError,
 )
-from agents.main_agent.session.hooks.oauth_consent import (
-    OAuthConsentHook,
-    _looks_like_auth_failure,
-)
+from apis.shared.oauth.auth_failure import looks_like_auth_failure
+from agents.main_agent.session.hooks.oauth_consent import OAuthConsentHook
 
 
 @pytest.fixture(autouse=True)
@@ -809,7 +807,7 @@ class TestLooksLikeAuthFailure:
         ],
     )
     def test_matches_genuine_auth_errors(self, text):
-        assert _looks_like_auth_failure(self._err(text)) is True
+        assert looks_like_auth_failure(self._err(text)) is True
 
     @pytest.mark.parametrize(
         "text",
@@ -842,22 +840,22 @@ class TestLooksLikeAuthFailure:
         ],
     )
     def test_avoids_false_positives(self, text):
-        assert _looks_like_auth_failure(self._err(text)) is False
+        assert looks_like_auth_failure(self._err(text)) is False
 
     def test_ignores_non_error_status(self):
         # Even an auth-shaped body doesn't count if status is success.
-        assert _looks_like_auth_failure(self._ok("401 Unauthorized")) is False
+        assert looks_like_auth_failure(self._ok("401 Unauthorized")) is False
 
     def test_ignores_non_dict_result(self):
-        assert _looks_like_auth_failure("HTTP 401 Unauthorized") is False
-        assert _looks_like_auth_failure(None) is False
-        assert _looks_like_auth_failure(["401"]) is False
+        assert looks_like_auth_failure("HTTP 401 Unauthorized") is False
+        assert looks_like_auth_failure(None) is False
+        assert looks_like_auth_failure(["401"]) is False
 
     def test_ignores_missing_content(self):
-        assert _looks_like_auth_failure({"status": "error"}) is False
-        assert _looks_like_auth_failure({"status": "error", "content": None}) is False
-        assert _looks_like_auth_failure({"status": "error", "content": []}) is False
+        assert looks_like_auth_failure({"status": "error"}) is False
+        assert looks_like_auth_failure({"status": "error", "content": None}) is False
+        assert looks_like_auth_failure({"status": "error", "content": []}) is False
 
     def test_ignores_non_dict_content_blocks(self):
         result = {"status": "error", "content": ["401 Unauthorized"]}
-        assert _looks_like_auth_failure(result) is False
+        assert looks_like_auth_failure(result) is False

--- a/backend/tests/apis/inference_api/test_app_tool_dispatch.py
+++ b/backend/tests/apis/inference_api/test_app_tool_dispatch.py
@@ -261,3 +261,228 @@ async def test_leaves_a_live_client_session_alone(monkeypatch):
     assert client.starts == 0
     assert client.stops == 0
     assert client.active is True
+
+
+class _FakeIntegration:
+    """Stands in for the process-wide `ExternalMCPIntegration` singleton."""
+
+    def __init__(self, provider_id=None) -> None:
+        self._provider_id = provider_id
+
+    def provider_for_client(self, _client):
+        return self._provider_id
+
+
+class _FakeDisconnectRepo:
+    def __init__(self, disconnected: bool = False) -> None:
+        self._disconnected = disconnected
+        self.calls: list = []
+
+    async def is_disconnected(self, user_id, provider_id) -> bool:
+        self.calls.append((user_id, provider_id))
+        return self._disconnected
+
+
+def _patch_oauth(
+    monkeypatch,
+    *,
+    provider_id="google-tasks",
+    resolved=None,
+    disconnected=False,
+):
+    """Wire the OAuth collaborators `_ensure_oauth_token` reaches for.
+
+    Each is imported lazily inside the dispatch module, so patching the
+    owning module's attribute is what the call actually resolves.
+    """
+    from agents.main_agent.integrations import external_mcp_client
+    from apis.shared.oauth import disconnect_repository, token_resolution
+
+    monkeypatch.setattr(
+        external_mcp_client,
+        "get_external_mcp_integration",
+        lambda: _FakeIntegration(provider_id),
+    )
+    repo = _FakeDisconnectRepo(disconnected)
+    monkeypatch.setattr(
+        disconnect_repository, "get_disconnect_repository", lambda: repo
+    )
+
+    calls: list = []
+
+    async def _resolve(pid, uid, *, force_authentication=False):
+        calls.append((pid, uid, force_authentication))
+        return resolved
+
+    monkeypatch.setattr(token_resolution, "resolve_token_or_consent_url", _resolve)
+    return calls
+
+
+@pytest.fixture
+def token_cache():
+    """The OAuth token cache is process-global — isolate each test."""
+    from agents.main_agent.integrations import oauth_token_cache
+
+    oauth_token_cache.clear_user("u1")
+    yield oauth_token_cache
+    oauth_token_cache.clear_user("u1")
+
+
+@pytest.mark.asyncio
+async def test_warms_a_cold_token_cache_from_the_vault(monkeypatch, token_cache):
+    """The reported bug: an App's tool calls fail after a page reload.
+
+    `OAuthConsentHook` warms the token cache on `BeforeToolCallEvent` — an
+    event this path never raises. On any container that has not run a
+    model-driven turn for this (user, provider) the cache is cold, the lazy
+    token provider returns None, and the call goes out with no Authorization
+    header. A server that allows an unauthenticated `tools/list` still lists
+    the tool, so the App renders and then every button answers with the
+    server's own "you aren't connected" text.
+    """
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    calls = _patch_oauth(monkeypatch, resolved={"token": "tok-1", "url": None})
+
+    payload = await _call(session_id="disp-oauth-cold")
+
+    assert payload["result"]["isError"] is False
+    # Resolved before the tool ran, so the request carries a Bearer token.
+    assert calls == [("google-tasks", "u1", False)]
+    assert token_cache.get("u1", "google-tasks") == "tok-1"
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_skips_the_vault(monkeypatch, token_cache):
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    calls = _patch_oauth(monkeypatch, resolved={"token": "fresh", "url": None})
+    token_cache.set("u1", "google-tasks", "already-warm")
+
+    await _call(session_id="disp-oauth-warm")
+
+    assert calls == []
+    assert token_cache.get("u1", "google-tasks") == "already-warm"
+
+
+@pytest.mark.asyncio
+async def test_consent_required_surfaces_as_409(monkeypatch, token_cache):
+    """No vaulted token means the user really hasn't connected the account.
+
+    409, not 401: the SPA's error interceptor reads any 401 as an expired
+    BFF session and redirects to login, so a 401 here would sign the user
+    out over an unconnected connector.
+    """
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    _patch_oauth(
+        monkeypatch, resolved={"token": None, "url": "https://consent.example"}
+    )
+
+    with pytest.raises(AppToolCallError) as ei:
+        await _call(session_id="disp-oauth-consent")
+
+    assert ei.value.code == 409
+    assert "google-tasks" in ei.value.message
+    # Never dispatched — there was no token to dispatch with.
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_provider_still_dispatches(monkeypatch, token_cache):
+    """`None` means "couldn't ask AgentCore", not "user must consent".
+
+    Prompting on it would tell a connected user to connect. Let the call go
+    out instead — the server's own error is a truer report than a guess.
+    """
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    _patch_oauth(monkeypatch, resolved=None)
+
+    payload = await _call(session_id="disp-oauth-unresolved")
+
+    assert payload["result"]["isError"] is False
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_disconnected_user_bypasses_the_cached_token(monkeypatch, token_cache):
+    """A disconnect must reach an App frame that is still open on screen.
+
+    Without this the App keeps working off the cached token for the rest of
+    its TTL after the user presses Disconnect.
+    """
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    _patch_oauth(
+        monkeypatch,
+        resolved={"token": None, "url": "https://consent.example"},
+        disconnected=True,
+    )
+    token_cache.set("u1", "google-tasks", "stale-post-disconnect")
+
+    with pytest.raises(AppToolCallError) as ei:
+        await _call(session_id="disp-oauth-disconnected")
+
+    assert ei.value.code == 409
+    assert token_cache.get("u1", "google-tasks") is None
+
+
+@pytest.mark.asyncio
+async def test_forces_reauth_when_disconnected(monkeypatch, token_cache):
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    calls = _patch_oauth(
+        monkeypatch,
+        resolved={"token": "re-consented", "url": None},
+        disconnected=True,
+    )
+
+    await _call(session_id="disp-oauth-force")
+
+    assert calls == [("google-tasks", "u1", True)]
+
+
+@pytest.mark.asyncio
+async def test_auth_shaped_failure_clears_the_cached_token(monkeypatch, token_cache):
+    """A rejected token must not stay cached for the rest of its TTL.
+
+    Cleared, not retried: an app-initiated call is whatever button the user
+    pressed, so re-firing a mutation off a regex match could apply the side
+    effect twice.
+    """
+    client = _FakeClient(_FakeResult("401 Unauthorized", is_error=True))
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    _patch_oauth(monkeypatch, resolved={"token": "revoked", "url": None})
+
+    payload = await _call(session_id="disp-oauth-401")
+
+    assert payload["result"]["isError"] is True
+    assert token_cache.get("u1", "google-tasks") is None
+    # One call only — no automatic retry of a possibly-mutating tool.
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_ordinary_tool_error_keeps_the_cached_token(monkeypatch, token_cache):
+    """Only auth-shaped failures invalidate the token."""
+    client = _FakeClient(_FakeResult("Task not found", is_error=True))
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    _patch_oauth(monkeypatch, resolved={"token": "tok-1", "url": None})
+
+    await _call(session_id="disp-oauth-plain-error")
+
+    assert token_cache.get("u1", "google-tasks") == "tok-1"
+
+
+@pytest.mark.asyncio
+async def test_non_oauth_client_never_asks_agentcore(monkeypatch, token_cache):
+    """A SigV4 / unauthenticated MCP server has no provider to resolve."""
+    client = _FakeClient()
+    _patch(monkeypatch, enabled=True, meta=_ui(["model", "app"]), client=client)
+    calls = _patch_oauth(monkeypatch, provider_id=None, resolved=None)
+
+    payload = await _call(session_id="disp-oauth-none")
+
+    assert payload["result"]["isError"] is False
+    assert calls == []


### PR DESCRIPTION
## The bug

Reload a conversation that has an embedded MCP App (Google Tasks), then click into the App: every button answers with the server's own *"Google Tasks isn't connected yet. Connect your Google account…"* — while the App itself renders fine and the same tools work when the model calls them.

## Root cause

An App-initiated `tools/call` (`dispatch_app_tool_call`) invokes the Strands MCP client **directly** — it never runs the agent's tool loop. So `BeforeToolCallEvent` never fires, and **`OAuthConsentHook` never runs**. That hook is the only thing that warms `oauth_token_cache`, and the MCP client's token provider is nothing more than `oauth_token_cache.get(user_id, provider_id)`.

The cache is per-process, so it is cold on any container that hasn't served a model-driven turn for that (user, provider) — a reload landing on a fresh runtime, a restarted local uvicorn, or simply the 3000s TTL lapsing. The request then goes out with **no `Authorization` header at all**.

It fails *silently* rather than 401-ing because Google Tasks accepts an unauthenticated `initialize`/`tools/list`, so the tool still registers and the App still mounts; only the calls fail. And because there's no 401, `_recover_oauth_preflight` — which *does* warm the cache from the vault — never fires. A server that 401s its `tools/list` would have self-healed; a permissive one exposes the gap.

Confirmed in the dev runtime logs: `oauth_auth.py:82` `No OAuth token available for request` immediately before three `200 OK`/`202 Accepted` responses from the Google Tasks Lambda URL, followed by `✅ Loaded external MCP tool: google_tasks (OAuth)`. In the model-driven turn right after, the hook mints the token (`Getting OAuth2 token...`) and the call succeeds — the path App calls never take.

The module docstring already *claimed* this parity ("auth … wired exactly as for a model-driven tool call"); it wasn't true. It now says what actually happens.

## The fix

`_ensure_oauth_token` repeats the hook's warm-the-cache half explicitly before dispatching: resolve the provider from the MCP client, honour the durable disconnect flag, then `resolve_token_or_consent_url` → warm the cache, or report that consent is required.

Two deliberate departures from the hook, both worth a reviewer's attention:

- **Consent-required returns 409, never 401.** The SPA's `error.interceptor` treats *any* 401 as an expired BFF session and calls `handleUnauthorized()` → login redirect. A 401 here would sign the user out over an unconnected connector. 409 is already this codebase's "needs connecting" status (file-source browser, export dialog both branch on it).
- **An auth-shaped failure clears the cached token but does not retry.** The hook retries model-driven calls; an app call is whatever button the user pressed (`complete_task`, `delete_event`), so a regex-triggered retry could apply a mutation twice. Clearing is enough — the next press misses the cache and re-resolves.

The auth-failure regex moves to `apis/shared/oauth/auth_failure.py` so the hook and the dispatch can't drift on what an auth failure looks like.

## Testing

- 9 new dispatch tests: cold cache warms from the vault, warm cache skips it, consent-required → 409 with no dispatch, unresolvable provider still dispatches, disconnect bypasses the cached token, disconnect forces re-auth, auth-shaped failure clears the token without retrying, ordinary tool error keeps it, non-OAuth client never asks AgentCore.
- Full backend suite: **7745 passed, 3 skipped** (two clean runs; a third hit the pre-existing `TestTruncationProperties::test_protected_indices_never_modified` hypothesis flake, which passes in isolation and is unrelated to this change).
- `ruff` clean.

**Not verified end-to-end against a deployed App** — the failing calls don't appear in 30 days of dev runtime logs, consistent with the repro happening on a local stack. The mechanism is confirmed from the code and from the server behaviour above, not from a captured log line of the exact failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
