### PR TITLE
fix(connectors): allow metadata-only edits on discovery-URL providers

### DIFF
--- a/backend/src/apis/app_api/admin/oauth/routes.py
+++ b/backend/src/apis/app_api/admin/oauth/routes.py
@@ -285,13 +285,32 @@ async def update_provider(
     )
 
     rotating_credentials = bool(updates.client_id and updates.client_secret)
+    # Only a *different* value counts as a discovery change. Clients that
+    # round-trip the whole record (the connector edit form does) resend the
+    # unchanged discovery URL on every save; treating any non-None value as
+    # a change would make metadata-only edits — scopes, display name, icon,
+    # enabled — impossible for a discovery-URL provider, because the admin
+    # cannot satisfy the rotation requirement (AgentCore never echoes the
+    # client secret back, so there is nothing to re-enter).
     changing_discovery = (
         updates.oauth_discovery_url is not None
-        or updates.authorization_server_metadata is not None
+        and updates.oauth_discovery_url != existing.oauth_discovery_url
+    ) or (
+        updates.authorization_server_metadata is not None
+        and updates.authorization_server_metadata
+        != existing.authorization_server_metadata
     )
 
     credential_info: CredentialProviderInfo | None = None
     if rotating_credentials or changing_discovery:
+        if not rotating_credentials:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Discovery config can only be updated together with a "
+                    "credential rotation (client_id + client_secret)."
+                ),
+            )
         discovery_url = (
             updates.oauth_discovery_url
             if updates.oauth_discovery_url is not None
@@ -302,14 +321,6 @@ async def update_provider(
             if updates.authorization_server_metadata is not None
             else existing.authorization_server_metadata
         )
-        if not rotating_credentials:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Discovery config can only be updated together with a "
-                    "credential rotation (client_id + client_secret)."
-                ),
-            )
         try:
             credential_info = registrar.update_credential_provider(
                 provider_id=provider_id,

--- a/backend/tests/apis/app_api/admin/oauth/test_update_provider_discovery_guard.py
+++ b/backend/tests/apis/app_api/admin/oauth/test_update_provider_discovery_guard.py
@@ -1,0 +1,244 @@
+"""Route tests for the discovery-change guard on `PATCH /admin/oauth-providers/{id}`.
+
+A discovery-config change requires a credential rotation, because AgentCore's
+update API demands the full config and never echoes the stored client secret
+back. The guard must fire on a *real* change only: clients that round-trip the
+whole record resend the unchanged discovery URL on every save, and rejecting
+those makes metadata-only edits (scopes, display name, icon, enabled)
+impossible for any provider that has one — the admin has no way to satisfy the
+rotation requirement. See `apis/app_api/admin/oauth/routes.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from apis.app_api.admin.oauth import routes
+from apis.shared.auth.models import User
+from apis.shared.oauth.agentcore_registrar import CredentialProviderInfo
+from apis.shared.oauth.models import (
+    OAuthProvider,
+    OAuthProviderType,
+    OAuthProviderUpdate,
+)
+
+_DISCOVERY_URL = "https://boisestate.instructure.com/.well-known/openid-configuration"
+
+
+def _admin() -> User:
+    return User(
+        email="admin@example.edu",
+        user_id="u1",
+        name="Admin",
+        roles=["system_admin"],
+        raw_token="admin-tok",
+    )
+
+
+def _provider(**overrides) -> OAuthProvider:
+    defaults = dict(
+        provider_id="canvas-faculty",
+        display_name="Canvas (Faculty)",
+        provider_type=OAuthProviderType.CANVAS,
+        scopes=["url:GET|/api/v1/courses"],
+        allowed_roles=["faculty"],
+        oauth_discovery_url=_DISCOVERY_URL,
+        credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:1:provider/canvas",
+    )
+    defaults.update(overrides)
+    return OAuthProvider(**defaults)
+
+
+class _FakeProviderRepo:
+    """Minimal stand-in for `OAuthProviderRepository`.
+
+    `apply_metadata_update` mirrors the real repository closely enough for
+    the guard's purposes: it copies the populated fields onto the record and
+    stamps `updated_at`.
+    """
+
+    def __init__(self, provider: OAuthProvider | None):
+        self._provider = provider
+        self.metadata_updates: list[OAuthProviderUpdate] = []
+
+    async def get_provider(self, provider_id: str) -> OAuthProvider | None:
+        return self._provider
+
+    async def apply_metadata_update(
+        self, provider_id: str, updates: OAuthProviderUpdate
+    ) -> OAuthProvider | None:
+        self.metadata_updates.append(updates)
+        if self._provider is None:
+            return None
+        if updates.scopes is not None:
+            self._provider.scopes = updates.scopes
+        if updates.display_name is not None:
+            self._provider.display_name = updates.display_name
+        if updates.oauth_discovery_url is not None:
+            self._provider.oauth_discovery_url = updates.oauth_discovery_url
+        self._provider.updated_at = "2026-09-10T00:00:00Z"
+        return self._provider
+
+    async def put_provider(self, provider: OAuthProvider) -> None:
+        self._provider = provider
+
+
+class _FakeRegistrar:
+    def __init__(self):
+        self.update_calls: list[dict] = []
+
+    def update_credential_provider(self, **kwargs) -> CredentialProviderInfo:
+        self.update_calls.append(kwargs)
+        return CredentialProviderInfo(
+            provider_id=kwargs["provider_id"],
+            vendor="CustomOauth2",
+            credential_provider_arn="arn:aws:bedrock-agentcore:us-west-2:1:provider/new",
+            client_secret_arn="arn:aws:secretsmanager:us-west-2:1:secret/new",
+            callback_url="https://example.edu/auth/callback",
+        )
+
+
+async def _update(updates: OAuthProviderUpdate, repo, registrar):
+    return await routes.update_provider(
+        provider_id="canvas-faculty",
+        updates=updates,
+        admin=_admin(),
+        provider_repo=repo,
+        registrar=registrar,
+    )
+
+
+class TestDiscoveryGuard:
+    @pytest.mark.asyncio
+    async def test_unchanged_discovery_url_allows_metadata_only_edit(self):
+        """The SPA resends the discovery URL verbatim; that must not 400."""
+        repo = _FakeProviderRepo(_provider())
+        registrar = _FakeRegistrar()
+
+        response = await _update(
+            OAuthProviderUpdate(
+                display_name="Canvas (Faculty)",
+                scopes=["url:GET|/api/v1/courses", "url:GET|/api/v1/users/:id"],
+                oauth_discovery_url=_DISCOVERY_URL,
+            ),
+            repo,
+            registrar,
+        )
+
+        assert response.scopes == [
+            "url:GET|/api/v1/courses",
+            "url:GET|/api/v1/users/:id",
+        ]
+        # No AgentCore call — nothing about the credential config changed.
+        assert registrar.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_scopes_only_edit_succeeds(self):
+        """The documented workaround payload — no discovery field at all."""
+        repo = _FakeProviderRepo(_provider())
+        registrar = _FakeRegistrar()
+
+        response = await _update(
+            OAuthProviderUpdate(scopes=["url:GET|/api/v1/courses"]), repo, registrar
+        )
+
+        assert response.scopes == ["url:GET|/api/v1/courses"]
+        assert registrar.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_changed_discovery_url_without_credentials_still_400s(self):
+        repo = _FakeProviderRepo(_provider())
+        registrar = _FakeRegistrar()
+
+        with pytest.raises(HTTPException) as exc:
+            await _update(
+                OAuthProviderUpdate(
+                    oauth_discovery_url="https://other.example.edu/.well-known/openid-configuration"
+                ),
+                repo,
+                registrar,
+            )
+
+        assert exc.value.status_code == 400
+        assert "credential rotation" in exc.value.detail
+        assert registrar.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_unchanged_metadata_dict_allows_metadata_only_edit(self):
+        """Same rule for the explicit-metadata flavor of the discovery config."""
+        metadata = {"issuer": "https://idp.example.edu", "authorization_endpoint": "/a"}
+        repo = _FakeProviderRepo(
+            _provider(oauth_discovery_url=None, authorization_server_metadata=metadata)
+        )
+        registrar = _FakeRegistrar()
+
+        response = await _update(
+            OAuthProviderUpdate(
+                scopes=["openid"],
+                authorization_server_metadata=dict(metadata),
+            ),
+            repo,
+            registrar,
+        )
+
+        assert response.scopes == ["openid"]
+        assert registrar.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_changed_metadata_dict_without_credentials_still_400s(self):
+        repo = _FakeProviderRepo(
+            _provider(
+                oauth_discovery_url=None,
+                authorization_server_metadata={"issuer": "https://idp.example.edu"},
+            )
+        )
+        registrar = _FakeRegistrar()
+
+        with pytest.raises(HTTPException) as exc:
+            await _update(
+                OAuthProviderUpdate(
+                    authorization_server_metadata={"issuer": "https://new.example.edu"}
+                ),
+                repo,
+                registrar,
+            )
+
+        assert exc.value.status_code == 400
+        assert registrar.update_calls == []
+
+    @pytest.mark.asyncio
+    async def test_changed_discovery_url_with_rotation_reaches_agentcore(self):
+        repo = _FakeProviderRepo(_provider())
+        registrar = _FakeRegistrar()
+        new_url = "https://other.example.edu/.well-known/openid-configuration"
+
+        response = await _update(
+            OAuthProviderUpdate(
+                client_id="new-client",
+                client_secret="new-secret",
+                oauth_discovery_url=new_url,
+            ),
+            repo,
+            registrar,
+        )
+
+        assert len(registrar.update_calls) == 1
+        assert registrar.update_calls[0]["discovery_url"] == new_url
+        assert registrar.update_calls[0]["client_id"] == "new-client"
+        assert response.callback_url == "https://example.edu/auth/callback"
+
+    @pytest.mark.asyncio
+    async def test_rotation_alone_carries_the_existing_discovery_url_forward(self):
+        """AgentCore needs the full config, so the stored URL is resent."""
+        repo = _FakeProviderRepo(_provider())
+        registrar = _FakeRegistrar()
+
+        await _update(
+            OAuthProviderUpdate(client_id="new-client", client_secret="new-secret"),
+            repo,
+            registrar,
+        )
+
+        assert len(registrar.update_calls) == 1
+        assert registrar.update_calls[0]["discovery_url"] == _DISCOVERY_URL

--- a/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
+++ b/frontend/ai.client/src/app/admin/connectors/pages/connector-form.page.ts
@@ -776,6 +776,15 @@ export class ConnectorFormPage implements OnInit {
   /** Same tri-state tracking for the export-target mapping. */
   private readonly exportAdapterLoadedFromServer = signal<string>('');
 
+  /**
+   * The discovery URL loaded from the server. Update only sends the field
+   * when it actually changed: the backend treats a discovery change as a
+   * credential-rotation event, and the admin cannot rotate (the client
+   * secret is never readable back), so resending an unchanged URL would
+   * block every metadata-only edit on a discovery-URL connector.
+   */
+  private readonly discoveryLoadedFromServer = signal<string>('');
+
   /** Every file-source adapter shipped in the backend registry. */
   readonly fileSourceAdapters = computed(() =>
     this.connectorsService.getFileSourceAdapters()
@@ -970,6 +979,7 @@ export class ConnectorFormPage implements OnInit {
       this.iconLoadedFromServer.set(connector.iconData ?? null);
       this.adapterLoadedFromServer.set(connector.fileSourceAdapterId ?? '');
       this.exportAdapterLoadedFromServer.set(connector.exportTargetAdapterId ?? '');
+      this.discoveryLoadedFromServer.set(connector.oauthDiscoveryUrl ?? '');
       this.selectedRoles.set(connector.allowedRoles.length > 0 ? connector.allowedRoles : ['*']);
       this.applyDiscoveryValidator();
     } catch (error) {
@@ -1118,8 +1128,16 @@ export class ConnectorFormPage implements OnInit {
           updates.clientId = formValue.clientId;
           updates.clientSecret = formValue.clientSecret;
         }
-        if (this.needsDiscovery() && formValue.oauthDiscoveryUrl) {
-          updates.oauthDiscoveryUrl = formValue.oauthDiscoveryUrl;
+        // Only send the discovery URL when the admin actually changed it —
+        // the backend requires a credential rotation alongside a discovery
+        // change, so an unchanged value would reject the whole save.
+        const currentDiscovery = formValue.oauthDiscoveryUrl || '';
+        if (
+          this.needsDiscovery() &&
+          currentDiscovery &&
+          currentDiscovery !== this.discoveryLoadedFromServer()
+        ) {
+          updates.oauthDiscoveryUrl = currentDiscovery;
         }
         await this.connectorsService.updateConnector(this.providerId()!, updates);
         this.router.navigate(['/admin/connectors']);


### PR DESCRIPTION
## Problem

A scopes-only edit is impossible through the admin Connectors UI for any provider that has an OIDC discovery URL. Changing only **Scopes** on `/admin/connectors/edit/canvas-faculty` and saving fails with:

> Invalid Request — Discovery config can only be updated together with a credential rotation (client_id + client_secret).

The guard in `update_provider` treated *any non-None* `oauth_discovery_url` / `authorization_server_metadata` as "changing discovery":

```python
changing_discovery = (
    updates.oauth_discovery_url is not None
    or updates.authorization_server_metadata is not None
)
```

The connector edit form sends the discovery URL on every PATCH — including when it is unchanged — so every save trips the guard. The admin cannot comply with what the error asks for: AgentCore never echoes the client secret back, so there is nothing to re-enter.

Net effect: scopes, display name, icon and the enabled flag are all documented as metadata-only edits that "write straight to DynamoDB", but none of them could be saved through the UI for a discovery-URL provider.

This blocks `docs/specs/canvas-rubric-agent.md` §8.2 step 4, which instructs a connectors admin to add OAuth scopes to the prod `canvas-faculty` provider.

## Fix

Both halves, as the issue suggested:

- **Backend** (`admin/oauth/routes.py`): compare against the stored record, so the guard means what its error message says — only a *different* discovery URL or metadata dict counts as a change. The `raise` also moves above the fallback computation, which previously computed `discovery_url` / `authorization_server_metadata` only to throw them away.
- **Frontend** (`connector-form.page.ts`): track `discoveryLoadedFromServer` and send `oauthDiscoveryUrl` only on a real change — the same tri-state the form already uses for the icon and the two adapter mappings.

The backend fix is the one that matters for correctness: it makes the contract right for the direct-PATCH workaround and any other client, not just this form.

## Tests

New `backend/tests/apis/app_api/admin/oauth/test_update_provider_discovery_guard.py` — 7 cases covering both flavors of discovery config (URL *and* explicit metadata dict):

- unchanged discovery URL + scopes change → succeeds, no AgentCore call
- scopes-only (no discovery field at all) → succeeds
- **changed** discovery URL without credentials → still 400s
- **changed** metadata dict without credentials → still 400s
- changed discovery URL *with* rotation → reaches AgentCore with the new config
- rotation alone → carries the stored discovery URL forward (AgentCore needs the full config)

Verified the tests actually catch the bug: reverting just the comparison makes the two "unchanged" cases fail with the exact 400 from the report, while the three guard cases pass either way.

- Backend: 1312 passed (`tests/apis`, `tests/architecture`, oauth models)
- Frontend: `npx tsc --noEmit` clean, `ng test` 2560 passed

## Verification still owed

Live dev verification is **not** done — the dev-ai SSO token has expired, so RBAC fails closed and every admin route 403s locally. After this deploys to dev:

1. `/admin/connectors/edit/canvas-faculty` → add one scope → **Update Connector** saves.
2. Confirm `scopes` + `updatedAt` changed on the `PROVIDER#canvas-faculty` / `CONFIG` item in `dev-boisestateai-v2-oauth-providers`.
3. Regression: change the **discovery URL** with credentials blank → must still 400 with the rotation message.
4. One pass on a non-discovery connector (Google/Slack) to confirm the vendor path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)