### PR TITLE
fix(mcp-apps): honor the App teardown contract and revalidate stale UI resources

### DIFF
--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -321,6 +321,120 @@ def _invalidate_oauth_token(user_id: str, provider_id: str, tool_name: str) -> N
     oauth_token_cache.clear_user_provider(user_id, provider_id)
 
 
+# --- opportunistic UI-resource revalidation ---------------------------------
+# The App HTML the SPA re-mounts on reload is whatever `resources/read`
+# returned when the tool first ran, replayed verbatim from the `UIRES#` row. So
+# a server that ships a new App version — or tightens the CSP its App runs
+# under — never reaches conversations that already exist.
+#
+# Re-reading needs a live MCP client, and the only path to one is a built
+# agent, so revalidating on every conversation open would add a full agent
+# rebuild (76% of sessions bypass the agent cache) to a page load that runs no
+# model turn. Instead we piggyback: an app-initiated tools/call ALREADY built
+# the agent and revived the client, so the read is nearly free here. The
+# refreshed shell lands on the NEXT load rather than this one — that is the
+# trade, and it converges for the Apps people actually use.
+_refresh_lock = threading.Lock()
+_refreshed_resources: set = set()
+_refresh_tasks: set = set()
+# One refresh per resource per process; a chatty App must not re-read its own
+# shell on every button press.
+_MAX_REFRESHED = 512
+
+
+def _claim_refresh(session_id: str, tool_use_id: str) -> bool:
+    """Whether this process should refresh this resource (once only)."""
+    key = f"{session_id}#{tool_use_id}"
+    with _refresh_lock:
+        if key in _refreshed_resources:
+            return False
+        if len(_refreshed_resources) >= _MAX_REFRESHED:
+            _refreshed_resources.clear()
+        _refreshed_resources.add(key)
+        return True
+
+
+def _refresh_ui_resource(user_id: str, session_id: str, tool_use_id: str) -> None:
+    """Re-read this App's `ui://` resource and overwrite its stored copy.
+
+    Best-effort and silent: this runs after the App already has its answer,
+    so nothing here may raise or slow the call down.
+    """
+    from apis.shared.mcp_apps.ui_resource_store import get_ui_resource_store
+
+    store = get_ui_resource_store()
+    provenance = store.get_provenance(user_id=user_id, tool_use_id=tool_use_id)
+    if not provenance:
+        return
+    # The tool that PRODUCED the frame, which is not the tool the App just
+    # called — the resourceUri hangs off the producing tool's catalog entry.
+    producing_tool = provenance.get("toolName")
+    if not producing_tool:
+        return
+
+    from agents.main_agent.integrations.mcp_apps import fetch_ui_resource
+
+    _, client = _resolve_client(None, producing_tool)
+    if client is None:
+        return
+    # `fetch_ui_resource` calls `read_resource_sync` straight through, and
+    # between turns Strands has already stopped the client's session — the
+    # same reason an app-initiated call needs this wrapper.
+    with _active_session(client):
+        payload = fetch_ui_resource(producing_tool, tool_use_id)
+    if not payload or not payload.get("html"):
+        return
+
+    store.store(
+        user_id=user_id,
+        session_id=session_id,
+        tool_use_id=tool_use_id,
+        resource_uri=payload.get("resourceUri", ""),
+        html=payload["html"],
+        mime_type=payload.get("mimeType", ""),
+        csp=payload.get("csp") or {},
+        permissions=payload.get("permissions") or {},
+        sandbox_origin=payload.get("sandboxOrigin", ""),
+        server_name=payload.get("serverName", ""),
+        icon=payload.get("icon", ""),
+        tool_name=producing_tool,
+        # Preserved: the anchor belongs to the producing turn, and a refresh
+        # must not renumber where the frame sits in the thread.
+        produced_by_message_index=provenance.get("producedByMessageIndex"),
+    )
+    logger.info(
+        "mcp-apps: revalidated UI resource (session=%s, toolUseId=%s)",
+        scrub_log(session_id),
+        scrub_log(tool_use_id),
+    )
+
+
+def _schedule_ui_resource_refresh(
+    user_id: str, session_id: str, tool_use_id: str
+) -> None:
+    """Fire the refresh off the response path; never fail the tool call."""
+    if not _claim_refresh(session_id, tool_use_id):
+        return
+
+    async def _run() -> None:
+        try:
+            await asyncio.to_thread(
+                _refresh_ui_resource, user_id, session_id, tool_use_id
+            )
+        except Exception:  # noqa: BLE001 - revalidation is best-effort
+            logger.warning(
+                "mcp-apps: UI resource revalidation failed (session=%s)",
+                scrub_log(session_id),
+                exc_info=True,
+            )
+
+    task = asyncio.create_task(_run())
+    # Hold a reference: asyncio only weakly references running tasks, so
+    # without this the refresh can be garbage-collected mid-flight.
+    _refresh_tasks.add(task)
+    task.add_done_callback(_refresh_tasks.discard)
+
+
 async def dispatch_app_tool_call(
     agent: Any,
     *,
@@ -419,6 +533,10 @@ async def dispatch_app_tool_call(
             },
         },
     )
+
+    # The agent is built and the client revived right now — the one moment
+    # re-reading this App's shell costs almost nothing. See the note above.
+    _schedule_ui_resource_refresh(user_id, session_id, tool_use_id)
 
     return {
         "toolUseId": tool_use_id,

--- a/backend/src/apis/shared/mcp_apps/ui_resource_store.py
+++ b/backend/src/apis/shared/mcp_apps/ui_resource_store.py
@@ -236,6 +236,39 @@ class UiResourceStore:
                 exc_info=True,
             )
 
+    def get_provenance(
+        self, *, user_id: str, tool_use_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """The producing tool name + message anchor for one persisted row.
+
+        Deliberately projects only the two attributes a revalidation needs
+        and NOT `htmlGz` — the caller is about to replace the HTML anyway,
+        and pulling a ~130KB blob back just to overwrite it would make the
+        opportunistic refresh cost more than the read it saves.
+
+        Returns None when the row is absent, the table isn't configured, or
+        the read fails; every caller treats that as "nothing to refresh".
+        """
+        if self._table is None:
+            return None
+        try:
+            resp = self._table.get_item(
+                Key={"PK": f"USER#{user_id}", "SK": f"UIRES#{tool_use_id}"},
+                ProjectionExpression="toolName, producedByMessageIndex",
+            )
+        except Exception:  # noqa: BLE001 - refresh is best-effort
+            logger.warning(
+                "mcp-apps ui-resource store: provenance read failed "
+                "(toolUseId=%s)",
+                tool_use_id,
+                exc_info=True,
+            )
+            return None
+        item = resp.get("Item")
+        if not item:
+            return None
+        return _decimal_to_native(item)
+
     def list_for_session(
         self, *, session_id: str, user_id: str
     ) -> List[Dict[str, Any]]:

--- a/backend/tests/apis/inference_api/test_app_tool_dispatch.py
+++ b/backend/tests/apis/inference_api/test_app_tool_dispatch.py
@@ -8,6 +8,7 @@ synthesized tool_use/tool_result into the per-session broker.
 
 import pytest
 
+from apis.inference_api.chat import app_tool_dispatch as dispatch_mod
 from apis.inference_api.chat.app_tool_dispatch import (
     AppToolCallError,
     dispatch_app_tool_call,
@@ -486,3 +487,111 @@ async def test_non_oauth_client_never_asks_agentcore(monkeypatch, token_cache):
 
     assert payload["result"]["isError"] is False
     assert calls == []
+
+# --- opportunistic UI-resource revalidation ---------------------------------
+
+
+class _FakeResourceStore:
+    """Stand-in for the `UIRES#` store: one provenance row, capture writes."""
+
+    def __init__(self, provenance=None):
+        self._provenance = provenance
+        self.stored: list = []
+
+    def get_provenance(self, *, user_id, tool_use_id):
+        return self._provenance
+
+    def store(self, **kwargs):
+        self.stored.append(kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _clear_refresh_claims():
+    """The once-per-process claim set is module state — reset per test."""
+    dispatch_mod._refreshed_resources.clear()
+    yield
+    dispatch_mod._refreshed_resources.clear()
+
+
+def test_claim_refresh_is_once_per_resource():
+    assert dispatch_mod._claim_refresh("s1", "tu1") is True
+    # A chatty App presses buttons all day; the shell is read exactly once.
+    assert dispatch_mod._claim_refresh("s1", "tu1") is False
+    # A different frame in the same conversation is its own resource.
+    assert dispatch_mod._claim_refresh("s1", "tu2") is True
+
+
+def test_claim_refresh_bounds_its_memory():
+    for i in range(dispatch_mod._MAX_REFRESHED):
+        dispatch_mod._claim_refresh("s", f"tu{i}")
+    assert len(dispatch_mod._refreshed_resources) == dispatch_mod._MAX_REFRESHED
+    dispatch_mod._claim_refresh("s", "overflow")
+    assert len(dispatch_mod._refreshed_resources) == 1
+
+
+def test_refresh_rereads_the_producing_tool_and_preserves_the_anchor(monkeypatch):
+    store = _FakeResourceStore(
+        {"toolName": "view_task_board", "producedByMessageIndex": 4}
+    )
+    monkeypatch.setattr(
+        "apis.shared.mcp_apps.ui_resource_store.get_ui_resource_store",
+        lambda: store,
+    )
+    monkeypatch.setattr(
+        dispatch_mod, "_resolve_client", lambda agent, name: (object(), _FakeClient())
+    )
+    seen = {}
+
+    def _fetch(tool_name, tool_use_id):
+        seen["tool_name"] = tool_name
+        return {
+            "resourceUri": "ui://tasks/board",
+            "html": "<html>fresh</html>",
+            "mimeType": "text/html",
+            "csp": {"connect-src": ["'self'"]},
+            "permissions": {},
+            "sandboxOrigin": "https://sandbox.example",
+            "serverName": "Google Tasks",
+            "icon": "",
+        }
+
+    monkeypatch.setattr(mcp_apps_mod, "fetch_ui_resource", _fetch)
+
+    dispatch_mod._refresh_ui_resource("u1", "s1", "tu1")
+
+    # Re-read is keyed on the tool that PRODUCED the frame, not whatever the
+    # App just called — the resourceUri hangs off the producing tool.
+    assert seen["tool_name"] == "view_task_board"
+    assert len(store.stored) == 1
+    written = store.stored[0]
+    assert written["html"] == "<html>fresh</html>"
+    assert written["csp"] == {"connect-src": ["'self'"]}
+    assert written["tool_name"] == "view_task_board"
+    # The anchor is the producing turn's; a refresh must not renumber it.
+    assert written["produced_by_message_index"] == 4
+
+
+def test_refresh_no_ops_without_a_stored_row(monkeypatch):
+    store = _FakeResourceStore(None)
+    monkeypatch.setattr(
+        "apis.shared.mcp_apps.ui_resource_store.get_ui_resource_store",
+        lambda: store,
+    )
+    dispatch_mod._refresh_ui_resource("u1", "s1", "tu1")
+    assert store.stored == []
+
+
+def test_refresh_keeps_the_old_copy_when_the_read_returns_nothing(monkeypatch):
+    """A server that is down must not blank an App that still works."""
+    store = _FakeResourceStore({"toolName": "view_task_board"})
+    monkeypatch.setattr(
+        "apis.shared.mcp_apps.ui_resource_store.get_ui_resource_store",
+        lambda: store,
+    )
+    monkeypatch.setattr(
+        dispatch_mod, "_resolve_client", lambda agent, name: (object(), _FakeClient())
+    )
+    monkeypatch.setattr(mcp_apps_mod, "fetch_ui_resource", lambda *a: None)
+
+    dispatch_mod._refresh_ui_resource("u1", "s1", "tu1")
+    assert store.stored == []

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-use/renderers/mcp-app-frame.component.ts
@@ -22,6 +22,7 @@ import { McpAppBridge } from '../../../../../services/mcp-apps/mcp-app-bridge';
 import { McpAppProxyService } from '../../../../../services/mcp-apps/mcp-app-proxy.service';
 import { McpAppMessageService } from '../../../../../services/mcp-apps/mcp-app-message.service';
 import { McpAppConsentService } from '../../../../../services/mcp-apps/mcp-app-consent.service';
+import { McpAppTeardownService } from '../../../../../services/mcp-apps/mcp-app-teardown.service';
 import { buildProxyUrl } from '../../../../../services/mcp-apps/proxy-url';
 import { McpAppConsentPromptComponent } from '../../mcp-app-consent-prompt/mcp-app-consent-prompt.component';
 import { JsonSyntaxHighlightPipe } from '../json-syntax-highlight.pipe';
@@ -375,6 +376,7 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   private readonly mcpAppProxy = inject(McpAppProxyService);
   private readonly mcpAppMessage = inject(McpAppMessageService);
   private readonly mcpAppConsent = inject(McpAppConsentService);
+  private readonly mcpAppTeardown = inject(McpAppTeardownService);
   private readonly chatRequest = inject(ChatRequestService);
   private readonly chatState = inject(ChatStateService);
   private readonly conversation = inject(SessionService);
@@ -434,6 +436,8 @@ export class McpAppFrameComponent implements ToolResultRenderer {
   );
 
   private bridge: McpAppBridge | null = null;
+  /** Deregisters this frame's bridge from the navigation teardown registry. */
+  private unregisterBridge: (() => void) | null = null;
   private readonly nonce =
     this.win?.crypto?.randomUUID?.() ?? `n-${Math.random().toString(36).slice(2)}`;
 
@@ -793,7 +797,12 @@ export class McpAppFrameComponent implements ToolResultRenderer {
         this.doc.body.style.overflow = this.lockedBodyOverflow;
         this.lockedBodyOverflow = null;
       }
-      this.bridge?.dispose('component-destroyed');
+      // Deregister first: a navigation-driven teardownAll() already fired
+      // the notification while this iframe was alive, and re-firing here
+      // would only reset a grace window whose View is already gone.
+      this.unregisterBridge?.();
+      this.unregisterBridge = null;
+      void this.bridge?.dispose('component-destroyed');
     });
   }
 
@@ -863,6 +872,7 @@ export class McpAppFrameComponent implements ToolResultRenderer {
         return resulting;
       },
     });
+    this.unregisterBridge = this.mcpAppTeardown.register(this.bridge);
     this.bridge.onSizeChanged((_w, h) => {
       if (h > 0) this.frameHeight.set(Math.ceil(h));
     });

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.spec.ts
@@ -529,16 +529,97 @@ describe('McpAppBridge', () => {
     expect(h.proxy.byId('p1').result).toEqual({});
   });
 
-  it('dispose() sends resource-teardown after init and detaches the listener', () => {
+  it('dispose() sends resource-teardown and stays attached through the grace window', async () => {
     handshake(h);
     h.host.deliver(
       { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
       h.proxy,
     );
-    h.bridge.dispose('bye');
+    const settled = h.bridge.dispose('bye', 5);
     const td = h.proxy.byMethod('ui/resource-teardown');
     expect(td).toHaveLength(1);
     expect(td[0].params).toEqual({ reason: 'bye' });
+    // Still listening: the App has been told it is going away and may answer
+    // by saving its state, and detaching here would drop that message.
+    expect(h.host.attached).toBe(true);
+
+    await settled;
+    expect(h.host.attached).toBe(false);
+  });
+
+  it('dispose() detaches immediately when the View never initialized', async () => {
+    handshake(h);
+    await h.bridge.dispose('bye', 10_000);
+    // Nothing to notify and nothing to wait for — no teardown, no grace.
+    expect(h.proxy.byMethod('ui/resource-teardown')).toHaveLength(0);
+    expect(h.host.attached).toBe(false);
+  });
+
+  it('dispose() resolves on the ack without burning the whole grace window', async () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    // A grace window long enough that only the ack can finish this test.
+    const settled = h.bridge.dispose('bye', 60_000);
+    const id = h.proxy.byMethod('ui/resource-teardown')[0].id;
+    h.host.deliver({ jsonrpc: '2.0', id, nonce: NONCE, result: {} }, h.proxy);
+
+    await settled;
+    expect(h.host.attached).toBe(false);
+  });
+
+  it('still proxies a tools/call the App makes in response to teardown', async () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    h.proxyToolCall.mockResolvedValue({ content: [], isError: false });
+
+    const settled = h.bridge.dispose('conversation-change', 50);
+    // This is the whole point of the grace window: an App that answers
+    // teardown by flushing its state must still reach its server.
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        id: 'save-1',
+        method: 'tools/call',
+        nonce: NONCE,
+        params: { name: 'save_board', arguments: { dirty: true } },
+      },
+      h.proxy,
+    );
+    expect(h.proxyToolCall).toHaveBeenCalledWith('save_board', { dirty: true });
+
+    await settled;
+    // ...and once the window closes, late messages are ignored.
+    h.proxyToolCall.mockClear();
+    h.host.deliver(
+      {
+        jsonrpc: '2.0',
+        id: 'save-2',
+        method: 'tools/call',
+        nonce: NONCE,
+        params: { name: 'save_board', arguments: {} },
+      },
+      h.proxy,
+    );
+    expect(h.proxyToolCall).not.toHaveBeenCalled();
+  });
+
+  it('repeat dispose() calls share the first teardown window', async () => {
+    handshake(h);
+    h.host.deliver(
+      { jsonrpc: '2.0', method: 'ui/notifications/initialized', nonce: NONCE },
+      h.proxy,
+    );
+    const first = h.bridge.dispose('nav', 5);
+    const second = h.bridge.dispose('component-destroyed', 5);
+    // One notification, not two — a second reason must not re-arm the window.
+    expect(h.proxy.byMethod('ui/resource-teardown')).toHaveLength(1);
+    await Promise.all([first, second]);
     expect(h.host.attached).toBe(false);
   });
 

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-bridge.ts
@@ -71,6 +71,13 @@ import {
   isRequest,
 } from './mcp-app-protocol';
 
+/**
+ * How long the bridge keeps listening after sending `ui/resource-teardown`.
+ * Long enough for the View to ack and post a save call, short enough that a
+ * dead App never holds up a navigation that awaits it.
+ */
+export const DEFAULT_TEARDOWN_GRACE_MS = 1500;
+
 /** Minimal window surface the bridge needs (eases testing). */
 export interface BridgeHostWindow {
   addEventListener(
@@ -172,6 +179,10 @@ export class McpAppBridge {
   /** Set on the View's `ui/notifications/initialized`. */
   private viewInitialized = false;
   private disposed = false;
+  /** Set once the listener is gone; `disposed` only means teardown began. */
+  private detached = false;
+  /** In-flight teardown, so repeat dispose() calls await the same window. */
+  private teardownSettled: Promise<void> | null = null;
 
   /** Notifications deferred until the View reports `initialized`. */
   private readonly preInitQueue: Array<{ method: string; params: unknown }> = [];
@@ -211,16 +222,46 @@ export class McpAppBridge {
   }
 
   /**
-   * Tear down: best-effort `ui/resource-teardown` toward the View, then
-   * detach. Safe to call multiple times.
+   * Tear down: `ui/resource-teardown` toward the View, then detach.
+   * Safe to call multiple times. Resolves when the View acks or the grace
+   * window expires — callers that can afford to wait (navigation) should
+   * await it; `onDestroy` cannot, and doesn't.
+   *
+   * The spec's teardown notification exists so the App can flush state to
+   * its server before it dies (SEP-1865: the host SHOULD wait for a
+   * response "to prevent data loss"). Detaching in the same tick as the
+   * send defeated exactly that: the ack landed on a removed listener, and
+   * an App that answered teardown by calling a save tool had its
+   * postMessage dropped on the floor. So we keep listening through the
+   * grace window — the App's flush is proxied over HTTP from the *host*
+   * page, so once its message is in, the request outlives the iframe.
    */
-  dispose(reason = 'host-teardown'): void {
-    if (this.disposed) return;
+  dispose(reason = 'host-teardown', graceMs = DEFAULT_TEARDOWN_GRACE_MS): Promise<void> {
+    if (this.disposed) return this.teardownSettled ?? Promise.resolve();
     this.disposed = true;
-    if (this.viewInitialized) {
-      // Fire-and-forget: we're going away regardless of the ack.
-      this.sendRequest(M_RESOURCE_TEARDOWN, { reason }).catch(() => undefined);
+
+    if (!this.viewInitialized) {
+      this.detach();
+      return Promise.resolve();
     }
+
+    const acked = this.sendRequest(M_RESOURCE_TEARDOWN, { reason }).then(
+      () => undefined,
+      () => undefined,
+    );
+    this.teardownSettled = Promise.race([
+      acked,
+      new Promise<void>((resolve) => setTimeout(resolve, graceMs)),
+    ]).then(() => {
+      this.detach();
+    });
+    return this.teardownSettled;
+  }
+
+  /** Remove the listener and fail anything still in flight. */
+  private detach(): void {
+    if (this.detached) return;
+    this.detached = true;
     if (this.listener) {
       this.d.hostWindow.removeEventListener('message', this.listener);
       this.listener = null;
@@ -239,7 +280,11 @@ export class McpAppBridge {
   // --- inbound ------------------------------------------------------------
 
   private onMessage(ev: MessageEvent): void {
-    if (this.disposed) return;
+    // Gated on `detached`, NOT `disposed`: between dispose() and the end of
+    // the teardown grace window the bridge is still live on purpose, so the
+    // App's teardown ack — and any save call it makes in response — are
+    // still served.
+    if (this.detached) return;
     const proxyWindow = this.d.getProxyWindow();
     // Source + origin gate. The proxy page is served from sandboxOrigin, so
     // its window's origin is a real URL (the null-origin inner frame only

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-teardown.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-teardown.service.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { McpAppTeardownService } from './mcp-app-teardown.service';
+import type { McpAppBridge } from './mcp-app-bridge';
+
+/** Only `dispose` is exercised; the registry never touches anything else. */
+function fakeBridge(dispose = vi.fn().mockResolvedValue(undefined)) {
+  return { dispose } as unknown as McpAppBridge & {
+    dispose: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('McpAppTeardownService', () => {
+  let svc: McpAppTeardownService;
+
+  beforeEach(() => {
+    svc = new McpAppTeardownService();
+  });
+
+  it('tears down every live App with the given reason', async () => {
+    const a = fakeBridge();
+    const b = fakeBridge();
+    svc.register(a);
+    svc.register(b);
+
+    await svc.teardownAll('conversation-change');
+
+    expect(a.dispose).toHaveBeenCalledWith('conversation-change');
+    expect(b.dispose).toHaveBeenCalledWith('conversation-change');
+  });
+
+  it('clears the registry so a second navigation re-notifies nothing', async () => {
+    const a = fakeBridge();
+    svc.register(a);
+
+    await svc.teardownAll('first');
+    await svc.teardownAll('second');
+
+    expect(a.dispose).toHaveBeenCalledTimes(1);
+    expect(svc.liveCount).toBe(0);
+  });
+
+  it('deregisters a frame that unmounts on its own', async () => {
+    const a = fakeBridge();
+    const unregister = svc.register(a);
+    unregister();
+
+    await svc.teardownAll('conversation-change');
+
+    expect(a.dispose).not.toHaveBeenCalled();
+    expect(svc.liveCount).toBe(0);
+  });
+
+  it('one hung App does not strand the others', async () => {
+    const rejecting = fakeBridge(vi.fn().mockRejectedValue(new Error('gone')));
+    const healthy = fakeBridge();
+    svc.register(rejecting);
+    svc.register(healthy);
+
+    // Navigation waits on this; a failed teardown must not reject it.
+    await expect(svc.teardownAll('conversation-change')).resolves.toBeUndefined();
+    expect(healthy.dispose).toHaveBeenCalled();
+  });
+
+  it('resolves immediately when no App is open', async () => {
+    await expect(svc.teardownAll('conversation-change')).resolves.toBeUndefined();
+    expect(svc.liveCount).toBe(0);
+  });
+});

--- a/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-teardown.service.ts
+++ b/frontend/ai.client/src/app/session/services/mcp-apps/mcp-app-teardown.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import type { McpAppBridge } from './mcp-app-bridge';
+
+/**
+ * Registry of live MCP App bridges, so the host can tell every open App
+ * that it is about to go away.
+ *
+ * SEP-1865 requires the host to send `ui/resource-teardown` before tearing
+ * a resource down "for any reason", and to wait for the response where it
+ * can, so the App gets a chance to flush state to its own server. That
+ * matters here more than it looks: the App's state is the App's own
+ * responsibility to persist — the host deliberately isn't the store of
+ * record — so a teardown the App never hears about is state nobody saves.
+ *
+ * The frame component already disposes its bridge on destroy, but by then
+ * Angular is removing the iframe in the same tick and the App's window is
+ * gone before it can react. This registry exists so teardown can be fired
+ * at *navigation intent* instead — while the iframes are still alive and
+ * their Views can still run code. The App's save call is proxied over HTTP
+ * from the host page, so once its message reaches us the request outlives
+ * the iframe.
+ */
+@Injectable({ providedIn: 'root' })
+export class McpAppTeardownService {
+  private readonly live = new Set<McpAppBridge>();
+
+  /** Track a bridge; returns the deregistration callback. */
+  register(bridge: McpAppBridge): () => void {
+    this.live.add(bridge);
+    return () => this.live.delete(bridge);
+  }
+
+  /** Number of live App bridges (specs + callers that want to skip work). */
+  get liveCount(): number {
+    return this.live.size;
+  }
+
+  /**
+   * Notify every live App that it is being torn down, and resolve once they
+   * have all acked or their grace windows have expired.
+   *
+   * Callers that can await (a route guard) get the spec's "wait for a
+   * response" behavior. Callers that can't — a synchronous navigation
+   * effect — should still call this WITHOUT awaiting: the notification goes
+   * out while the iframes are alive, and each bridge keeps listening
+   * through its own grace window, which is the part that actually rescues
+   * the App's flush.
+   */
+  teardownAll(reason: string): Promise<void> {
+    if (!this.live.size) return Promise.resolve();
+    const bridges = [...this.live];
+    this.live.clear();
+    return Promise.all(
+      bridges.map((bridge) => bridge.dispose(reason).catch(() => undefined)),
+    ).then(() => undefined);
+  }
+}

--- a/frontend/ai.client/src/app/session/session.page.ts
+++ b/frontend/ai.client/src/app/session/session.page.ts
@@ -22,6 +22,7 @@ import { ArtifactStateService } from './services/artifacts/artifact-state.servic
 import { ArtifactHttpService } from './services/artifacts/artifact-http.service';
 import { McpAppCardStateService } from './services/mcp-apps/mcp-app-card-state.service';
 import { McpAppCardHttpService } from './services/mcp-apps/mcp-app-card-http.service';
+import { McpAppTeardownService } from './services/mcp-apps/mcp-app-teardown.service';
 import { McpAppConsentService } from './services/mcp-apps/mcp-app-consent.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { AssistantService } from '../assistants/services/assistant.service';
@@ -63,6 +64,7 @@ export class ConversationPage implements OnDestroy {
   private artifactState = inject(ArtifactStateService);
   private mcpAppCardState = inject(McpAppCardStateService);
   private mcpAppCardHttp = inject(McpAppCardHttpService);
+  private mcpAppTeardown = inject(McpAppTeardownService);
   private mcpAppConsent = inject(McpAppConsentService);
   private oauthConsent = inject(OAuthConsentService);
   private artifactHttp = inject(ArtifactHttpService);
@@ -416,6 +418,18 @@ export class ConversationPage implements OnDestroy {
       // loads so a prior session's cards don't bleed in, then re-hydrate
       // from the app-api list endpoint below.
       this.artifactState.reset();
+
+      // Tell every open MCP App it is going away BEFORE its iframe
+      // unmounts with the message list (SEP-1865: the host sends
+      // `ui/resource-teardown` for any teardown, so the App can flush state
+      // to its own server — the host is deliberately not the store of
+      // record for App state). Fired, not awaited: this effect is
+      // synchronous, and the value is in the timing, not the wait — the
+      // notification goes out while the Views are still alive, and each
+      // bridge keeps listening through its grace window so a save call the
+      // App makes in response is still proxied. A truly blocking wait would
+      // need a route guard; see the follow-up note in the teardown service.
+      void this.mcpAppTeardown.teardownAll('conversation-change');
 
       // MCP App UI resources are deliberately NOT cleared here. They are
       // held per conversation in McpAppStateService and retained for the


### PR DESCRIPTION
## What

Two SEP-1865 lifecycle gaps found while working through what the spec actually requires of a host that rehydrates App frames.

### 1. An App never got a real chance to flush before teardown

The spec has the host send `ui/resource-teardown` before tearing a resource down for any reason, and wait for the response where it can, so the App can save state to its own server. That matters more here than it looks: **the host is deliberately not the store of record for App state**, so a teardown the App never hears about is state nobody saves.

`dispose()` defeated exactly that — it fired the notification and then, in the same tick, removed the message listener and rejected every pending request. The ack landed on nothing, and an App that answered teardown by calling a save tool had its `postMessage` dropped on the floor. The comment said "we're going away regardless of the ack", which was true and was the bug.

- The bridge now stays attached through a grace window; `dispose()` returns a promise settling on the ack or window expiry. Inbound routing gates on a new `detached` flag rather than `disposed`, so the window is live on purpose.
- Teardown fires at **navigation intent**, not just component destroy. By the time Angular destroys the frame it removes the iframe in the same tick and the View is gone before it can run anything, so a registry of live bridges lets the conversation-change path notify every open App while its iframe is still alive.

Fired, not awaited: the App's save call is proxied over HTTP from the *host* page, so once its message reaches us the request outlives the iframe. The value is in the timing, not the wait.

### 2. A stored UI resource was never revalidated

The App HTML the SPA re-mounts on reload is whatever `resources/read` returned when the tool first ran, replayed verbatim from its `UIRES#` row **along with the CSP and permissions captured at that moment**. A server that ships a new App version — or tightens the policy its App runs under — never reached existing conversations, and we had quietly become the durable store of record for a resource that belongs to the server.

Re-reading needs a live MCP client, and the only path to one is a built agent. Revalidating on conversation open would add a full agent rebuild (76% of sessions bypass the agent cache per `docs/specs/agent-cache-extra-tools-bypass.md`) to a page load that runs no model turn, for every App whether or not anyone touches it. So this piggybacks on an app-initiated `tools/call`, where the agent is built and the client already revived.

**The trade:** the refreshed shell lands on the *next* load, not the current one. It converges for the Apps people actually use and costs nothing for the ones they don't.

Bounded and non-blocking: one refresh per resource per process, dispatched off the response path, silent on every failure — a server that is down must not blank an App that still works. `get_provenance` projects only the producing tool name and message anchor, never the ~130KB HTML the refresh is about to replace.

## Known limits

- Hard refresh and tab close still get no teardown window. A blocking wait on in-SPA navigation would need a route guard the app doesn't have.
- Reparenting the iframe to outlive its component is **not** an option — moving an iframe in the DOM reloads it, destroying the state this is trying to save.

## Testing

938 backend tests, 2533 SPA tests, clean build.

New coverage: the grace window keeps serving a `tools/call` posted in response to teardown and stops once it closes; the ack short-circuits the window; repeat `dispose()` calls share one window; a hung App doesn't strand the others; revalidation re-reads the **producing** tool (not the one the App just called — the `resourceUri` hangs off the producing tool's catalog entry) and preserves the message anchor; a read that returns nothing leaves the stored copy alone.

One existing assertion changed: the old dispose test asserted the same-tick detach, which is precisely the behavior this fixes.

**Not browser-verified.** Both paths need a real App session against the dev backend, and the teardown path specifically needs an App that has a flush to lose.

## Note for review

Rebased onto #1001, which rewrote `app_tool_dispatch.py`. The addition is additive and that PR's tests still pass alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)