### PR TITLE
feat(fine-tuning): checkpoint training jobs and resume on restart

### DIFF
--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -596,6 +596,7 @@ async def create_job(
     # S3 paths
     output_s3_prefix = s3_service.get_output_s3_prefix(user.user_id, job_id)
     output_s3_uri = s3_service.get_output_s3_uri(user.user_id, job_id)
+    checkpoint_s3_uri = s3_service.get_checkpoint_s3_uri(user.user_id, job_id)
     input_s3_uri = f"s3://{s3_service.bucket_name}/{request.dataset_s3_key}"
 
     # Create DynamoDB job record
@@ -625,6 +626,7 @@ async def create_job(
             max_runtime=max_runtime_seconds,
             source_dir_s3_uri=scripts_s3_uri,
             task_type=spec.task_type,
+            checkpoint_s3_uri=checkpoint_s3_uri,
         )
         job = jobs_repo.update_job_status(user.user_id, job_id, "TRAINING")
     except Exception as e:

--- a/backend/src/apis/app_api/fine_tuning/s3_service.py
+++ b/backend/src/apis/app_api/fine_tuning/s3_service.py
@@ -95,6 +95,16 @@ class FineTuningS3Service:
         prefix = self.get_output_s3_prefix(user_id, job_id)
         return f"s3://{self.bucket_name}/{prefix}"
 
+    def get_checkpoint_s3_uri(self, user_id: str, job_id: str) -> str:
+        """Return the s3:// URI SageMaker mirrors the checkpoint dir to.
+
+        Kept beside the job's output rather than inside it: SageMaker writes
+        the finished ``model.tar.gz`` under the output prefix, and mixing a
+        live-mirrored directory into the same prefix makes it ambiguous which
+        objects belong to the completed artifact.
+        """
+        return f"s3://{self.bucket_name}/checkpoints/{user_id}/{job_id}"
+
     # =====================================================================
     # Inference (Batch Transform) S3 methods
     # =====================================================================

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_common.py
@@ -20,6 +20,7 @@ without them.
 """
 
 import logging
+import math
 import os
 import shutil
 import zipfile
@@ -56,6 +57,17 @@ DATASET_READERS = {
 
 #: Image files an archive-based dataset may reference.
 SUPPORTED_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff")
+
+#: Where Trainer writes checkpoints. SageMaker mirrors this directory to S3
+#: continuously when CheckpointConfig names the same LocalPath, and restores it
+#: before the script runs again — which is what makes a restart resumable.
+CHECKPOINT_DIR = "/opt/ml/checkpoints"
+
+#: Roughly how many checkpoints a run should produce. Fewer means more lost
+#: work per interruption; more means more S3 traffic. Ten is a compromise that
+#: costs at most ~10% of a run.
+TARGET_CHECKPOINTS = 10
+
 
 #: Directory the training script unpacks an uploaded archive into.  Sits
 #: outside the input channel so the extracted tree is never mistaken for
@@ -285,6 +297,72 @@ def split_frame(frame, split_ratio, seed):
         f"Data split: {len(dataset['train'])} train / {len(dataset['test'])} eval"
     )
     return dataset["train"].shuffle(seed=seed), dataset["test"].shuffle(seed=seed)
+
+
+# =========================================================================
+# Checkpointing
+# =========================================================================
+
+def resolve_save_steps(num_examples, batch_size, gradient_accumulation_steps,
+                       epochs, target=TARGET_CHECKPOINTS):
+    """Optimizer-step interval that yields roughly ``target`` checkpoints.
+
+    A fixed interval cannot work across these jobs.  ``save_steps`` counts
+    *optimizer* steps, not samples, and a generative VLM trains at batch 1 with
+    heavy gradient accumulation — a 90-sample epoch is about 5 steps.  Against
+    a hardcoded ``save_steps=50`` the longest, most interruption-exposed job in
+    the catalog would never checkpoint at all, while a fast text classifier
+    with thousands of steps would checkpoint constantly.
+
+    Scaling to the run's own step count fixes both ends.  Returns at least 1.
+    """
+    per_epoch_batches = max(1, math.ceil(num_examples / max(1, batch_size)))
+    steps_per_epoch = max(1, math.ceil(
+        per_epoch_batches / max(1, gradient_accumulation_steps)
+    ))
+    total_steps = max(1, int(steps_per_epoch * max(1, epochs)))
+    return max(1, total_steps // max(1, target))
+
+
+def checkpoint_arguments(save_steps, enabled=True):
+    """TrainingArguments kwargs for periodic checkpointing.
+
+    ``save_total_limit=1`` keeps only the newest checkpoint: resume needs the
+    latest and nothing else, and an unbounded set would grow the mirrored S3
+    prefix for the whole run.
+    """
+    if not enabled or not save_steps or save_steps <= 0:
+        return {"save_strategy": "no"}
+    return {
+        "save_strategy": "steps",
+        "save_steps": int(save_steps),
+        "save_total_limit": 1,
+    }
+
+
+def latest_checkpoint(checkpoint_dir=CHECKPOINT_DIR):
+    """Path to the checkpoint SageMaker restored, or None for a fresh start.
+
+    On a spot interruption or any other restart SageMaker repopulates
+    ``CHECKPOINT_DIR`` from S3 before re-running the script, so the presence of
+    a checkpoint here is how a resumed attempt distinguishes itself from a
+    first one.  Never raises: a malformed checkpoint should cost the run its
+    progress, not fail the job outright.
+    """
+    if not os.path.isdir(checkpoint_dir):
+        return None
+
+    try:
+        from transformers.trainer_utils import get_last_checkpoint
+
+        found = get_last_checkpoint(checkpoint_dir)
+    except Exception as error:  # pragma: no cover - defensive
+        logger.warning(f"Could not inspect {checkpoint_dir}: {error}")
+        return None
+
+    if found:
+        logger.info(f"Resuming from checkpoint {found}")
+    return found
 
 
 # =========================================================================

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_classification.py
@@ -103,19 +103,32 @@ def train(args, spec):
         frame, args.split_ratio, args.seed
     )
 
+    # Checkpoint often enough that an interruption costs a fraction of the
+    # run, and rarely enough that the S3 mirror stays cheap.
+    save_steps = task_common.resolve_save_steps(
+        len(train_dataset), args.per_device_train_batch_size, 1, args.epochs
+    )
+    checkpointing = task_common.checkpoint_arguments(
+        save_steps, enabled=args.checkpointing
+    )
+    logger.info(
+        f"Checkpointing: {checkpointing.get('save_strategy')} "
+        f"every {checkpointing.get('save_steps', 'n/a')} step(s)"
+    )
+
     training_args = task_common.build_training_arguments(
-        output_dir="/opt/ml/checkpoints",
+        output_dir=task_common.CHECKPOINT_DIR,
         learning_rate=args.learning_rate,
         num_train_epochs=args.epochs,
         per_device_train_batch_size=args.per_device_train_batch_size,
         weight_decay=args.weight_decay,
         eval_strategy="epoch",
-        save_strategy="no",
         logging_dir="/opt/ml/output/tensorboard",
         # The collator returns pixel tensors, not model-signature columns;
         # Trainer's default column pruning would strip the image paths it
         # needs before the collator ever sees them.
         remove_unused_columns=False,
+        **checkpointing,
     )
 
     trainer = Trainer(
@@ -134,7 +147,7 @@ def train(args, spec):
         f"batch_size={args.per_device_train_batch_size}, "
         f"image_size={args.image_size}"
     )
-    trainer.train()
+    trainer.train(resume_from_checkpoint=task_common.latest_checkpoint())
 
     metrics = trainer.evaluate()
     logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_classification.py
@@ -248,17 +248,30 @@ def train(args, spec):
         frame, args.split_ratio, args.seed
     )
 
+    # Checkpoint often enough that an interruption costs a fraction of the
+    # run, and rarely enough that the S3 mirror stays cheap.
+    save_steps = task_common.resolve_save_steps(
+        len(train_dataset), args.per_device_train_batch_size, 1, args.epochs
+    )
+    checkpointing = task_common.checkpoint_arguments(
+        save_steps, enabled=args.checkpointing
+    )
+    logger.info(
+        f"Checkpointing: {checkpointing.get('save_strategy')} "
+        f"every {checkpointing.get('save_steps', 'n/a')} step(s)"
+    )
+
     training_args = task_common.build_training_arguments(
-        output_dir="/opt/ml/checkpoints",
+        output_dir=task_common.CHECKPOINT_DIR,
         learning_rate=args.learning_rate,
         num_train_epochs=args.epochs,
         per_device_train_batch_size=args.per_device_train_batch_size,
         weight_decay=args.weight_decay,
         eval_strategy="epoch",
-        save_strategy="no",
         logging_dir="/opt/ml/output/tensorboard",
         remove_unused_columns=False,
         label_names=["labels"],
+        **checkpointing,
     )
 
     trainer = Trainer(
@@ -276,7 +289,7 @@ def train(args, spec):
         f"model={args.model_name_or_path}, epochs={args.epochs}, "
         f"batch_size={args.per_device_train_batch_size}"
     )
-    trainer.train()
+    trainer.train(resume_from_checkpoint=task_common.latest_checkpoint())
 
     metrics = trainer.evaluate()
     logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_to_text.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_image_text_to_text.py
@@ -350,15 +350,27 @@ def train(args, spec):
     image_token_ids = resolve_image_token_ids(processor, model.config)
     logger.info(f"Masking image placeholder token ids: {sorted(image_token_ids)}")
 
+    # Checkpoint often enough that an interruption costs a fraction of the
+    # run, and rarely enough that the S3 mirror stays cheap.
+    save_steps = task_common.resolve_save_steps(
+        len(train_dataset), args.per_device_train_batch_size, args.gradient_accumulation_steps, args.epochs
+    )
+    checkpointing = task_common.checkpoint_arguments(
+        save_steps, enabled=args.checkpointing
+    )
+    logger.info(
+        f"Checkpointing: {checkpointing.get('save_strategy')} "
+        f"every {checkpointing.get('save_steps', 'n/a')} step(s)"
+    )
+
     training_args = task_common.build_training_arguments(
-        output_dir="/opt/ml/checkpoints",
+        output_dir=task_common.CHECKPOINT_DIR,
         learning_rate=args.learning_rate,
         num_train_epochs=args.epochs,
         per_device_train_batch_size=args.per_device_train_batch_size,
         gradient_accumulation_steps=args.gradient_accumulation_steps,
         weight_decay=args.weight_decay,
         eval_strategy="epoch",
-        save_strategy="no",
         logging_dir="/opt/ml/output/tensorboard",
         remove_unused_columns=False,
         label_names=["labels"],
@@ -368,6 +380,7 @@ def train(args, spec):
         # sequence causes; it is a bitsandbytes optimiser, so it is only
         # available on the quantised path.
         optim="paged_adamw_8bit" if args.load_in_4bit else "adamw_torch",
+        **checkpointing,
     )
 
     collator = build_collator(processor, spec, effective_context, image_token_ids)
@@ -388,7 +401,7 @@ def train(args, spec):
         f"batch_size={args.per_device_train_batch_size} x "
         f"{args.gradient_accumulation_steps} accumulation"
     )
-    trainer.train()
+    trainer.train(resume_from_checkpoint=task_common.latest_checkpoint())
 
     metrics = trainer.evaluate()
     logger.info(f"Final evaluation: loss={metrics.get('eval_loss', 'N/A')}")

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_text_classification.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/task_text_classification.py
@@ -92,15 +92,28 @@ def train(args, spec):
     train_dataset = train_dataset.map(tokenize_function, batched=True)
     eval_dataset = eval_dataset.map(tokenize_function, batched=True)
 
+    # Checkpoint often enough that an interruption costs a fraction of the
+    # run, and rarely enough that the S3 mirror stays cheap.
+    save_steps = task_common.resolve_save_steps(
+        len(train_dataset), args.per_device_train_batch_size, 1, args.epochs
+    )
+    checkpointing = task_common.checkpoint_arguments(
+        save_steps, enabled=args.checkpointing
+    )
+    logger.info(
+        f"Checkpointing: {checkpointing.get('save_strategy')} "
+        f"every {checkpointing.get('save_steps', 'n/a')} step(s)"
+    )
+
     training_args = task_common.build_training_arguments(
-        output_dir="/opt/ml/checkpoints",
+        output_dir=task_common.CHECKPOINT_DIR,
         learning_rate=args.learning_rate,
         num_train_epochs=args.epochs,
         per_device_train_batch_size=args.per_device_train_batch_size,
         weight_decay=args.weight_decay,
         eval_strategy="epoch",
-        save_strategy="no",
         logging_dir="/opt/ml/output/tensorboard",
+        **checkpointing,
     )
 
     trainer = Trainer(
@@ -117,7 +130,7 @@ def train(args, spec):
         f"model={args.model_name_or_path}, epochs={args.epochs}, "
         f"batch_size={args.per_device_train_batch_size}"
     )
-    trainer.train()
+    trainer.train(resume_from_checkpoint=task_common.latest_checkpoint())
 
     metrics = trainer.evaluate()
     logger.info(f"Final evaluation: accuracy={metrics.get('eval_accuracy', 'N/A')}")

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
@@ -103,6 +103,10 @@ def parse_args(argv=None):
     parser.add_argument("--context_length", type=int, default=512)
     parser.add_argument("--image_size", type=int, default=224)
     parser.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    # Kill switch. Checkpointing is what makes a restart — a spot interruption,
+    # or a job killed at the budget-clamped MaxRuntime — resume instead of
+    # starting over, so it is on unless deliberately turned off.
+    parser.add_argument("--checkpointing", type=str2bool, default=True)
 
     # Generative VLM (LoRA) hyperparameters.  Ignored by the classification
     # tasks, which train every weight of a much smaller model.

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
@@ -48,6 +48,10 @@ _INFERENCE_IMAGE_TAGS = {
 
 # The AWS-owned account that publishes Deep Learning Containers. Same in every
 # region we support.
+#: Must match ``task_common.CHECKPOINT_DIR`` — SageMaker only mirrors the
+#: directory it is told about, and the trainer only writes to the one it knows.
+CHECKPOINT_LOCAL_PATH = "/opt/ml/checkpoints"
+
 _DLC_REGISTRY_ACCOUNT = "763104351884"
 
 _SUPPORTED_DLC_REGIONS = (
@@ -126,6 +130,7 @@ class SageMakerService:
         instance_type: str,
         instance_count: int = 1,
         max_runtime: int = 86400,
+        checkpoint_s3_uri: Optional[str] = None,
         source_dir_s3_uri: str = "",
         task_type: Optional[str] = None,
         volume_size_gb: Optional[int] = None,
@@ -189,6 +194,16 @@ class SageMakerService:
             },
             "HyperParameters": hyperparameters,
         }
+
+        # Mirror the container's checkpoint directory to S3 while the job runs,
+        # and restore it before a restarted attempt runs again. Without this
+        # the trainer still writes checkpoints, but they die with the instance
+        # — so a job stopped at MaxRuntime, or interrupted, yields nothing.
+        if checkpoint_s3_uri:
+            params["CheckpointConfig"] = {
+                "S3Uri": checkpoint_s3_uri,
+                "LocalPath": CHECKPOINT_LOCAL_PATH,
+            }
 
         if subnets and security_groups:
             params["VpcConfig"] = {

--- a/backend/tests/fine_tuning/test_checkpointing.py
+++ b/backend/tests/fine_tuning/test_checkpointing.py
@@ -1,0 +1,171 @@
+"""Checkpointing: what makes a restarted training job resume rather than restart.
+
+Two things restart a job: a spot interruption, and SageMaker killing it at
+MaxRuntimeInSeconds — which the dollar-quota clamp makes routine for long runs.
+Before this existed, `save_strategy="no"` meant the adapter was only written
+after `trainer.train()` returned, so either restart produced *nothing* for the
+money already spent.
+"""
+
+import os
+
+import pytest
+from unittest.mock import MagicMock
+
+from apis.app_api.fine_tuning import task_types
+from apis.app_api.fine_tuning.sagemaker_scripts import task_common
+from apis.app_api.fine_tuning.sagemaker_scripts import train as train_script
+from apis.app_api.fine_tuning import sagemaker_service as sm_service
+
+
+class TestResolveSaveSteps:
+    """A fixed save_steps cannot serve both ends of this catalog."""
+
+    def test_vlm_shaped_run_still_checkpoints(self):
+        """The trap this function exists for.
+
+        A 34B VLM trains at batch 1 with 16-step accumulation, so a
+        90-sample epoch is ~6 optimizer steps. Against a hardcoded
+        save_steps=50 the longest, most interruption-exposed job in the
+        catalog would never checkpoint at all.
+        """
+        steps = task_common.resolve_save_steps(
+            num_examples=90, batch_size=1, gradient_accumulation_steps=16, epochs=1
+        )
+        assert steps >= 1
+        assert steps < 50
+
+    def test_scales_with_a_long_run(self):
+        """A text classifier with thousands of steps must not checkpoint constantly."""
+        steps = task_common.resolve_save_steps(
+            num_examples=50_000, batch_size=16, gradient_accumulation_steps=1, epochs=3
+        )
+        # ~9375 optimizer steps / 10 targets
+        assert steps > 100
+
+    def test_targets_roughly_ten_checkpoints(self):
+        total_steps = 1000
+        steps = task_common.resolve_save_steps(
+            num_examples=total_steps, batch_size=1, gradient_accumulation_steps=1, epochs=1
+        )
+        assert 1 <= total_steps // steps <= 20
+
+    def test_never_returns_zero(self):
+        """save_steps=0 is rejected by TrainingArguments."""
+        assert task_common.resolve_save_steps(1, 64, 64, 1) >= 1
+
+    def test_tolerates_degenerate_inputs(self):
+        """Guards against a division-by-zero on an unset hyperparameter."""
+        assert task_common.resolve_save_steps(10, 0, 0, 0) >= 1
+
+    def test_accumulation_reduces_the_step_count(self):
+        """Accumulation means fewer optimizer steps for the same data."""
+        without = task_common.resolve_save_steps(1000, 1, 1, 1)
+        with_accum = task_common.resolve_save_steps(1000, 1, 16, 1)
+        assert with_accum < without
+
+
+class TestCheckpointArguments:
+
+    def test_enabled_produces_step_strategy(self):
+        args = task_common.checkpoint_arguments(25)
+        assert args["save_strategy"] == "steps"
+        assert args["save_steps"] == 25
+
+    def test_keeps_only_the_newest(self):
+        """Resume needs the latest checkpoint; older ones only grow the mirror."""
+        assert task_common.checkpoint_arguments(25)["save_total_limit"] == 1
+
+    def test_kill_switch_restores_the_old_behaviour(self):
+        args = task_common.checkpoint_arguments(25, enabled=False)
+        assert args == {"save_strategy": "no"}
+
+    def test_zero_steps_disables(self):
+        assert task_common.checkpoint_arguments(0)["save_strategy"] == "no"
+
+
+class TestLatestCheckpoint:
+
+    def test_missing_directory_is_a_fresh_start(self, tmp_path):
+        assert task_common.latest_checkpoint(str(tmp_path / "nope")) is None
+
+    def test_empty_directory_is_a_fresh_start(self, tmp_path):
+        assert task_common.latest_checkpoint(str(tmp_path)) is None
+
+    def test_an_unreadable_checkpoint_does_not_fail_the_job(self, tmp_path):
+        """Losing progress is survivable; failing the whole run is not.
+
+        In the backend venv transformers is absent by design, so this
+        exercises the real import-failure path: a directory that *looks* like
+        it holds a checkpoint must still yield a quiet fresh start rather than
+        an ImportError escaping into the trainer.
+        """
+        (tmp_path / "checkpoint-10").mkdir()
+        assert task_common.latest_checkpoint(str(tmp_path)) is None
+
+
+class TestCheckpointConfigWiring:
+    """The container writing checkpoints is useless if S3 never mirrors them."""
+
+    def _service(self):
+        return sm_service.SageMakerService(
+            sagemaker_client=MagicMock(), logs_client=MagicMock()
+        )
+
+    def _create(self, **overrides):
+        service = self._service()
+        kwargs = dict(
+            job_name="j", hyperparameters={"a": "b"},
+            input_s3_uri="s3://b/in", output_s3_uri="s3://b/out",
+            instance_type="ml.g6e.xlarge", max_runtime=3600,
+            source_dir_s3_uri="s3://b/src.tar.gz",
+            task_type=task_types.IMAGE_TEXT_TO_TEXT,
+        )
+        kwargs.update(overrides)
+        service.create_training_job(**kwargs)
+        return service._sagemaker.create_training_job.call_args[1]
+
+    def test_checkpoint_config_is_sent(self):
+        params = self._create(checkpoint_s3_uri="s3://bucket/checkpoints/u/j")
+        assert params["CheckpointConfig"]["S3Uri"] == "s3://bucket/checkpoints/u/j"
+
+    def test_local_path_matches_what_the_trainer_writes(self):
+        """SageMaker only mirrors the directory it is told about."""
+        params = self._create(checkpoint_s3_uri="s3://bucket/checkpoints/u/j")
+        assert params["CheckpointConfig"]["LocalPath"] == task_common.CHECKPOINT_DIR
+
+    def test_omitted_when_no_uri_is_given(self):
+        """Absent config must not become an empty one — SageMaker rejects that."""
+        assert "CheckpointConfig" not in self._create()
+
+
+class TestCheckpointS3Uri:
+
+    def _s3(self):
+        from apis.app_api.fine_tuning.s3_service import FineTuningS3Service
+
+        return FineTuningS3Service(s3_client=MagicMock(), bucket_name="ft-bucket")
+
+    def test_is_scoped_per_user_and_job(self):
+        uri = self._s3().get_checkpoint_s3_uri("user-1", "job-9")
+        assert uri == "s3://ft-bucket/checkpoints/user-1/job-9"
+
+    def test_does_not_collide_with_the_output_prefix(self):
+        """model.tar.gz lands under output/; a live mirror there is ambiguous."""
+        s3 = self._s3()
+        assert not s3.get_checkpoint_s3_uri("u", "j").startswith(
+            s3.get_output_s3_uri("u", "j")
+        )
+
+
+class TestCheckpointingHyperparameter:
+
+    def test_defaults_on(self):
+        args = train_script.parse_args(["--model_name_or_path", "x"])
+        assert args.checkpointing is True
+
+    def test_can_be_disabled(self):
+        args = train_script.parse_args(
+            ["--model_name_or_path", "x", "--checkpointing", "false"]
+        )
+        assert args.checkpointing is False


### PR DESCRIPTION
Prerequisite for managed spot training (follow-up PR), but it fixes a real on-demand failure on its own.

## Why this matters before spot

Two things restart a training job:

1. **A spot interruption** — the reason this is a prerequisite.
2. **SageMaker killing the job at `MaxRuntimeInSeconds`** — which the dollar-quota clamp makes *routine*. A $14 balance buys **3.7h** on `ml.g6e.4xlarge`, while a realistic LLaVA-34B run needs 10–48h.

Until now `save_strategy="no"` meant the adapter was written only after `trainer.train()` returned. So a job stopped at the budget wall spent the entire quota and produced **nothing** — no adapter, no partial result. That is a live bug on on-demand today, independent of spot.

## What changed

`Trainer` checkpoints periodically, SageMaker mirrors `/opt/ml/checkpoints` to S3 via `CheckpointConfig`, and a restarted attempt resumes from whatever was restored.

## The interval is computed, not fixed

`save_steps` counts **optimizer** steps. A 34B VLM trains at batch 1 with 16-step accumulation, so a 90-sample epoch is roughly **6 steps**. Against a hardcoded `save_steps=50`:

- the longest, most interruption-exposed job in the catalog would **never checkpoint**;
- a text classifier with thousands of steps would checkpoint constantly.

`resolve_save_steps` scales to the run's own step count, targeting ~10 checkpoints, so an interruption costs at most about a tenth of the run. `save_total_limit=1` keeps the S3 mirror bounded — resume needs the newest checkpoint and nothing else.

This is cheap here specifically because we use LoRA: the measured SmolVLM adapter is **108MB**, not the tens of GB a full fine-tune would checkpoint.

## Smaller decisions

- Checkpoints go to a `checkpoints/` prefix, not inside the job's `output/` prefix where SageMaker writes the finished `model.tar.gz`. Mixing a live-mirrored directory into that prefix makes it ambiguous which objects belong to the completed artifact.
- `CheckpointConfig.LocalPath` is asserted to match `task_common.CHECKPOINT_DIR` — SageMaker only mirrors the directory it is told about, and the trainer only writes to the one it knows. A test pins them together.
- `latest_checkpoint` never raises: an unreadable checkpoint should cost the run its progress, not fail the job.
- `--checkpointing=false` restores the previous behaviour.

Applied to all four task types, since the MaxRuntime kill affects every one of them.

## Testing

`tests/fine_tuning` + `tests/architecture`: **593 passed**, 3 skipped (20 new). Coverage includes the accumulation trap above as a named case, the degenerate-input guard against division by zero, the LocalPath/CHECKPOINT_DIR agreement, and that an absent `checkpoint_s3_uri` omits the config rather than sending an empty one (SageMaker rejects that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
