### PR TITLE
Enforce managed-KB byte cap at document upload time (Req 12.11)

### DIFF
--- a/backend/Dockerfile.kb-sync
+++ b/backend/Dockerfile.kb-sync
@@ -43,6 +43,11 @@ COPY backend/src/apis/shared/embeddings/ ${LAMBDA_TASK_ROOT}/apis/shared/embeddi
 # that package are stdlib only (test_kb_backend_boundary.py), so this adds
 # files, not dependencies.
 COPY backend/src/apis/shared/kb_backend/ ${LAMBDA_TASK_ROOT}/apis/shared/kb_backend/
+# observability/ — kb_backend/metrics.py (reached via byte_cap, which
+# document_service uses to release a managed-KB byte reservation on a stale
+# or failed upload) emits through observability/emf.py. Stdlib-only closure
+# (test_lambda_image_imports.py enforces it); this adds files, not deps.
+COPY backend/src/apis/shared/observability/ ${LAMBDA_TASK_ROOT}/apis/shared/observability/
 # assistants/ — document_service verifies assistant ownership via
 # get_assistant before soft-deleting; the worker's miss-eviction path
 # (_delete_missing_web_document) goes through it.

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -19,7 +19,7 @@ from apis.app_api.documents.models import (
     ReportUploadFailureRequest,
     UploadUrlResponse,
 )
-from apis.app_api.documents.services.document_service import _generate_document_id, create_document, list_assistant_documents, update_document_status
+from apis.app_api.documents.services.document_service import _generate_document_id, create_document, list_assistant_documents, update_document_status, release_reservation_if_managed
 from apis.app_api.documents.services.document_service import get_document as get_document_service
 from apis.app_api.documents.services.import_service import run_import
 from apis.app_api.documents.services.storage_service import (
@@ -35,6 +35,7 @@ from apis.shared.oauth.provider_repository import (
     get_provider_repository,
 )
 from apis.shared.rbac.service import AppRoleService, get_app_role_service
+from apis.shared.kb_backend.byte_cap import ByteCapExceeded
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,73 @@ async def _require_edit_permission(assistant_id: str, current_user: User) -> str
     return assistant.owner_id
 
 
+async def _resolve_managed_kb(assistant_id: str) -> tuple[bool, bool]:
+    """Return ``(is_managed, elevated)`` for this assistant's knowledge base.
+
+    Reads the KB_Record once. A legacy knowledge base — an absent record, or any
+    record whose engine is not the exact managed literal — returns
+    ``(False, False)`` so the caller skips all cap logic: legacy S3-Vectors
+    knowledge bases stay uncapped (Requirement 12.11 scopes the cap to managed
+    KBs). The elevated tier is READ from the existing ``elevatedByteCap`` flag,
+    never written here — granting it is a separate feature.
+    """
+    from apis.shared.kb_backend.records import ENGINE_MANAGED, get_kb_record, resolve_engine
+
+    # app_kb_id == assistant_id this phase. get_kb_record is a blocking boto3 call.
+    record = await asyncio.to_thread(get_kb_record, assistant_id, assistant_id)
+    if resolve_engine(record) != ENGINE_MANAGED:
+        return False, False
+    return True, bool((record or {}).get("elevatedByteCap"))
+
+
+async def _reserve_managed_upload(assistant_id: str, size_bytes: int) -> int:
+    """Provisionally reserve a declared upload size against the managed-KB cap.
+
+    Returns the number of bytes reserved — ``0`` for a legacy knowledge base,
+    which is uncapped and never touched. Raises
+    :class:`~apis.shared.kb_backend.byte_cap.ByteCapExceeded` if the reservation
+    would breach the binding cap; the endpoint turns that into HTTP 413 with the
+    numbers (Requirement 12.12).
+
+    The reservation is PROVISIONAL. ``size_bytes`` is the client's own declaration
+    and a client that under-reports its size would defeat the cap, so this only
+    buys fast, friendly feedback before a presigned URL is issued — the
+    authoritative gate is the S3-HEAD reconcile at ingestion (Requirement 12.3).
+    ``effective_cap`` folds the per-owner allowance and the per-KB ceiling into one
+    atomic conditional write (Requirement 12.1/12.5).
+    """
+    from apis.shared.kb_backend import byte_cap
+
+    is_managed, elevated = await _resolve_managed_kb(assistant_id)
+    if not is_managed:
+        return 0
+    cap = byte_cap.effective_cap(elevated)
+    await asyncio.to_thread(byte_cap.reserve, assistant_id, assistant_id, size_bytes, cap)
+    return size_bytes
+
+
+async def _release_managed_reservation(assistant_id: str, size_bytes: int) -> None:
+    """Return a managed-KB reservation taken earlier in THIS request.
+
+    Used only to unwind the request-time reservation when a later step of the same
+    upload-URL request fails (document-row create, presigned-URL generation) before
+    the client is ever handed a URL. No ``settle_once`` guard here: the reservation
+    was taken microseconds ago by this same request, the document is not yet
+    visible to any other settlement path, and the ``DOC#`` row may not even exist —
+    stamping a marker on it would conjure a partial row. The abandoned-after-URL
+    cases (client upload failure, stale sweep) settle through their own guarded
+    paths (Requirement 12.6).
+    """
+    from apis.shared.kb_backend import byte_cap
+
+    if size_bytes <= 0:
+        return
+    is_managed, _ = await _resolve_managed_kb(assistant_id)
+    if not is_managed:
+        return
+    await asyncio.to_thread(byte_cap.release, assistant_id, assistant_id, size_bytes)
+
+
 @router.post("/upload-url", response_model=UploadUrlResponse, status_code=status.HTTP_200_OK)
 async def generate_upload_url_endpoint(
     assistant_id: str,
@@ -80,6 +148,14 @@ async def generate_upload_url_endpoint(
         # 1. Resolve permission — owner or editor may upload documents
         await _require_edit_permission(assistant_id, current_user)
 
+        # 1b. Managed KBs are byte-capped on EVERY path that adds bytes
+        #     (Requirement 12.11); the interactive upload path is enforced here.
+        #     Reserve the client-declared size BEFORE creating the DOC# row or
+        #     issuing a presigned URL, so an over-cap upload is refused with a 413
+        #     the client can act on rather than after the bytes are already staged.
+        #     Legacy KBs return 0 and are never checked.
+        reserved_bytes = await _reserve_managed_upload(assistant_id, request.size_bytes)
+
         # 2. Generate document_id and S3 key
         from apis.app_api.documents.services.storage_service import _get_s3_key, _sanitize_filename
 
@@ -88,24 +164,45 @@ async def generate_upload_url_endpoint(
         sanitized_filename = _sanitize_filename(request.filename)
         s3_key = _get_s3_key(assistant_id, document_id, sanitized_filename)
 
-        # 3. Create document record in DynamoDB (status='uploading')
-        _ = await create_document(
-            assistant_id=assistant_id,
-            filename=request.filename,
-            content_type=request.content_type,
-            size_bytes=request.size_bytes,
-            s3_key=s3_key,
-            document_id=document_id,
-        )
+        try:
+            # 3. Create document record in DynamoDB (status='uploading'). The
+            #    declared size is persisted as sizeBytes — the value the ingestion
+            #    step reconciles the true S3 size against (Requirement 12.3).
+            _ = await create_document(
+                assistant_id=assistant_id,
+                filename=request.filename,
+                content_type=request.content_type,
+                size_bytes=request.size_bytes,
+                s3_key=s3_key,
+                document_id=document_id,
+            )
 
-        # 4. Generate presigned S3 URL
-        presigned_url, _ = await generate_upload_url(
-            assistant_id=assistant_id, document_id=document_id, filename=request.filename, content_type=request.content_type, expires_in=3600
-        )
+            # 4. Generate presigned S3 URL
+            presigned_url, _ = await generate_upload_url(
+                assistant_id=assistant_id, document_id=document_id, filename=request.filename, content_type=request.content_type, expires_in=3600
+            )
+        except Exception:
+            # A step after the reservation failed and the client never received a
+            # URL, so this upload can never settle the bytes. Return the
+            # reservation now rather than leak it (Requirement 12.6).
+            await _release_managed_reservation(assistant_id, reserved_bytes)
+            raise
 
         # 5. Return response
         return UploadUrlResponse(documentId=document_id, uploadUrl=presigned_url, expiresIn=3600)
 
+    except ByteCapExceeded as e:
+        # Requirement 12.12: the numbers make the error actionable — the user can
+        # see how far over they are and request an elevated tier.
+        used = "" if e.already_used is None else f" (currently using {e.already_used} bytes)"
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=(
+                f"This file ({e.requested} bytes) would put the assistant over its "
+                f"{e.cap}-byte knowledge-base limit{used}. Delete unused documents "
+                f"or request an elevated storage tier."
+            ),
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -239,6 +336,12 @@ async def report_upload_failure(
 
         if not updated:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update document status")
+
+        # The client's upload to S3 never landed, so the bytes reserved at
+        # request time will never be settled by the ingestion consumer. Return
+        # them now (Requirement 12.6). settle_once makes this idempotent against a
+        # concurrent stale-document sweep marking the same document failed.
+        await release_reservation_if_managed(document)
 
         return DocumentResponse.model_validate(updated.model_dump(by_alias=True))
 

--- a/backend/src/apis/app_api/documents/services/document_service.py
+++ b/backend/src/apis/app_api/documents/services/document_service.py
@@ -82,7 +82,47 @@ async def _auto_fail_stale_document(document: Document) -> Document:
         error_message='Processing timed out. The document may need to be re-uploaded.',
         error_details=f'Document was stuck in "{document.status}" state since {document.updated_at}',
     )
+    # A document that timed out in a processing state never reached the ingestion
+    # consumer's terminal reconcile, so its request-time byte reservation (managed
+    # KBs only) would leak. Return it (Requirement 12.6); settle_once keeps this
+    # idempotent against a concurrent client-reported failure on the same document.
+    await release_reservation_if_managed(document)
     return updated if updated else document
+
+
+async def release_reservation_if_managed(document: Document) -> None:
+    """Return a managed-KB byte reservation for a document abandoned before its
+    bytes were settled by the ingestion consumer (Requirement 12.6).
+
+    Exactly-once via ``byte_cap.settle_once``: the request-time reservation is
+    released by whichever terminal path the document reaches first — a
+    client-reported upload failure, this stale sweep, or the ingestion consumer's
+    own failure path — and the guard stops two of them double-crediting the
+    allowance. A no-op for legacy knowledge bases (uncapped) and for zero-size
+    rows (nothing was reserved).
+
+    ``app_kb_id == assistant_id`` this phase. boto3 is called synchronously here,
+    matching the rest of this module.
+    """
+    from apis.shared.kb_backend import byte_cap
+    from apis.shared.kb_backend.records import ENGINE_MANAGED, get_kb_record, resolve_engine
+
+    size_bytes = int(document.size_bytes or 0)
+    if size_bytes <= 0:
+        return
+    assistant_id = document.assistant_id
+    try:
+        record = get_kb_record(assistant_id, assistant_id)
+        if resolve_engine(record) != ENGINE_MANAGED:
+            return
+        if not byte_cap.settle_once(assistant_id, document.document_id):
+            return
+        byte_cap.release(assistant_id, assistant_id, size_bytes)
+    except Exception as e:  # noqa: BLE001 - a bookkeeping failure must not break the status write
+        logger.error(
+            f"Failed to release byte reservation for document {document.document_id}: {e}",
+            exc_info=True,
+        )
 
 
 async def create_document(

--- a/backend/src/apis/app_api/kb_migration/ingestion_consumer.py
+++ b/backend/src/apis/app_api/kb_migration/ingestion_consumer.py
@@ -467,6 +467,124 @@ def wait_until_retrievable(
     return None
 
 
+def _get_doc_row(assistant_id: str, document_id: str) -> Optional[Dict[str, Any]]:
+    """The ``DOC#`` row, or ``None``. Read once per invocation.
+
+    Carries the declared ``sizeBytes`` reconciled against the true S3 size, and the
+    ``byteCapSettled`` marker that makes settlement idempotent across redeliveries.
+    """
+    response = _table().get_item(
+        Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{document_id}"}
+    )
+    return response.get("Item")
+
+
+def _declared_bytes(doc_row: Optional[Dict[str, Any]]) -> int:
+    """The size the client declared at request time, or 0 if the row has none.
+
+    0 is the correct default for a document that reserved nothing at request time
+    (an imported file, whose row is created with ``sizeBytes=0`` and whose true
+    size is only known here) — the reconcile then reserves the whole real size.
+    """
+    if not doc_row:
+        return 0
+    try:
+        return int(doc_row.get("sizeBytes") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _delete_s3_object(bucket: str, key: str) -> None:
+    """Best-effort delete of an orphaned source object that overshot the cap.
+
+    A failure to delete must not turn a cap rejection into an unhandled error: the
+    document is already being failed, and a stranded object is a smaller problem
+    than a stuck ingestion. boto3 is imported here to keep this module's
+    module-level imports stdlib-only (image-size discipline).
+    """
+    try:
+        import boto3
+
+        boto3.client("s3").delete_object(Bucket=bucket, Key=key)
+    except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+        logger.warning(f"failed to delete orphaned object s3://{bucket}/{key}: {exc}")
+
+
+def _release_reservation(assistant_id: str, document_id: str, declared: int) -> None:
+    """Return the request-time reservation on a terminal ingestion FAILURE.
+
+    Exactly-once via ``byte_cap.settle_once`` (Requirement 12.6). Called only from
+    genuinely terminal failure paths — never from the "leave it non-terminal for
+    redelivery" paths, where the bytes must stay reserved for the delivery that
+    eventually completes the document.
+    """
+    from apis.shared.kb_backend import byte_cap
+
+    if declared <= 0:
+        return
+    if not byte_cap.settle_once(assistant_id, document_id):
+        return
+    byte_cap.release(assistant_id, assistant_id, declared)
+
+
+def _reconcile_bytes_on_complete(
+    assistant_id: str,
+    document_id: str,
+    bucket: str,
+    key: str,
+    record: Optional[Dict[str, Any]],
+    declared: int,
+) -> None:
+    """Settle the byte reservation against the AUTHORITATIVE S3 size (Req 12.3/12.4).
+
+    The request-time reservation used the client-declared size, which is an input,
+    not a measurement. Here — the document is indexed and its bytes are really in
+    S3 — the true size is taken from an S3 HEAD and the reservation is reconciled:
+
+    * ``real == declared`` — commit the reservation as-is.
+    * ``real < declared`` — the client over-reported; commit the real size and
+      release the difference so the owner is not charged for bytes never stored.
+    * ``real > declared`` — the client UNDER-reported, which is the case that could
+      defeat the cap. Reserve the shortfall against the binding cap. If that
+      breaches it, the document overshoots: raise :class:`ByteCapExceeded` so the
+      caller fails it — but first return the original reservation and delete the
+      orphaned S3 object, leaving no bytes charged and no stranded source.
+
+    Exactly-once via ``byte_cap.settle_once``: a redelivery that re-examines an
+    already-settled document does nothing, which is what stops a second commit
+    driving ``reservedBytes`` negative.
+    """
+    from apis.shared.kb_backend import byte_cap
+
+    if not byte_cap.settle_once(assistant_id, document_id):
+        # A prior delivery already settled this document's bytes.
+        return
+
+    real = byte_cap.object_size_bytes(bucket, key)
+
+    if real == declared:
+        byte_cap.commit(assistant_id, assistant_id, real)
+        return
+    if real < declared:
+        byte_cap.commit(assistant_id, assistant_id, real)
+        byte_cap.release(assistant_id, assistant_id, declared - real)
+        return
+
+    # real > declared: reserve the shortfall the client did not declare.
+    elevated = bool((record or {}).get("elevatedByteCap"))
+    cap = byte_cap.effective_cap(elevated)
+    try:
+        byte_cap.reserve(assistant_id, assistant_id, real - declared, cap)
+    except byte_cap.ByteCapExceeded:
+        # Overshoots the cap. Undo everything this document reserved and remove the
+        # source object, then let the caller mark it failed.
+        if declared > 0:
+            byte_cap.release(assistant_id, assistant_id, declared)
+        _delete_s3_object(bucket, key)
+        raise
+    byte_cap.commit(assistant_id, assistant_id, real)
+
+
 def handle_object(bucket: str, key: str) -> Dict[str, Any]:
     """Route one uploaded object. Returns a summary for logging and tests."""
     from apis.shared.kb_backend.records import ENGINE_MANAGED
@@ -500,6 +618,30 @@ def handle_object(bucket: str, key: str) -> Dict[str, Any]:
     from apis.shared.kb_backend.managed_backend import ManagedKbBackend
     from apis.shared.kb_backend.protocol import DocumentSource
 
+    # The DOC# row carries the size declared and reserved at request time
+    # (sizeBytes) and the byteCapSettled marker. Read it once. If a PRIOR delivery
+    # already drove this document terminal AND settled its bytes, this is a
+    # redelivery and re-running the byte accounting would double-count — a second
+    # commit drives reservedBytes negative, a second release over-credits the cap.
+    # Return without touching anything (Requirement 12.4/12.5).
+    doc_row = _get_doc_row(assistant_id, document_id)
+    if (
+        doc_row
+        and doc_row.get("byteCapSettled")
+        and doc_row.get("status") in (STATUS_COMPLETE, STATUS_FAILED)
+    ):
+        logger.info(
+            f"document {document_id} is already {doc_row.get('status')} and its "
+            f"bytes are settled; skipping to avoid double-counting"
+        )
+        return {
+            "routed": "managed",
+            "ingested": False,
+            "document_id": document_id,
+            "status": doc_row.get("status"),
+            "note": "already-settled",
+        }
+    declared = _declared_bytes(doc_row)
     # The backend takes the App_KB_Id and resolves the AWS identifiers itself on
     # every operation. Threading them in from here would defeat that: a
     # dormancy/rehydration cycle replaces them, and a caller holding a stale pair
@@ -527,6 +669,7 @@ def handle_object(bucket: str, key: str) -> Dict[str, Any]:
             assistant_id, document_id, STATUS_FAILED,
             error=f"the knowledge base reports this document as {status}",
         )
+        _release_reservation(assistant_id, document_id, declared)
         return {"routed": "managed", "ingested": False, "document_id": document_id,
                 "status": status}
 
@@ -537,6 +680,7 @@ def handle_object(bucket: str, key: str) -> Dict[str, Any]:
         except Exception as exc:
             logger.error(f"direct ingestion of {document_id} failed: {exc}", exc_info=True)
             set_document_terminal(assistant_id, document_id, STATUS_FAILED, error=str(exc))
+            _release_reservation(assistant_id, document_id, declared)
             raise
     else:
         # Already submitted — a redelivery, or a document still being worked on.
@@ -560,6 +704,7 @@ def handle_object(bucket: str, key: str) -> Dict[str, Any]:
             assistant_id, document_id, STATUS_FAILED,
             error=f"the knowledge base reports this document as {status}",
         )
+        _release_reservation(assistant_id, document_id, declared)
         return {"routed": "managed", "ingested": True, "document_id": document_id,
                 "status": status}
 
@@ -593,6 +738,40 @@ def handle_object(bucket: str, key: str) -> Dict[str, Any]:
             f"document {document_id} is INDEXED but was not retrievable within the "
             f"poll window; leaving it for redelivery"
         )
+
+    # INDEXED and retrievable. Settle the byte reservation against the AUTHORITATIVE
+    # S3 size before declaring success (Requirement 12.3): the request-time reserve
+    # used the client's declared size, which is not trustworthy. This commits the
+    # true bytes, or — if the client under-reported and the real size overshoots the
+    # cap — fails the document and removes the orphaned object.
+    from apis.shared.kb_backend.byte_cap import ByteCapExceeded
+
+    try:
+        _reconcile_bytes_on_complete(
+            assistant_id, document_id, bucket, key, record, declared
+        )
+    except ByteCapExceeded:
+        # The reservation has been returned and the source object deleted inside the
+        # reconcile. Fail the document with an actionable message (Requirement
+        # 12.12) rather than reporting a success that breaches the cap.
+        logger.warning(
+            f"document {document_id} indexed but its true size overshoots the byte "
+            f"cap; marking failed and removing the orphaned object"
+        )
+        set_document_terminal(
+            assistant_id, document_id, STATUS_FAILED,
+            error=(
+                "this document exceeds the knowledge base's storage limit; delete "
+                "unused documents or request an elevated storage tier"
+            ),
+        )
+        return {
+            "routed": "managed",
+            "ingested": True,
+            "document_id": document_id,
+            "status": STATUS_FAILED,
+            "note": "byte-cap-exceeded",
+        }
 
     set_document_terminal(
         assistant_id,

--- a/backend/src/apis/shared/kb_backend/byte_cap.py
+++ b/backend/src/apis/shared/kb_backend/byte_cap.py
@@ -127,6 +127,24 @@ def per_kb_ceiling() -> int:
     return _env_int("MANAGED_KB_PER_KB_CEILING_BYTES", DEFAULT_PER_KB_CEILING_BYTES)
 
 
+def effective_cap(elevated: bool = False) -> int:
+    """The single binding cap for an owner's knowledge base this phase.
+
+    ``App_KB_Id == assistant_id`` today, so one owner has exactly one managed
+    knowledge base and both limits — the per-owner allowance and the per-KB
+    ceiling — apply to the *same* accounting record. The binding limit is
+    therefore the smaller of the two.
+
+    Returning ``min`` and reserving against it lets a single atomic
+    :func:`reserve` enforce both caps at once (Requirement 12.1). The obvious
+    alternative — reserve against the owner cap, then a second read-and-compare
+    against the ceiling — is not atomic: two concurrent uploads could each pass a
+    separate ceiling check and collectively breach it, which is the exact race a
+    cap exists to close. Folding both into one conditional write keeps 12.5.
+    """
+    return min(per_owner_cap(elevated), per_kb_ceiling())
+
+
 def _table():
     import boto3
 
@@ -232,6 +250,45 @@ def release(assistant_id: str, app_kb_id: str, n_bytes: int) -> None:
         ExpressionAttributeNames={"#reserved": "reservedBytes", "#total": "totalBytes"},
         ExpressionAttributeValues={":neg": Decimal(-n_bytes)},
     )
+
+
+def settle_once(assistant_id: str, document_id: str) -> bool:
+    """Claim the one-time right to settle a document's reservation.
+
+    Returns ``True`` for exactly one caller per document and ``False`` for every
+    caller after it, by atomically stamping ``byteCapSettled`` on the ``DOC#`` row
+    under ``attribute_not_exists``.
+
+    This is what makes commit/release idempotent. A reservation taken at request
+    time is settled — converted to stored bytes, or returned — on whichever
+    terminal path the document actually reaches: the ingestion consumer, a
+    client-reported upload failure, or the stale-document sweep. But those paths
+    are not mutually exclusive under concurrency, and the ingestion consumer in
+    particular is *redelivered* (its whole design turns on EventBridge's 2-retry
+    cap), so a document that reaches ``INDEXED`` is re-examined on every
+    redelivery. Without this guard a redelivery would commit the same bytes twice
+    — driving ``reservedBytes`` negative and inflating ``storedBytes`` — and two
+    racing failure paths would release the same reservation twice, over-crediting
+    the allowance and defeating the cap. Both break the invariant
+    ``totalBytes == storedBytes + reservedBytes`` that Property 5 rests on.
+
+    Keyed on the ``DOC#`` row rather than a separate ledger so the claim shares the
+    document's own lifetime: delete the document and the marker goes with it.
+    """
+    from botocore.exceptions import ClientError
+
+    try:
+        _table().update_item(
+            Key={"PK": f"AST#{assistant_id}", "SK": f"DOC#{document_id}"},
+            UpdateExpression="SET byteCapSettled = :true",
+            ConditionExpression="attribute_not_exists(byteCapSettled)",
+            ExpressionAttributeValues={":true": True},
+        )
+        return True
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
 
 
 def reserve_snapshot(

--- a/backend/tests/lambdas/test_kb_ingestion_consumer.py
+++ b/backend/tests/lambdas/test_kb_ingestion_consumer.py
@@ -30,6 +30,13 @@ DOCUMENT_ID = "doc-ing01"
 BUCKET = "docs-bucket"
 KEY = f"assistants/{ASSISTANT_ID}/documents/{DOCUMENT_ID}/report.pdf"
 
+#: Size of the object the fixture stages in S3. The reconcile HEADs the real
+#: object, so a managed document that reaches `complete` must have real bytes to
+#: measure. The DOC# rows are seeded WITHOUT a declared sizeBytes (declared == 0),
+#: so the common managed path exercises the "client under-reported" reconcile
+#: branch: reserve the real size, then commit it — net-zero on reservedBytes.
+OBJECT_BYTES = 2048
+
 
 @pytest.fixture()
 def table(monkeypatch):
@@ -53,6 +60,13 @@ def table(monkeypatch):
             ],
             BillingMode="PAY_PER_REQUEST",
         )
+        # The RAG documents bucket, with the uploaded object in place. The reconcile
+        # takes the authoritative size from an S3 HEAD, so the object must exist for
+        # a managed document to complete.
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+        s3.put_object(Bucket=BUCKET, Key=KEY, Body=b"x" * OBJECT_BYTES)
+
         t = boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
         t.put_item(
             Item={
@@ -779,3 +793,202 @@ class TestUndeclaredStatusesAreWaitedOut:
             "TEXT_INDEXED was handled by the unknown-status fallback; it is a state "
             "we have observed in production and it should be classified explicitly"
         )
+
+
+# ---------------------------------------------------------------------------
+# The byte cap is settled against the AUTHORITATIVE S3 size (Req 12.3/12.4/12.6)
+# ---------------------------------------------------------------------------
+class TestByteCapReconcileAtIngestion:
+    """Enforcement of Requirement 12.11 on the ingestion side.
+
+    The request-time reservation used the client-declared size, which is not
+    trustworthy. When a managed document reaches ``complete`` the reservation is
+    reconciled against the real S3 size; on every terminal FAILURE the reservation
+    is returned so a failed upload never permanently shrinks the owner's allowance.
+    """
+
+    def _seed_managed(self, table):
+        _seed_kb(table, retrievalEngine="managed", awsKbId="KB123", awsDataSourceId="DS456")
+
+    def _reserve(self, table, declared):
+        """Model the request-time state: DOC# declares ``declared`` and the KB
+        record already holds that many reserved bytes."""
+        table.update_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"DOC#{DOCUMENT_ID}"},
+            UpdateExpression="SET sizeBytes = :d",
+            ExpressionAttributeValues={":d": declared},
+        )
+        table.update_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"KB#{ASSISTANT_ID}"},
+            UpdateExpression="SET reservedBytes = :d, storedBytes = :z, totalBytes = :d",
+            ExpressionAttributeValues={":d": declared, ":z": 0},
+        )
+
+    def _put_object(self, size):
+        boto3.client("s3", region_name=REGION).put_object(
+            Bucket=BUCKET, Key=KEY, Body=b"x" * size
+        )
+
+    def _kb(self, table):
+        return table.get_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"KB#{ASSISTANT_ID}"}
+        ).get("Item") or {}
+
+    def _run(self, table, statuses=("NOT_FOUND", "INDEXED"), backend_cls=_FakeBackend):
+        fake = backend_cls(statuses=list(statuses))
+        with patch(
+            "apis.shared.kb_backend.managed_backend.ManagedKbBackend", return_value=fake
+        ):
+            return fake, ic.handle_object(BUCKET, KEY)
+
+    def test_real_equals_declared_commits_the_reservation(self, table):
+        self._seed_managed(table)
+        self._reserve(table, 2048)
+        self._put_object(2048)
+
+        self._run(table)
+
+        kb = self._kb(table)
+        assert int(kb["storedBytes"]) == 2048
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == 2048
+        assert _doc(table)["status"] == "complete"
+
+    def test_real_smaller_than_declared_commits_real_and_releases_the_difference(self, table):
+        """Client over-reported: charge only what was stored, return the rest."""
+        self._seed_managed(table)
+        self._reserve(table, 4096)
+        self._put_object(2048)
+
+        self._run(table)
+
+        kb = self._kb(table)
+        assert int(kb["storedBytes"]) == 2048
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == 2048  # 4096 reserved, 2048 released
+
+    def test_real_larger_than_declared_reserves_the_shortfall_then_commits(self, table):
+        """Client under-reported but still under the cap: reserve the extra, commit."""
+        self._seed_managed(table)
+        self._reserve(table, 1024)
+        self._put_object(2048)
+
+        self._run(table)
+
+        kb = self._kb(table)
+        assert int(kb["storedBytes"]) == 2048
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == 2048
+        assert _doc(table)["status"] == "complete"
+
+    def test_real_over_cap_fails_the_document_deletes_object_and_releases(self, table, monkeypatch):
+        """Client under-reported AND the true size overshoots the cap.
+
+        The document must be failed, the orphaned S3 object deleted, and the
+        original reservation returned — no bytes charged, no stranded source.
+        """
+        monkeypatch.setenv("MANAGED_KB_PER_OWNER_DEFAULT_BYTES", "2048")
+        monkeypatch.setenv("MANAGED_KB_PER_KB_CEILING_BYTES", "2048")
+        self._seed_managed(table)
+        self._reserve(table, 1024)
+        self._put_object(4096)  # real; 1024 declared -> shortfall 3072 over the 2048 cap
+
+        _, result = self._run(table)
+
+        assert result["status"] == "failed"
+        assert result.get("note") == "byte-cap-exceeded"
+        assert _doc(table)["status"] == "failed"
+        # The reservation is returned in full.
+        kb = self._kb(table)
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == 0
+        assert int(kb.get("storedBytes") or 0) == 0
+        # The orphaned object is gone.
+        with pytest.raises(Exception):
+            boto3.client("s3", region_name=REGION).head_object(Bucket=BUCKET, Key=KEY)
+
+    def test_a_failed_ingestion_releases_the_reservation(self, table):
+        """NAMED mutation guard: dropping the release-on-failure in the Bedrock-
+        FAILED path must fail here. A failed upload may not permanently shrink the
+        owner's allowance (Requirement 12.6)."""
+        self._seed_managed(table)
+        self._reserve(table, 2048)
+
+        self._run(table, statuses=["FAILED"])
+
+        kb = self._kb(table)
+        assert int(kb["reservedBytes"]) == 0, (
+            "a Bedrock-FAILED document did not release its reservation; a failed "
+            "upload has permanently shrunk the owner's cap"
+        )
+        assert int(kb["totalBytes"]) == 0
+        assert _doc(table)["status"] == "failed"
+
+    def test_an_ingest_exception_releases_the_reservation(self, table):
+        """The submit itself raising is also terminal and must release."""
+        self._seed_managed(table)
+        self._reserve(table, 2048)
+
+        class _Failing(_FakeBackend):
+            async def ingest(self, kb_ref, source):
+                raise RuntimeError("bedrock unavailable")
+
+        with patch(
+            "apis.shared.kb_backend.managed_backend.ManagedKbBackend",
+            return_value=_Failing(statuses=["NOT_FOUND"]),
+        ):
+            with pytest.raises(RuntimeError):
+                ic.handle_object(BUCKET, KEY)
+
+        kb = self._kb(table)
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == 0
+
+    def test_a_still_indexing_document_does_NOT_release(self, table):
+        """The non-terminal 'leave for redelivery' path must keep the bytes
+        reserved — the delivery that completes the document will settle them."""
+        self._seed_managed(table)
+        self._reserve(table, 2048)
+
+        with patch(
+            "apis.shared.kb_backend.managed_backend.ManagedKbBackend",
+            return_value=_FakeBackend(statuses=["IN_PROGRESS"]),
+        ):
+            with pytest.raises(ic.IngestionRoutingError):
+                ic.handle_object(BUCKET, KEY)
+
+        kb = self._kb(table)
+        assert int(kb["reservedBytes"]) == 2048, (
+            "a document still indexing released its reservation; the completing "
+            "delivery would then find nothing reserved"
+        )
+
+    def test_a_redelivery_does_not_double_commit(self, table):
+        """settle_once + the terminal early-exit make the byte accounting
+        idempotent: a second delivery of an already-complete document must not
+        drive reservedBytes negative."""
+        self._seed_managed(table)
+        self._reserve(table, 2048)
+        self._put_object(2048)
+
+        # Delivery 1 completes and commits.
+        self._run(table, statuses=["NOT_FOUND", "INDEXED"])
+        kb1 = self._kb(table)
+        assert int(kb1["storedBytes"]) == 2048
+        assert int(kb1["reservedBytes"]) == 0
+
+        # Delivery 2: Bedrock still reports INDEXED. Must be a no-op for accounting.
+        _, result = self._run(table, statuses=["INDEXED"])
+        assert result.get("note") == "already-settled"
+        kb2 = self._kb(table)
+        assert int(kb2["storedBytes"]) == 2048
+        assert int(kb2["reservedBytes"]) == 0, (
+            "a redelivery committed a second time and drove reservedBytes negative"
+        )
+
+    def test_a_legacy_document_is_never_byte_accounted(self, table):
+        """Legacy KBs stay uncapped: no reservation is created or touched."""
+        _seed_kb(table)  # no retrievalEngine -> legacy
+        ic.handle_object(BUCKET, KEY)
+        kb = self._kb(table)
+        assert "reservedBytes" not in kb and "storedBytes" not in kb

--- a/backend/tests/routes/test_document_upload_byte_cap.py
+++ b/backend/tests/routes/test_document_upload_byte_cap.py
@@ -1,0 +1,219 @@
+"""Request-time byte-cap enforcement on the document upload-URL endpoint.
+
+Feature: managed-kb-migration — enforce the managed-KB Byte_Cap at document
+upload time (completes Requirement 12.11; the interactive upload path was the one
+byte-adding path left uncapped).
+
+The endpoint reserves the client-declared size against the binding cap BEFORE it
+creates the DOC# row or issues a presigned URL, so an over-cap upload is refused
+with a 413 carrying the numbers (Req 12.12) rather than after the bytes are
+staged. The reservation is provisional — the authoritative gate is the S3-HEAD
+reconcile at ingestion (Req 12.3) — but it gives fast, friendly feedback and is
+released if a later step of the same request fails (Req 12.6). Legacy KBs are
+never checked.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import boto3
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from moto import mock_aws
+
+from apis.app_api.documents.routes import router
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+
+ROUTES_MODULE = "apis.app_api.documents.routes"
+REGION = "us-east-1"
+TABLE = "test-upload-byte-cap"
+ASSISTANT_ID = "ast-cap01"
+USER_ID = "user-001"
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+
+    with mock_aws():
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+@pytest.fixture()
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    _app.dependency_overrides[get_current_user_from_session] = lambda: User(
+        user_id=USER_ID, email=f"{USER_ID}@example.com", name="Test User", roles=["User"]
+    )
+    return _app
+
+
+def _seed_managed_kb(table, **overrides):
+    item = {
+        "PK": f"AST#{ASSISTANT_ID}",
+        "SK": f"KB#{ASSISTANT_ID}",
+        "appKbId": ASSISTANT_ID,
+        "ownerUserId": USER_ID,
+        "retrievalEngine": "managed",
+        "storedBytes": 0,
+        "reservedBytes": 0,
+        "totalBytes": 0,
+    }
+    item.update(overrides)
+    table.put_item(Item=item)
+
+
+def _kb(table):
+    return table.get_item(
+        Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"KB#{ASSISTANT_ID}"}
+    ).get("Item")
+
+
+def _post(app, size_bytes):
+    return TestClient(app).post(
+        f"/assistants/{ASSISTANT_ID}/documents/upload-url",
+        json={"filename": "report.pdf", "contentType": "application/pdf", "sizeBytes": size_bytes},
+    )
+
+
+def _owner():
+    return (SimpleNamespace(owner_id=USER_ID), "owner")
+
+
+class TestManagedUploadIsCapped:
+    def test_an_over_cap_upload_is_rejected_413_with_the_numbers(self, table, app, monkeypatch):
+        """NAMED mutation guard: dropping the request-time reserve makes this pass
+        as a 200. The cap is 5000 bytes and the file is 10000."""
+        monkeypatch.setenv("MANAGED_KB_PER_OWNER_DEFAULT_BYTES", "5000")
+        monkeypatch.setenv("MANAGED_KB_PER_KB_CEILING_BYTES", "5000")
+        _seed_managed_kb(table)
+
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ) as create, patch(
+            f"{ROUTES_MODULE}.generate_upload_url", new_callable=AsyncMock
+        ) as gen:
+            resp = _post(app, 10000)
+
+        assert resp.status_code == 413
+        detail = resp.json()["detail"]
+        assert "10000" in detail and "5000" in detail  # requested and cap (Req 12.12)
+        # The row was never created and no URL was issued.
+        create.assert_not_awaited()
+        gen.assert_not_awaited()
+        # No bytes were reserved (the reserve raised before mutating on a fits check;
+        # n > cap short-circuits without a write).
+        assert int(_kb(table)["reservedBytes"]) == 0
+
+    def test_an_under_cap_upload_succeeds_and_reserves_the_declared_size(self, table, app):
+        _seed_managed_kb(table)
+
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ), patch(
+            f"{ROUTES_MODULE}.generate_upload_url",
+            new_callable=AsyncMock,
+            return_value=("https://signed.example/put", None),
+        ):
+            resp = _post(app, 2048)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["uploadUrl"] == "https://signed.example/put"
+        assert body["documentId"]
+        assert int(_kb(table)["reservedBytes"]) == 2048  # provisional reservation
+
+    def test_the_elevated_tier_is_read_from_the_record(self, table, app, monkeypatch):
+        """A 10000-byte file that fails the 5000 default cap succeeds when the
+        owner carries elevatedByteCap=true and the elevated cap is 100000."""
+        monkeypatch.setenv("MANAGED_KB_PER_OWNER_DEFAULT_BYTES", "5000")
+        monkeypatch.setenv("MANAGED_KB_PER_OWNER_ELEVATED_BYTES", "100000")
+        _seed_managed_kb(table, elevatedByteCap=True)
+
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ), patch(
+            f"{ROUTES_MODULE}.generate_upload_url",
+            new_callable=AsyncMock,
+            return_value=("https://signed.example/put", None),
+        ):
+            resp = _post(app, 10000)
+
+        assert resp.status_code == 200
+        assert int(_kb(table)["reservedBytes"]) == 10000
+
+    def test_a_later_step_failing_releases_the_reservation(self, table, app):
+        """Req 12.6: if URL generation fails after the reserve, the bytes are
+        returned rather than leaked."""
+        _seed_managed_kb(table)
+
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ), patch(
+            f"{ROUTES_MODULE}.generate_upload_url",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("s3 signer down"),
+        ):
+            resp = _post(app, 2048)
+
+        assert resp.status_code == 500
+        assert int(_kb(table)["reservedBytes"]) == 0, "reservation leaked on a failed request"
+
+
+class TestLegacyUploadIsNotCapped:
+    def test_a_legacy_kb_is_never_reserved_against(self, table, app):
+        """No KB_Record -> legacy -> uncapped. The upload succeeds and nothing is
+        written to a KB accounting record."""
+        # deliberately no _seed_managed_kb
+
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ), patch(
+            f"{ROUTES_MODULE}.create_document", new_callable=AsyncMock
+        ), patch(
+            f"{ROUTES_MODULE}.generate_upload_url",
+            new_callable=AsyncMock,
+            return_value=("https://signed.example/put", None),
+        ):
+            resp = _post(app, 10_000_000_000)  # 10 GB, would fail any managed cap
+
+        assert resp.status_code == 200
+        assert _kb(table) is None, "a legacy upload created a byte-cap record"

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -124,6 +124,9 @@ case "$SERVICE" in
             # cleanup_service.py reads records.resolve_engine and calls
             # ManagedKbBackend to delete from a promoted knowledge base.
             "backend/src/apis/shared/kb_backend"
+            # observability/ — reached via kb_backend/metrics.py when
+            # document_service releases a managed-KB byte reservation.
+            "backend/src/apis/shared/observability"
             "backend/src/apis/app_api/file_sources"
             "backend/src/apis/app_api/documents"
             "backend/src/apis/app_api/web_sources"


### PR DESCRIPTION
## What

Enforces the managed-KB per-owner **Byte_Cap** (standard 100 MB / elevated 1 GB / per-KB ceiling 500 MB) on the **interactive document-upload path** — the one byte-adding path that was still uncapped. Migration was already covered (`worker.py` -> `byte_cap.reserve_snapshot`). **Managed KBs only**; legacy S3-Vectors KBs stay uncapped, resolved via `resolve_engine == ENGINE_MANAGED`.

## How (enforced at both points, the approved design)

**1. Request-time pre-check** — `backend/src/apis/app_api/documents/routes.py`, `generate_upload_url_endpoint`
- If the assistant's KB is managed, reserve `request.size_bytes` against `effective_cap = min(per_owner_cap(elevated), per_kb_ceiling())` **before** creating the `DOC#` row or issuing a presigned URL. Over-cap => **HTTP 413** carrying used / cap / requested (**Req 12.12**).
- The reservation is **provisional** — the declared size is not authoritative (**Req 12.3**); it is persisted as `sizeBytes` for the ingestion step to reconcile against.
- Legacy KBs skip entirely.

**2. Authoritative reconcile at ingestion** — `backend/src/apis/app_api/kb_migration/ingestion_consumer.py`, `handle_object` (managed path)
- On `INDEXED`+retrievable: `real = object_size_bytes(bucket, key)` (S3 HEAD, **Req 12.3**), then `real == declared` -> commit; `real < declared` -> commit real + release diff; `real > declared` -> reserve shortfall, and if that breaches the cap -> **fail the doc, delete the orphaned S3 object, release** (**Req 12.4**).
- **Every** managed terminal-failure path releases the reservation (**Req 12.6**).

**3. Leak prevention** — release the reservation on client-reported upload failure (`report_upload_failure`) and on the stale auto-fail sweep (`document_service._auto_fail_stale_document`).

## New primitives (`byte_cap.py`)
- `effective_cap(elevated)` — folds both caps into **one atomic** `reserve` (**Req 12.1 / 12.5**).
- `settle_once(assistant_id, document_id)` — stamps `byteCapSettled` on the `DOC#` row so commit/release is **exactly-once** across EventBridge redeliveries and racing failure paths (prevents double-commit -> negative `reservedBytes`, and double-release -> cap defeat). A terminal early-exit in `handle_object` complements it.

## Requirements
12.1, 12.3, 12.4, 12.5, 12.6, 12.11, 12.12 — 12.14 (`KbByteCapRejected`) already emitted by `reserve()`.

## Tests (targeted, mutation-verified)
- `tests/routes/test_document_upload_byte_cap.py` — over-cap 413 (+numbers), under-cap success + reservation, elevated tier read, release-on-later-failure, legacy never checked.
- `tests/lambdas/test_kb_ingestion_consumer.py` — reconcile branches (==, <, > under cap, > over cap -> fail+delete+release), release on every failure path, non-terminal path does **not** release, redelivery does not double-commit, legacy never accounted. Fixture now stages the S3 object the reconcile HEADs.
- **Mutation checks confirmed**: dropping the request-time reject fails `test_an_over_cap_upload_is_rejected_413_with_the_numbers`; dropping the ingestion release-on-failure fails `test_a_failed_ingestion_releases_the_reservation`.
- Property (`test_pbt_kb_byte_cap`), import-boundary, and Lambda-image supply-chain suites stay green. `kb-sync` image gains a `COPY observability/` (the `byte_cap -> metrics -> emf` closure), with `build-one.sh` `SOURCE_DIRS` kept in lockstep.

## Notes / follow-ups
- Frontend messaging for the new 413 is minimal by design; a friendly "request an elevated tier" surface could follow.
- The reconcile also naturally caps the **import** path (its rows declare `sizeBytes=0`, so the real size is reserved at ingestion) — a bonus toward Req 12.11.
- **Out of scope:** the admin UI/endpoint to *set* `elevatedByteCap` (separate feature); this only reads it.

Not deployed. No prod changes.
