### PR TITLE
fix(mcp-apps): carry app-tool errors across the AgentCore boundary

### DIFF
--- a/backend/src/apis/app_api/mcp_apps/routes.py
+++ b/backend/src/apis/app_api/mcp_apps/routes.py
@@ -37,6 +37,7 @@ from apis.app_api.chat import proxy_routes
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.mcp_apps.card_store import get_app_card_store
+from apis.shared.mcp_apps.error_envelope import read_error_envelope
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +119,16 @@ async def proxy_call(
     except Exception:  # noqa: BLE001 - upstream returned non-JSON
         raise HTTPException(status_code=502, detail="Bad upstream response")
 
+    # inference-api reports app-tool errors as 200 + an envelope, because
+    # AgentCore Runtime flattens any non-2xx it returns into a generic 424
+    # and discards the message. Restore the real status here, before the
+    # card write below — an enveloped error is a failed call and must not
+    # persist a provenance card.
+    enveloped = read_error_envelope(payload)
+    if enveloped is not None:
+        message, status = enveloped
+        return JSONResponse({"error": message}, status_code=status)
+
     # Option A (PR #6): on success, persist a static provenance card so the
     # call survives a page reload (the broker is in-memory; the live thread
     # event is otherwise lost on refresh). Best-effort + provenance-only —
@@ -140,9 +151,11 @@ async def proxy_call(
                 "mcp-apps: failed to persist provenance card", exc_info=True
             )
 
-    # Relay inference-api's status verbatim (403 not-app-visible, 409 no
-    # live client, 502 tool failure, 200 success) so the bridge can answer
-    # the iframe's JSON-RPC with the right error.
+    # Relay inference-api's status verbatim so the bridge can answer the
+    # iframe's JSON-RPC with the right error. Reached only for a success
+    # (200) or for an error raised *before* the app-tool handler — anything
+    # that handler reports arrives as a 200 + envelope and returned above,
+    # because AgentCore Runtime would otherwise flatten its status to 424.
     return JSONResponse(payload, status_code=response.status_code)
 
 
@@ -224,6 +237,12 @@ async def update_context(
         payload = response.json()
     except Exception:  # noqa: BLE001 - upstream returned non-JSON
         raise HTTPException(status_code=502, detail="Bad upstream response")
+
+    # Same AgentCore flattening as proxy-call; restore the real status.
+    enveloped = read_error_envelope(payload)
+    if enveloped is not None:
+        message, status = enveloped
+        return JSONResponse({"error": message}, status_code=status)
 
     return JSONResponse(payload, status_code=response.status_code)
 

--- a/backend/src/apis/inference_api/chat/app_tool_dispatch.py
+++ b/backend/src/apis/inference_api/chat/app_tool_dispatch.py
@@ -47,8 +47,13 @@ logger = logging.getLogger(__name__)
 class AppToolCallError(Exception):
     """Dispatch failed in a way the caller should surface as an error.
 
-    `code` is an app-api HTTP status hint; `message` is safe to return to
-    the client (no internals).
+    `code` is the status app-api should ultimately answer the SPA with, NOT
+    the status this container returns — AgentCore Runtime flattens any
+    non-2xx into a 424 and drops the body. The route encodes `code` and
+    `message` into a 200 response body and app-api restores the status.
+    See `apis/shared/mcp_apps/error_envelope.py`.
+
+    `message` is safe to return to the client (no internals).
     """
 
     def __init__(self, message: str, code: int = 400) -> None:
@@ -285,13 +290,23 @@ async def _ensure_oauth_token(client: Any, user_id: str) -> Optional[str]:
 
     # No token and a consent URL: the user has not authorized this
     # connector. There is no turn to interrupt here, so surface it as an
-    # error the App can render — the SPA relays `message` verbatim.
+    # error the App can render.
+    #
+    # `code` is NOT this response's HTTP status. AgentCore Runtime rewrites
+    # any non-2xx from this container into a generic 424 and discards the
+    # body, so returning 409 directly reached the SPA as "Received error
+    # (409) from runtime. Please check your CloudWatch logs" — verified
+    # live on dev 2026-09-08. The route returns 200 + an envelope carrying
+    # this code and message, and app-api restores the real status before
+    # replying to the SPA. See `apis/shared/mcp_apps/error_envelope.py`.
     #
     # 409, never 401: the SPA's error interceptor treats *any* 401 as an
     # expired BFF session and redirects to login, so answering "connect
     # your account" with a 401 would sign the user out. 409 is already this
     # codebase's "connector needs connecting" status (the file-source
     # browser and the export dialog both branch on it to show Connect).
+    # The envelope reader enforces this independently — it will not relay
+    # a 401 even if one is asked for here.
     raise AppToolCallError(
         f"Authorization required for '{provider_id}'. Connect the account, "
         "then try again.",

--- a/backend/src/apis/inference_api/chat/routes.py
+++ b/backend/src/apis/inference_api/chat/routes.py
@@ -67,6 +67,8 @@ from .app_context_dispatch import (
     dispatch_app_context_update,
     merge_and_clear_pending_context,
 )
+from apis.shared.mcp_apps.error_envelope import app_tool_error_response
+
 from .app_tool_dispatch import AppToolCallError, dispatch_app_tool_call
 from .agent_binding_policy import binds_conversation
 from .models import FileContent, InvocationRequest
@@ -1338,7 +1340,12 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             )
             return JSONResponse(payload)
         except AppToolCallError as e:
-            return JSONResponse({"error": e.message}, status_code=e.code)
+            # 200 + envelope, not `status_code=e.code`: AgentCore Runtime
+            # rewrites any non-2xx to a generic 424 and discards the
+            # message, so a deliberate 409 ("connect the account") reached
+            # the SPA as "check your CloudWatch logs". app-api restores the
+            # real status. See `mcp_apps.error_envelope`.
+            return app_tool_error_response(e.message, e.code)
         except HTTPException:
             raise
         except Exception:
@@ -1386,7 +1393,8 @@ async def invocations(request: InvocationRequest, current_user: User = Depends(g
             )
             return JSONResponse(payload)
         except AppContextUpdateError as e:
-            return JSONResponse({"error": e.message}, status_code=e.code)
+            # Same AgentCore flattening as the app_tool_call path above.
+            return app_tool_error_response(e.message, e.code)
         except HTTPException:
             raise
         except Exception:

--- a/backend/src/apis/shared/mcp_apps/error_envelope.py
+++ b/backend/src/apis/shared/mcp_apps/error_envelope.py
@@ -1,0 +1,100 @@
+"""Carry an app-tool error across the AgentCore Runtime boundary.
+
+inference-api runs behind AgentCore Runtime, which rewrites **any** non-2xx
+container response to a generic ``424``::
+
+    {"message": "Received error (409) from runtime. Please check your
+     CloudWatch logs for more information."}
+
+Both the status *and* the human-readable message are destroyed. So an
+app-initiated `tools/call` that needs OAuth consent — which
+`dispatch_app_tool_call` reports as a deliberate 409 carrying "Connect the
+account, then try again" — reached the SPA as a 424 whose body told the user
+to go read CloudWatch logs. Verified live on dev 2026-09-08.
+
+The fix: inference-api answers **200** with the error in the body instead,
+and app-api translates it back to the real HTTP status before replying to
+the SPA. The SPA's contract is unchanged — it still sees 403 / 409 / 502
+with ``{"error": "<message>"}`` — so only the one hop that crosses AgentCore
+changes shape.
+
+**Never widen `_RELAYABLE_STATUSES` to include 401.** The SPA's
+`error.interceptor` treats any 401 as an expired BFF session and redirects
+to login, so relaying a 401 here would sign the user out over an unconnected
+connector.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from fastapi.responses import JSONResponse
+
+# The key is deliberately distinct from the plain ``error`` key a direct
+# (non-AgentCore) inference-api response uses, so app-api can tell an
+# enveloped error from an ordinary error body without guessing.
+ENVELOPE_KEY = "appToolError"
+
+# Statuses app-api will re-emit from an envelope. An upstream that names
+# anything else collapses to 502 rather than letting a malformed payload
+# choose app-api's status code.
+_RELAYABLE_STATUSES = frozenset({400, 403, 404, 409, 422, 502})
+
+_FALLBACK_STATUS = 502
+_FALLBACK_MESSAGE = "Tool call failed"
+
+
+def build_error_envelope(message: str, code: int) -> Dict[str, Any]:
+    """Body for a 200 response that actually reports an error.
+
+    Returned by inference-api in place of ``JSONResponse({...}, code)``,
+    which AgentCore would flatten.
+    """
+    return {ENVELOPE_KEY: {"code": int(code), "message": str(message)}}
+
+
+def app_tool_error_response(message: str, code: int) -> "JSONResponse":
+    """inference-api's reply for a failed app-tool call: **200** + envelope.
+
+    The 200 is the whole point — returning `code` directly is what AgentCore
+    flattens into a 424. Use this instead of `JSONResponse({...}, code)` in
+    any inference-api handler whose response crosses the Runtime boundary.
+    """
+    from fastapi.responses import JSONResponse
+
+    return JSONResponse(build_error_envelope(message, code), status_code=200)
+
+
+def read_error_envelope(
+    payload: Any,
+) -> Optional[Tuple[str, int]]:
+    """Return ``(message, status)`` if `payload` carries an envelope.
+
+    ``None`` means the payload is an ordinary result and the caller should
+    relay it unchanged. A malformed or unlisted status falls back to 502 so
+    a bad upstream can never pick app-api's status code — in particular it
+    can never produce a 401.
+    """
+    if not isinstance(payload, dict):
+        return None
+    envelope = payload.get(ENVELOPE_KEY)
+    if not isinstance(envelope, dict):
+        return None
+
+    raw_message = envelope.get("message")
+    message = (
+        raw_message.strip()
+        if isinstance(raw_message, str) and raw_message.strip()
+        else _FALLBACK_MESSAGE
+    )
+
+    raw_code = envelope.get("code")
+    try:
+        code = int(raw_code)
+    except (TypeError, ValueError):
+        code = _FALLBACK_STATUS
+    if code not in _RELAYABLE_STATUSES:
+        code = _FALLBACK_STATUS
+
+    return message, code

--- a/backend/tests/apis/app_api/test_mcp_apps_proxy_call.py
+++ b/backend/tests/apis/app_api/test_mcp_apps_proxy_call.py
@@ -132,3 +132,114 @@ def test_maps_unreachable_inference_to_502(
 
     resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
     assert resp.status_code == 502
+
+
+# --- AgentCore envelope translation ----------------------------------------
+#
+# inference-api can't use HTTP status to report an app-tool error: AgentCore
+# Runtime rewrites any non-2xx to a generic 424 and drops the message. It
+# answers 200 + `appToolError` instead, and app-api restores the real status
+# here. See `apis/shared/mcp_apps/error_envelope.py`.
+
+
+def test_restores_status_and_message_from_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consent case that reached users as "check your CloudWatch logs"."""
+    consent = (
+        "Authorization required for 'google_tasks'. Connect the account, "
+        "then try again."
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"appToolError": {"code": 409, "message": consent}}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
+    assert resp.status_code == 409
+    assert resp.json()["error"] == consent
+
+
+def test_enveloped_error_never_relays_a_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 would trip the SPA interceptor and sign the user out."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"appToolError": {"code": 401, "message": "nope"}}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
+    assert resp.status_code == 502
+
+
+def test_enveloped_error_persists_no_provenance_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enveloped error is a failed call — it must not look like a success.
+
+    The card write is gated on the upstream's 200, and an envelope now
+    arrives *with* a 200, so this is the regression the ordering guards
+    against.
+    """
+    stored: list[dict] = []
+
+    class _Store:
+        def store(self, **kwargs: object) -> None:
+            stored.append(dict(kwargs))
+
+    monkeypatch.setattr(
+        "apis.app_api.mcp_apps.routes.get_app_card_store", lambda: _Store()
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"appToolError": {"code": 409, "message": "connect"}}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
+    assert resp.status_code == 409
+    assert stored == []
+
+
+def test_successful_call_still_persists_a_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Control for the test above: the envelope check must not swallow success."""
+    stored: list[dict] = []
+
+    class _Store:
+        def store(self, **kwargs: object) -> None:
+            stored.append(dict(kwargs))
+
+    monkeypatch.setattr(
+        "apis.app_api.mcp_apps.routes.get_app_card_store", lambda: _Store()
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "toolUseId": "tu-1",
+                "result": {"content": [{"text": "ok"}], "isError": False},
+            },
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
+    assert resp.status_code == 200
+    assert len(stored) == 1
+    assert stored[0]["tool_name"] == "widget_tool"

--- a/backend/tests/apis/app_api/test_mcp_apps_update_context.py
+++ b/backend/tests/apis/app_api/test_mcp_apps_update_context.py
@@ -123,3 +123,40 @@ def test_maps_unreachable_inference_to_502(
 
     resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
     assert resp.status_code == 502
+
+
+def test_restores_status_and_message_from_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same AgentCore 424 flattening as proxy-call.
+
+    See `apis/shared/mcp_apps/error_envelope.py`.
+    """
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"appToolError": {"code": 400, "message": "needs content"}},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "needs content"
+
+
+def test_enveloped_error_never_relays_a_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"appToolError": {"code": 401, "message": "nope"}}
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    app = _build_app(user_override=_user())
+
+    resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
+    assert resp.status_code == 502

--- a/backend/tests/shared/test_mcp_app_error_envelope.py
+++ b/backend/tests/shared/test_mcp_app_error_envelope.py
@@ -1,0 +1,132 @@
+"""Guards for the app-tool error envelope (AgentCore 424 flattening).
+
+inference-api runs behind AgentCore Runtime, which rewrites any non-2xx to a
+generic 424 and discards the message. These tests pin the 200 + envelope
+workaround and, most importantly, that a malformed upstream can never make
+app-api emit a 401 (which would sign the user out).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from apis.shared.mcp_apps.error_envelope import (
+    ENVELOPE_KEY,
+    app_tool_error_response,
+    build_error_envelope,
+    read_error_envelope,
+)
+
+
+def test_round_trips_message_and_status() -> None:
+    payload = build_error_envelope(
+        "Authorization required for 'google_tasks'. Connect the account, "
+        "then try again.",
+        409,
+    )
+    assert read_error_envelope(payload) == (
+        "Authorization required for 'google_tasks'. Connect the account, "
+        "then try again.",
+        409,
+    )
+
+
+@pytest.mark.parametrize("code", [400, 403, 404, 409, 422, 502])
+def test_relayable_statuses_pass_through(code: int) -> None:
+    assert read_error_envelope(build_error_envelope("nope", code)) == (
+        "nope",
+        code,
+    )
+
+
+def test_ordinary_result_is_not_an_envelope() -> None:
+    # A successful dispatch payload must relay unchanged.
+    assert read_error_envelope({"toolUseId": "tu-1", "result": {}}) is None
+
+
+def test_plain_error_body_is_not_an_envelope() -> None:
+    # A direct (non-AgentCore) inference-api error keeps its own status,
+    # so app-api must not mistake it for an envelope.
+    assert read_error_envelope({"error": "boom"}) is None
+
+
+def test_non_dict_payload_is_not_an_envelope() -> None:
+    assert read_error_envelope(["not", "a", "dict"]) is None
+    assert read_error_envelope(None) is None
+
+
+def test_non_dict_envelope_value_is_ignored() -> None:
+    assert read_error_envelope({ENVELOPE_KEY: "not-a-dict"}) is None
+
+
+# --- the safety property: never let upstream choose a 401 -------------------
+
+
+def test_401_is_never_relayed() -> None:
+    """A 401 would trip the SPA's interceptor and sign the user out."""
+    message, status = read_error_envelope(build_error_envelope("nope", 401))
+    assert status == 502
+    assert message == "nope"
+
+
+@pytest.mark.parametrize("code", [401, 301, 500, 200, -1, 999])
+def test_unlisted_status_collapses_to_502(code: int) -> None:
+    _, status = read_error_envelope(build_error_envelope("nope", code))
+    assert status == 502
+
+
+@pytest.mark.parametrize("code", [None, "abc", {"a": 1}, [409]])
+def test_malformed_status_collapses_to_502(code: object) -> None:
+    _, status = read_error_envelope({ENVELOPE_KEY: {"message": "m", "code": code}})
+    assert status == 502
+
+
+def test_numeric_string_status_is_coerced_then_whitelisted() -> None:
+    # Coercible, so it is honoured — but still checked against the
+    # whitelist, so a coercible 401 is no more relayable than an int one.
+    assert read_error_envelope({ENVELOPE_KEY: {"message": "m", "code": "409"}}) == (
+        "m",
+        409,
+    )
+    _, status = read_error_envelope({ENVELOPE_KEY: {"message": "m", "code": "401"}})
+    assert status == 502
+
+
+@pytest.mark.parametrize("message", [None, "", "   ", 42])
+def test_malformed_message_falls_back(message: object) -> None:
+    text, _ = read_error_envelope(
+        {ENVELOPE_KEY: {"message": message, "code": 409}}
+    )
+    assert text == "Tool call failed"
+
+
+# --- the response helper inference-api actually returns ---------------------
+
+
+def test_error_response_is_http_200() -> None:
+    """The 200 is the fix.
+
+    Returning the real status here is exactly what AgentCore Runtime
+    flattens into a 424 with the message discarded — the bug this envelope
+    exists to route around. If this assertion ever fails, the consent
+    message stops reaching users.
+    """
+    resp = app_tool_error_response("connect the account", 409)
+    assert resp.status_code == 200
+
+
+def test_error_response_body_carries_code_and_message() -> None:
+    resp = app_tool_error_response("connect the account", 409)
+    assert json.loads(resp.body) == {
+        ENVELOPE_KEY: {"code": 409, "message": "connect the account"}
+    }
+
+
+def test_error_response_round_trips_through_the_reader() -> None:
+    resp = app_tool_error_response("connect the account", 409)
+    assert read_error_envelope(json.loads(resp.body)) == (
+        "connect the account",
+        409,
+    )


### PR DESCRIPTION
## The bug

Press a button in an embedded MCP App that needs OAuth consent and you get:

> **Error** — Received error (409) from runtime. Please check your CloudWatch logs for more information.

Found while regression-testing today's MCP Apps merges (#1000 / #1001 / #1002) against dev. #1000 and #1002 are clean; this is the one defect.

## Root cause

`dispatch_app_tool_call` reports consent-required as a deliberate `409` carrying *"Authorization required for 'google_tasks'. Connect the account, then try again."* But inference-api runs behind **AgentCore Runtime, which rewrites any non-2xx container response to a generic `424`** and discards the body:

```
POST /api/mcp-apps/proxy-call → 424
{"message":"Received error (409) from runtime. Please check your CloudWatch logs for more information."}
```

Both the status **and** the human-readable message are destroyed, so three things in the code were untrue:

- `app_api/mcp_apps/routes.py` claimed to relay the status *"verbatim (403 not-app-visible, 409 no consent)"* — by then it was always 424.
- `app_tool_dispatch.py` claimed *"the SPA relays `message` verbatim"* — the message was gone.
- `mcp-app-proxy.service.ts` has no consent branch, so it rendered the raw runtime text.

**#1001's detection logic was correct all along** — it does warm the cache and does refuse to dispatch unauthenticated. Only its reporting was lost. Its "409, never 401" choice also held up: `/api/auth/session` stayed 200 and the user was not signed out.

## The fix

inference-api answers **200** with an `appToolError` envelope carrying the code and message; app-api restores the real status before replying to the SPA.

The SPA's contract is unchanged — it still sees 403/409/502 with `{"error": "<message>"}` — so only the single hop that crosses AgentCore changes shape, and **no frontend change is needed**. Applied to both proxied directives: `app_tool_call` and `app_context_update` (identical flattening).

Two properties `error_envelope` enforces independently of its callers:

- **Never relays a 401.** The SPA's `error.interceptor` treats any 401 as an expired BFF session and signs the user out, so an unlisted or malformed status collapses to 502 rather than letting upstream choose the status.
- **An enveloped error persists no provenance card.** The card write is gated on the upstream's 200, and an envelope now arrives *with* a 200 — so the envelope check must run first, and a test pins that ordering.

## Testing

- 30 new guards in `tests/shared/test_mcp_app_error_envelope.py`, plus relay tests on both routes.
- **Mutation-tested**, all mutants compiling:
  - reverting the 200 to the real status → fails `test_error_response_is_http_200`
  - admitting 401 to the whitelist → fails 5 named tests across all three files
  - moving the envelope check after the card write → fails `test_enveloped_error_persists_no_provenance_card`
- Full backend suite: **7786 passed**. (8 pre-existing `tests/fine_tuning` failures are a missing `pandas` in the local venv, unrelated to this change.)
- `ruff` clean on every changed file. The 4 remaining errors in `inference_api/chat/routes.py` (lines 1649/1792/1876/2142) are pre-existing and untouched.

## Note for review

**Not verifiable locally, by construction.** A local uvicorn talks to app-api directly with no AgentCore in the path, so the flattening cannot reproduce — which is exactly why this survived #1001's unit tests and a full CI run. Confirming the toast now reads "Connect the account, then try again" needs a dev deploy.

Separately worth knowing: while chasing this I could not find the dispatch in the runtime log group that serves it. SSM `/dev-boisestateai-v2/inference-api/runtime-id` confirms dev app-api targets `dev_boisestateai_v2_agentcore_runtime-Z6D3HsHKs6`, and that group is live (1,492 events/90min) — but every line is `GET /ping 200`, with **no `POST /invocations` at all**. That's why I still can't say which of the three 409 paths fired. Unrelated to this fix, but it undercuts the runtime log group as a debugging instrument and probably deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)