### PR TITLE
fix(mcp-apps): let the consent message reach the toast

### DIFF
--- a/backend/src/apis/app_api/mcp_apps/routes.py
+++ b/backend/src/apis/app_api/mcp_apps/routes.py
@@ -37,7 +37,10 @@ from apis.app_api.chat import proxy_routes
 from apis.shared.auth.dependencies import get_current_user_from_session
 from apis.shared.auth.models import User
 from apis.shared.mcp_apps.card_store import get_app_card_store
-from apis.shared.mcp_apps.error_envelope import read_error_envelope
+from apis.shared.mcp_apps.error_envelope import (
+    app_tool_error_body,
+    read_error_envelope,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +130,7 @@ async def proxy_call(
     enveloped = read_error_envelope(payload)
     if enveloped is not None:
         message, status = enveloped
-        return JSONResponse({"error": message}, status_code=status)
+        return JSONResponse(app_tool_error_body(message), status_code=status)
 
     # Option A (PR #6): on success, persist a static provenance card so the
     # call survives a page reload (the broker is in-memory; the live thread
@@ -242,7 +245,7 @@ async def update_context(
     enveloped = read_error_envelope(payload)
     if enveloped is not None:
         message, status = enveloped
-        return JSONResponse({"error": message}, status_code=status)
+        return JSONResponse(app_tool_error_body(message), status_code=status)
 
     return JSONResponse(payload, status_code=response.status_code)
 

--- a/backend/src/apis/shared/mcp_apps/error_envelope.py
+++ b/backend/src/apis/shared/mcp_apps/error_envelope.py
@@ -66,6 +66,28 @@ def app_tool_error_response(message: str, code: int) -> "JSONResponse":
     return JSONResponse(build_error_envelope(message, code), status_code=200)
 
 
+def app_tool_error_body(message: str) -> Dict[str, str]:
+    """app-api's error body for a failed app-tool call.
+
+    Carries the same text under **both** keys on purpose, because two
+    independent consumers read it and they disagree on the key:
+
+    - ``error`` — `McpAppProxyService` reads ``err.error?.error`` and hands
+      the text to the iframe's JSON-RPC reply.
+    - ``detail`` — the SPA's global `ErrorService` renders the toast. It
+      reads ``detail`` / ``error.detail`` / ``error.message`` / ``message``,
+      and treats a *string* ``error`` as no message at all — falling back to
+      a generic per-status string ("The request conflicts with the current
+      state." for 409). ``detail`` is also FastAPI's own `HTTPException`
+      shape, which the rest of this router already emits.
+
+    Verified on dev 2026-09-09: with only ``error``, a consent failure
+    surfaced as the generic 409 toast even though the message was present
+    in the body.
+    """
+    return {"error": message, "detail": message}
+
+
 def read_error_envelope(
     payload: Any,
 ) -> Optional[Tuple[str, int]]:

--- a/backend/tests/apis/app_api/test_mcp_apps_proxy_call.py
+++ b/backend/tests/apis/app_api/test_mcp_apps_proxy_call.py
@@ -161,7 +161,11 @@ def test_restores_status_and_message_from_envelope(
 
     resp = TestClient(app).post("/mcp-apps/proxy-call", json=_BODY)
     assert resp.status_code == 409
+    # `error` feeds the App bridge; `detail` is what the SPA's global
+    # ErrorService renders in the toast. Without `detail` the user gets
+    # the generic "The request conflicts with the current state."
     assert resp.json()["error"] == consent
+    assert resp.json()["detail"] == consent
 
 
 def test_enveloped_error_never_relays_a_401(

--- a/backend/tests/apis/app_api/test_mcp_apps_update_context.py
+++ b/backend/tests/apis/app_api/test_mcp_apps_update_context.py
@@ -145,6 +145,7 @@ def test_restores_status_and_message_from_envelope(
     resp = TestClient(app).post("/mcp-apps/update-context", json=_BODY)
     assert resp.status_code == 400
     assert resp.json()["error"] == "needs content"
+    assert resp.json()["detail"] == "needs content"
 
 
 def test_enveloped_error_never_relays_a_401(

--- a/backend/tests/shared/test_mcp_app_error_envelope.py
+++ b/backend/tests/shared/test_mcp_app_error_envelope.py
@@ -14,6 +14,7 @@ import pytest
 
 from apis.shared.mcp_apps.error_envelope import (
     ENVELOPE_KEY,
+    app_tool_error_body,
     app_tool_error_response,
     build_error_envelope,
     read_error_envelope,
@@ -130,3 +131,26 @@ def test_error_response_round_trips_through_the_reader() -> None:
         "connect the account",
         409,
     )
+
+
+# --- the body the SPA's two consumers actually read ------------------------
+
+
+def test_error_body_carries_both_keys() -> None:
+    """`error` for the App bridge, `detail` for the global toast.
+
+    A string-valued `error` alone matches none of ErrorService's four
+    lookups, so the toast fell back to "The request conflicts with the
+    current state." while the real message sat unread in the body.
+    """
+    assert app_tool_error_body("connect the account") == {
+        "error": "connect the account",
+        "detail": "connect the account",
+    }
+
+
+def test_error_body_detail_is_what_the_toast_reads() -> None:
+    # ErrorService priority 1 is a top-level string `detail`.
+    body = app_tool_error_body("Authorization required for 'google-tasks'.")
+    assert isinstance(body.get("detail"), str)
+    assert body["detail"] == "Authorization required for 'google-tasks'."


### PR DESCRIPTION
Follow-up to #1009, found by validating it on dev after deploy.

## What #1009 fixed, and what it didn't

#1009 did what it claimed — the status and message now survive the AgentCore Runtime boundary intact:

```
POST /api/mcp-apps/proxy-call → 409
{"error":"Authorization required for 'google-tasks'. Connect the account, then try again."}
```

**409, not 424, and the real message is in the body.** That part is confirmed working on dev.

But the user still didn't see it. The toast read:

> **Conflict** — The request conflicts with the current state.

## Root cause

`ErrorService.handleHttpError` looks for a message under `detail`, `error.detail`, `error.message`, or `message` — in that order. app-api returns `error` as a plain **string**, which matches none of them (priority 2 requires `error` to be an *object*), so it falls through to `createErrorMessageFromStatus` and renders the generic per-status text while the real message sits unread in the body.

This also explains the pre-#1009 symptom, and it's the part worth noticing: AgentCore's 424 body used the key `message`, which *did* match priority 3. So the useless "check your CloudWatch logs" text was rendered for exactly the reason the useful text was not.

## The fix

`app_tool_error_body()` emits the same text under both keys:

- `error` — `McpAppProxyService` reads `err.error?.error` and hands it to the iframe's JSON-RPC reply (unchanged behaviour).
- `detail` — what `ErrorService` actually renders, and FastAPI's own `HTTPException` shape, which the rest of this router already emits.

**No SPA change.** The fix is to speak the key the SPA already reads, rather than to teach the SPA a fifth shape.

## Testing

- 2 new guards on the body shape; both relay tests now assert `detail` alongside `error`.
- **Mutation-tested**: dropping `detail` fails 4 named tests across all three files; the mutant compiles.
- 46 passed across the envelope and both route suites. `ruff` clean on every changed file.

## Still open after this

The dev account genuinely isn't connected to Google Tasks, so the consent path is the live behaviour there — that's what made it testable. Once this deploys I'll confirm the toast reads the real message.

Unrelated and still unexplained from #1009's investigation: no `POST /invocations` appears in the runtime log group that serves dev, so I still can't say which of the three 409 paths fires. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)