### PR TITLE
feat(fine-tuning): opt-in managed spot training

### DIFF
--- a/backend/src/apis/app_api/fine_tuning/job_models.py
+++ b/backend/src/apis/app_api/fine_tuning/job_models.py
@@ -343,6 +343,11 @@ class CreateJobRequest(BaseModel):
     hyperparameters: Optional[Dict[str, str]] = None
     max_runtime_seconds: int = Field(default=86400, le=432000, gt=0)
     custom_huggingface_model_id: Optional[str] = None
+    #: Run on managed spot capacity. Opt-in, not default: spot trades a large
+    #: discount for a longer queue, and measured on-demand waits for these GPU
+    #: families already ran 28-58 minutes — a researcher who needs a result
+    #: this afternoon should be able to pay for certainty.
+    use_spot: bool = False
 
 
 class JobResponse(BaseModel):
@@ -369,6 +374,7 @@ class JobResponse(BaseModel):
     error_message: Optional[str] = None
     max_runtime_seconds: int = 86400
     training_progress: Optional[float] = None
+    use_spot: bool = False
 
 
 class JobListResponse(BaseModel):

--- a/backend/src/apis/app_api/fine_tuning/job_repository.py
+++ b/backend/src/apis/app_api/fine_tuning/job_repository.py
@@ -67,6 +67,9 @@ class FineTuningJobsRepository:
             "updated_at": item["updatedAt"],
             "error_message": item.get("error_message"),
             "max_runtime_seconds": int(item.get("max_runtime_seconds", 86400)),
+            # Absent on every row written before spot existed, and those all
+            # ran on-demand.
+            "use_spot": bool(item.get("use_spot", False)),
             "training_progress": round(float(item["training_progress"]) * 100, 1) if item.get("training_progress") is not None else None,
         }
         return result
@@ -84,6 +87,7 @@ class FineTuningJobsRepository:
         sagemaker_job_name: str,
         output_s3_prefix: str,
         max_runtime_seconds: int = 86400,
+        use_spot: bool = False,
         task_type: str = task_types.DEFAULT_TASK_TYPE,
     ) -> dict:
         """Create a new training job record."""
@@ -105,6 +109,7 @@ class FineTuningJobsRepository:
             "instance_count": 1,
             "sagemaker_job_name": sagemaker_job_name,
             "max_runtime_seconds": max_runtime_seconds,
+            "use_spot": use_spot,
             "createdAt": now,
             "updatedAt": now,
         }

--- a/backend/src/apis/app_api/fine_tuning/pricing.py
+++ b/backend/src/apis/app_api/fine_tuning/pricing.py
@@ -130,16 +130,31 @@ def transform_rate(instance_type: str) -> Optional[float]:
 
 
 def calculate_cost(
-    instance_type: str, billable_seconds: int, *, transform: bool = False
+    instance_type: str,
+    billable_seconds: int,
+    *,
+    transform: bool = False,
+    instance_count: int = 1,
 ) -> float:
     """Cost in USD for ``billable_seconds`` on ``instance_type``.
+
+    ``BillableTimeInSeconds`` is per instance — AWS documents multiplying it
+    by the instance count to get the total compute time billed.  Harmless
+    while every job runs on one instance, but silent under-billing the moment
+    a multi-instance job lands, so the multiply is here rather than waiting to
+    be discovered.
+
+    This is also correct for **managed spot**, with no special casing: AWS
+    expresses the spot discount by *shrinking* BillableTimeInSeconds against
+    the same on-demand rate, which is why the documented savings formula is
+    ``(1 - BillableTimeInSeconds / TrainingTimeInSeconds) * 100``.
 
     Returns 0.0 for an instance we have no rate for.  Callers must not rely on
     that to mean "free" — validate the instance up front instead; a silent
     0.0 is exactly the blind spot that lets unpriced GPU time go unbilled.
     """
     rate = transform_rate(instance_type) if transform else training_rate(instance_type)
-    return round((rate or 0.0) * (billable_seconds / 3600), 4)
+    return round((rate or 0.0) * (billable_seconds / 3600) * max(1, instance_count), 4)
 
 
 def estimate_max_cost(

--- a/backend/src/apis/app_api/fine_tuning/routes.py
+++ b/backend/src/apis/app_api/fine_tuning/routes.py
@@ -573,6 +573,22 @@ async def create_job(
 
     if request.hyperparameters:
         hyperparameters.update(request.hyperparameters)
+
+    # Spot restarts the job from the last checkpoint. With checkpointing off
+    # it restarts from zero, and a run longer than the mean time between
+    # interruptions then almost never completes — it just re-bills the same
+    # early steps forever. Refuse the combination rather than sell it.
+    if request.use_spot and not task_types.str2bool(
+        hyperparameters.get("checkpointing", "true")
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Managed spot requires checkpointing. Without it an "
+                "interrupted job restarts from the beginning, so a long run "
+                "may never finish while still being billed for every attempt."
+            ),
+        )
     hyperparameters["model_name_or_path"] = huggingface_id
     hyperparameters["task_type"] = spec.task_type
 
@@ -613,6 +629,7 @@ async def create_job(
         sagemaker_job_name=sagemaker_job_name,
         output_s3_prefix=output_s3_prefix,
         max_runtime_seconds=max_runtime_seconds,
+        use_spot=request.use_spot,
     )
 
     # Start SageMaker training job
@@ -627,6 +644,7 @@ async def create_job(
             source_dir_s3_uri=scripts_s3_uri,
             task_type=spec.task_type,
             checkpoint_s3_uri=checkpoint_s3_uri,
+            use_spot=request.use_spot,
         )
         job = jobs_repo.update_job_status(user.user_id, job_id, "TRAINING")
     except Exception as e:
@@ -769,6 +787,11 @@ def _estimate_training_progress(sm_status: dict, job: dict) -> Optional[float]:
         "DownloadingTrainingImage": 6.0,
         "Downloading": 8.0,
         "Uploading": 92.0,
+        # Spot only: the job is stalled waiting to be rescheduled, not
+        # progressing. Without this the elapsed-time curve below keeps
+        # climbing and the bar lies about a job that is standing still.
+        "Interrupted": 10.0,
+        "MaxWaitTimeExceeded": 0.0,
     }
     if secondary in phase_progress:
         return phase_progress[secondary]

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_scripts/train.py
@@ -54,15 +54,10 @@ TASK_MODULES = {
 }
 
 
-def str2bool(value):
-    """Parse a boolean hyperparameter.
-
-    SageMaker passes every hyperparameter as a string, so ``bool("false")`` —
-    which is True — is the trap this exists to avoid.
-    """
-    if isinstance(value, bool):
-        return value
-    return str(value).strip().lower() in ("1", "true", "yes", "on")
+#: Re-exported so the container script and app-api parse boolean
+#: hyperparameters identically — a disagreement here would let app-api admit a
+#: job the trainer then runs with different settings.
+str2bool = task_types.str2bool
 
 
 def resolve_task_module(task_type):

--- a/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
+++ b/backend/src/apis/app_api/fine_tuning/sagemaker_service.py
@@ -52,6 +52,18 @@ _INFERENCE_IMAGE_TAGS = {
 #: directory it is told about, and the trainer only writes to the one it knows.
 CHECKPOINT_LOCAL_PATH = "/opt/ml/checkpoints"
 
+#: Head-room added to MaxRuntimeInSeconds to get MaxWaitTimeInSeconds for a
+#: spot job. MaxWaitTime covers capacity waiting *and* training, and the API
+#: requires it to exceed MaxRuntime, so it cannot simply equal it.
+#:
+#: Four hours because measured on-demand capacity waits for the GPU families
+#: this feature uses ran 28-58 minutes in us-west-2; spot draws from the
+#: surplus of those same constrained pools, so its queue is longer, not
+#: shorter. Waiting is not billed — only running is — so a generous allowance
+#: costs nothing but patience, while a tight one fails the job outright with
+#: MaxWaitTimeExceeded after it has already queued.
+SPOT_CAPACITY_WAIT_ALLOWANCE_SECONDS = 4 * 60 * 60
+
 _DLC_REGISTRY_ACCOUNT = "763104351884"
 
 _SUPPORTED_DLC_REGIONS = (
@@ -131,6 +143,7 @@ class SageMakerService:
         instance_count: int = 1,
         max_runtime: int = 86400,
         checkpoint_s3_uri: Optional[str] = None,
+        use_spot: bool = False,
         source_dir_s3_uri: str = "",
         task_type: Optional[str] = None,
         volume_size_gb: Optional[int] = None,
@@ -204,6 +217,20 @@ class SageMakerService:
                 "S3Uri": checkpoint_s3_uri,
                 "LocalPath": CHECKPOINT_LOCAL_PATH,
             }
+
+        if use_spot:
+            # MaxWaitTimeInSeconds must be strictly larger than
+            # MaxRuntimeInSeconds, and it covers waiting for capacity *plus*
+            # training — so it is the runtime plus an allowance for the queue,
+            # not the runtime itself.
+            params["EnableManagedSpotTraining"] = True
+            params["StoppingCondition"]["MaxWaitTimeInSeconds"] = (
+                max_runtime + SPOT_CAPACITY_WAIT_ALLOWANCE_SECONDS
+            )
+            logger.info(
+                f"Managed spot enabled for {job_name}: MaxWait="
+                f"{params['StoppingCondition']['MaxWaitTimeInSeconds']}s"
+            )
 
         if subnets and security_groups:
             params["VpcConfig"] = {

--- a/backend/src/apis/app_api/fine_tuning/task_types.py
+++ b/backend/src/apis/app_api/fine_tuning/task_types.py
@@ -335,6 +335,22 @@ GENERATIVE_TASK_TYPES: Tuple[str, ...] = tuple(
 )
 
 
+def str2bool(value) -> bool:
+    """Parse a boolean hyperparameter.
+
+    Lives here because both sides need it and this is the only module they
+    share: app-api validates a submission before billing a GPU, and the
+    training script parses the same value inside the container.
+
+    ``bool("false")`` is True, which is the trap this exists to avoid —
+    SageMaker passes every hyperparameter as a string, and JSON-parses some of
+    them back into Python-style ``"False"`` on the command line.
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
 def get_task_spec(task_type: Optional[str]) -> TaskSpec:
     """Return the spec for ``task_type``.
 

--- a/backend/tests/fine_tuning/test_job_routes.py
+++ b/backend/tests/fine_tuning/test_job_routes.py
@@ -178,6 +178,84 @@ class TestCreateJob:
         body = resp.json()
         assert body["model_id"] == "distilgpt2"
 
+    def _spot_app(self, make_user):
+        app = _create_app()
+        user = make_user(email="user@example.com")
+
+        mock_s3 = MagicMock()
+        mock_s3.check_object_exists.return_value = True
+        mock_s3.get_output_s3_prefix.return_value = "output/user-001/job-abc"
+        mock_s3.get_output_s3_uri.return_value = "s3://bucket/output/user-001/job-abc"
+        mock_s3.get_checkpoint_s3_uri.return_value = "s3://bucket/checkpoints/user-001/job-abc"
+        mock_s3.bucket_name = "test-bucket"
+
+        mock_jobs = MagicMock()
+        mock_jobs.create_job.return_value = SAMPLE_JOB
+        mock_jobs.update_job_status.return_value = {**SAMPLE_JOB, "status": "TRAINING"}
+
+        mock_sm = MagicMock()
+        mock_sm.create_training_job.return_value = {}
+
+        mock_script = MagicMock()
+        mock_script.ensure_scripts_uploaded.return_value = "s3://test-bucket/scripts/sourcedir-text.tar.gz"
+
+        _setup_deps(app, user, SAMPLE_GRANT, mock_jobs, mock_s3, mock_sm,
+                    MagicMock(), mock_script)
+        return TestClient(app), mock_sm
+
+    def test_spot_is_off_unless_asked_for(self, make_user):
+        client, mock_sm = self._spot_app(make_user)
+        resp = client.post("/fine-tuning/jobs", json={
+            "model_id": "distilgpt2",
+            "dataset_s3_key": "datasets/user-001/abc/train.jsonl",
+        })
+        assert resp.status_code == 201
+        assert mock_sm.create_training_job.call_args[1]["use_spot"] is False
+
+    def test_spot_is_forwarded_to_sagemaker(self, make_user):
+        client, mock_sm = self._spot_app(make_user)
+        resp = client.post("/fine-tuning/jobs", json={
+            "model_id": "distilgpt2",
+            "dataset_s3_key": "datasets/user-001/abc/train.jsonl",
+            "use_spot": True,
+        })
+        assert resp.status_code == 201
+        assert mock_sm.create_training_job.call_args[1]["use_spot"] is True
+
+    def test_spot_with_checkpointing_disabled_is_refused(self, make_user):
+        """Spot restarts from the last checkpoint. With none, a long run
+        restarts from zero and may never finish while billing every attempt —
+        refuse the combination rather than sell it."""
+        client, mock_sm = self._spot_app(make_user)
+        resp = client.post("/fine-tuning/jobs", json={
+            "model_id": "distilgpt2",
+            "dataset_s3_key": "datasets/user-001/abc/train.jsonl",
+            "use_spot": True,
+            "hyperparameters": {"checkpointing": "false"},
+        })
+        assert resp.status_code == 400
+        assert "checkpointing" in resp.json()["detail"].lower()
+        mock_sm.create_training_job.assert_not_called()
+
+    def test_checkpointing_off_without_spot_is_allowed(self, make_user):
+        """The kill switch stays usable on on-demand."""
+        client, mock_sm = self._spot_app(make_user)
+        resp = client.post("/fine-tuning/jobs", json={
+            "model_id": "distilgpt2",
+            "dataset_s3_key": "datasets/user-001/abc/train.jsonl",
+            "hyperparameters": {"checkpointing": "false"},
+        })
+        assert resp.status_code == 201
+
+    def test_checkpoint_uri_reaches_sagemaker(self, make_user):
+        client, mock_sm = self._spot_app(make_user)
+        client.post("/fine-tuning/jobs", json={
+            "model_id": "distilgpt2",
+            "dataset_s3_key": "datasets/user-001/abc/train.jsonl",
+        })
+        uri = mock_sm.create_training_job.call_args[1]["checkpoint_s3_uri"]
+        assert uri == "s3://bucket/checkpoints/user-001/job-abc"
+
     def test_rejects_dataset_the_trainer_cannot_read(self, make_user):
         """Last gate before SageMaker: no GPU is provisioned for a doomed job."""
         app = _create_app()

--- a/backend/tests/fine_tuning/test_managed_spot.py
+++ b/backend/tests/fine_tuning/test_managed_spot.py
@@ -1,0 +1,122 @@
+"""Managed spot training.
+
+Spot trades a large discount for a longer queue and the risk of being
+interrupted. It is only safe here because checkpointing landed first: without
+it an interrupted job restarts from zero, and a run longer than the mean time
+between interruptions almost never completes while being billed for every
+attempt.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from apis.app_api.fine_tuning import pricing, task_types
+from apis.app_api.fine_tuning import sagemaker_service as sm_service
+from apis.app_api.fine_tuning.sagemaker_scripts import task_common
+
+
+def _params(**overrides):
+    service = sm_service.SageMakerService(
+        sagemaker_client=MagicMock(), logs_client=MagicMock()
+    )
+    kwargs = dict(
+        job_name="j", hyperparameters={"a": "b"},
+        input_s3_uri="s3://b/in", output_s3_uri="s3://b/out",
+        instance_type="ml.g6e.xlarge", max_runtime=3600,
+        source_dir_s3_uri="s3://b/src.tar.gz",
+        task_type=task_types.IMAGE_TEXT_TO_TEXT,
+        checkpoint_s3_uri="s3://b/checkpoints/u/j",
+    )
+    kwargs.update(overrides)
+    service.create_training_job(**kwargs)
+    return service._sagemaker.create_training_job.call_args[1]
+
+
+class TestSpotStoppingCondition:
+
+    def test_off_by_default(self):
+        """Opt-in: a researcher who needs a result today pays for certainty."""
+        params = _params()
+        assert "EnableManagedSpotTraining" not in params
+        assert "MaxWaitTimeInSeconds" not in params["StoppingCondition"]
+
+    def test_enables_the_flag(self):
+        assert _params(use_spot=True)["EnableManagedSpotTraining"] is True
+
+    def test_max_wait_strictly_exceeds_max_runtime(self):
+        """The API rejects MaxWaitTime <= MaxRuntime."""
+        params = _params(use_spot=True, max_runtime=3600)
+        assert params["StoppingCondition"]["MaxWaitTimeInSeconds"] > 3600
+
+    def test_max_wait_leaves_room_for_the_capacity_queue(self):
+        """MaxWaitTime covers waiting AND training.
+
+        Measured on-demand waits for these GPU families ran 28-58 minutes;
+        spot draws from the surplus of the same constrained pools, so a wait
+        allowance shorter than that fails the job with MaxWaitTimeExceeded
+        after it has already queued.
+        """
+        params = _params(use_spot=True, max_runtime=3600)
+        slack = params["StoppingCondition"]["MaxWaitTimeInSeconds"] - 3600
+        assert slack >= 3600
+
+    def test_max_runtime_is_unchanged_by_spot(self):
+        """Spot must not quietly extend the budget-clamped stopping condition."""
+        params = _params(use_spot=True, max_runtime=1234)
+        assert params["StoppingCondition"]["MaxRuntimeInSeconds"] == 1234
+
+    def test_spot_still_carries_checkpoint_config(self):
+        """The pairing that makes spot survivable."""
+        params = _params(use_spot=True)
+        assert params["CheckpointConfig"]["LocalPath"] == task_common.CHECKPOINT_DIR
+
+
+class TestSpotCostAccounting:
+    """AWS shrinks BillableTimeInSeconds rather than discounting the rate."""
+
+    def test_on_demand_rate_is_correct_for_spot(self):
+        """The documented savings formula is
+        (1 - BillableTimeInSeconds / TrainingTimeInSeconds) * 100 — i.e. the
+        discount is already inside billable_seconds, so multiplying it by the
+        on-demand rate is right and needs no spot branch."""
+        full = pricing.calculate_cost("ml.g6e.xlarge", 3600)
+        discounted = pricing.calculate_cost("ml.g6e.xlarge", 1200)
+        assert discounted == pytest.approx(full / 3)
+
+    def test_multiplies_by_instance_count(self):
+        """AWS documents BillableTimeInSeconds as per-instance."""
+        one = pricing.calculate_cost("ml.g6e.xlarge", 3600, instance_count=1)
+        four = pricing.calculate_cost("ml.g6e.xlarge", 3600, instance_count=4)
+        assert four == pytest.approx(one * 4)
+
+    def test_default_instance_count_is_one(self):
+        assert pricing.calculate_cost("ml.g6e.xlarge", 3600) == pytest.approx(
+            pricing.calculate_cost("ml.g6e.xlarge", 3600, instance_count=1)
+        )
+
+    def test_a_zero_count_does_not_zero_the_bill(self):
+        """Defensive: a bad count must not silently make GPU time free."""
+        assert pricing.calculate_cost("ml.g6e.xlarge", 3600, instance_count=0) > 0
+
+
+class TestSharedBooleanParsing:
+    """app-api and the container must agree, or app-api admits a job the
+    trainer then runs with different settings."""
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on", True])
+    def test_truthy(self, value):
+        assert task_types.str2bool(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "", False])
+    def test_falsy(self, value):
+        assert task_types.str2bool(value) is False
+
+    def test_the_string_False_is_not_truthy(self):
+        """SageMaker JSON-parses "false" and passes back Python-style "False"."""
+        assert bool("False") is True
+        assert task_types.str2bool("False") is False
+
+    def test_train_script_reexports_the_same_function(self):
+        from apis.app_api.fine_tuning.sagemaker_scripts import train
+
+        assert train.str2bool is task_types.str2bool

--- a/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
+++ b/frontend/ai.client/src/app/fine-tuning/models/fine-tuning.models.ts
@@ -81,6 +81,9 @@ export interface CreateJobRequest {
   hyperparameters?: Record<string, string>;
   max_runtime_seconds?: number;
   custom_huggingface_model_id?: string;
+  /** Run on managed spot capacity — cheaper, but queues longer and can be
+   * interrupted. Safe because the job checkpoints and resumes. */
+  use_spot?: boolean;
 }
 
 export interface JobResponse {
@@ -106,6 +109,7 @@ export interface JobResponse {
   error_message: string | null;
   max_runtime_seconds: number;
   training_progress: number | null;
+  use_spot: boolean;
 }
 
 export interface JobListResponse {

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -526,7 +526,26 @@
             />
           </div>
 
-          <!-- Max Runtime -->
+                    <!-- Managed spot — opt-in -->
+          <div class="sm:col-span-2">
+            <label class="flex items-start gap-3 rounded-sm border border-gray-300 p-3 dark:border-gray-600">
+              <input
+                type="checkbox"
+                formControlName="useSpot"
+                class="mt-0.5 size-4 rounded-sm border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600"
+              />
+              <span class="text-sm/6">
+                <span class="font-medium text-gray-700 dark:text-gray-300">Use spot capacity</span>
+                <span class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                  Much cheaper, but the job waits longer to start and can be interrupted.
+                  It saves checkpoints and resumes where it left off, so nothing is lost —
+                  only the finish time is less predictable. Leave off if you need a result soon.
+                </span>
+              </span>
+            </label>
+          </div>
+
+<!-- Max Runtime -->
           <div>
             <label for="hp-runtime" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Max Runtime (hours)</label>
             <input

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.spec.ts
@@ -62,6 +62,7 @@ const mockJobResponse: JobResponse = {
   error_message: null,
   max_runtime_seconds: 86400,
   training_progress: null,
+  use_spot: false,
 };
 
 function createMockState() {
@@ -440,6 +441,39 @@ describe('CreateTrainingJobPage', () => {
       const call = mockState.createTrainingJob.mock.calls[0][0];
       expect(call.hyperparameters).not.toHaveProperty('lora_r');
       expect(call.hyperparameters).not.toHaveProperty('load_in_4bit');
+    });
+  });
+
+  describe('managed spot', () => {
+    async function submitWith(component: CreateTrainingJobPage) {
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockResolvedValue(true);
+      component.selectModel(mockModel);
+      component.uploadState.set({
+        file: new File([''], 'test.jsonl'),
+        progress: 100,
+        status: 'complete',
+        s3Key: 'uploads/test.jsonl',
+      });
+      await component.submitJob();
+      return mockState.createTrainingJob.mock.calls[0][0];
+    }
+
+    it('defaults to off', () => {
+      const component = createComponent();
+      expect(component.form.getRawValue().useSpot).toBe(false);
+    });
+
+    it('sends use_spot false unless the user opts in', async () => {
+      const call = await submitWith(createComponent());
+      expect(call.use_spot).toBe(false);
+    });
+
+    it('sends use_spot true when enabled', async () => {
+      const component = createComponent();
+      component.form.patchValue({ useSpot: true });
+      const call = await submitWith(component);
+      expect(call.use_spot).toBe(true);
     });
   });
 

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.ts
@@ -174,6 +174,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
     loraAlpha: ['32'],
     loadIn4bit: ['true'],
     maxRuntimeHours: [24, [Validators.required, Validators.min(1), Validators.max(120)]],
+    useSpot: [false],
   });
 
   ngOnInit(): void {
@@ -483,6 +484,7 @@ export class CreateTrainingJobPage implements OnInit, OnDestroy {
         ...(isCustom ? {} : { instance_type: model!.default_instance_type }),
         hyperparameters,
         max_runtime_seconds: (formValues.maxRuntimeHours ?? 24) * 3600,
+        use_spot: formValues.useSpot ?? false,
         ...(isCustom ? { custom_huggingface_model_id: customHfId } : {}),
       };
 

--- a/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/dashboard/fine-tuning-dashboard.page.spec.ts
@@ -36,6 +36,7 @@ const mockTrainingJob: JobResponse = {
   error_message: null,
   max_runtime_seconds: 86400,
   training_progress: null,
+  use_spot: false,
 };
 
 const mockInferenceJob: InferenceJobResponse = {

--- a/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/pages/training-job-detail/training-job-detail.page.spec.ts
@@ -29,6 +29,7 @@ const mockJob: JobResponse = {
   error_message: null,
   max_runtime_seconds: 86400,
   training_progress: 45,
+  use_spot: false,
 };
 
 function createMockState() {

--- a/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.spec.ts
+++ b/frontend/ai.client/src/app/fine-tuning/services/fine-tuning-state.service.spec.ts
@@ -25,6 +25,7 @@ describe('FineTuningStateService', () => {
     billable_seconds: null, estimated_cost_usd: null, created_at: '2026-03-01T00:00:00Z',
     updated_at: '2026-03-01T00:00:00Z', error_message: null, max_runtime_seconds: 86400,
     training_progress: null,
+    use_spot: false,
   };
 
   const mockInferenceJob: InferenceJobResponse = {


### PR DESCRIPTION
**Stacked on #1024 (checkpointing)** — review/merge that first; this targets that branch, not `develop`.

## Why it is safe only now

Managed spot trades ~65% off for a longer queue and possible interruption. Simulated expected *billed* hours, with startup re-paid on every restart:

| Workload | interrupt/hr | on-demand | spot, **no** ckpt | spot, ckpt 30m |
|---|---|---|---|---|
| 7B, ~1k samples | 0.15 | 3.3h | 1.4h | 1.2h |
| 34B, ~500 samples | 0.15 | 10.5h | 8.4h | 3.9h |
| 34B, ~5k samples | 0.15 | 48.5h | **3,198h** | 17.9h |

That 3,198h is not a rounding artifact: when the job is much longer than the mean time between interruptions, the chance of ever completing a clean run is ~0.07%, so it restarts forever and bills the whole time. **Spot without checkpointing isn't worse value for a long job — it's a job that never finishes while spending money.**

So the combination is refused at submit rather than sold: `use_spot: true` with `checkpointing: "false"` returns 400.

## Off by default

Measured on-demand capacity waits for these GPU families ran **28–58 minutes** in us-west-2 across three real jobs; spot draws from the surplus of those same constrained pools. A researcher who needs a result this afternoon should be able to pay for certainty, so this is a per-job opt-in with a checkbox that says plainly what the trade is.

## MaxWaitTimeInSeconds

Covers waiting for capacity **and** training, and the API requires it to strictly exceed `MaxRuntimeInSeconds` — so it is the runtime plus a four-hour queue allowance, not the runtime itself. Waiting isn't billed, so a generous allowance costs only patience, while a tight one fails the job with `MaxWaitTimeExceeded` after it has already queued. `MaxRuntime` itself is untouched: spot must not quietly extend the budget clamp.

## Cost accounting needs no spot branch

AWS expresses the discount by *shrinking* `BillableTimeInSeconds` against the same on-demand rate — the documented savings formula is `(1 - BillableTimeInSeconds / TrainingTimeInSeconds) * 100`. The existing `calculate_cost` was therefore already correct for spot, and the quota charges the discounted amount automatically. A test pins this so nobody "fixes" it by adding a discount multiplier.

## Two adjacent fixes

- **`calculate_cost` now multiplies by `instance_count`.** AWS documents `BillableTimeInSeconds` as per-instance. Harmless while every job runs on one, silent under-billing the moment a multi-instance job lands.
- **The progress estimator knows `Interrupted` and `MaxWaitTimeExceeded`.** Without them the elapsed-time curve kept climbing on a job that was stalled waiting to be rescheduled — the bar would lie about a job standing still.

`str2bool` moves to `task_types`, the only module app-api and the container share, so both parse the same value identically. A disagreement there would let app-api admit a job the trainer then runs with different settings.

## Testing

Backend **622 passed** (`tests/fine_tuning` + `tests/architecture`), frontend **2561 passed**. 29 new tests covering the MaxWait ordering constraint, the queue allowance, that spot leaves MaxRuntime alone, the 400 guard, that the checkpointing kill switch still works on on-demand, and that a zero instance count can't make GPU time free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
