### PR TITLE
feat(fine-tuning): add generative VLM fine-tuning (image-text-to-text)

### DIFF
--- a/backend/src/apis/app_api/fine_tuning/job_models.py
+++ b/backend/src/apis/app_api/fine_tuning/job_models.py
@@ -39,6 +39,7 @@ def _hyperparameters(task_type: str, **overrides: str) -> Dict[str, str]:
 _TEXT = task_types.TEXT_CLASSIFICATION
 _IMAGE = task_types.IMAGE_CLASSIFICATION
 _IMAGE_TEXT = task_types.IMAGE_TEXT_CLASSIFICATION
+_VLM = task_types.IMAGE_TEXT_TO_TEXT
 
 
 AVAILABLE_MODELS: List[AvailableModel] = [
@@ -229,6 +230,81 @@ AVAILABLE_MODELS: List[AvailableModel] = [
         default_instance_type="ml.g6.xlarge",
         default_hyperparameters=_hyperparameters(_IMAGE_TEXT),
     ),
+    # ---------------------------------------------------------------
+    # Image + text to text (generative VLM)
+    #
+    # These are LoRA-adapted, not fully fine-tuned: a full fine-tune of even
+    # the smallest entry here needs more optimiser memory than the largest
+    # instance we offer.  Every entry must ship a chat template, because the
+    # trainer formats turns with it rather than inventing a dialogue format
+    # the checkpoint has never seen.
+    #
+    # context_length is the sequence budget INCLUDING expanded image tokens.
+    # LLaVA-1.5 emits 576 per image; the 1.6/NeXT models tile at higher
+    # resolution and emit up to 2880, which is why they get a larger budget.
+    # ---------------------------------------------------------------
+    AvailableModel(
+        model_id="smolvlm-instruct",
+        model_name="SmolVLM Instruct",
+        huggingface_model_id="HuggingFaceTB/SmolVLM-Instruct",
+        description="2.2B parameter vision-language model from HuggingFace, small enough to iterate on quickly and the cheapest way to validate a dataset",
+        task_type=_VLM,
+        default_instance_type="ml.g6e.xlarge",
+        default_hyperparameters=_hyperparameters(
+            _VLM,
+            # Small enough to train in bf16, which is faster than 4-bit and
+            # avoids the dequantisation overhead entirely.
+            load_in_4bit="false",
+            per_device_train_batch_size="2",
+            gradient_accumulation_steps="4",
+        ),
+    ),
+    AvailableModel(
+        model_id="llava-1.5-7b",
+        model_name="LLaVA 1.5 7B",
+        huggingface_model_id="llava-hf/llava-1.5-7b-hf",
+        description="7B parameter vision-language model, the standard baseline for visual instruction tuning at a fixed 576 image tokens",
+        task_type=_VLM,
+        default_instance_type="ml.g6e.xlarge",
+        default_hyperparameters=_hyperparameters(_VLM),
+    ),
+    AvailableModel(
+        model_id="llava-1.6-mistral-7b",
+        model_name="LLaVA 1.6 Mistral 7B",
+        huggingface_model_id="llava-hf/llava-v1.6-mistral-7b-hf",
+        description="7.6B parameter LLaVA-NeXT on Mistral, higher-resolution tiling than 1.5 and correspondingly slower per record",
+        task_type=_VLM,
+        default_instance_type="ml.g6e.xlarge",
+        default_hyperparameters=_hyperparameters(_VLM, context_length="2048"),
+    ),
+    AvailableModel(
+        model_id="qwen25-vl-7b-instruct",
+        model_name="Qwen2.5-VL 7B Instruct",
+        huggingface_model_id="Qwen/Qwen2.5-VL-7B-Instruct",
+        description="8.3B parameter vision-language model from Alibaba with dynamic resolution, strong on documents, charts and OCR-heavy images",
+        task_type=_VLM,
+        default_instance_type="ml.g6e.xlarge",
+        default_hyperparameters=_hyperparameters(_VLM, context_length="2048"),
+    ),
+    AvailableModel(
+        model_id="llava-1.6-34b",
+        model_name="LLaVA 1.6 34B",
+        huggingface_model_id="llava-hf/llava-v1.6-34b-hf",
+        description="34.8B parameter LLaVA-NeXT on Yi-34B, the most capable option and by far the slowest — expect multi-hour runs and budget accordingly",
+        task_type=_VLM,
+        # One L40S still holds the 4-bit weights (~18GB), so the cheapest
+        # instance that fits is a single-GPU one.  The larger size is for host
+        # RAM, not VRAM: the base arrives as 15 shards that are quantised on
+        # the way in.
+        default_instance_type="ml.g6e.4xlarge",
+        default_hyperparameters=_hyperparameters(
+            _VLM,
+            context_length="2048",
+            gradient_accumulation_steps="16",
+            lora_r="8",
+            lora_alpha="16",
+        ),
+    ),
 ]
 
 MODEL_CATALOG: Dict[str, AvailableModel] = {m.model_id: m for m in AVAILABLE_MODELS}
@@ -311,3 +387,7 @@ class TaskTypeResponse(BaseModel):
     requires_archive: bool
     inference_upload_extensions: List[str]
     default_instance_type: str
+    #: True when the task emits free text rather than class probabilities.
+    #: Defaulted so a client built against the classification-only shape keeps
+    #: deserialising this response.
+    is_generative: bool = False

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -124,6 +124,7 @@ async def list_task_types(
             requires_archive=spec.requires_archive,
             inference_upload_extensions=list(spec.inference_upload_extensions),
             default_instance_type=spec.default_instance_type,
+            is_generative=spec.is_generative,
         )
         for spec in (
             task_types.get_task_spec(t) for t in task_types.TASK_TYPES
@@ -588,8 +589,9 @@ async def create_job(
     hyperparameters["job_pk"] = f"USER#{user.user_id}"
     hyperparameters["job_sk"] = f"JOB#{job_id}"
 
-    # Ensure training scripts are uploaded and get the S3 URI
-    scripts_s3_uri = script_service.ensure_scripts_uploaded()
+    # Ensure training scripts are uploaded and get the S3 URI.  The archive is
+    # per DLC family: the families install different dependency sets.
+    scripts_s3_uri = script_service.ensure_scripts_uploaded(spec.task_type)
 
     # S3 paths
     output_s3_prefix = s3_service.get_output_s3_prefix(user.user_id, job_id)

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/inference.py
@@ -23,11 +23,13 @@ try:  # package context: unit tests and the app-api container
     from .. import task_types
     from . import task_image_classification
     from . import task_image_text_classification
+    from . import task_image_text_to_text
     from . import task_text_classification
 except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
     import task_types  # type: ignore
     import task_image_classification  # type: ignore
     import task_image_text_classification  # type: ignore
+    import task_image_text_to_text  # type: ignore
     import task_text_classification  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -40,6 +42,7 @@ TASK_MODULES = {
     task_types.TEXT_CLASSIFICATION: task_text_classification,
     task_types.IMAGE_CLASSIFICATION: task_image_classification,
     task_types.IMAGE_TEXT_CLASSIFICATION: task_image_text_classification,
+    task_types.IMAGE_TEXT_TO_TEXT: task_image_text_to_text,
 }
 
 #: Task type of the artifact currently loaded, remembered at module scope.
@@ -151,21 +154,11 @@ def _escape_csv(value):
     return '"' + str(value).replace('"', '""') + '"'
 
 
-def output_fn(prediction, accept="text/csv"):
-    """Format predictions as CSV with one probability column per class.
-
-    Output format:
-        id,prob_label1,prob_label2,...
-        "example.jpg",0.850000,0.150000
-
-    The first column is whatever identifies a record for the task: the input
-    text for text classification, the archive-relative image path for the
-    image tasks.
-    """
+def _classification_rows(prediction, identifier_column):
+    """CSV rows for a task that emits one probability column per class."""
     identifiers = prediction["identifiers"]
     probabilities = prediction["probabilities"]
     labels = prediction["labels"]
-    identifier_column = prediction.get("identifier_column", "id")
 
     header = identifier_column + "," + ",".join(
         f"prob_{_sanitize_label(label)}" for label in labels
@@ -181,5 +174,56 @@ def output_fn(prediction, accept="text/csv"):
         else:
             values = ",".join("0.000000" for _ in labels)
         rows.append(f"{_escape_csv(identifier)},{values}")
+    return rows
+
+
+def _generative_rows(prediction, identifier_column):
+    """CSV rows for a task that emits free text.
+
+    Still CSV, and still one row per input record, so the result file
+    downloads and opens exactly like a classification result.  Generated text
+    routinely contains commas, quotes and newlines; ``_escape_csv`` quotes and
+    doubles them, which is valid CSV for all three.
+    """
+    identifiers = prediction["identifiers"]
+    prompts = prediction.get("prompts", [])
+    generations = prediction["generations"]
+
+    rows = [f"{identifier_column},prompt,output"]
+    for index, identifier in enumerate(identifiers):
+        prompt = prompts[index] if index < len(prompts) else ""
+        generation = generations[index] if index < len(generations) else ""
+        rows.append(
+            f"{_escape_csv(identifier)},{_escape_csv(prompt)},{_escape_csv(generation)}"
+        )
+    return rows
+
+
+def output_fn(prediction, accept="text/csv"):
+    """Format predictions as CSV.
+
+    Two shapes, chosen by what the task produced rather than by a flag the
+    caller has to pass:
+
+    Classification — an identifier followed by one probability per class::
+
+        id,prob_label1,prob_label2
+        "example.jpg",0.850000,0.150000
+
+    Generative — an identifier, the prompt, and the generated text::
+
+        image,prompt,output
+        "cat.jpg","What is this?","A tabby cat sitting on a windowsill."
+
+    The first column is whatever identifies a record for the task: the input
+    text for text classification, the archive-relative image path for every
+    image task.
+    """
+    identifier_column = prediction.get("identifier_column", "id")
+
+    if "generations" in prediction:
+        rows = _generative_rows(prediction, identifier_column)
+    else:
+        rows = _classification_rows(prediction, identifier_column)
 
     return "\n".join(rows)

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/requirements-vlm.txt
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/requirements-vlm.txt
@@ -1,0 +1,15 @@
+# Packaged AS requirements.txt for generative-VLM jobs only.
+#
+# These cannot go in the shared requirements.txt: bitsandbytes requires
+# torch>=2.4 and the text DLC is torch 2.1, so one shared file would fail to
+# install on the container every existing text job runs in.  The packaging
+# service picks the file by DLC family — see
+# script_packaging_service.REQUIREMENTS_BY_FAMILY.
+#
+# torch, transformers, datasets, evaluate and accelerate are supplied by the
+# DLC and are deliberately unpinned here; pinning them would fight the image.
+pandas
+scikit-learn
+pillow==12.3.0
+peft==0.20.0
+bitsandbytes==0.50.2

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
@@ -505,6 +505,7 @@ INFERENCE_BUNDLE_FILES = (
     "task_text_classification.py",
     "task_image_classification.py",
     "task_image_text_classification.py",
+    "task_image_text_to_text.py",
 )
 
 

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_to_text.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_to_text.py
@@ -1,0 +1,586 @@
+"""Generative vision-language fine-tuning: (image, prompt) -> free text.
+
+The three classification tasks all end in a softmax over a fixed class list.
+This one does not: the model keeps its language-modelling head and learns to
+*write* the response, so the dataset has no label column and the result file
+carries a text column instead of one probability column per class.
+
+**Why LoRA and not a full fine-tune.**  A generative VLM worth using starts
+around 7B parameters and the catalog goes to 34B.  A full fine-tune needs
+roughly 16 bytes per parameter once gradients and the AdamW moments are
+resident — ~550GB for a 34B model, against the 384GB on the largest instance
+we offer.  Quantising the frozen base to 4-bit and training only low-rank
+adapters brings the same model to ~18GB of weights, which fits one 48GB card
+and leaves the activations room to breathe.  The trade is that the artifact is
+an *adapter*, not a model: it is a few hundred MB rather than 69GB, and
+inference reloads the base from the Hub and applies the adapter on top.
+
+**Prompt masking.**  Loss is computed on the response only.  Training on the
+prompt as well is the usual accident here: the model spends most of its
+gradient budget learning to reproduce questions it will always be given.  The
+prompt length is measured by rendering each record twice — once with the
+generation prompt and no answer, once complete — and masking that many leading
+positions.
+"""
+
+import json
+import logging
+import os
+
+try:  # package context: unit tests and the app-api container
+    from . import task_common
+except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
+    import task_common  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+#: Written next to the adapter so inference can rebuild base + adapter without
+#: being told which base was used.
+ADAPTER_CONFIG_FILENAME = "vlm_adapter.json"
+
+#: Ignored index for positions that must not contribute to the loss.
+LABEL_IGNORE_INDEX = -100
+
+def prompt_mask_limit(prompt_length, sequence_length):
+    """How many leading positions of a row to exclude from the loss.
+
+    Truncation can cut a long prompt so short that nothing of the response
+    survives.  Masking the whole row makes its loss NaN, which propagates
+    through the batch average and destroys the step — so the last position is
+    always left scoreable and such an example contributes almost nothing
+    instead of poisoning the batch.
+    """
+    return max(0, min(int(prompt_length), int(sequence_length) - 1))
+
+
+#: Generation runs one record at a time.  Batched generation needs left
+#: padding and a per-architecture agreement about where image placeholders may
+#: sit relative to the pad run; getting it subtly wrong produces fluent
+#: garbage rather than an error, which is the worst failure mode for a result
+#: file a researcher will treat as data.
+GENERATION_BATCH_SIZE = 1
+
+
+# =========================================================================
+# Chat rendering
+# =========================================================================
+
+def build_messages(prompt, response=None):
+    """Return chat messages for one record.
+
+    ``response=None`` yields the prompt half only, which is what both the
+    generation path and the prompt-length measurement need.
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image"}, {"type": "text", "text": str(prompt)}],
+        }
+    ]
+    if response is not None:
+        messages.append(
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": str(response)}],
+            }
+        )
+    return messages
+
+
+def render_chat(processor, messages, add_generation_prompt):
+    """Render messages to a string using the processor's chat template.
+
+    Every model in the catalog ships a chat template.  A checkpoint without
+    one would otherwise be rendered with an invented format that does not
+    match its pre-training, which trains the model to answer in a dialogue
+    shape it has never seen — so this raises instead of guessing.
+    """
+    template = getattr(processor, "chat_template", None) or getattr(
+        getattr(processor, "tokenizer", None), "chat_template", None
+    )
+    if not template:
+        raise ValueError(
+            "This checkpoint ships no chat template, so there is no faithful "
+            "way to format an image/prompt/response turn for it. Choose a "
+            "instruction-tuned vision-language model (the catalog entries all "
+            "carry one)."
+        )
+    return processor.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=add_generation_prompt
+    )
+
+
+# =========================================================================
+# Model loading
+# =========================================================================
+
+def build_quantization_config(load_in_4bit):
+    """Return a BitsAndBytesConfig for 4-bit NF4, or None to load in bf16."""
+    if not load_in_4bit:
+        return None
+
+    import torch
+    from transformers import BitsAndBytesConfig
+
+    return BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_compute_dtype=torch.bfloat16,
+    )
+
+
+def load_base_model(model_name_or_path, load_in_4bit):
+    """Load a vision-language model for training or inference.
+
+    ``device_map="auto"`` shards across whatever GPUs the instance has, which
+    is what lets a 34B adapter run on a multi-GPU instance without any
+    distributed launcher.
+    """
+    import torch
+    from transformers import AutoModelForImageTextToText
+
+    quantization_config = build_quantization_config(load_in_4bit)
+    kwargs = {
+        "torch_dtype": torch.bfloat16,
+        "device_map": "auto",
+    }
+    if quantization_config is not None:
+        kwargs["quantization_config"] = quantization_config
+
+    logger.info(
+        f"Loading {model_name_or_path} "
+        f"({'4-bit NF4' if load_in_4bit else 'bfloat16'})"
+    )
+    return AutoModelForImageTextToText.from_pretrained(model_name_or_path, **kwargs)
+
+
+def resolve_image_token_ids(processor, model_config):
+    """Best-effort set of token ids standing in for image patches.
+
+    These positions carry no text the model should be scored on, so they are
+    masked out of the labels.  The attribute moved between transformers
+    versions and differs by architecture, so every known spelling is tried and
+    an empty set is an acceptable answer: the pad and prompt masking below
+    still apply, and a handful of unmasked placeholder positions degrades the
+    loss slightly rather than breaking it.
+    """
+    ids = set()
+
+    for attribute in ("image_token_index", "image_token_id"):
+        value = getattr(model_config, attribute, None)
+        if isinstance(value, int):
+            ids.add(value)
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    token = getattr(processor, "image_token", None)
+    if tokenizer is not None and isinstance(token, str) and token:
+        try:
+            resolved = tokenizer.convert_tokens_to_ids(token)
+            if isinstance(resolved, int) and resolved >= 0:
+                ids.add(resolved)
+        except Exception:  # pragma: no cover - tokenizer without the token
+            pass
+
+    return ids
+
+
+# =========================================================================
+# Collation
+# =========================================================================
+
+def build_collator(processor, spec, context_length, image_token_ids=()):
+    """Return a collate_fn producing model inputs with response-only labels."""
+    import torch
+
+    try:
+        from . import task_image_classification
+    except ImportError:  # pragma: no cover - flat sourcedir
+        import task_image_classification  # type: ignore
+
+    image_token_ids = set(image_token_ids)
+    tokenizer = getattr(processor, "tokenizer", None)
+    pad_token_id = getattr(tokenizer, "pad_token_id", None)
+
+    def _process(images, texts):
+        return processor(
+            images=images,
+            text=texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=context_length,
+        )
+
+    def collate(features):
+        images = [
+            task_image_classification.load_image(feature[spec.image_column])
+            for feature in features
+        ]
+        prompts = [feature[spec.text_column] for feature in features]
+        responses = [feature[spec.response_column] for feature in features]
+
+        full_texts = [
+            render_chat(processor, build_messages(p, r), add_generation_prompt=False)
+            for p, r in zip(prompts, responses)
+        ]
+        batch = _process(images, full_texts)
+
+        # Measure the prompt half in the same tokenisation the full render
+        # used, so the count is a true prefix length rather than an estimate.
+        prompt_texts = [
+            render_chat(processor, build_messages(p), add_generation_prompt=True)
+            for p in prompts
+        ]
+        prompt_batch = _process(images, prompt_texts)
+        prompt_lengths = prompt_batch["attention_mask"].sum(dim=1).tolist()
+
+        labels = batch["input_ids"].clone()
+        if pad_token_id is not None:
+            labels[labels == pad_token_id] = LABEL_IGNORE_INDEX
+        if "attention_mask" in batch:
+            labels[batch["attention_mask"] == 0] = LABEL_IGNORE_INDEX
+        for token_id in image_token_ids:
+            labels[labels == token_id] = LABEL_IGNORE_INDEX
+
+        for row, prompt_length in enumerate(prompt_lengths):
+            limit = prompt_mask_limit(prompt_length, labels.shape[1])
+            if limit > 0:
+                labels[row, :limit] = LABEL_IGNORE_INDEX
+
+        batch["labels"] = labels
+        return batch
+
+    return collate
+
+
+# =========================================================================
+# Training
+# =========================================================================
+
+def train(args, spec):
+    """LoRA fine-tune a generative vision-language model."""
+    import torch
+    from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+    from transformers import AutoProcessor, Trainer
+
+    train_channel = os.environ.get("SM_CHANNEL_TRAIN", "/opt/ml/input/data/train")
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+
+    frame, _ = task_common.prepare_dataset(train_channel, spec)
+
+    processor = AutoProcessor.from_pretrained(args.model_name_or_path)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is not None and tokenizer.pad_token_id is None:
+        # Several VLM decoders ship no pad token.  Padding with EOS is safe
+        # because every padded position is masked out of both the attention
+        # mask and the labels.
+        tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer is not None:
+        tokenizer.padding_side = "right"
+
+    model = load_base_model(args.model_name_or_path, args.load_in_4bit)
+
+    max_ctx = task_common.resolve_max_context_length(model.config, tokenizer)
+    effective_context = (
+        min(args.context_length, max_ctx) if max_ctx else args.context_length
+    )
+    logger.info(
+        f"Context length: requested={args.context_length}, "
+        f"effective={effective_context}"
+        f"{' (capped)' if max_ctx and args.context_length > max_ctx else ''}"
+    )
+
+    if args.load_in_4bit:
+        model = prepare_model_for_kbit_training(
+            model, use_gradient_checkpointing=True
+        )
+    # Gradient checkpointing recomputes activations instead of storing them,
+    # which is what makes a multi-thousand-token image sequence fit at all.
+    # With a frozen, quantised base no input tensor requires grad, so the
+    # recomputation graph would be empty without this.
+    model.gradient_checkpointing_enable()
+    if hasattr(model, "enable_input_require_grads"):
+        model.enable_input_require_grads()
+
+    # peft accepts either the "all-linear" sentinel or an explicit list; a
+    # comma-separated hyperparameter is the only way to spell a list through
+    # SageMaker, which passes every value as a string.
+    raw_targets = (args.lora_target_modules or "").strip()
+    if not raw_targets:
+        target_modules = "all-linear"
+    elif "," in raw_targets:
+        target_modules = [t.strip() for t in raw_targets.split(",") if t.strip()]
+    else:
+        target_modules = raw_targets
+    lora_config = LoraConfig(
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        bias="none",
+        task_type="CAUSAL_LM",
+        target_modules=target_modules,
+    )
+    model = get_peft_model(model, lora_config)
+    trainable, total = model.get_nb_trainable_parameters()
+    logger.info(
+        f"LoRA: r={args.lora_r}, alpha={args.lora_alpha}, "
+        f"targets={target_modules}, trainable={trainable:,}/{total:,} "
+        f"({100 * trainable / total:.3f}%)"
+    )
+
+    train_dataset, eval_dataset = task_common.split_frame(
+        frame, args.split_ratio, args.seed
+    )
+
+    image_token_ids = resolve_image_token_ids(processor, model.config)
+    logger.info(f"Masking image placeholder token ids: {sorted(image_token_ids)}")
+
+    training_args = task_common.build_training_arguments(
+        output_dir="/opt/ml/checkpoints",
+        learning_rate=args.learning_rate,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        weight_decay=args.weight_decay,
+        eval_strategy="epoch",
+        save_strategy="no",
+        logging_dir="/opt/ml/output/tensorboard",
+        remove_unused_columns=False,
+        label_names=["labels"],
+        bf16=torch.cuda.is_available(),
+        gradient_checkpointing=True,
+        # Paged optimiser states survive the memory spikes a long image
+        # sequence causes; it is a bitsandbytes optimiser, so it is only
+        # available on the quantised path.
+        optim="paged_adamw_8bit" if args.load_in_4bit else "adamw_torch",
+    )
+
+    collator = build_collator(processor, spec, effective_context, image_token_ids)
+    check_collation(collator, train_dataset)
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        callbacks=task_common.build_callbacks(args),
+        data_collator=collator,
+    )
+
+    logger.info(
+        f"Starting fine-tuning: task={spec.task_type}, "
+        f"model={args.model_name_or_path}, epochs={args.epochs}, "
+        f"batch_size={args.per_device_train_batch_size} x "
+        f"{args.gradient_accumulation_steps} accumulation"
+    )
+    trainer.train()
+
+    metrics = trainer.evaluate()
+    logger.info(f"Final evaluation: loss={metrics.get('eval_loss', 'N/A')}")
+
+    # Only the adapter is saved.  The base stays on the Hub and is named in
+    # the sidecar so model_fn can rebuild the pair.
+    model.save_pretrained(model_dir)
+    processor.save_pretrained(model_dir)
+    save_adapter_config(model_dir, args)
+    logger.info(f"Saved LoRA adapter to {model_dir}")
+
+    return metrics
+
+
+def check_collation(collator, dataset, sample_size=2):
+    """Collate a couple of records before the Trainer starts.
+
+    The expensive failure here is a processor/template mismatch — most often
+    truncation cutting into the run of image placeholder tokens, which makes
+    the count of placeholders disagree with the number of image features and
+    fails inside the first forward pass.  Without this the job has already
+    downloaded tens of GB of weights and provisioned a GPU before finding out.
+
+    Raising early costs one CPU-side batch and turns a mid-run stack trace
+    into a message naming the fix.
+    """
+    if len(dataset) == 0:  # pragma: no cover - prepare_dataset rejects this
+        return
+
+    sample = [dataset[i] for i in range(min(sample_size, len(dataset)))]
+    try:
+        collator(sample)
+    except Exception as error:
+        raise ValueError(
+            f"Could not build a training batch from this dataset and model: "
+            f"{error}. The usual cause is a context length too short for the "
+            f"model's image tokens — a high-resolution VLM can spend a "
+            f"thousand or more tokens on the image alone, before your prompt. "
+            f"Raise context_length, or choose a model that tiles less "
+            f"aggressively."
+        ) from error
+    logger.info(f"Collation check passed on {len(sample)} record(s)")
+
+
+def save_adapter_config(model_dir, args):
+    """Record what the adapter was trained against, for the inference side."""
+    os.makedirs(model_dir, exist_ok=True)
+    payload = {
+        "base_model_id": args.model_name_or_path,
+        "load_in_4bit": bool(args.load_in_4bit),
+        "max_new_tokens": int(args.max_new_tokens),
+    }
+    path = os.path.join(model_dir, ADAPTER_CONFIG_FILENAME)
+    with open(path, "w") as handle:
+        json.dump(payload, handle, indent=2)
+    return path
+
+
+# =========================================================================
+# Inference
+# =========================================================================
+
+def model_fn(model_dir):
+    """Rebuild base + adapter. The inverse of what ``train`` saved."""
+    import torch
+    from peft import PeftModel
+    from transformers import AutoProcessor
+
+    with open(os.path.join(model_dir, ADAPTER_CONFIG_FILENAME)) as handle:
+        adapter_config = json.load(handle)
+
+    processor = AutoProcessor.from_pretrained(model_dir)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is not None:
+        if tokenizer.pad_token_id is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        # Generation continues from the right-hand edge, so any padding has to
+        # sit on the left or the model continues from pad tokens.
+        tokenizer.padding_side = "left"
+
+    base = load_base_model(
+        adapter_config["base_model_id"], adapter_config.get("load_in_4bit", True)
+    )
+    model = PeftModel.from_pretrained(base, model_dir)
+    model.eval()
+
+    device = next(model.parameters()).device
+    logger.info(
+        f"Loaded LoRA adapter from {model_dir} over "
+        f"{adapter_config['base_model_id']} on {device}"
+    )
+    return {
+        "model": model,
+        "processor": processor,
+        "device": device,
+        "max_new_tokens": adapter_config.get("max_new_tokens", 256),
+    }
+
+
+def input_fn(request_body, content_type, spec):
+    """Unpack a .zip holding a manifest plus images into records.
+
+    The manifest needs ``image`` and ``prompt``; ``response`` is the training
+    target and is not required at inference.
+    """
+    import tempfile
+
+    if not isinstance(request_body, (bytes, bytearray)):
+        raise ValueError(
+            f"Expected archive bytes for {spec.task_type}, got "
+            f"{type(request_body).__name__}"
+        )
+
+    work_dir = tempfile.mkdtemp(prefix="inference-vlm-")
+    archive_path = os.path.join(work_dir, "input.zip")
+    with open(archive_path, "wb") as handle:
+        handle.write(bytes(request_body))
+
+    root = task_common.extract_archive(archive_path, os.path.join(work_dir, "extracted"))
+    manifest_path = task_common.find_file_in_dir(
+        root, spec.manifest_extensions, "manifest"
+    )
+
+    import pandas as pd
+
+    reader_name, reader_kwargs = task_common.resolve_dataset_reader(manifest_path)
+    frame = getattr(pd, reader_name)(manifest_path, **reader_kwargs)
+
+    missing = [
+        c for c in (spec.image_column, spec.text_column) if c not in frame.columns
+    ]
+    if missing:
+        raise ValueError(
+            f"Inference manifest is missing required column(s): "
+            f"{', '.join(missing)}."
+        )
+
+    records = []
+    for _index, row in frame.iterrows():
+        relative = str(row[spec.image_column]).strip()
+        records.append(
+            {
+                spec.image_column: task_common.resolve_image_path(root, relative),
+                spec.text_column: str(row[spec.text_column]),
+                "identifier": relative,
+            }
+        )
+
+    if not records:
+        raise ValueError("Inference manifest contains no records.")
+
+    logger.info(f"Unpacked {len(records)} image/prompt pairs for inference")
+    return records
+
+
+def predict_fn(records, loaded, spec):
+    """Generate a response for each record."""
+    import torch
+
+    try:
+        from . import task_image_classification
+    except ImportError:  # pragma: no cover - flat sourcedir
+        import task_image_classification  # type: ignore
+
+    model, processor = loaded["model"], loaded["processor"]
+    device, max_new_tokens = loaded["device"], loaded["max_new_tokens"]
+
+    if not records:
+        return {"identifiers": [], "prompts": [], "generations": []}
+
+    generations = []
+    with torch.no_grad():
+        for start in range(0, len(records), GENERATION_BATCH_SIZE):
+            chunk = records[start : start + GENERATION_BATCH_SIZE]
+            images = [
+                task_image_classification.load_image(record[spec.image_column])
+                for record in chunk
+            ]
+            texts = [
+                render_chat(
+                    processor,
+                    build_messages(record[spec.text_column]),
+                    add_generation_prompt=True,
+                )
+                for record in chunk
+            ]
+            batch = processor(
+                images=images, text=texts, return_tensors="pt", padding=True
+            ).to(device)
+
+            output_ids = model.generate(
+                **batch, max_new_tokens=max_new_tokens, do_sample=False
+            )
+            # generate() returns the prompt followed by the continuation, so
+            # slice the prompt off rather than decoding it back to the user.
+            prompt_length = batch["input_ids"].shape[1]
+            for row in output_ids:
+                generations.append(
+                    processor.decode(
+                        row[prompt_length:], skip_special_tokens=True
+                    ).strip()
+                )
+
+    logger.info(f"Generated {len(generations)} responses")
+    return {
+        "identifiers": [record["identifier"] for record in records],
+        "prompts": [record[spec.text_column] for record in records],
+        "generations": generations,
+    }

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
@@ -26,12 +26,14 @@ try:  # package context: unit tests and the app-api container
     from . import task_common
     from . import task_image_classification
     from . import task_image_text_classification
+    from . import task_image_text_to_text
     from . import task_text_classification
 except ImportError:  # pragma: no cover - flat sourcedir inside the SageMaker DLC
     import task_types  # type: ignore
     import task_common  # type: ignore
     import task_image_classification  # type: ignore
     import task_image_text_classification  # type: ignore
+    import task_image_text_to_text  # type: ignore
     import task_text_classification  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -48,7 +50,19 @@ TASK_MODULES = {
     task_types.TEXT_CLASSIFICATION: task_text_classification,
     task_types.IMAGE_CLASSIFICATION: task_image_classification,
     task_types.IMAGE_TEXT_CLASSIFICATION: task_image_text_classification,
+    task_types.IMAGE_TEXT_TO_TEXT: task_image_text_to_text,
 }
+
+
+def str2bool(value):
+    """Parse a boolean hyperparameter.
+
+    SageMaker passes every hyperparameter as a string, so ``bool("false")`` —
+    which is True — is the trap this exists to avoid.
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
 
 
 def resolve_task_module(task_type):
@@ -88,6 +102,16 @@ def parse_args(argv=None):
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--context_length", type=int, default=512)
     parser.add_argument("--image_size", type=int, default=224)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+
+    # Generative VLM (LoRA) hyperparameters.  Ignored by the classification
+    # tasks, which train every weight of a much smaller model.
+    parser.add_argument("--load_in_4bit", type=str2bool, default=True)
+    parser.add_argument("--lora_r", type=int, default=16)
+    parser.add_argument("--lora_alpha", type=int, default=32)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
+    parser.add_argument("--lora_target_modules", type=str, default="")
+    parser.add_argument("--max_new_tokens", type=int, default=256)
 
     # DynamoDB progress reporting
     parser.add_argument("--dynamodb_table_name", type=str, default="")

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
@@ -31,11 +31,19 @@ logger = logging.getLogger(__name__)
 _TRAINING_IMAGE_TAGS = {
     task_types.DLC_FAMILY_TEXT: "huggingface-pytorch-training:2.1.0-transformers4.36.0-gpu-py310-cu121-ubuntu20.04",
     task_types.DLC_FAMILY_VISION: "huggingface-pytorch-training:2.8.0-transformers4.56.2-gpu-py312-cu129-ubuntu22.04",
+    # Generative VLMs run the same container as the vision tasks — torch 2.8
+    # satisfies bitsandbytes' torch>=2.4 floor and transformers 4.56 knows
+    # every architecture in the catalog.  The family exists to select the
+    # dependency set (peft + bitsandbytes), not a different image; keeping it
+    # separate means a future VLM-only image bump cannot re-baseline the
+    # image-classification jobs.
+    task_types.DLC_FAMILY_VLM: "huggingface-pytorch-training:2.8.0-transformers4.56.2-gpu-py312-cu129-ubuntu22.04",
 }
 
 _INFERENCE_IMAGE_TAGS = {
     task_types.DLC_FAMILY_TEXT: "huggingface-pytorch-inference:2.1.0-transformers4.37.0-gpu-py310-cu118-ubuntu20.04",
     task_types.DLC_FAMILY_VISION: "huggingface-pytorch-inference:2.6.0-transformers4.51.3-gpu-py312-cu124-ubuntu22.04",
+    task_types.DLC_FAMILY_VLM: "huggingface-pytorch-inference:2.6.0-transformers4.51.3-gpu-py312-cu124-ubuntu22.04",
 }
 
 # The AWS-owned account that publishes Deep Learning Containers. Same in every

--- a/backend/src/apis/app_api/fine_tuning/script_packaging_service.py
+++ b/backend/src/apis/app_api/fine_tuning/script_packaging_service.py
@@ -10,6 +10,8 @@ from typing import Optional
 import boto3
 from botocore.exceptions import ClientError
 
+from . import task_types
+
 logger = logging.getLogger(__name__)
 
 # Directory containing the SageMaker scripts (relative to this module)
@@ -26,18 +28,42 @@ PACKAGE_DIR = os.path.dirname(__file__)
 SCRIPT_FILES = [
     "train.py",
     "inference.py",
-    "requirements.txt",
     "task_common.py",
     "task_text_classification.py",
     "task_image_classification.py",
     "task_image_text_classification.py",
+    "task_image_text_to_text.py",
 ]
 
 # Files pulled from the package directory rather than sagemaker_scripts/.
 SHARED_FILES = ["task_types.py"]
 
-# S3 key for the packaged scripts
-SCRIPTS_S3_KEY = "scripts/sourcedir.tar.gz"
+# The dependency file each DLC family gets, packaged into the archive AS
+# ``requirements.txt`` — which is the only name the DLC installs from.
+#
+# One shared file cannot serve all three.  The VLM family needs peft and
+# bitsandbytes, and bitsandbytes requires torch>=2.4 while the text container
+# is torch 2.1: adding them to the shared file would break dependency
+# installation for every existing text job.  Selecting the file per family is
+# the same reasoning that already keys the DLC image by family.
+REQUIREMENTS_BY_FAMILY = {
+    task_types.DLC_FAMILY_TEXT: "requirements.txt",
+    task_types.DLC_FAMILY_VISION: "requirements.txt",
+    task_types.DLC_FAMILY_VLM: "requirements-vlm.txt",
+}
+
+#: Name the requirements file must have inside the archive.
+PACKAGED_REQUIREMENTS_NAME = "requirements.txt"
+
+
+def scripts_s3_key(dlc_family: str) -> str:
+    """S3 key for one family's source directory.
+
+    Keyed by family because the archives differ only in their requirements
+    file; a single key would make the last job to run overwrite the
+    dependency set of the other families.
+    """
+    return f"scripts/sourcedir-{dlc_family}.tar.gz"
 
 
 class ScriptPackagingService:
@@ -54,10 +80,10 @@ class ScriptPackagingService:
         self._bucket = bucket_name or os.environ.get(
             "S3_FINE_TUNING_BUCKET_NAME", "fine-tuning-data"
         )
-        self._cached_s3_uri: Optional[str] = None
+        self._cached_s3_uris: dict = {}
 
     @staticmethod
-    def _source_paths() -> list:
+    def _source_paths(dlc_family: str) -> list:
         """Return (archive name, source path) for every packaged file.
 
         Ordered deterministically so the content hash is stable across calls —
@@ -65,19 +91,26 @@ class ScriptPackagingService:
         """
         paths = [(name, os.path.join(SCRIPTS_DIR, name)) for name in SCRIPT_FILES]
         paths += [(name, os.path.join(PACKAGE_DIR, name)) for name in SHARED_FILES]
+
+        requirements = REQUIREMENTS_BY_FAMILY.get(
+            dlc_family, REQUIREMENTS_BY_FAMILY[task_types.DLC_FAMILY_TEXT]
+        )
+        paths.append(
+            (PACKAGED_REQUIREMENTS_NAME, os.path.join(SCRIPTS_DIR, requirements))
+        )
         return sorted(paths, key=lambda pair: pair[0])
 
-    def _compute_content_hash(self) -> str:
+    def _compute_content_hash(self, dlc_family: str) -> str:
         """Compute SHA256 hash of all script file contents."""
         hasher = hashlib.sha256()
-        for name, filepath in self._source_paths():
+        for name, filepath in self._source_paths(dlc_family):
             if os.path.exists(filepath):
                 hasher.update(name.encode("utf-8"))
                 with open(filepath, "rb") as f:
                     hasher.update(f.read())
         return hasher.hexdigest()
 
-    def _create_tar_gz(self) -> bytes:
+    def _create_tar_gz(self, dlc_family: str) -> bytes:
         """Create an in-memory tar.gz archive of the scripts.
 
         Files are added at the root level of the archive (no subdirectory),
@@ -85,7 +118,7 @@ class ScriptPackagingService:
         """
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            for name, filepath in self._source_paths():
+            for name, filepath in self._source_paths(dlc_family):
                 if os.path.exists(filepath):
                     tar.add(filepath, arcname=name)
                 else:
@@ -93,12 +126,12 @@ class ScriptPackagingService:
         buf.seek(0)
         return buf.read()
 
-    def _check_s3_hash(self, content_hash: str) -> bool:
+    def _check_s3_hash(self, content_hash: str, key: str) -> bool:
         """Check if the S3 object exists and has a matching content hash."""
         try:
             response = self._s3.head_object(
                 Bucket=self._bucket,
-                Key=SCRIPTS_S3_KEY,
+                Key=key,
             )
             s3_hash = response.get("Metadata", {}).get("content-hash", "")
             return s3_hash == content_hash
@@ -107,33 +140,36 @@ class ScriptPackagingService:
                 return False
             raise
 
-    def ensure_scripts_uploaded(self) -> str:
-        """Ensure scripts tar.gz is uploaded to S3. Returns the S3 URI.
+    def ensure_scripts_uploaded(self, task_type: Optional[str] = None) -> str:
+        """Ensure the source dir for ``task_type``'s family is in S3.
 
         Uses content-hash caching to skip re-upload if scripts haven't changed.
-        Caches the URI in memory after the first successful call.
+        Caches the URI per family in memory after the first successful call.
         """
-        if self._cached_s3_uri:
-            return self._cached_s3_uri
+        dlc_family = task_types.get_task_spec(task_type).dlc_family
 
-        content_hash = self._compute_content_hash()
+        cached = self._cached_s3_uris.get(dlc_family)
+        if cached:
+            return cached
 
-        if not self._check_s3_hash(content_hash):
-            tar_bytes = self._create_tar_gz()
+        key = scripts_s3_key(dlc_family)
+        content_hash = self._compute_content_hash(dlc_family)
+
+        if not self._check_s3_hash(content_hash, key):
+            tar_bytes = self._create_tar_gz(dlc_family)
             self._s3.put_object(
                 Bucket=self._bucket,
-                Key=SCRIPTS_S3_KEY,
+                Key=key,
                 Body=tar_bytes,
                 Metadata={"content-hash": content_hash},
             )
-            logger.info(
-                f"Uploaded scripts tar.gz to s3://{self._bucket}/{SCRIPTS_S3_KEY}"
-            )
+            logger.info(f"Uploaded scripts tar.gz to s3://{self._bucket}/{key}")
         else:
-            logger.debug("Scripts tar.gz already up-to-date in S3")
+            logger.debug(f"Scripts tar.gz already up-to-date in S3 for {dlc_family}")
 
-        self._cached_s3_uri = f"s3://{self._bucket}/{SCRIPTS_S3_KEY}"
-        return self._cached_s3_uri
+        uri = f"s3://{self._bucket}/{key}"
+        self._cached_s3_uris[dlc_family] = uri
+        return uri
 
 
 # Singleton access

--- a/backend/src/apis/app_api/fine_tuning/task_types.py
+++ b/backend/src/apis/app_api/fine_tuning/task_types.py
@@ -34,6 +34,7 @@ from typing import Dict, Mapping, Optional, Tuple
 TEXT_CLASSIFICATION = "text-classification"
 IMAGE_CLASSIFICATION = "image-classification"
 IMAGE_TEXT_CLASSIFICATION = "image-text-classification"
+IMAGE_TEXT_TO_TEXT = "image-text-to-text"
 
 #: Task assumed for a job record written before task types existed, and for a
 #: request that omits the field.  Must stay ``TEXT_CLASSIFICATION`` — every
@@ -53,6 +54,12 @@ DEFAULT_TASK_TYPE = TEXT_CLASSIFICATION
 # exact container they were validated on.
 DLC_FAMILY_TEXT = "text"
 DLC_FAMILY_VISION = "vision"
+# Generative VLMs need PEFT and bitsandbytes on top of the vision stack.
+# bitsandbytes requires torch>=2.4, which the text container (torch 2.1)
+# cannot satisfy, so the dependency set cannot simply be added to the shared
+# requirements file — the family is what selects the right one at packaging
+# time.  See ``script_packaging_service.REQUIREMENTS_BY_FAMILY``.
+DLC_FAMILY_VLM = "vlm"
 
 
 # =========================================================================
@@ -70,8 +77,9 @@ class TaskSpec:
     # --- Training record contract -------------------------------------
     #: Columns every training record must carry.
     required_columns: Tuple[str, ...]
-    #: Column holding the target class.
-    label_column: str
+    #: Column holding the target class, or None for a generative task, which
+    #: has no fixed label set.
+    label_column: Optional[str]
     #: Column holding an image path relative to the archive root, or None for
     #: text-only tasks.
     image_column: Optional[str]
@@ -103,6 +111,15 @@ class TaskSpec:
     hf_pipeline_tags: Tuple[str, ...]
     default_instance_type: str
     default_hyperparameters: Mapping[str, str]
+
+    # --- Generative tasks ----------------------------------------------
+    #: Column holding the target text a generative task learns to produce.
+    #: None for the classification tasks.  Defaulted so the three existing
+    #: specs are untouched.
+    response_column: Optional[str] = None
+    #: True when the model emits free text rather than a class distribution.
+    #: Drives the output contract: probability columns vs a text column.
+    is_generative: bool = False
 
     def supports_extension(self, filename: str) -> bool:
         """True when ``filename`` is an acceptable training upload."""
@@ -227,9 +244,10 @@ TASK_SPECS: Dict[str, TaskSpec] = {
         #
         # "image-text-to-text" (LLaVA, Qwen-VL) and "visual-question-answering"
         # (ViLT, BLIP) are generative or fusion models with no text tower to
-        # pool, and are excluded on purpose: allowing them would let the
-        # pre-flight pass a model that only fails later, on a billed GPU,
-        # inside the trainer's dual-encoder check.
+        # pool, and stay excluded here: allowing them would let the pre-flight
+        # pass a model that only fails later, on a billed GPU, inside the
+        # trainer's dual-encoder check.  Generative VLMs have their own task —
+        # see IMAGE_TEXT_TO_TEXT below.
         hf_pipeline_tags=("zero-shot-image-classification",),
         default_instance_type="ml.g6.xlarge",
         default_hyperparameters={
@@ -239,6 +257,55 @@ TASK_SPECS: Dict[str, TaskSpec] = {
             "context_length": "77",
         },
     ),
+    IMAGE_TEXT_TO_TEXT: TaskSpec(
+        task_type=IMAGE_TEXT_TO_TEXT,
+        display_name="Image + text to text",
+        description=(
+            "Teach a vision-language model to answer about an image in your "
+            "own style or vocabulary. Upload a .zip containing a manifest "
+            '(CSV/JSONL/JSON) with "image", "prompt" and "response" fields, '
+            "plus the image files the manifest points at."
+        ),
+        required_columns=("image", "prompt", "response"),
+        # Generative: there is no class list, so no label column and no
+        # softmax.  ``response`` is the target text, not a category.
+        label_column=None,
+        image_column="image",
+        text_column="prompt",
+        response_column="response",
+        is_generative=True,
+        upload_extensions=(".zip",),
+        manifest_extensions=_MANIFEST_EXTENSIONS,
+        requires_archive=True,
+        inference_upload_extensions=(".zip",),
+        inference_content_type="application/zip",
+        inference_max_payload_mb=100,
+        dlc_family=DLC_FAMILY_VLM,
+        hf_pipeline_tags=("image-text-to-text",),
+        # 48GB (L40S).  A 7B VLM in 4-bit needs ~5GB of weights but the
+        # activations for a high-resolution image are what actually size the
+        # card: LLaVA-1.6's AnyRes tiling emits up to 2880 image tokens per
+        # image.  The 24GB g6/g5 instances OOM on the larger checkpoints, so
+        # the default starts where the whole catalog fits.
+        default_instance_type="ml.g6e.xlarge",
+        default_hyperparameters={
+            **_COMMON_HYPERPARAMETERS,
+            # LoRA wants a markedly higher LR than full fine-tuning: only the
+            # adapter matrices move, and they start at zero.
+            "learning_rate": "1e-4",
+            # One sequence per step, recovered to an effective batch of 8 by
+            # accumulation.  A VLM sequence is thousands of tokens, so a
+            # literal batch of 16 OOMs on any instance we offer.
+            "per_device_train_batch_size": "1",
+            "gradient_accumulation_steps": "8",
+            "context_length": "1024",
+            "load_in_4bit": "true",
+            "lora_r": "16",
+            "lora_alpha": "32",
+            "lora_dropout": "0.05",
+            "max_new_tokens": "256",
+        },
+    ),
 }
 
 #: Stable, deterministic ordering for anything user-facing.
@@ -246,11 +313,19 @@ TASK_TYPES: Tuple[str, ...] = (
     TEXT_CLASSIFICATION,
     IMAGE_CLASSIFICATION,
     IMAGE_TEXT_CLASSIFICATION,
+    IMAGE_TEXT_TO_TEXT,
 )
 
 #: Task types whose upload is an archive of a manifest plus image files.
 ARCHIVE_TASK_TYPES: Tuple[str, ...] = tuple(
     t for t in TASK_TYPES if TASK_SPECS[t].requires_archive
+)
+
+#: Task types that emit free text instead of a class distribution.  These are
+#: the ones whose result file carries an output column rather than one
+#: probability column per class.
+GENERATIVE_TASK_TYPES: Tuple[str, ...] = tuple(
+    t for t in TASK_TYPES if TASK_SPECS[t].is_generative
 )
 
 
@@ -275,3 +350,8 @@ def get_task_spec(task_type: Optional[str]) -> TaskSpec:
 def requires_images(task_type: Optional[str]) -> bool:
     """True when the task's training records reference image files."""
     return get_task_spec(task_type).image_column is not None
+
+
+def is_generative(task_type: Optional[str]) -> bool:
+    """True when the task produces free text rather than class probabilities."""
+    return get_task_spec(task_type).is_generative

--- a/backend/tests/fine_tuning/test_inference_script.py
+++ b/backend/tests/fine_tuning/test_inference_script.py
@@ -344,3 +344,84 @@ class TestTextPredictFn:
         )
 
         assert result["labels"] == ["class_0", "class_1", "class_2"]
+
+
+class TestGenerativeOutputFn:
+    """A generative task emits text, not a probability per class.
+
+    The result is still one CSV row per input record, so the download and the
+    result viewer are unchanged by the new modality.
+    """
+
+    def _prediction(self, **overrides):
+        prediction = {
+            "identifiers": ["cat.jpg"],
+            "prompts": ["What is this?"],
+            "generations": ["A tabby cat."],
+            "identifier_column": "image",
+        }
+        prediction.update(overrides)
+        return prediction
+
+    def test_header_names_prompt_and_output(self):
+        header = output_fn(self._prediction()).split("\n")[0]
+        assert header == "image,prompt,output"
+
+    def test_row_carries_the_generated_text(self):
+        rows = output_fn(self._prediction()).split("\n")
+        assert rows[1] == '"cat.jpg","What is this?","A tabby cat."'
+
+    def test_generative_shape_is_chosen_without_a_flag(self):
+        """Dispatch is on what the task produced, not on a caller-passed hint."""
+        classification = {
+            "identifiers": ["a"],
+            "probabilities": np.array([[0.25, 0.75]]),
+            "labels": ["no", "yes"],
+            "identifier_column": "id",
+        }
+        assert "prob_yes" in output_fn(classification)
+        assert "prob_" not in output_fn(self._prediction())
+
+    def test_embedded_newlines_are_quoted(self):
+        """Generated text is multi-line far more often than a label is."""
+        rendered = output_fn(
+            self._prediction(generations=["line one\nline two"])
+        )
+        assert '"line one\nline two"' in rendered
+
+    def test_embedded_quotes_are_doubled(self):
+        rendered = output_fn(self._prediction(generations=['He said "hi"']))
+        assert '"He said ""hi"""' in rendered
+
+    def test_embedded_commas_do_not_split_the_row(self):
+        rendered = output_fn(self._prediction(generations=["red, green, blue"]))
+        assert '"red, green, blue"' in rendered
+
+    def test_multiple_records(self):
+        rendered = output_fn(
+            self._prediction(
+                identifiers=["a.jpg", "b.jpg"],
+                prompts=["p1", "p2"],
+                generations=["g1", "g2"],
+            )
+        )
+        assert len(rendered.split("\n")) == 3
+
+    def test_missing_prompts_do_not_drop_the_row(self):
+        """A short prompts list must degrade to blank, not truncate results."""
+        rendered = output_fn(
+            self._prediction(
+                identifiers=["a.jpg", "b.jpg"],
+                prompts=[],
+                generations=["g1", "g2"],
+            )
+        )
+        rows = rendered.split("\n")
+        assert len(rows) == 3
+        assert rows[2] == '"b.jpg","","g2"'
+
+    def test_empty_prediction_still_emits_a_header(self):
+        rendered = output_fn(
+            self._prediction(identifiers=[], prompts=[], generations=[])
+        )
+        assert rendered == "image,prompt,output"

--- a/backend/tests/fine_tuning/test_script_packaging_service.py
+++ b/backend/tests/fine_tuning/test_script_packaging_service.py
@@ -1,13 +1,23 @@
 """Unit tests for ScriptPackagingService."""
 
+import io
+import tarfile
+
 import pytest
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock
 from botocore.exceptions import ClientError
 
+from apis.app_api.fine_tuning import task_types
 from apis.app_api.fine_tuning.script_packaging_service import (
     ScriptPackagingService,
-    SCRIPTS_S3_KEY,
+    scripts_s3_key,
 )
+
+TEXT = task_types.TEXT_CLASSIFICATION
+VLM = task_types.IMAGE_TEXT_TO_TEXT
+
+TEXT_KEY = scripts_s3_key(task_types.DLC_FAMILY_TEXT)
+VLM_KEY = scripts_s3_key(task_types.DLC_FAMILY_VLM)
 
 
 @pytest.fixture
@@ -20,6 +30,12 @@ def service(mock_s3):
     return ScriptPackagingService(s3_client=mock_s3, bucket_name="test-bucket")
 
 
+def _archive_member(tar_bytes, name):
+    """Return one member's bytes from an in-memory tar.gz."""
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+        return tar.extractfile(name).read().decode("utf-8")
+
+
 class TestEnsureScriptsUploaded:
 
     def test_uploads_when_not_in_s3(self, service, mock_s3):
@@ -29,25 +45,25 @@ class TestEnsureScriptsUploaded:
             "HeadObject",
         )
 
-        result = service.ensure_scripts_uploaded()
+        result = service.ensure_scripts_uploaded(TEXT)
 
-        assert result == f"s3://test-bucket/{SCRIPTS_S3_KEY}"
+        assert result == f"s3://test-bucket/{TEXT_KEY}"
         mock_s3.put_object.assert_called_once()
         call_kwargs = mock_s3.put_object.call_args[1]
         assert call_kwargs["Bucket"] == "test-bucket"
-        assert call_kwargs["Key"] == SCRIPTS_S3_KEY
+        assert call_kwargs["Key"] == TEXT_KEY
         assert "content-hash" in call_kwargs["Metadata"]
 
     def test_skips_upload_when_hash_matches(self, service, mock_s3):
         """Should skip upload when S3 object has matching content hash."""
-        content_hash = service._compute_content_hash()
+        content_hash = service._compute_content_hash(task_types.DLC_FAMILY_TEXT)
         mock_s3.head_object.return_value = {
             "Metadata": {"content-hash": content_hash},
         }
 
-        result = service.ensure_scripts_uploaded()
+        result = service.ensure_scripts_uploaded(TEXT)
 
-        assert result == f"s3://test-bucket/{SCRIPTS_S3_KEY}"
+        assert result == f"s3://test-bucket/{TEXT_KEY}"
         mock_s3.put_object.assert_not_called()
 
     def test_reuploads_when_hash_differs(self, service, mock_s3):
@@ -56,24 +72,31 @@ class TestEnsureScriptsUploaded:
             "Metadata": {"content-hash": "stale-hash-from-old-scripts"},
         }
 
-        result = service.ensure_scripts_uploaded()
+        result = service.ensure_scripts_uploaded(TEXT)
 
-        assert result == f"s3://test-bucket/{SCRIPTS_S3_KEY}"
+        assert result == f"s3://test-bucket/{TEXT_KEY}"
         mock_s3.put_object.assert_called_once()
 
     def test_caches_uri_after_first_call(self, service, mock_s3):
         """Should cache URI and skip S3 checks on subsequent calls."""
-        content_hash = service._compute_content_hash()
+        content_hash = service._compute_content_hash(task_types.DLC_FAMILY_TEXT)
         mock_s3.head_object.return_value = {
             "Metadata": {"content-hash": content_hash},
         }
 
-        uri1 = service.ensure_scripts_uploaded()
-        uri2 = service.ensure_scripts_uploaded()
+        uri1 = service.ensure_scripts_uploaded(TEXT)
+        uri2 = service.ensure_scripts_uploaded(TEXT)
 
         assert uri1 == uri2
         # head_object should only be called once (cached after first call)
         mock_s3.head_object.assert_called_once()
+
+    def test_omitting_the_task_uses_the_legacy_default(self, service, mock_s3):
+        """A caller that passes nothing gets the text family, as before."""
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+        assert service.ensure_scripts_uploaded() == f"s3://test-bucket/{TEXT_KEY}"
 
     def test_sets_metadata_on_upload(self, service, mock_s3):
         """Should include content-hash metadata when uploading."""
@@ -82,7 +105,7 @@ class TestEnsureScriptsUploaded:
             "HeadObject",
         )
 
-        service.ensure_scripts_uploaded()
+        service.ensure_scripts_uploaded(TEXT)
 
         call_kwargs = mock_s3.put_object.call_args[1]
         metadata = call_kwargs["Metadata"]
@@ -90,17 +113,83 @@ class TestEnsureScriptsUploaded:
         assert len(metadata["content-hash"]) == 64  # SHA256 hex digest
 
 
+class TestPerFamilyPackaging:
+    """One archive per DLC family, because the dependency sets differ."""
+
+    def test_families_use_separate_keys(self, service, mock_s3):
+        """A shared key would let the last job overwrite another family's deps."""
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+
+        assert service.ensure_scripts_uploaded(TEXT) == f"s3://test-bucket/{TEXT_KEY}"
+        assert service.ensure_scripts_uploaded(VLM) == f"s3://test-bucket/{VLM_KEY}"
+        assert TEXT_KEY != VLM_KEY
+
+    def test_cache_is_per_family(self, service, mock_s3):
+        """A cached text URI must not be served to a VLM job."""
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+
+        service.ensure_scripts_uploaded(TEXT)
+        service.ensure_scripts_uploaded(VLM)
+
+        keys = [c[1]["Key"] for c in mock_s3.put_object.call_args_list]
+        assert keys == [TEXT_KEY, VLM_KEY]
+
+    def test_family_hashes_differ(self, service):
+        """Same scripts, different requirements — the hash has to notice."""
+        assert service._compute_content_hash(
+            task_types.DLC_FAMILY_TEXT
+        ) != service._compute_content_hash(task_types.DLC_FAMILY_VLM)
+
+    def test_vlm_archive_carries_the_peft_stack(self, service):
+        """peft and bitsandbytes must reach the container that needs them."""
+        tar_bytes = service._create_tar_gz(task_types.DLC_FAMILY_VLM)
+        requirements = _archive_member(tar_bytes, "requirements.txt")
+        assert "peft==" in requirements
+        assert "bitsandbytes==" in requirements
+
+    def test_text_archive_excludes_bitsandbytes(self, service):
+        """bitsandbytes needs torch>=2.4; the text DLC is torch 2.1.
+
+        Shipping it to the text container would break dependency installation
+        for every existing text job.
+        """
+        tar_bytes = service._create_tar_gz(task_types.DLC_FAMILY_TEXT)
+        requirements = _archive_member(tar_bytes, "requirements.txt")
+        assert "bitsandbytes" not in requirements
+        assert "peft" not in requirements
+
+    def test_every_family_packages_a_requirements_file(self, service):
+        """A family with no requirements.txt installs nothing and fails late."""
+        for family in (
+            task_types.DLC_FAMILY_TEXT,
+            task_types.DLC_FAMILY_VISION,
+            task_types.DLC_FAMILY_VLM,
+        ):
+            names = [n for n, _ in service._source_paths(family)]
+            assert names.count("requirements.txt") == 1
+
+    def test_every_task_module_is_packaged(self, service):
+        """train.py imports every task module at load time."""
+        names = [n for n, _ in service._source_paths(task_types.DLC_FAMILY_VLM)]
+        assert "task_image_text_to_text.py" in names
+        assert "task_types.py" in names
+
+
 class TestComputeContentHash:
 
     def test_returns_consistent_hash(self, service):
         """Same scripts should produce the same hash."""
-        hash1 = service._compute_content_hash()
-        hash2 = service._compute_content_hash()
+        hash1 = service._compute_content_hash(task_types.DLC_FAMILY_TEXT)
+        hash2 = service._compute_content_hash(task_types.DLC_FAMILY_TEXT)
         assert hash1 == hash2
 
     def test_hash_is_64_char_hex(self, service):
         """SHA256 hex digest should be 64 characters."""
-        content_hash = service._compute_content_hash()
+        content_hash = service._compute_content_hash(task_types.DLC_FAMILY_TEXT)
         assert len(content_hash) == 64
         assert all(c in "0123456789abcdef" for c in content_hash)
 
@@ -109,11 +198,11 @@ class TestCreateTarGz:
 
     def test_produces_non_empty_bytes(self, service):
         """Should create a non-empty tar.gz archive."""
-        tar_bytes = service._create_tar_gz()
+        tar_bytes = service._create_tar_gz(task_types.DLC_FAMILY_TEXT)
         assert len(tar_bytes) > 0
 
     def test_is_valid_gzip(self, service):
         """Output should start with gzip magic bytes."""
-        tar_bytes = service._create_tar_gz()
+        tar_bytes = service._create_tar_gz(task_types.DLC_FAMILY_TEXT)
         # Gzip magic bytes: 0x1f 0x8b
         assert tar_bytes[0:2] == b"\x1f\x8b"

--- a/backend/tests/fine_tuning/test_task_types.py
+++ b/backend/tests/fine_tuning/test_task_types.py
@@ -37,9 +37,19 @@ class TestRegistry:
         assert list(task_types.TASK_SPECS) == list(task_types.TASK_SPECS)
 
     @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
-    def test_label_column_is_required(self, task_type):
+    def test_the_target_column_is_required(self, task_type):
+        """Whatever a task learns to predict has to be in every record.
+
+        For a classifier that is the label column; for a generative task
+        there is no label set at all and the target is the response text.
+        """
         spec = task_types.get_task_spec(task_type)
-        assert spec.label_column in spec.required_columns
+        if spec.is_generative:
+            assert spec.label_column is None
+            assert spec.response_column in spec.required_columns
+        else:
+            assert spec.response_column is None
+            assert spec.label_column in spec.required_columns
 
     @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
     def test_image_tasks_require_an_archive(self, task_type):
@@ -61,7 +71,20 @@ class TestRegistry:
         assert task_types.ARCHIVE_TASK_TYPES == (
             task_types.IMAGE_CLASSIFICATION,
             task_types.IMAGE_TEXT_CLASSIFICATION,
+            task_types.IMAGE_TEXT_TO_TEXT,
         )
+
+    def test_generative_task_list_matches_the_specs(self):
+        assert task_types.GENERATIVE_TASK_TYPES == (task_types.IMAGE_TEXT_TO_TEXT,)
+
+    def test_is_generative_predicate(self):
+        assert not task_types.is_generative(task_types.TEXT_CLASSIFICATION)
+        assert not task_types.is_generative(task_types.IMAGE_TEXT_CLASSIFICATION)
+        assert task_types.is_generative(task_types.IMAGE_TEXT_TO_TEXT)
+
+    def test_legacy_rows_are_never_generative(self):
+        """A row with no task_type predates task types and is a classifier."""
+        assert not task_types.is_generative(None)
 
     @pytest.mark.parametrize("task_type", task_types.TASK_TYPES)
     def test_payload_size_is_within_batch_transform_limits(self, task_type):
@@ -75,6 +98,59 @@ class TestRegistry:
         spec = task_types.get_task_spec(task_type)
         assert pricing.training_rate(spec.default_instance_type) is not None
         assert pricing.transform_rate(spec.default_instance_type) is not None
+
+
+class TestGenerativeTask:
+    """Invariants specific to image-text-to-text."""
+
+    def _spec(self):
+        return task_types.get_task_spec(task_types.IMAGE_TEXT_TO_TEXT)
+
+    def test_pipeline_tag_matches_the_hub(self):
+        """The pre-flight compares this against the Hub's own tag verbatim.
+
+        llava-hf/llava-v1.6-34b-hf and every other catalog VLM is tagged
+        "image-text-to-text"; a different spelling here rejects all of them.
+        """
+        assert self._spec().hf_pipeline_tags == ("image-text-to-text",)
+
+    def test_generative_tag_stays_out_of_the_dual_encoder_task(self):
+        """image-text-classification needs a text tower to pool.
+
+        Letting a generative tag through there passes the pre-flight and then
+        fails on a billed GPU inside the dual-encoder check.
+        """
+        fusion = task_types.get_task_spec(task_types.IMAGE_TEXT_CLASSIFICATION)
+        assert task_types.IMAGE_TEXT_TO_TEXT not in fusion.hf_pipeline_tags
+
+    def test_prompt_and_response_are_distinct_columns(self):
+        spec = self._spec()
+        assert spec.text_column == "prompt"
+        assert spec.response_column == "response"
+        assert spec.text_column != spec.response_column
+
+    def test_runs_in_its_own_dlc_family(self):
+        """Sharing the vision family would put bitsandbytes in its requirements."""
+        spec = self._spec()
+        assert spec.dlc_family == task_types.DLC_FAMILY_VLM
+        assert spec.dlc_family != task_types.DLC_FAMILY_VISION
+
+    def test_default_instance_has_enough_vram_for_a_quantised_vlm(self):
+        """24GB cards OOM on the larger catalog entries."""
+        spec = self._spec()
+        assert pricing.ACCELERATOR_MEMORY_GB[spec.default_instance_type] >= 48
+
+    def test_lora_defaults_are_present(self):
+        """The trainer reads these straight off the hyperparameters."""
+        defaults = self._spec().default_hyperparameters
+        for key in ("lora_r", "lora_alpha", "lora_dropout", "load_in_4bit"):
+            assert key in defaults
+
+    def test_effective_batch_is_recovered_by_accumulation(self):
+        """A literal batch of 1 would make the gradient estimate very noisy."""
+        defaults = self._spec().default_hyperparameters
+        assert int(defaults["per_device_train_batch_size"]) == 1
+        assert int(defaults["gradient_accumulation_steps"]) > 1
 
 
 class TestCatalog:

--- a/backend/tests/fine_tuning/test_vlm_task.py
+++ b/backend/tests/fine_tuning/test_vlm_task.py
@@ -1,0 +1,285 @@
+"""Unit tests for the generative vision-language task module.
+
+``task_image_text_to_text`` runs inside the SageMaker DLC, where torch,
+transformers and peft exist.  They do not exist in the backend venv, so these
+cover the parts that must hold *before* a GPU is billed: the module imports
+cleanly, the chat rendering is faithful to the checkpoint's own template, the
+label-masking arithmetic cannot produce an all-masked row, and the adapter
+sidecar records what inference needs to rebuild the pair.
+"""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock
+
+from apis.app_api.fine_tuning import task_types
+from apis.app_api.fine_tuning.sagemaker_scripts import task_image_text_to_text as vlm
+from apis.app_api.fine_tuning.sagemaker_scripts import train as train_script
+
+SPEC = task_types.get_task_spec(task_types.IMAGE_TEXT_TO_TEXT)
+
+
+def _processor(chat_template="{{ messages }}"):
+    """A processor stub exposing only what render_chat touches."""
+    processor = MagicMock()
+    processor.chat_template = chat_template
+    processor.apply_chat_template.side_effect = (
+        lambda messages, tokenize, add_generation_prompt: json.dumps(
+            {"messages": messages, "generation_prompt": add_generation_prompt}
+        )
+    )
+    return processor
+
+
+class TestImportContract:
+    """The module must load without the ML stack, like its siblings."""
+
+    def test_imports_without_torch(self):
+        import sys
+
+        assert "torch" not in sys.modules
+        assert vlm.LABEL_IGNORE_INDEX == -100
+
+    def test_registered_in_both_dispatchers(self):
+        from apis.app_api.fine_tuning.sagemaker_scripts import inference
+
+        assert train_script.TASK_MODULES[task_types.IMAGE_TEXT_TO_TEXT] is vlm
+        assert inference.TASK_MODULES[task_types.IMAGE_TEXT_TO_TEXT] is vlm
+
+
+class TestBuildMessages:
+
+    def test_prompt_only_has_no_assistant_turn(self):
+        messages = vlm.build_messages("What is this?")
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    def test_image_precedes_text_in_the_user_turn(self):
+        """Every catalog template expects the image first."""
+        content = vlm.build_messages("caption it")[0]["content"]
+        assert [part["type"] for part in content] == ["image", "text"]
+
+    def test_response_becomes_the_assistant_turn(self):
+        messages = vlm.build_messages("q", "a")
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"][0]["text"] == "a"
+
+    def test_non_string_fields_are_coerced(self):
+        """A CSV column of digits loads as int64 and would break the template."""
+        messages = vlm.build_messages(42, 7)
+        assert messages[0]["content"][1]["text"] == "42"
+        assert messages[1]["content"][0]["text"] == "7"
+
+    def test_empty_response_still_produces_a_turn(self):
+        """An empty string is a real target; only None means prompt-only."""
+        assert len(vlm.build_messages("q", "")) == 2
+
+
+class TestRenderChat:
+
+    def test_uses_the_processor_template(self):
+        processor = _processor()
+        rendered = vlm.render_chat(
+            processor, vlm.build_messages("q", "a"), add_generation_prompt=False
+        )
+        assert json.loads(rendered)["generation_prompt"] is False
+        processor.apply_chat_template.assert_called_once()
+
+    def test_generation_prompt_flag_is_passed_through(self):
+        rendered = vlm.render_chat(
+            _processor(), vlm.build_messages("q"), add_generation_prompt=True
+        )
+        assert json.loads(rendered)["generation_prompt"] is True
+
+    def test_template_on_the_tokenizer_is_accepted(self):
+        """Some processors carry the template on their tokenizer instead."""
+        processor = _processor(chat_template=None)
+        processor.tokenizer.chat_template = "{{ messages }}"
+        assert vlm.render_chat(processor, vlm.build_messages("q"), False)
+
+    def test_missing_template_raises_rather_than_inventing_a_format(self):
+        """Guessing trains the model on a dialogue shape it has never seen."""
+        processor = _processor(chat_template=None)
+        processor.tokenizer.chat_template = None
+        with pytest.raises(ValueError, match="no chat template"):
+            vlm.render_chat(processor, vlm.build_messages("q"), False)
+
+
+class TestPromptMaskLimit:
+    """Loss is computed on the response only — but never on nothing."""
+
+    def test_masks_the_whole_prompt_when_the_response_survives(self):
+        assert vlm.prompt_mask_limit(10, 40) == 10
+
+    def test_never_masks_the_final_position(self):
+        """An all-masked row yields NaN loss and poisons the batch average."""
+        assert vlm.prompt_mask_limit(40, 40) == 39
+        assert vlm.prompt_mask_limit(100, 40) == 39
+
+    def test_zero_length_prompt_masks_nothing(self):
+        assert vlm.prompt_mask_limit(0, 40) == 0
+
+    def test_never_returns_a_negative_limit(self):
+        """A degenerate single-token row must not produce a negative slice."""
+        assert vlm.prompt_mask_limit(0, 1) == 0
+        assert vlm.prompt_mask_limit(5, 1) == 0
+
+
+class TestResolveImageTokenIds:
+
+    def test_reads_the_config_attribute(self):
+        config = MagicMock(spec=["image_token_index"])
+        config.image_token_index = 32000
+        assert 32000 in vlm.resolve_image_token_ids(MagicMock(), config)
+
+    def test_reads_the_renamed_attribute(self):
+        """transformers renamed this between the versions we run."""
+        config = MagicMock(spec=["image_token_id"])
+        config.image_token_id = 151655
+        assert 151655 in vlm.resolve_image_token_ids(MagicMock(), config)
+
+    def test_resolves_through_the_tokenizer(self):
+        processor = MagicMock()
+        processor.image_token = "<image>"
+        processor.tokenizer.convert_tokens_to_ids.return_value = 128256
+        assert 128256 in vlm.resolve_image_token_ids(processor, MagicMock(spec=[]))
+
+    def test_unknown_placeholder_is_not_an_error(self):
+        """Pad and prompt masking still apply; a few live placeholders only
+        nudge the loss, so an unrecognised architecture must not fail here."""
+        processor = MagicMock()
+        processor.image_token = None
+        assert vlm.resolve_image_token_ids(processor, MagicMock(spec=[])) == set()
+
+    def test_ignores_a_non_integer_attribute(self):
+        config = MagicMock(spec=["image_token_index"])
+        config.image_token_index = "<image>"
+        processor = MagicMock()
+        processor.image_token = None
+        assert vlm.resolve_image_token_ids(processor, config) == set()
+
+
+class TestQuantizationConfig:
+
+    def test_disabled_returns_none_without_importing_bitsandbytes(self):
+        """bf16 training must not require the quantisation stack at all."""
+        assert vlm.build_quantization_config(False) is None
+
+
+class TestAdapterConfig:
+    """Only the adapter is saved; this sidecar names the base it belongs to."""
+
+    def _args(self, **overrides):
+        defaults = {
+            "model_name_or_path": "llava-hf/llava-v1.6-34b-hf",
+            "load_in_4bit": True,
+            "max_new_tokens": 256,
+        }
+        defaults.update(overrides)
+        return MagicMock(**defaults)
+
+    def test_records_the_base_model(self, tmp_path):
+        vlm.save_adapter_config(str(tmp_path), self._args())
+        payload = json.loads(
+            (tmp_path / vlm.ADAPTER_CONFIG_FILENAME).read_text()
+        )
+        assert payload["base_model_id"] == "llava-hf/llava-v1.6-34b-hf"
+
+    def test_records_the_quantisation_mode(self, tmp_path):
+        """Loading a bf16-trained adapter over a 4-bit base changes the model."""
+        vlm.save_adapter_config(str(tmp_path), self._args(load_in_4bit=False))
+        payload = json.loads(
+            (tmp_path / vlm.ADAPTER_CONFIG_FILENAME).read_text()
+        )
+        assert payload["load_in_4bit"] is False
+
+    def test_creates_a_missing_directory(self, tmp_path):
+        target = tmp_path / "model"
+        vlm.save_adapter_config(str(target), self._args())
+        assert (target / vlm.ADAPTER_CONFIG_FILENAME).is_file()
+
+
+class TestBooleanHyperparameters:
+    """SageMaker passes every hyperparameter as a string."""
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on", True])
+    def test_truthy(self, value):
+        assert train_script.str2bool(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "off", "", False])
+    def test_falsy(self, value):
+        assert train_script.str2bool(value) is False
+
+    def test_the_string_false_is_not_truthy(self):
+        """bool("false") is True — the whole reason this parser exists."""
+        assert bool("false") is True
+        assert train_script.str2bool("false") is False
+
+    def test_parser_applies_it_to_load_in_4bit(self):
+        args = train_script.parse_args(
+            ["--model_name_or_path", "x", "--load_in_4bit", "false"]
+        )
+        assert args.load_in_4bit is False
+
+
+class TestGenerativeHyperparameterPlumbing:
+    """Every default in the registry must reach a real parser argument."""
+
+    @pytest.mark.parametrize("key", sorted(SPEC.default_hyperparameters))
+    def test_default_is_a_known_argument(self, key):
+        args = train_script.parse_args(["--model_name_or_path", "x"])
+        # split_ratio/seed/epochs etc. are shared; the LoRA ones are new.
+        assert hasattr(args, key), f"{key} has no --{key} argument"
+
+    def test_defaults_parse_as_their_declared_types(self):
+        argv = ["--model_name_or_path", "x", "--task_type", SPEC.task_type]
+        for key, value in SPEC.default_hyperparameters.items():
+            argv += [f"--{key}", value]
+        args = train_script.parse_args(argv)
+
+        assert args.lora_r == 16
+        assert args.lora_alpha == 32
+        assert args.lora_dropout == pytest.approx(0.05)
+        assert args.load_in_4bit is True
+        assert args.gradient_accumulation_steps == 8
+        assert args.max_new_tokens == 256
+        assert args.learning_rate == pytest.approx(1e-4)
+
+
+class TestCollationCheck:
+    """A canary batch, so a bad pairing fails before the GPU bill starts."""
+
+    def test_passes_a_working_collator(self):
+        vlm.check_collation(lambda batch: {"ok": True}, [{"a": 1}, {"a": 2}])
+
+    def test_reraises_with_actionable_guidance(self):
+        def collator(_batch):
+            raise RuntimeError("Image features and image tokens do not match")
+
+        with pytest.raises(ValueError, match="context_length"):
+            vlm.check_collation(collator, [{"a": 1}])
+
+    def test_preserves_the_original_error(self):
+        def collator(_batch):
+            raise RuntimeError("tokens do not match: 2928 vs 1024")
+
+        with pytest.raises(ValueError, match="2928 vs 1024"):
+            vlm.check_collation(collator, [{"a": 1}])
+
+    def test_samples_at_most_the_requested_records(self):
+        seen = []
+
+        def collator(batch):
+            seen.append(len(batch))
+            return {}
+
+        vlm.check_collation(collator, [{"a": i} for i in range(50)])
+        assert seen == [2]
+
+    def test_shorter_dataset_than_the_sample_size(self):
+        """A one-record dataset must not index past the end."""
+        vlm.check_collation(lambda batch: {}, [{"a": 1}])
+
+    def test_empty_dataset_is_a_no_op(self):
+        vlm.check_collation(lambda batch: 1 / 0, [])

--- a/docs-site/src/content/docs/admin/fine-tuning.md
+++ b/docs-site/src/content/docs/admin/fine-tuning.md
@@ -20,10 +20,16 @@ Deep Learning Container the job runs in.
 | `text-classification` | text → label | `.csv` / `.jsonl` / `.json` | `text`, `label` |
 | `image-classification` | image → label | `.zip` | `image`, `label` |
 | `image-text-classification` | image + text → label | `.zip` | `image`, `text`, `label` |
+| `image-text-to-text` | image + prompt → free text | `.zip` | `image`, `prompt`, `response` |
 
-All three produce the same output: a softmax over the dataset's own classes,
-written as a CSV with one probability column per class. That shared contract is
-deliberate — it means a new modality never breaks the result viewer.
+The three classification tasks produce the same output: a softmax over the
+dataset's own classes, written as a CSV with one probability column per class.
+
+`image-text-to-text` is **generative** — it keeps the model's language head and
+learns to write the response, so it has no label column and no class list. Its
+result is still a CSV with one row per input record, carrying an `output`
+column instead of probability columns, so the download and the result viewer
+are unchanged.
 
 ### Image datasets
 
@@ -68,6 +74,13 @@ Each task declares a DLC *family*, and the two families move independently:
 |---|---|---|
 | `text` | PyTorch 2.1 / transformers 4.36 | Every existing text model was trained and validated here. Bumping it would re-baseline all of them at once. |
 | `vision` | PyTorch 2.8 / transformers 4.56 | Modern vision checkpoints do not load on 4.36. |
+| `vlm` | PyTorch 2.8 / transformers 4.56 | Same image as `vision`, but its own family so it can install `peft` and `bitsandbytes` — and so a future VLM-only image bump cannot re-baseline the image classifiers. |
+
+Each family gets its own `sourcedir-<family>.tar.gz`, because the dependency
+sets differ. `bitsandbytes` requires torch >= 2.4, which the text container
+(torch 2.1) cannot satisfy, so a single shared `requirements.txt` would break
+dependency installation for every existing text job. The file each family gets
+is `script_packaging_service.REQUIREMENTS_BY_FAMILY`.
 
 If a tag is retired or lags in a region, override it without a code deploy:
 
@@ -145,9 +158,32 @@ The commonest refusal is a **GGUF-only repository**. GGUF is a llama.cpp
 inference format and cannot be fine-tuned by transformers at all — look for the
 original, unquantised repository instead.
 
-Note that generative vision-language models (`image-text-to-text`, e.g. LLaVA
-or Qwen-VL) are **not** supported. They emit tokens rather than a class
-distribution, and would need a separate generative task type with LoRA/PEFT.
+Generative vision-language models (LLaVA, Qwen-VL) belong to the
+`image-text-to-text` task, not to `image-text-classification` — the latter
+needs a *dual encoder* exposing `get_image_features` and `get_text_features`
+(the CLIP/SigLIP/ALIGN family), and a generative checkpoint has no text tower
+to pool.
+
+### Generative VLMs are LoRA-adapted, not fully fine-tuned
+
+A full fine-tune needs roughly 16 bytes per parameter once gradients and the
+AdamW moments are resident — about 550 GB for a 34B model, against the 384 GB
+on the largest instance offered. So `image-text-to-text` quantises the frozen
+base to 4-bit (NF4) and trains low-rank adapters on top. Two consequences worth
+knowing:
+
+- **The artifact is an adapter, not a model.** It is a few hundred MB rather
+  than tens of GB, and inference reloads the base from the Hub and applies the
+  adapter over it. `vlm_adapter.json` inside the artifact records which base
+  and whether it was quantised.
+- **Loss is computed on the response only.** The prompt is masked out, so the
+  model does not spend its gradient budget learning to reproduce questions it
+  will always be given.
+
+`load_in_4bit`, `lora_r` and `lora_alpha` are exposed on the create-job form
+for this task. Models below about 3B are faster in bfloat16 — the 4-bit path
+pays a dequantisation cost that only earns its keep when the model would not
+otherwise fit.
 
 ## Admin surface
 

--- a/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
+++ b/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
@@ -22,7 +22,8 @@ export interface FineTuningAccessResponse {
 export type FineTuningTaskType =
   | 'text-classification'
   | 'image-classification'
-  | 'image-text-classification';
+  | 'image-text-classification'
+  | 'image-text-to-text';
 
 export const DEFAULT_TASK_TYPE: FineTuningTaskType = 'text-classification';
 
@@ -35,6 +36,11 @@ export interface TaskTypeResponse {
   requires_archive: boolean;
   inference_upload_extensions: string[];
   default_instance_type: string;
+  /** True when the model emits free text rather than class probabilities.
+   * Generative tasks are LoRA-adapted, so they expose adapter controls and
+   * their result file carries an output column instead of one probability
+   * column per class. */
+  is_generative: boolean;
 }
 
 // ── Model Catalog ───────────────────────────────────────────────────────

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -464,8 +464,9 @@
             </div>
           }
 
-          <!-- Image Size — image-bearing tasks only -->
-          @if (requiresArchive()) {
+          <!-- Image Size — image classifiers only; the generative trainer
+               takes its resolution from the model's own processor. -->
+          @if (showImageSize()) {
             <div>
               <label for="hp-img" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Image Size</label>
               <input
@@ -474,6 +475,43 @@
                 type="text"
                 class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               />
+            </div>
+          }
+
+          <!-- LoRA adapter — generative tasks only -->
+          @if (isGenerative()) {
+            <div>
+              <label for="hp-lora-r" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">LoRA Rank</label>
+              <input
+                id="hp-lora-r"
+                formControlName="loraR"
+                type="text"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Higher adapts more, and costs more memory.</p>
+            </div>
+
+            <div>
+              <label for="hp-lora-alpha" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">LoRA Alpha</label>
+              <input
+                id="hp-lora-alpha"
+                formControlName="loraAlpha"
+                type="text"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              />
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Conventionally twice the rank.</p>
+            </div>
+
+            <div>
+              <label for="hp-4bit" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Quantization</label>
+              <select
+                id="hp-4bit"
+                formControlName="loadIn4bit"
+                class="mt-1 block w-full rounded-sm border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              >
+                <option value="true">4-bit (fits larger models)</option>
+                <option value="false">bfloat16 (faster, needs more VRAM)</option>
+              </select>
             </div>
           }
 

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
@@ -9,6 +9,7 @@ import { FineTuningHttpService } from '../../services/fine-tuning-http.service';
 import { FineTuningUploadService } from '../../services/fine-tuning-upload.service';
 import type {
   AvailableModel,
+  FineTuningTaskType,
   JobResponse,
   PresignResponse,
   TaskTypeResponse,
@@ -84,6 +85,7 @@ const mockTaskTypes: TaskTypeResponse[] = [
     requires_archive: false,
     inference_upload_extensions: ['.txt', '.csv', '.jsonl', '.json'],
     default_instance_type: 'ml.g5.xlarge',
+    is_generative: false,
   },
   {
     task_type: 'image-classification',
@@ -94,6 +96,18 @@ const mockTaskTypes: TaskTypeResponse[] = [
     requires_archive: true,
     inference_upload_extensions: ['.zip'],
     default_instance_type: 'ml.g6.xlarge',
+    is_generative: false,
+  },
+  {
+    task_type: 'image-text-to-text',
+    display_name: 'Image + text to text',
+    description: 'Teach a vision-language model to answer about an image.',
+    required_columns: ['image', 'prompt', 'response'],
+    upload_extensions: ['.zip'],
+    requires_archive: true,
+    inference_upload_extensions: ['.zip'],
+    default_instance_type: 'ml.g6e.xlarge',
+    is_generative: true,
   },
 ];
 
@@ -328,6 +342,105 @@ describe('CreateTrainingJobPage', () => {
         learning_rate: '1e-4',
       }),
     );
+  });
+
+  describe('generative (image-text-to-text) tasks', () => {
+    const vlmModel: AvailableModel = {
+      model_id: 'llava-1.5-7b',
+      model_name: 'LLaVA 1.5 7B',
+      huggingface_model_id: 'llava-hf/llava-1.5-7b-hf',
+      description: 'Vision-language model',
+      task_type: 'image-text-to-text',
+      default_instance_type: 'ml.g6e.xlarge',
+      default_hyperparameters: {
+        epochs: '3',
+        learning_rate: '1e-4',
+        per_device_train_batch_size: '1',
+        context_length: '1024',
+        lora_r: '8',
+        lora_alpha: '16',
+        load_in_4bit: 'false',
+        split_ratio: '0.8',
+      },
+    };
+
+    /** The task list is fetched on a microtask, so the spec has to let
+     * loadTaskTypes() settle before a task can be selected by name. */
+    async function selectTask(taskType: FineTuningTaskType) {
+      const component = createComponent();
+      await Promise.resolve();
+      component.selectTaskType(taskType);
+      return component;
+    }
+
+    const selectVlmTask = () => selectTask('image-text-to-text');
+
+    it('reports the task as generative from the backend spec', async () => {
+      const component = await selectVlmTask();
+      expect(component.isGenerative()).toBe(true);
+    });
+
+    it('hides the image-size knob the generative trainer ignores', async () => {
+      const component = await selectVlmTask();
+      // Archive-based, so the classification gate alone would show it.
+      expect(component.requiresArchive()).toBe(true);
+      expect(component.showImageSize()).toBe(false);
+    });
+
+    it('still shows image size for an image classifier', async () => {
+      const component = await selectTask('image-classification');
+      expect(component.showImageSize()).toBe(true);
+    });
+
+    it('seeds the adapter controls from the model defaults', async () => {
+      const component = await selectVlmTask();
+      component.selectModel(vlmModel);
+      const values = component.form.getRawValue();
+      expect(values.loraR).toBe('8');
+      expect(values.loraAlpha).toBe('16');
+      expect(values.loadIn4bit).toBe('false');
+    });
+
+    it('submits the adapter settings for a generative task', async () => {
+      const component = await selectVlmTask();
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      component.selectModel(vlmModel);
+      component.uploadState.set({
+        file: new File([''], 'data.zip'),
+        progress: 100,
+        status: 'complete',
+        s3Key: 'uploads/data.zip',
+      });
+
+      await component.submitJob();
+
+      const call = mockState.createTrainingJob.mock.calls[0][0];
+      expect(call.hyperparameters).toEqual(
+        expect.objectContaining({ lora_r: '8', lora_alpha: '16', load_in_4bit: 'false' }),
+      );
+    });
+
+    it('omits the adapter settings for a classification task', async () => {
+      const component = createComponent();
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      component.selectModel(mockModel);
+      component.uploadState.set({
+        file: new File([''], 'test.jsonl'),
+        progress: 100,
+        status: 'complete',
+        s3Key: 'uploads/test.jsonl',
+      });
+
+      await component.submitJob();
+
+      const call = mockState.createTrainingJob.mock.calls[0][0];
+      expect(call.hyperparameters).not.toHaveProperty('lora_r');
+      expect(call.hyperparameters).not.toHaveProperty('load_in_4bit');
+    });
   });
 
   it('should convert max runtime hours to seconds', async () => {

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
@@ -93,6 +93,17 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
   /** Whether the selected task expects a .zip bundling images with a manifest. */
   readonly requiresArchive = computed(() => this.selectedTaskSpec()?.requires_archive ?? false);
 
+  /** Whether the selected task emits free text rather than class probabilities.
+   * Generative tasks are LoRA-adapted, so they expose adapter controls the
+   * classification tasks have no use for. */
+  readonly isGenerative = computed(() => this.selectedTaskSpec()?.is_generative ?? false);
+
+  /** Whether to show the image-resolution knob.
+   * The generative trainer never reads image_size — the model's own processor
+   * decides tiling and resolution — so offering the field there would be a
+   * control that silently does nothing. */
+  readonly showImageSize = computed(() => this.requiresArchive() && !this.isGenerative());
+
   /** Columns a record must carry, for the upload hint. */
   readonly requiredColumns = computed(() => this.selectedTaskSpec()?.required_columns ?? []);
 
@@ -159,6 +170,9 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
     seed: ['42'],
     contextLength: ['512'],
     imageSize: ['224'],
+    loraR: ['16'],
+    loraAlpha: ['32'],
+    loadIn4bit: ['true'],
     maxRuntimeHours: [24, [Validators.required, Validators.min(1), Validators.max(120)]],
   });
 
@@ -396,6 +410,9 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       seed: hp['seed'] ?? '42',
       contextLength: hp['context_length'] ?? '512',
       imageSize: hp['image_size'] ?? '224',
+      loraR: hp['lora_r'] ?? '16',
+      loraAlpha: hp['lora_alpha'] ?? '32',
+      loadIn4bit: hp['load_in_4bit'] ?? 'true',
     });
 
     // Sync slider from model defaults (e.g. "0.8" → 80)
@@ -443,6 +460,14 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
       if (formValues.seed) hyperparameters['seed'] = formValues.seed;
       if (formValues.contextLength) hyperparameters['context_length'] = formValues.contextLength;
       if (formValues.imageSize) hyperparameters['image_size'] = formValues.imageSize;
+      // Adapter settings only mean something to a generative task. Sending
+      // them for a classifier would put dead keys in its job record, which is
+      // what the hyperparameters panel on the detail page renders.
+      if (this.isGenerative()) {
+        if (formValues.loraR) hyperparameters['lora_r'] = formValues.loraR;
+        if (formValues.loraAlpha) hyperparameters['lora_alpha'] = formValues.loraAlpha;
+        if (formValues.loadIn4bit) hyperparameters['load_in_4bit'] = formValues.loadIn4bit;
+      }
 
       // Convert slider percentage (e.g. 80) to decimal string (e.g. "0.8")
       hyperparameters['split_ratio'] = (this.splitSlider.value / 100).toString();


### PR DESCRIPTION
Adds a fourth fine-tuning task type so vision-language models (LLaVA, Qwen-VL) can be fine-tuned. Prompted by "can we fine-tune `llava-hf/llava-v1.6-34b-hf`?" — we could not: its `image-text-to-text` Hub tag matched no task's `hf_pipeline_tags`, and all three existing tasks end in a softmax over a fixed class list.

## What changed

**New task type `image-text-to-text`.** Records are `image` / `prompt` / `response`; there is no label column. `TaskSpec` gains `response_column` and `is_generative` (both defaulted, so the three existing specs are untouched).

**Output contract stays CSV.** `output_fn` branches on what the task produced rather than on a caller-passed flag — probability columns for classifiers, `image,prompt,output` for generative. The download and result viewer are unchanged.

**LoRA, not a full fine-tune.** A full fine-tune of the largest catalog entry is not possible on our fleet: ~550GB of optimiser state for a 34B model against 384GB on the biggest instance offered. The frozen base is quantised to 4-bit NF4 and only adapters train, so the artifact is a few hundred MB and `vlm_adapter.json` records which base it belongs to. Loss is masked to the response only.

**Source dir is now packaged per DLC family.** `peft` and `bitsandbytes` cannot go in the shared `requirements.txt`: `bitsandbytes` requires `torch>=2.4` and the text container is torch 2.1, so one shared file would break dependency installation for **every existing text job**. The new `vlm` family points at the same image as `vision` but carries its own dependency set — which also means a future VLM-only image bump cannot re-baseline the image classifiers.

**Catalog**: SmolVLM 2.2B (bf16, cheapest way to validate a dataset), LLaVA 1.5 7B, LLaVA 1.6 Mistral 7B, Qwen2.5-VL 7B, LLaVA 1.6 34B. All five checked on the Hub first — ungated, correct tag, chat template present.

## New dependencies

`peft==0.20.0` and `bitsandbytes==0.50.2`, installed only inside the VLM SageMaker container. Both provenance-checked: peft is HuggingFace's (`benjamin@huggingface.co`, `github.com/huggingface/peft`, 36 releases since Jan 2023); bitsandbytes is Tim Dettmers' (`github.com/bitsandbytes-foundation`, 62 releases since Aug 2022, docs on huggingface.co). Neither version is yanked, and bitsandbytes ships a `manylinux_2_24_x86_64` wheel so it installs rather than compiles in the Ubuntu 22.04 DLC.

## Testing

- Backend full suite: **7940 passed**, 3 skipped
- Frontend full suite: **2558 passed**
- Pre-flight against the **live** Hub: `llava-v1.6-34b-hf` accepted for the new task, still correctly rejected for the three classification tasks; CLIP correctly rejected for the generative task
- Assembled SageMaker params verified with mocked AWS (VLM image, `sourcedir-vlm.tar.gz`, adapter hyperparameters, `application/zip` transform)

Two existing invariant tests were tightened rather than loosened: `test_label_column_is_required` now expresses "whatever the task predicts must be in every record" — label column for classifiers, response column for generative.

## Reviewer notes / known risks

1. **The transform container now needs HuggingFace egress.** Today every Batch Transform job loads purely from `model_dir`. The adapter path downloads the base from the Hub at `model_fn` time (~69GB for the 34B) on every job start. Training already proves egress works, but the transform container has never needed it. This is the thing to validate on the first real run.
2. **The collator has no unit test.** torch/transformers/peft are absent from the backend venv by design. The masking arithmetic is extracted to a pure, covered helper; the collator is guarded at runtime by `check_collation`, a two-record canary that runs before `Trainer` starts — the expensive failure is truncation cutting into the image-placeholder run, which otherwise crashes minutes into a billed GPU.
3. **Quota.** A 34B QLoRA run is estimated at ~$163 on a single L40S (FLOP-based, ±2×), against a $15/month default. Grants will need raising for the largest entry; the 7B entries land around $10/run and fit today's quota.

Managed Spot Training (~65% off these numbers) was scoped but deliberately left out of this PR — it is independent work, and `save_strategy="no"` makes interruptions fatal until checkpointing lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
