### PR TITLE
fix(infra): grant app-api sagemaker:CreateModel for Batch Transform

### DIFF
--- a/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
+++ b/infrastructure/lib/constructs/app-api/app-api-iam-grants.ts
@@ -429,6 +429,24 @@ export function grantAppApiPermissions(props: AppApiIamGrantsProps): void {
                   `arn:aws:sagemaker:${config.awsRegion}:${config.awsAccount}:transform-job/${config.projectPrefix}-*`],
     }),
   );
+  // Batch Transform is a two-step API: CreateModel to register the trained
+  // artifact, then CreateTransformJob against that model. Without this the
+  // transform path dies at step one with AccessDeniedException, which is what
+  // it did — inference only ever worked when app-api was run locally under a
+  // developer's own credentials, never from the deployed task role.
+  //
+  // Separate from SageMakerJobManagement because the resource pattern differs:
+  // sagemaker_service names the model `model-{job_name}`, so the ARN carries a
+  // `model-` prefix ahead of the project prefix and would not match the
+  // job-shaped pattern above.
+  taskRole.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      sid: 'SageMakerModelManagement',
+      effect: iam.Effect.ALLOW,
+      actions: ['sagemaker:CreateModel'],
+      resources: [`arn:aws:sagemaker:${config.awsRegion}:${config.awsAccount}:model/model-${config.projectPrefix}-*`],
+    }),
+  );
   taskRole.addToPrincipalPolicy(
     new iam.PolicyStatement({
       sid: 'PassSageMakerRole',

--- a/infrastructure/test/fine-tuning-batch-transform-iam.test.ts
+++ b/infrastructure/test/fine-tuning-batch-transform-iam.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The app-api task role can create the SageMaker Model that Batch Transform
+ * needs.
+ *
+ * Batch Transform is a two-step API: `CreateModel` registers the trained
+ * artifact, then `CreateTransformJob` runs against that model. The task role
+ * was granted the job actions but never `sagemaker:CreateModel`, so every
+ * inference job from the deployed app failed at step one with
+ * AccessDeniedException.
+ *
+ * It went unnoticed for months because the failure is invisible from a
+ * developer machine: CloudTrail showed every successful `CreateModel` was
+ * called by a human's SSO credentials running app-api locally against dev
+ * data. The deployed task role had never once succeeded.
+ *
+ * The subtle part is the ARN. `sagemaker_service` names the model
+ * `model-{job_name}`, so the resource is `model/model-<prefix>-...` — the
+ * literal `model-` sits *ahead* of the project prefix. A pattern written to
+ * match the training-job and transform-job ARNs looks right and denies every
+ * call.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { PlatformStack } from '../lib/platform-stack';
+import {
+  createMockConfig,
+  mockSsmContext,
+  MOCK_ACCOUNT,
+  MOCK_REGION,
+  MOCK_PREFIX,
+} from './helpers/mock-config';
+
+type Statement = {
+  Sid?: string;
+  Action?: string | string[];
+  Resource?: unknown;
+};
+
+function taskRoleStatements(): Statement[] {
+  const app = new cdk.App();
+  const config = createMockConfig();
+  mockSsmContext(app, config);
+  const stack = new PlatformStack(app, 'TestPlatformStack', {
+    config,
+    env: { account: MOCK_ACCOUNT, region: MOCK_REGION },
+  });
+  stack.wireCompute();
+  const template = Template.fromStack(stack);
+
+  const statements: Statement[] = [];
+  for (const resource of Object.values(template.findResources('AWS::IAM::Policy'))) {
+    statements.push(...((resource.Properties?.PolicyDocument?.Statement ?? []) as Statement[]));
+  }
+  for (const resource of Object.values(template.findResources('AWS::IAM::ManagedPolicy'))) {
+    statements.push(...((resource.Properties?.PolicyDocument?.Statement ?? []) as Statement[]));
+  }
+  return statements;
+}
+
+function actionsOf(statement: Statement): string[] {
+  const action = statement.Action;
+  if (!action) return [];
+  return Array.isArray(action) ? action : [action];
+}
+
+describe('app-api SageMaker Batch Transform IAM', () => {
+  let statements: Statement[];
+
+  beforeAll(() => {
+    statements = taskRoleStatements();
+  });
+
+  it('grants sagemaker:CreateModel somewhere on the task role', () => {
+    const granted = statements.some((s) => actionsOf(s).includes('sagemaker:CreateModel'));
+    expect(granted).toBe(true);
+  });
+
+  it('scopes CreateModel to the model- prefixed ARN the service actually uses', () => {
+    const statement = statements.find((s) =>
+      actionsOf(s).includes('sagemaker:CreateModel'),
+    );
+    expect(statement).toBeDefined();
+
+    const rendered = JSON.stringify(statement!.Resource);
+    // sagemaker_service builds `model-{job_name}`, and job_name already starts
+    // with the project prefix.
+    expect(rendered).toContain(`model/model-${MOCK_PREFIX}-`);
+  });
+
+  it('still grants the transform job actions it pairs with', () => {
+    const actions = statements.flatMap(actionsOf);
+    expect(actions).toContain('sagemaker:CreateTransformJob');
+    expect(actions).toContain('sagemaker:DescribeTransformJob');
+  });
+
+  it('does not widen to sagemaker:* anywhere on the task role', () => {
+    const wildcard = statements.some((s) =>
+      actionsOf(s).some((a) => a === 'sagemaker:*'),
+    );
+    expect(wildcard).toBe(false);
+  });
+});


### PR DESCRIPTION
Fine-tuning **inference has never worked from the deployed app**. Found while validating #1014 on dev.

## The bug

```
AccessDeniedException: User: .../AppApiTaskDefinition.../... is not authorized to perform:
sagemaker:CreateModel on resource: model/model-dev-boisestateai-v2-inf-8b155931-...
```

Batch Transform is a two-step API — `CreateModel` registers the trained artifact, then `CreateTransformJob` runs against that model. The task role had the job actions but not `CreateModel`, so every inference job failed at step one.

This blocks **all** task types, not just the new VLM one. It is unrelated to #1014, which touched no infrastructure.

## Why it went unnoticed

The failure is invisible from a developer machine. CloudTrail on dev:

| Time | Caller | Result |
|---|---|---|
| 2026-09-04 (×4) | `s_PhilMerrell@boisestate.edu` | succeeded |
| 2026-08-28 | `s_PhilMerrell@boisestate.edu` | succeeded |
| 2026-09-09 | ECS task role `e188ce8a…` | **denied** |

Every previously successful `CreateModel` came from a human's SSO credentials running app-api locally against dev data. The deployed task role had never once succeeded. `sagemaker:CreateModel` appears in **no revision** of the infrastructure.

## The subtle part

`sagemaker_service` names the model `model-{job_name}`, and `job_name` already starts with the project prefix — so the resource is `model/model-<prefix>-*`, with the literal `model-` *ahead* of the prefix. A pattern written to match the neighbouring `training-job/<prefix>-*` and `transform-job/<prefix>-*` ARNs looks correct and denies every call. That is why this is a separate statement rather than extra actions on `SageMakerJobManagement`.

## Scope

Grants **only** `sagemaker:CreateModel` — `create_model` is the sole model API `sagemaker_service` calls. No `sagemaker:*` widening.

Models are left behind after each transform job (they are free metadata, but they accumulate). Worth a follow-up to clean up, not a reason to grant `DeleteModel` speculatively here.

## Testing

New `test/fine-tuning-batch-transform-iam.test.ts` — 4 tests, passing. It asserts the grant exists, that the resource carries the `model/model-<prefix>-` shape (the exact detail that would be got wrong), that the paired transform actions survive, and that nothing widened to `sagemaker:*`.

`npx tsc --noEmit` clean.

## Deploy note

This is a CDK change, so it needs **`platform.yml`**, not `backend.yml`. Inference will keep failing until that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
