### PR TITLE
chore(deps): strands-agents-tools 0.8.6 → 0.8.8 (calculator sandbox escape)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 # AgentCore-specific dependencies (for inference_api)
 agentcore = [
     "strands-agents==1.51.0",
-    "strands-agents-tools==0.8.6",
+    "strands-agents-tools==0.8.8",
 
     "aws-opentelemetry-distro==0.19.0",
     "bedrock-agentcore==1.21.0",

--- a/backend/tests/security/test_calculator_sandbox.py
+++ b/backend/tests/security/test_calculator_sandbox.py
@@ -1,0 +1,101 @@
+"""Regression tests for the sandbox in the vendored ``strands_tools.calculator``.
+
+``calculator`` is registered in ``create_default_registry()`` and seeded with
+``enabledByDefault=True``, so it is reachable by every user on every agent and
+it evaluates model-supplied expressions. Its AST allowlist is therefore a real
+security boundary, not an input-validation nicety.
+
+The boundary permits a string literal only as a positional argument to a small
+set of constructors that parse it as a plain name or numeric literal
+(``Symbol``, ``symbols``, ``Rational``, ``Integer``, ``Float``); everywhere else
+a string is rejected, which blocks the ``sympify``-backed re-parse escape.
+
+Up to ``strands-agents-tools`` 0.8.6 that check ignored the call's keyword
+arguments, so ``symbols('...', cls=N)`` rerouted ``symbols`` to apply ``N`` —
+and therefore ``sympify`` — to the string, re-parsing it outside the restricted
+namespace. 0.8.8 trusts a string literal only when every keyword on the call is
+a boolean assumption flag, and treats ``**kwargs`` unpacking as untrusted
+because it can smuggle in ``cls``.
+
+These tests pin that behaviour to the installed wheel, so a downgrade or a
+resolver drift back below 0.8.8 fails the suite instead of silently reopening
+the escape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_tools.calculator import _validate_expression_ast, parse_expression
+
+# ---------------------------------------------------------------------------
+# The escape: a keyword that reroutes how the string argument is parsed.
+# ---------------------------------------------------------------------------
+
+REROUTED_STRING_ARGS = [
+    # The disclosed form: cls=N makes symbols apply N (sympify) to the string.
+    "symbols('x', cls=N)",
+    # The same reroute carrying a payload that must never reach sympify.
+    "symbols('__import__(\"os\").system(\"id\")', cls=N)",
+    # cls on the other string constructors is rejected for the same reason.
+    "Symbol('1+1', cls=N)",
+    # **kwargs unpacking can smuggle in cls, so it is untrusted too.
+    "symbols('x', **kw)",
+    # A non-boolean keyword is not an assumption flag.
+    "symbols('x', cls=Float)",
+]
+
+
+@pytest.mark.parametrize("expression", REROUTED_STRING_ARGS)
+def test_string_arg_with_rerouting_keyword_rejected(expression: str) -> None:
+    """A string literal is not trusted when the call carries a rerouting keyword."""
+    with pytest.raises(ValueError, match="string literals are not supported"):
+        parse_expression(expression)
+
+
+def test_string_arg_outside_safe_constructors_rejected() -> None:
+    """The pre-existing half of the boundary: sympify-backed constructors stay closed."""
+    with pytest.raises(ValueError, match="string literals are not supported"):
+        parse_expression("N('1+1')")
+
+
+# ---------------------------------------------------------------------------
+# The fix must not narrow legitimate use — calculator is on for every user.
+# ---------------------------------------------------------------------------
+
+LEGITIMATE_EXPRESSIONS = [
+    "2 + 2 * 10",
+    "x**2 + 2*x + 1",
+    "sin(pi/2) + log(E)",
+    "Symbol('x')",
+    "symbols('x y')",
+    "Rational('1/3')",
+    "Integer('42')",
+    "Float('3.14')",
+]
+
+
+@pytest.mark.parametrize("expression", LEGITIMATE_EXPRESSIONS)
+def test_ordinary_expressions_still_parse(expression: str) -> None:
+    """Ordinary arithmetic and symbolic input are unaffected by the tightened check."""
+    assert parse_expression(expression) is not None
+
+
+ASSUMPTION_KEYWORD_CALLS = [
+    "Symbol('x', positive=True)",
+    "Symbol('x', real=True, positive=True)",
+    "symbols('x y', positive=True)",
+]
+
+
+@pytest.mark.parametrize("expression", ASSUMPTION_KEYWORD_CALLS)
+def test_assumption_keywords_remain_trusted(expression: str) -> None:
+    """Boolean assumption flags do not reroute parsing, so the string stays trusted.
+
+    Asserted against the validator rather than ``parse_expression`` because these
+    calls fail further downstream for an unrelated, pre-existing reason: sympy's
+    ``implicit_multiplication_application`` transform rewrites ``positive=True``
+    into a multiplication before ``parse_expr`` sees it. That behaviour is
+    identical on 0.8.6 and 0.8.8 — the security boundary is the layer under test.
+    """
+    _validate_expression_ast(expression)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -125,7 +125,7 @@ requires-dist = [
     { name = "starlette", specifier = "==1.3.1" },
     { name = "strands-agents", marker = "extra == 'agentcore'", specifier = "==1.51.0" },
     { name = "strands-agents", extras = ["bidi"], marker = "extra == 'bidi'", specifier = "==1.51.0" },
-    { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.8.6" },
+    { name = "strands-agents-tools", marker = "extra == 'agentcore'", specifier = "==0.8.8" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = "==0.12.0" },
     { name = "trafilatura", specifier = "==2.0.0" },
     { name = "types-aiofiles", marker = "extra == 'dev'", specifier = "==25.1.0.20260409" },
@@ -4715,7 +4715,7 @@ bidi = [
 
 [[package]]
 name = "strands-agents-tools"
-version = "0.8.6"
+version = "0.8.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4736,9 +4736,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/63031f0d5483a036eb732ae52624e6429ed1385d9c68515763c323da00fd/strands_agents_tools-0.8.6.tar.gz", hash = "sha256:3cdafd706909be6e8cab5411067cdc5af269bec29f1903788629e3f092d9e8aa", size = 533539, upload-time = "2026-08-07T18:09:03.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e2/18f496ee1f3c17071228b76be67b50621d9f9061ee54c320bcb8b1683370/strands_agents_tools-0.8.8.tar.gz", hash = "sha256:7ec790d888ea5e24df038f40bcd52aa6ba82d86c578e5148f306c0969e5cbade", size = 539062, upload-time = "2026-09-04T14:58:21.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/32/36ff3b19528430d68f740bf61d6fe1f4afbf670f69a2ca204ae1f04139e2/strands_agents_tools-0.8.6-py3-none-any.whl", hash = "sha256:ed87ef1c405c635164e7e85e1cb0a1560bd30156b54b3c6cb11574e67d111d5c", size = 338989, upload-time = "2026-08-07T18:09:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4d/7680c2c620c7531eb063f2964804c763b580f1bfea5b948ef862b3031f29/strands_agents_tools-0.8.8-py3-none-any.whl", hash = "sha256:5e075462cdfc3cd96b31d5a3a552e24d5eacae42687e5378c1e5a469c7ef9d64", size = 339705, upload-time = "2026-09-04T14:58:19.783Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `strands-agents-tools` from 0.8.6 to 0.8.8 (released 2026-09-04). One-line pin change plus the lockfile and a regression test.

## Why

0.8.8 closes a sandbox escape in `strands_tools/calculator.py`.

The calculator validates model-supplied expressions against an AST allowlist before parsing. That allowlist trusts a string literal only as a positional argument to constructors that parse it as a plain name or numeric literal — `Symbol`, `symbols`, `Rational`, `Integer`, `Float` — which is what blocks the `sympify`-backed re-parse escape (`N("...")`, `simplify("...")`, `solve("...")`).

Through 0.8.6 that check ignored the call's **keyword** arguments. `symbols('...', cls=N)` reroutes `symbols` to apply an arbitrary constructor — here `N` — to the string, which re-parses it through `sympify` and escapes the restricted namespace.

0.8.8 adds `_has_only_assumption_keywords()`: a string positional is trusted only when every keyword on the call is a boolean assumption flag (`Symbol('x', positive=True)`). `**kwargs` unpacking (`kw.arg is None`) is treated as untrusted too, since it can smuggle in `cls`.

**This is reachable by every user.** `calculator` is registered in `create_default_registry()` (`backend/src/agents/main_agent/tools/tool_registry.py:93`) and seeded with `enabledByDefault=True` (`backend/scripts/seed_bootstrap_data.py`), so it is on by default and evaluates model-supplied input.

## Verification

Release notes for this package are monorepo-wide and unreliable, so this was verified by diffing the actual 0.8.6 and 0.8.8 wheels.

**Six files differ**: `calculator.py`, `http_request.py`, `mem0_memory.py`, `mongodb_memory.py`, `think.py`, `use_aws.py`. We import only `strands_tools.calculator` — confirmed by grep, the sole import in the repo is `from strands_tools.calculator import calculator`, plus one mention in `USAGE_EXAMPLES.md`. The other five are unreachable from our import graph, and `calculator.py` itself imports none of them. (`strands_tools.browser` exists but is unused and would need Playwright, which is deliberately not installed.) `strands_tools/__init__.py` is byte-identical between the two versions.

**The `calculator.py` diff is exactly this fix** — the new helper plus a `continue` at the call site. Nothing else.

**Behavioural check against both versions:**

| Input | 0.8.6 | 0.8.8 |
|---|---|---|
| `symbols('x', cls=N)` | allowed | rejected |
| `symbols('__import__("os").system("id")', cls=N)` | allowed | rejected |
| `symbols('x', **kw)` | allowed | rejected |
| `2 + 2 * 10`, `Symbol('x')`, `Rational('1/3')` | allowed | allowed |

**Through the real agent path** (`create_default_registry()` → `calculator`): `2 + 2 * 10` → `Result: 22`, `sin(pi/2) + log(E)` → `Result: 2`, and `symbols('x', cls=N)` → `{'status': 'error', ...'string literals are not supported'}`.

**Full backend suite green**: 7796 passed, 3 skipped, 0 failed.

**Lockfile churn is minimal** — only the `strands-agents-tools` entry moves; no transitive resolution changes. (0.8.8's metadata loosens `rich<15` → `rich<16` and the `agent-core-*` extras' `bedrock-agentcore` bound, but we install neither extra and `rich` did not move.)

## Regression test

`backend/tests/security/test_calculator_sandbox.py` — a sibling to the existing `test_python_ast_policy.py`, pinning the boundary to the installed wheel so a downgrade or resolver drift back below 0.8.8 fails the suite instead of silently reopening the escape. It fails on 0.8.6 (all 5 escape cases) and passes on 0.8.8.

One test asserts the assumption-keyword carve-out against the validator rather than `parse_expression`, because `Symbol('x', positive=True)` fails further downstream for an unrelated **pre-existing** reason: sympy's `implicit_multiplication_application` transform rewrites `positive=True` into a multiplication before `parse_expr` sees it. Verified identical on 0.8.6 — not introduced by this bump.

## Scope

Deliberately kept to this one bump:

- `strands-agents==1.51.0` untouched — a separate PR is taking that to 1.55.0 on `feature/strands-1-55-upgrade`. Both touch adjacent lines in `backend/pyproject.toml`, so expect a trivial conflict on whichever merges second; **resolve by keeping both bumps**.
- `bedrock-agentcore==1.21.0` untouched — 1.22.0 is entirely the unused `payments/` module.

## Noted, not addressed here

- `calculator` is marked deprecated upstream ("becomes an error log in v0.9.0", suggesting the vended `bash` tool instead). This is **pre-existing in 0.8.6**, not new in 0.8.8, but it is worth a follow-up given we ship the tool on by default — the suggested replacement has a materially wider security boundary.
- `backend/README.md:440` still lists `strands-agents-tools 0.2.3`, stale since well before this PR. Left alone to keep the diff to one logical change.

## Deploy

Merging to `develop` auto-deploys dev (backend.yml, frontend-deploy.yml, platform.yml are all push-triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)