### PR TITLE
feat(frontend): drill into tool detail from the tools drawer

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -19,7 +19,8 @@
         "main.py"
       ],
       "port": 8000,
-      "cwd": "backend/src/apis/app_api"
+      "cwd": "backend/src/apis/app_api",
+      "autoPort": false
     },
     {
       "name": "inference-api",
@@ -28,7 +29,8 @@
         "main.py"
       ],
       "port": 8001,
-      "cwd": "backend/src/apis/inference_api"
+      "cwd": "backend/src/apis/inference_api",
+      "autoPort": false
     },
     {
       "name": "docs-site",

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -21,19 +21,40 @@
   aria-labelledby="model-settings-title"
 >
   <div class="flex h-full flex-col bg-white shadow-xl dark:bg-gray-900">
-    <!-- Header -->
+    <!--
+      Header. The title is the drawer's own when the list is showing, and the
+      tool's name once you drill in — so the pane you're looking at always names
+      itself, and Back is where Close would be.
+    -->
     <div class="border-b border-gray-200 px-4 py-4 dark:border-white/10">
-      <div class="flex items-center justify-between">
-        <h2
-          id="model-settings-title"
-          class="text-base/7 font-semibold text-gray-900 dark:text-white"
-        >
-          Settings
-        </h2>
+      <div class="flex items-center gap-2">
+        @if (detailTool(); as detail) {
+          <button
+            type="button"
+            (click)="closeToolDetail()"
+            class="-ml-1 flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            aria-label="Back to all tools"
+          >
+            <ng-icon name="heroArrowLeft" class="size-5" aria-hidden="true" />
+          </button>
+          <h2
+            id="model-settings-title"
+            class="min-w-0 flex-1 truncate text-base/7 font-semibold text-gray-900 dark:text-white"
+          >
+            {{ detail.displayName }}
+          </h2>
+        } @else {
+          <h2
+            id="model-settings-title"
+            class="flex-1 text-base/7 font-semibold text-gray-900 dark:text-white"
+          >
+            Settings
+          </h2>
+        }
         <button
           type="button"
           (click)="close()"
-          class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
           aria-label="Close settings panel"
         >
           <ng-icon name="heroXMark" class="size-5" aria-hidden="true" />
@@ -41,8 +62,19 @@
       </div>
     </div>
 
-    <!-- Content -->
-    <div class="flex-1 overflow-y-auto">
+    <!--
+      Two panes in one clipped stack. They slide as a pair rather than the detail
+      replacing the list, so the list keeps its scroll position and the drawer
+      never reflows underneath you. The hidden pane is `inert` so it takes no
+      focus mid-transition.
+    -->
+    <div class="relative flex-1 overflow-hidden">
+      <div
+        class="absolute inset-0 overflow-y-auto transition-transform duration-300 ease-in-out motion-reduce:transition-none"
+        [class.translate-x-0]="!detailTool()"
+        [class.-translate-x-1/4]="!!detailTool()"
+        [attr.inert]="detailTool() ? '' : null"
+      >
       <!-- Model Selection Section -->
       <div class="border-b border-gray-200 p-4 dark:border-white/10">
         <label
@@ -505,7 +537,7 @@
         </button>
 
         @if (isToolsOpen()) {
-          <div id="tools-body" class="px-4 pb-4">
+          <div id="tools-body" class="px-2 pb-4">
             @if (toolService.agentLocked()) {
               <p
                 class="mb-3 flex items-center gap-1.5 rounded-md bg-gray-50 px-3 py-2 text-xs/5 text-gray-500 dark:bg-white/5 dark:text-gray-400"
@@ -523,55 +555,54 @@
             } @else if (toolService.tools().length === 0) {
               <div class="text-sm/6 text-gray-500 dark:text-gray-400">No tools available</div>
             } @else {
-              <div class="space-y-3" role="group" aria-labelledby="tools-heading">
+              <!--
+                Split row, matching agent-listing-row.component.ts: the body is
+                the way into the detail pane and the switch is its SIBLING, never
+                nested — a <button> inside a <button> is invalid and swallows its
+                own activation. The switch is persistent rather than revealed on
+                hover, because a hover-only control does not exist on touch.
+              -->
+              <ul class="flex flex-col gap-0.5" role="group" aria-labelledby="tools-heading">
                 @for (tool of toolService.visibleTools(); track tool.toolId) {
-                  <div>
-                    <div class="flex items-start justify-between gap-3">
-                      <div class="flex min-w-0 flex-1 items-start gap-1.5">
-                        @if (isMcpServer(tool)) {
-                          <button
-                            type="button"
-                            (click)="toggleServerExpanded(tool.toolId)"
-                            [attr.aria-expanded]="isServerExpanded(tool.toolId)"
-                            [attr.aria-label]="
-                              (isServerExpanded(tool.toolId) ? 'Collapse ' : 'Expand ') +
-                              tool.displayName
-                            "
-                            class="-ml-1 mt-0.5 flex size-5 shrink-0 items-center justify-center rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                          >
-                            <ng-icon
-                              [name]="
-                                isServerExpanded(tool.toolId)
-                                  ? 'heroChevronDown'
-                                  : 'heroChevronRight'
-                              "
-                              class="size-4"
-                              aria-hidden="true"
-                            />
-                          </button>
-                        }
-                        <div class="min-w-0 flex-1">
-                          <label
-                            [id]="'tool-label-' + tool.toolId"
-                            [for]="'tool-toggle-' + tool.toolId"
-                            class="text-sm/6 font-medium text-gray-900 dark:text-white"
-                          >
-                            {{ tool.displayName }}
-                          </label>
-                          <p
-                            [id]="'tool-desc-' + tool.toolId"
-                            class="text-xs/5 text-gray-500 dark:text-gray-400"
-                          >
-                            {{ tool.description }}
-                          </p>
-                          @if (isMcpServer(tool) && partialServerLabel(tool); as label) {
-                            <p class="text-xs/5 font-medium text-primary-600 dark:text-primary-400">
-                              {{ label }}
-                            </p>
-                          }
-                        </div>
-                      </div>
-                      <!-- Toggle Switch (whole server) -->
+                  <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
+                    <button
+                      type="button"
+                      (click)="openToolDetail(tool.toolId)"
+                      class="flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-2xl px-2 py-2.5 text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                      [attr.aria-label]="'Open details for ' + tool.displayName"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+                        >{{ monogram(tool) }}</span
+                      >
+                      <span class="block min-w-0 flex-1 overflow-hidden">
+                        <span
+                          [id]="'tool-label-' + tool.toolId"
+                          class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+                          >{{ tool.displayName }}</span
+                        >
+                        <span
+                          [id]="'tool-desc-' + tool.toolId"
+                          class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
+                          >{{ subtitle(tool) }}</span
+                        >
+                      </span>
+                    </button>
+                    <!--
+                      Agent-locked shows a lock instead of a disabled switch: a
+                      disabled toggle invites a click and then refuses it, where a
+                      lock says who decided. Same call as agent-listing-row.
+                    -->
+                    @if (toolService.agentLocked()) {
+                      <span
+                        class="grid size-8 shrink-0 place-items-center text-gray-400 dark:text-gray-500"
+                        [attr.title]="'Fixed by this agent'"
+                      >
+                        <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
+                        <span class="sr-only">{{ tool.displayName }} is fixed by this agent</span>
+                      </span>
+                    } @else {
                       <button
                         type="button"
                         role="switch"
@@ -579,125 +610,30 @@
                         [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
                         [attr.aria-labelledby]="'tool-label-' + tool.toolId"
                         [attr.aria-describedby]="'tool-desc-' + tool.toolId"
-                        [disabled]="toolService.agentLocked()"
                         (click)="toggleTool(tool.toolId)"
                         (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
-                        (keydown.enter)="toggleTool(tool.toolId)"
-                        class="relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                        [class.cursor-pointer]="!toolService.agentLocked()"
-                        [class.cursor-not-allowed]="toolService.agentLocked()"
-                        [class.opacity-60]="toolService.agentLocked()"
-                        [class]="
-                          toolService.isToolShownEnabled(tool)
-                            ? 'bg-primary-600 dark:bg-primary-500'
-                            : 'bg-gray-200 dark:bg-gray-700'
-                        "
+                        class="grid size-10 shrink-0 cursor-pointer place-items-center rounded-full focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
                       >
                         <span
                           aria-hidden="true"
-                          class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                          [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
-                          [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
+                          class="relative inline-flex h-6 w-11 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
+                          [class]="
+                            toolService.isToolShownEnabled(tool)
+                              ? 'bg-primary-600 dark:bg-primary-500'
+                              : 'bg-gray-200 dark:bg-gray-700'
+                          "
                         >
+                          <span
+                            class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                            [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
+                            [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
+                          ></span>
                         </span>
                       </button>
-                    </div>
-
-                    <!-- Per-tool sub-toggles -->
-                    @if (isMcpServer(tool) && isServerExpanded(tool.toolId)) {
-                      <div
-                        class="mt-2 space-y-2 border-l border-gray-200 pl-4 dark:border-white/10"
-                      >
-                        @if (tool.serverTools && tool.serverTools.length > 0) {
-                          @for (sub of tool.serverTools; track sub.name) {
-                            <div class="flex items-start justify-between gap-3">
-                              <div class="min-w-0 flex-1">
-                                <span
-                                  [id]="'subtool-label-' + tool.toolId + '-' + sub.name"
-                                  class="block truncate font-mono text-xs/5 text-gray-700 dark:text-gray-200"
-                                  >{{ sub.name }}</span
-                                >
-                                @if (sub.description) {
-                                  <span
-                                    class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
-                                    >{{ sub.description }}</span
-                                  >
-                                }
-                              </div>
-                              <button
-                                type="button"
-                                role="switch"
-                                [attr.aria-checked]="toolService.isSubToolShownEnabled(tool, sub)"
-                                [attr.aria-labelledby]="
-                                  'subtool-label-' + tool.toolId + '-' + sub.name
-                                "
-                                [disabled]="toolService.agentLocked()"
-                                (click)="toggleServerTool(tool.toolId, sub.name)"
-                                (keydown.space)="
-                                  $event.preventDefault(); toggleServerTool(tool.toolId, sub.name)
-                                "
-                                (keydown.enter)="toggleServerTool(tool.toolId, sub.name)"
-                                class="relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-                                [class.cursor-pointer]="!toolService.agentLocked()"
-                                [class.cursor-not-allowed]="toolService.agentLocked()"
-                                [class.opacity-60]="toolService.agentLocked()"
-                                [class]="
-                                  toolService.isSubToolShownEnabled(tool, sub)
-                                    ? 'bg-primary-600 dark:bg-primary-500'
-                                    : 'bg-gray-200 dark:bg-gray-700'
-                                "
-                              >
-                                <span
-                                  aria-hidden="true"
-                                  class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                                  [class.translate-x-4]="
-                                    toolService.isSubToolShownEnabled(tool, sub)
-                                  "
-                                  [class.translate-x-0]="
-                                    !toolService.isSubToolShownEnabled(tool, sub)
-                                  "
-                                >
-                                </span>
-                              </button>
-                            </div>
-                          }
-                        } @else {
-                          <div class="flex flex-col gap-1">
-                            <button
-                              type="button"
-                              (click)="discoverServerTools(tool)"
-                              [disabled]="discoveringServers().has(tool.toolId)"
-                              class="inline-flex w-fit items-center gap-1.5 rounded px-1.5 py-1 text-xs/5 font-medium text-primary-600 hover:bg-primary-50 disabled:opacity-50 dark:text-primary-400 dark:hover:bg-primary-900/30"
-                            >
-                              <ng-icon
-                                name="heroArrowPath"
-                                class="size-3.5"
-                                [class.animate-spin]="discoveringServers().has(tool.toolId)"
-                                aria-hidden="true"
-                              />
-                              {{
-                                discoveringServers().has(tool.toolId)
-                                  ? 'Discovering…'
-                                  : 'Discover tools'
-                              }}
-                            </button>
-                            @if (discoverError()[tool.toolId]) {
-                              <span class="text-xs/5 text-state-danger-600 dark:text-state-danger-400">{{
-                                discoverError()[tool.toolId]
-                              }}</span>
-                            } @else {
-                              <span class="text-xs/5 text-gray-500 dark:text-gray-400"
-                                >Discover this server’s tools to enable only the ones you
-                                need.</span
-                              >
-                            }
-                          </div>
-                        }
-                      </div>
                     }
-                  </div>
+                  </li>
                 }
-              </div>
+              </ul>
             }
           </div>
         }
@@ -768,6 +704,23 @@
           }
         </div>
       }
+      </div>
+
+      <!--
+        Detail pane. Stays mounted on the last-opened tool after Back so the exit
+        transition has something to slide out; `detailOpen()` alone drives the
+        transform.
+      -->
+      <div
+        class="absolute inset-0 overflow-hidden bg-white transition-transform duration-300 ease-in-out motion-reduce:transition-none dark:bg-gray-900"
+        [class.translate-x-0]="!!detailTool()"
+        [class.translate-x-full]="!detailTool()"
+        [attr.inert]="detailTool() ? null : ''"
+      >
+        @if (lastDetailTool(); as detail) {
+          <app-tool-detail [tool]="detail" />
+        }
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
@@ -38,7 +38,7 @@ describe('ModelSettings', () => {
       setSelectedModel: vi.fn(),
     };
     mockToolService = {
-      tools: signal([]),
+      tools: signal<any[]>([]),
       enabledTools: signal([]),
       toolsByCategory: signal(new Map()),
       categories: signal([]),
@@ -99,5 +99,116 @@ describe('ModelSettings', () => {
     component.selectModel(mockModel);
     expect(mockModelService.setSelectedModel).toHaveBeenCalledWith(mockModel);
     expect(component['isModelDropdownOpen']()).toBe(false);
+  });
+
+  describe('tool detail pane', () => {
+    const gmail = {
+      toolId: 'gmail_employee',
+      displayName: 'Gmail for Employees',
+      description: 'Securely connect to your inbox',
+      category: 'utility',
+      icon: null,
+      protocol: 'mcp_external',
+      status: 'active',
+      grantedBy: ['employee'],
+      enabledByDefault: false,
+      userEnabled: null,
+      isEnabled: false,
+      serverTools: [
+        { name: 'search_messages', enabled: true },
+        { name: 'send_message', enabled: false },
+      ],
+    };
+
+    beforeEach(() => {
+      mockToolService.tools.set([gmail]);
+    });
+
+    it('opens the detail pane for a tool', async () => {
+      const component = await createComponent();
+      component.openToolDetail('gmail_employee');
+      expect(component['detailTool']()?.toolId).toBe('gmail_employee');
+    });
+
+    it('keeps the last tool rendered after Back so the pane can slide out', async () => {
+      const component = await createComponent();
+      component.openToolDetail('gmail_employee');
+      component.closeToolDetail();
+
+      expect(component['detailTool']()).toBeNull();
+      expect(component['lastDetailTool']()?.toolId).toBe('gmail_employee');
+    });
+
+    it('re-reads the tool from the service rather than holding a stale object', async () => {
+      const component = await createComponent();
+      component.openToolDetail('gmail_employee');
+
+      // Toggling a sub-tool replaces the object in tools(); a captured
+      // reference would keep rendering the old switch states.
+      mockToolService.tools.set([
+        { ...gmail, serverTools: [{ name: 'search_messages', enabled: false }] },
+      ]);
+
+      expect(component['detailTool']()?.serverTools).toEqual([
+        { name: 'search_messages', enabled: false },
+      ]);
+    });
+
+    it('escape backs out of the detail instead of closing the drawer', async () => {
+      const component = await createComponent();
+      component.openToolDetail('gmail_employee');
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape' });
+      const prevented = vi.spyOn(event, 'preventDefault');
+      component.onEscape(event);
+
+      expect(component['detailTool']()).toBeNull();
+      expect(prevented).toHaveBeenCalled();
+    });
+
+    it('escape leaves the detail alone while the model dropdown owns it', async () => {
+      const component = await createComponent();
+      component.openToolDetail('gmail_employee');
+      component.toggleModelDropdown();
+
+      component.onEscape(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(component['detailTool']()?.toolId).toBe('gmail_employee');
+    });
+
+    it('leads the subtitle with the partial count when only some tools are on', async () => {
+      const component = await createComponent();
+      expect(component.subtitle(gmail as any)).toBe(
+        '1 of 2 tools on · Securely connect to your inbox'
+      );
+    });
+
+    it('leads the subtitle with the total when every tool is on', async () => {
+      const component = await createComponent();
+      const allOn = {
+        ...gmail,
+        serverTools: [
+          { name: 'search_messages', enabled: true },
+          { name: 'send_message', enabled: true },
+        ],
+      };
+      expect(component.subtitle(allOn as any)).toBe(
+        '2 tools · Securely connect to your inbox'
+      );
+    });
+
+    it('uses the plain description for a tool with no sub-tools', async () => {
+      const component = await createComponent();
+      const calculator = { ...gmail, serverTools: [], description: 'Does sums' };
+      expect(component.subtitle(calculator as any)).toBe('Does sums');
+    });
+
+    it('builds a monogram from the display name', async () => {
+      const component = await createComponent();
+      expect(component.monogram(gmail as any)).toBe('GF');
+      expect(component.monogram({ displayName: 'Excalidraw' } as any)).toBe('E');
+      expect(component.monogram({ displayName: '1Password' } as any)).toBe('P');
+      expect(component.monogram({ displayName: '///' } as any)).toBe('?');
+    });
   });
 });

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject, input, output, signal, computed, effect, ElementRef } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { ToolDetailComponent } from './tool-detail/tool-detail.component';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService, Tool } from '../../services/tool/tool.service';
 import { SkillService } from '../../services/skill/skill.service';
@@ -40,10 +41,11 @@ interface AdvancedParamRow {
 @Component({
   selector: 'app-model-settings',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon],
-  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroLockClosed })],
+  imports: [NgIcon, ToolDetailComponent],
+  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed })],
   host: {
     '(document:click)': 'onDocumentClick($event)',
+    '(document:keydown.escape)': 'onEscape($event)',
   },
   templateUrl: './model-settings.html',
   styleUrl: './model-settings.css',
@@ -190,6 +192,13 @@ export class ModelSettings {
         this.hasBeenOpened.set(true);
       }
 
+      // Closing the drawer resets it to the list. Reopening onto whichever tool
+      // you last inspected would be a surprise — the drawer's job on open is to
+      // show what this conversation is carrying.
+      if (!isOpen) {
+        this.detailToolId.set(null);
+      }
+
       // Load the skills picker lazily on first open. SkillService deliberately
       // has no constructor load (unlike ToolService): skills are opt-in and the
       // feature is off in every deployed env until PR-5, so a boot-time fetch
@@ -278,12 +287,31 @@ export class ModelSettings {
     }
   }
 
-  /** Which MCP server rows are expanded to show their per-tool toggles. */
-  protected expandedServers = signal<Set<string>>(new Set());
-  /** Servers with a live discovery request in flight. */
-  protected discoveringServers = signal<Set<string>>(new Set());
-  /** Per-server discovery error messages. */
-  protected discoverError = signal<Record<string, string>>({});
+  /**
+   * The tool whose detail pane is open, or null for the list.
+   *
+   * Held as an id rather than the object so the pane re-reads the live tool from
+   * the service — toggling a sub-tool replaces the object in `tools()`, and a
+   * captured reference would show stale switches.
+   */
+  private readonly detailToolId = signal<string | null>(null);
+
+  /**
+   * The last tool the detail pane showed. Kept after Back so the pane still has
+   * something to render on the way out; clearing it would make the detail
+   * disappear instantly instead of sliding.
+   */
+  protected readonly lastDetailTool = computed<Tool | null>(() => {
+    const id = this.lastDetailToolId();
+    return id ? (this.toolService.tools().find((t) => t.toolId === id) ?? null) : null;
+  });
+  private readonly lastDetailToolId = signal<string | null>(null);
+
+  /** The open tool, or null when the list is showing. Drives the transforms. */
+  protected readonly detailTool = computed<Tool | null>(() => {
+    const id = this.detailToolId();
+    return id ? (this.toolService.tools().find((t) => t.toolId === id) ?? null) : null;
+  });
 
   toggleTool(toolId: string): void {
     this.toolService.toggleTool(toolId);
@@ -294,55 +322,55 @@ export class ModelSettings {
     return tool.protocol === 'mcp' || tool.protocol === 'mcp_external';
   }
 
-  isServerExpanded(toolId: string): boolean {
-    return this.expandedServers().has(toolId);
-  }
-
-  /** "3 of 8 tools enabled" when a server is partially enabled, else null. */
-  partialServerLabel(tool: Tool): string | null {
+  /**
+   * The row's one subtitle line. Leads with the count for an MCP server, and
+   * with the partial-selection state when only some of its tools are on —
+   * that's the fact a row can't afford to bury now that the per-tool switches
+   * live a pane away.
+   */
+  subtitle(tool: Tool): string {
     const subs = tool.serverTools ?? [];
-    if (subs.length === 0) return null;
+    const description = tool.description || 'No description recorded.';
+    if (subs.length === 0) return description;
     const on = subs.filter((s) => s.enabled).length;
-    if (on === 0 || on === subs.length) return null;
-    return `${on} of ${subs.length} tools enabled`;
+    const prefix =
+      on > 0 && on < subs.length
+        ? `${on} of ${subs.length} tools on`
+        : `${subs.length} tools`;
+    return `${prefix} · ${description}`;
   }
 
-  toggleServerExpanded(toolId: string): void {
-    this.expandedServers.update((set) => {
-      const next = new Set(set);
-      if (next.has(toolId)) {
-        next.delete(toolId);
-      } else {
-        next.add(toolId);
-      }
-      return next;
-    });
+  /** Initials, so a row reads as an object rather than a line of text. */
+  monogram(tool: Tool): string {
+    const initials = tool.displayName
+      .replace(/[^A-Za-z ]/g, '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join('');
+    return initials.toUpperCase() || '?';
   }
 
-  toggleServerTool(toolId: string, name: string): void {
-    this.toolService.toggleServerTool(toolId, name);
+  openToolDetail(toolId: string): void {
+    this.detailToolId.set(toolId);
+    this.lastDetailToolId.set(toolId);
   }
 
-  async discoverServerTools(tool: Tool): Promise<void> {
-    this.discoveringServers.update((s) => new Set(s).add(tool.toolId));
-    this.discoverError.update((m) => {
-      const next = { ...m };
-      delete next[tool.toolId];
-      return next;
-    });
-    try {
-      await this.toolService.discoverServerTools(tool.toolId);
-    } catch {
-      this.discoverError.update((m) => ({
-        ...m,
-        [tool.toolId]: 'Could not list this server’s tools.',
-      }));
-    } finally {
-      this.discoveringServers.update((s) => {
-        const next = new Set(s);
-        next.delete(tool.toolId);
-        return next;
-      });
+  closeToolDetail(): void {
+    this.detailToolId.set(null);
+  }
+
+  /**
+   * Escape backs out of the detail before it closes the drawer, so the key does
+   * the least destructive thing available. The model dropdown handles its own
+   * Escape on keydown and stops there.
+   */
+  onEscape(event: Event): void {
+    if (this.isModelDropdownOpen()) return;
+    if (this.detailToolId() !== null) {
+      event.preventDefault();
+      this.closeToolDetail();
     }
   }
 

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
@@ -1,0 +1,214 @@
+@let t = tool();
+
+<!-- Identity -->
+<div class="border-b border-gray-200 px-4 py-4 dark:border-white/10">
+  <div class="flex items-start gap-3">
+    <span
+      aria-hidden="true"
+      class="grid size-10 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-sm font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+      >{{ monogram() }}</span
+    >
+    <div class="min-w-0 flex-1">
+      <h3 class="text-sm/6 font-semibold text-gray-900 dark:text-white">{{ t.displayName }}</h3>
+      <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">{{ t.toolId }}</p>
+    </div>
+  </div>
+
+  @if (t.description) {
+    <p class="mt-3 text-sm/6 text-gray-600 dark:text-gray-300">{{ t.description }}</p>
+  }
+
+  <div
+    class="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-3 py-2 dark:border-white/10 dark:bg-white/5"
+  >
+    <span id="tool-detail-state" class="text-sm/6 font-medium text-gray-900 dark:text-white">
+      {{ toolService.isToolShownEnabled(t) ? 'On in this conversation' : 'Off' }}
+    </span>
+    @if (toolService.agentLocked()) {
+      <span class="flex items-center gap-1.5 text-xs/5 text-gray-500 dark:text-gray-400">
+        <ng-icon name="heroLockClosed" class="size-3.5" aria-hidden="true" />
+        Fixed by this agent
+      </span>
+    } @else {
+      <button
+        type="button"
+        role="switch"
+        [attr.aria-checked]="toolService.isToolShownEnabled(t)"
+        aria-labelledby="tool-detail-state"
+        (click)="toggleTool()"
+        (keydown.space)="$event.preventDefault(); toggleTool()"
+        class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        [class]="
+          toolService.isToolShownEnabled(t)
+            ? 'bg-primary-600 dark:bg-primary-500'
+            : 'bg-gray-200 dark:bg-gray-700'
+        "
+      >
+        <span
+          aria-hidden="true"
+          class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+          [class.translate-x-5]="toolService.isToolShownEnabled(t)"
+          [class.translate-x-0]="!toolService.isToolShownEnabled(t)"
+        ></span>
+      </button>
+    }
+  </div>
+</div>
+
+<!-- Tabs. A tool that isn't an MCP server has a single panel, so it gets no strip. -->
+@if (isMcpServer()) {
+  <div
+    role="tablist"
+    aria-label="Tool details"
+    class="flex gap-1 border-b border-gray-200 px-3 dark:border-white/10"
+  >
+    @for (item of tabs(); track item.id) {
+      <button
+        type="button"
+        role="tab"
+        [id]="'tool-detail-tab-' + item.id"
+        [attr.aria-selected]="tab() === item.id"
+        [attr.aria-controls]="'tool-detail-panel-' + item.id"
+        [tabindex]="tab() === item.id ? 0 : -1"
+        (click)="tab.set(item.id)"
+        (keydown)="onTabKeydown($event)"
+        class="-mb-px flex items-center gap-1.5 border-b-2 px-2.5 py-3 text-sm/6 whitespace-nowrap focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+        [class]="
+          tab() === item.id
+            ? 'border-primary-600 font-semibold text-primary-600 dark:border-primary-400 dark:text-primary-400'
+            : 'border-transparent font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+        "
+      >
+        {{ item.label }}
+        @if (item.count !== null) {
+          <span
+            class="rounded bg-gray-100 px-1.5 font-mono text-xs/5 text-gray-500 tabular-nums dark:bg-white/5 dark:text-gray-400"
+            >{{ item.count }}</span
+          >
+        }
+      </button>
+    }
+  </div>
+}
+
+<!-- Panels -->
+<div class="flex-1 overflow-y-auto px-4 py-3">
+  @if (tab() === 'tools') {
+    <div
+      role="tabpanel"
+      id="tool-detail-panel-tools"
+      aria-labelledby="tool-detail-tab-tools"
+      tabindex="0"
+    >
+      @if (subTools().length > 0) {
+        <p class="mb-3 text-xs/5 text-gray-500 dark:text-gray-400">
+          Turn off the ones this conversation doesn’t need — only the tools left on are sent
+          to the model.
+        </p>
+        <ul class="flex flex-col gap-2">
+          @for (sub of subTools(); track sub.name) {
+            <li
+              class="flex items-start justify-between gap-3 rounded-2xl border border-gray-200 px-3 py-2.5 dark:border-white/10"
+            >
+              <div class="min-w-0 flex-1">
+                <span
+                  [id]="'subtool-' + t.toolId + '-' + sub.name"
+                  class="block font-mono text-xs/5 font-medium text-gray-900 dark:text-white"
+                  >{{ sub.name }}</span
+                >
+                @if (sub.description) {
+                  <!--
+                    Clamped, because these are raw Python docstrings: several
+                    carry their whole "Args:" block, and one unclamped tool
+                    description filled two thirds of the pane on Student
+                    MyBoiseState. Splitting the agent-facing text from a
+                    human-facing summary is the real fix, and it belongs in the
+                    catalog rather than here.
+                  -->
+                  <!--
+                    No `block` here: line-clamp-2 sets display:-webkit-box, and
+                    a display utility alongside it wins the cascade and silently
+                    un-clamps the text.
+                  -->
+                  <span
+                    class="mt-0.5 line-clamp-2 text-xs/5 text-gray-500 dark:text-gray-400"
+                    [attr.title]="sub.description"
+                    >{{ sub.description }}</span
+                  >
+                }
+              </div>
+              <button
+                type="button"
+                role="switch"
+                [attr.aria-checked]="toolService.isSubToolShownEnabled(t, sub)"
+                [attr.aria-labelledby]="'subtool-' + t.toolId + '-' + sub.name"
+                [disabled]="toolService.agentLocked()"
+                (click)="toggleServerTool(sub.name)"
+                (keydown.space)="$event.preventDefault(); toggleServerTool(sub.name)"
+                class="relative mt-0.5 inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                [class.cursor-pointer]="!toolService.agentLocked()"
+                [class.cursor-not-allowed]="toolService.agentLocked()"
+                [class.opacity-60]="toolService.agentLocked()"
+                [class]="
+                  toolService.isSubToolShownEnabled(t, sub)
+                    ? 'bg-primary-600 dark:bg-primary-500'
+                    : 'bg-gray-200 dark:bg-gray-700'
+                "
+              >
+                <span
+                  aria-hidden="true"
+                  class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                  [class.translate-x-4]="toolService.isSubToolShownEnabled(t, sub)"
+                  [class.translate-x-0]="!toolService.isSubToolShownEnabled(t, sub)"
+                ></span>
+              </button>
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          This server hasn’t been asked what it offers yet.
+        </p>
+        <button
+          type="button"
+          (click)="discover()"
+          [disabled]="discovering()"
+          class="mt-3 inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 px-3 py-1.5 text-sm/6 font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          <ng-icon
+            name="heroArrowPath"
+            class="size-4"
+            [class.animate-spin]="discovering()"
+            aria-hidden="true"
+          />
+          {{ discovering() ? 'Listing tools…' : 'List this server’s tools' }}
+        </button>
+        @if (discoverError(); as message) {
+          <p class="mt-2 text-xs/5 text-state-danger-600 dark:text-state-danger-400" role="alert">
+            {{ message }}
+          </p>
+        }
+      }
+    </div>
+  } @else {
+    <div
+      role="tabpanel"
+      id="tool-detail-panel-about"
+      aria-labelledby="tool-detail-tab-about"
+      tabindex="0"
+    >
+      <dl class="flex flex-col gap-2.5">
+        @for (fact of facts(); track fact.label) {
+          <div class="flex items-baseline justify-between gap-4">
+            <dt class="text-xs/5 text-gray-500 dark:text-gray-400">{{ fact.label }}</dt>
+            <dd
+              class="min-w-0 text-right font-mono text-xs/5 break-words text-gray-700 dark:text-gray-200"
+            >
+              {{ fact.value }}
+            </dd>
+          </div>
+        }
+      </dl>
+    </div>
+  }
+</div>

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { ToolDetailComponent } from './tool-detail.component';
+import { Tool, ToolService } from '../../../services/tool/tool.service';
+
+/**
+ * Rendered rather than instantiated: the point of this component is what the
+ * pane shows for a given tool, and half of that ("no tabs for a plain tool",
+ * "discover instead of a list") only exists in the template.
+ */
+describe('ToolDetailComponent', () => {
+  let mockToolService: any;
+  let fixture: ComponentFixture<ToolDetailComponent>;
+
+  const mcpServer: Tool = {
+    toolId: 'gmail_employee',
+    displayName: 'Gmail for Employees',
+    description: 'Securely connect to your inbox',
+    category: 'utility',
+    icon: null,
+    protocol: 'mcp_external',
+    status: 'active',
+    grantedBy: ['employee'],
+    enabledByDefault: false,
+    userEnabled: null,
+    isEnabled: true,
+    serverTools: [
+      { name: 'search_messages', description: 'Search the mailbox.', enabled: true },
+      { name: 'send_message', description: 'Send an email.', enabled: false },
+    ],
+  };
+
+  const localTool: Tool = {
+    toolId: 'calculator',
+    displayName: 'Calculator',
+    description: 'Evaluate arithmetic.',
+    category: 'utility',
+    icon: null,
+    protocol: 'local',
+    status: 'active',
+    grantedBy: [],
+    enabledByDefault: false,
+    userEnabled: null,
+    isEnabled: false,
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    mockToolService = {
+      tools: signal<Tool[]>([]),
+      agentLocked: signal(false),
+      isToolShownEnabled: (tool: Tool) => tool.isEnabled,
+      isSubToolShownEnabled: (_tool: Tool, sub: { enabled: boolean }) => sub.enabled,
+      toggleTool: vi.fn().mockResolvedValue(undefined),
+      toggleServerTool: vi.fn().mockResolvedValue(undefined),
+      discoverServerTools: vi.fn().mockResolvedValue(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ToolDetailComponent],
+      providers: [{ provide: ToolService, useValue: mockToolService }],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function render(tool: Tool): ComponentFixture<ToolDetailComponent> {
+    fixture = TestBed.createComponent(ToolDetailComponent);
+    fixture.componentRef.setInput('tool', tool);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = () => fixture.nativeElement.textContent as string;
+
+  it('lists an MCP server’s tools on the Tools tab', () => {
+    render(mcpServer);
+    expect(text()).toContain('search_messages');
+    expect(text()).toContain('send_message');
+    expect(text()).toContain('Search the mailbox.');
+  });
+
+  it('shows a tab strip with the tool count for an MCP server', () => {
+    render(mcpServer);
+    const tabs = fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(tabs.length).toBe(2);
+    expect(tabs[0].textContent).toContain('Tools');
+    expect(tabs[0].textContent).toContain('2');
+  });
+
+  it('gives a plain tool no tab strip and opens it on About', () => {
+    render(localTool);
+    expect(fixture.nativeElement.querySelectorAll('[role="tab"]').length).toBe(0);
+    expect(fixture.nativeElement.querySelector('#tool-detail-panel-about')).toBeTruthy();
+    expect(text()).toContain('calculator');
+  });
+
+  it('offers discovery instead of an empty list when a server has no known tools', () => {
+    render({ ...mcpServer, serverTools: [] });
+    expect(text()).toContain('hasn’t been asked what it offers yet');
+    const button = fixture.nativeElement.querySelector('button[disabled]');
+    expect(button).toBeNull();
+  });
+
+  it('calls the service when a sub-tool is toggled', () => {
+    render(mcpServer);
+    const switches = fixture.nativeElement.querySelectorAll(
+      '[role="switch"][aria-labelledby^="subtool-"]'
+    );
+    switches[1].click();
+    expect(mockToolService.toggleServerTool).toHaveBeenCalledWith(
+      'gmail_employee',
+      'send_message'
+    );
+  });
+
+  it('surfaces a discovery failure rather than failing silently', async () => {
+    mockToolService.discoverServerTools.mockRejectedValue(new Error('502'));
+    render({ ...mcpServer, serverTools: [] });
+
+    await fixture.componentInstance['discover']();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Could not list this server');
+    expect(fixture.nativeElement.querySelector('[role="alert"]')).toBeTruthy();
+  });
+
+  it('replaces the switch with a lock when the toolset is agent-bound', () => {
+    mockToolService.agentLocked.set(true);
+    render(mcpServer);
+
+    // Removed, not disabled: a disabled toggle invites a click and then
+    // refuses it. The server-level switch must be absent entirely.
+    const stateSwitch = fixture.nativeElement.querySelector(
+      '[role="switch"][aria-labelledby="tool-detail-state"]'
+    );
+    expect(stateSwitch).toBeNull();
+    expect(text()).toContain('Fixed by this agent');
+  });
+
+  it('shows catalog facts on the About tab', () => {
+    render(mcpServer);
+    fixture.componentInstance['tab'].set('about');
+    fixture.detectChanges();
+
+    expect(text()).toContain('mcp_external');
+    expect(text()).toContain('employee');
+    expect(text()).toContain('gmail_employee');
+  });
+
+  it('resets to the default tab when a different tool is shown', () => {
+    render(mcpServer);
+    fixture.componentInstance['tab'].set('about');
+    fixture.detectChanges();
+
+    fixture.componentRef.setInput('tool', { ...mcpServer, toolId: 'canvas_faculty' });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['tab']()).toBe('tools');
+  });
+
+  it('moves between tabs with the arrow keys', () => {
+    render(mcpServer);
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+    fixture.componentInstance['onTabKeydown'](event);
+    expect(fixture.componentInstance['tab']()).toBe('about');
+
+    fixture.componentInstance['onTabKeydown'](new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    expect(fixture.componentInstance['tab']()).toBe('tools');
+  });
+});

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
@@ -1,0 +1,145 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  linkedSignal,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroArrowPath, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { Tool, ToolService } from '../../../services/tool/tool.service';
+
+/** Which panel of the detail view is showing. */
+export type ToolDetailTab = 'tools' | 'about';
+
+/**
+ * The second pane of the tools drawer: everything about one tool that a row
+ * 320px wide cannot hold.
+ *
+ * Why a pane and not an inline expansion: the drawer used to expand an MCP
+ * server's per-tool toggles *into the row itself*, so Student MyBoiseState
+ * pushed 17 nested rows into a column narrower than a phone. The list and this
+ * pane now sit side by side in one clipped stack and slide as a pair — the
+ * detail gets the drawer's full width, and the list keeps its scroll position
+ * underneath.
+ *
+ * Deliberately absent: MCP **prompts** and **resources**. The backend only ever
+ * calls `tools/list` (see `app_api/tools/discovery.py`); there is no
+ * `prompts/list` or `resources/list` call anywhere in the stack, so a tab for
+ * either would be an empty promise. The strip is built to take them once
+ * discovery exists.
+ */
+@Component({
+  selector: 'app-tool-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroArrowPath, heroLockClosed })],
+  host: { class: 'flex h-full flex-col' },
+  templateUrl: './tool-detail.component.html',
+})
+export class ToolDetailComponent {
+  protected readonly toolService = inject(ToolService);
+
+  readonly tool = input.required<Tool>();
+
+  protected readonly isMcpServer = computed(() => {
+    const protocol = this.tool().protocol;
+    return protocol === 'mcp' || protocol === 'mcp_external';
+  });
+
+  /**
+   * Resets whenever a *different tool* is shown, so you never land on the tab
+   * you left open on the previous one. A non-MCP tool has no Tools panel, so it
+   * starts on About.
+   *
+   * The source has to be the tool id, not the computation's own reads. Written
+   * as a bare `linkedSignal(() => this.isMcpServer() ? ... )` it only reset when
+   * the *protocol* changed — so Gmail → Canvas, both `mcp_external`, kept the
+   * stale tab.
+   */
+  protected readonly tab = linkedSignal<string, ToolDetailTab>({
+    source: () => this.tool().toolId,
+    computation: () => (this.isMcpServer() ? 'tools' : 'about'),
+  });
+
+  protected readonly discovering = signal(false);
+  protected readonly discoverError = signal<string | null>(null);
+
+  protected readonly subTools = computed(() => this.tool().serverTools ?? []);
+
+  protected readonly tabs = computed(() => [
+    { id: 'tools' as const, label: 'Tools', count: this.subTools().length },
+    { id: 'about' as const, label: 'About', count: null },
+  ]);
+
+  /** Initials, so a row reads as an object rather than a line of text. */
+  protected readonly monogram = computed(() => {
+    const initials = this.tool()
+      .displayName.replace(/[^A-Za-z ]/g, '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join('');
+    return initials.toUpperCase() || '?';
+  });
+
+  /** Catalog facts the drawer row has no room for. */
+  protected readonly facts = computed(() => {
+    const tool = this.tool();
+    const rows: { label: string; value: string }[] = [
+      { label: 'Tool ID', value: tool.toolId },
+      { label: 'Protocol', value: tool.protocol },
+      { label: 'Category', value: tool.category },
+      { label: 'Status', value: tool.status },
+      { label: 'On by default', value: tool.enabledByDefault ? 'yes' : 'no' },
+    ];
+    if (tool.grantedBy.length > 0) {
+      rows.push({ label: 'Granted by', value: tool.grantedBy.join(', ') });
+    }
+    return rows;
+  });
+
+  protected toggleTool(): void {
+    this.toolService.toggleTool(this.tool().toolId).catch((err) => {
+      console.error('Failed to toggle tool:', err);
+    });
+  }
+
+  protected toggleServerTool(name: string): void {
+    this.toolService.toggleServerTool(this.tool().toolId, name).catch((err) => {
+      console.error('Failed to toggle server tool:', err);
+    });
+  }
+
+  /** Roving-tabindex arrow navigation, as the tablist pattern requires. */
+  protected onTabKeydown(event: KeyboardEvent): void {
+    const ids = this.tabs().map((item) => item.id);
+    const current = ids.indexOf(this.tab());
+    let next = current;
+
+    if (event.key === 'ArrowRight') next = (current + 1) % ids.length;
+    else if (event.key === 'ArrowLeft') next = (current - 1 + ids.length) % ids.length;
+    else if (event.key === 'Home') next = 0;
+    else if (event.key === 'End') next = ids.length - 1;
+    else return;
+
+    event.preventDefault();
+    this.tab.set(ids[next]);
+    document.getElementById('tool-detail-tab-' + ids[next])?.focus();
+  }
+
+  protected async discover(): Promise<void> {
+    this.discovering.set(true);
+    this.discoverError.set(null);
+    try {
+      await this.toolService.discoverServerTools(this.tool().toolId);
+    } catch {
+      this.discoverError.set('Could not list this server’s tools.');
+    } finally {
+      this.discovering.set(false);
+    }
+  }
+}


### PR DESCRIPTION
## Why

Prod now carries **31 catalog entries that expand to ~128 callable tools**, rendered as one flat list in a 320px slide-over. The drawer also expanded an MCP server's per-tool toggles *inline, into that same column* — Student MyBoiseState pushed 17 nested rows into a space narrower than a phone — and there was nowhere to put anything a row cannot hold.

This is PR-1 of a larger look at tool discovery: the drill-down only. Search and category grouping are deliberately not here.

## What changed

The list and a new detail pane now sit side by side in one clipped stack and slide as a pair. The list keeps its scroll position underneath, and the detail gets the drawer's full width.

Rows become the **split row already shipped in `agent-listing-row.component.ts`**: the body opens the detail, the switch is its sibling. Three rules come with that pattern, each already paid for in that component:

- **Siblings, never nested** — a `<button>` inside a `<button>` is invalid and swallows its own activation. This ends the tool name's `<label for>` binding to the switch, so the switch takes its own `aria-label`.
- **Persistent, not hover-revealed** — a hover-only control does not exist on touch.
- **Lock, don't disable** — an agent-bound toolset now *removes* the switch and shows a lock, rather than a 60%-opacity toggle that invites a click and then refuses it.

The detail pane carries a **Tools** tab (per-tool switches and live discovery, both moved out of the row) and an **About** tab of catalog facts the row has no room for. `Escape` backs out of the detail before it closes the drawer; closing the drawer resets to the list.

Deleted: `expandedServers`, `toggleServerExpanded`, `isServerExpanded`, `partialServerLabel`. Partial selection state moved into the row's single subtitle line — `12 tools · …` becomes `3 of 12 tools on · …`.

## Verified in the browser, against the live dev catalog

Not just unit tests — the whole flow was driven on `localhost:4200`:

- Drill-down, Back, and `Escape` all behave; list scroll holds at exactly 400px across the round trip
- `inert` flips correctly, so focus never lands in the hidden pane
- About tab populates from the real catalog (Student MyBoiseState: `mcp_external` / 17 tools / granted by `system_admin, public`)
- A plain tool (Calculator) correctly renders **no tab strip** and opens on About
- Light and dark both check out

**Two bugs the browser caught that the tests did not:**

1. **Docstrings ate the pane.** `get_academic_programs` rendered its entire `Args:` block — one tool filled two-thirds of the drawer, and that server has 17. Worse to scan than the inline expansion this replaces. Now clamped to two lines with the full text on `title`.
2. **A class of mine fought Tailwind.** The first clamp did nothing: `line-clamp-2` sets `display: -webkit-box`, and the `block` beside it won the cascade — `-webkit-line-clamp: 2` was applied and inert. Eight tools now fit where one and a half did.

`ng test`: **2577 passing across 224 files**, 21 new.

## Deliberately not in this PR

- **MCP prompts and resources.** The backend only ever calls `tools/list` (`app_api/tools/discovery.py`); there is no `prompts/list` or `resources/list` call anywhere in the stack, so a tab for either would be an empty promise. The tab strip is built to take them once discovery exists.
- **Connection state on rows.** Needs a `GET /connectors/{id}/status` fan-out.
- **Search and category grouping.** Independently valuable; own PR.

## Follow-ups this surfaced

- **Split agent-facing from human-facing tool descriptions.** The clamp is a bandage. Those docstrings are also sitting in `toolConfig` — inside the cached prompt prefix — on every turn of every session that enables the server, so this is a token-cost item as much as a UI one.
- **Six prod servers have zero curated tools** (Github Orgs, Github Repos, Travel Auth among them) because OAuth-gated discovery runs without a consent token. Their Tools tab renders the honest empty state; the real fix is discovering with the caller's vaulted token.

## Second commit

`chore(dev): pin app-api and inference-api to their fixed ports` — both `launch.json` entries omitted `autoPort`, so a collision would silently start them elsewhere and the SPA cannot follow: `environment.ts` hardcodes `http://localhost:8000`.

## Reviewer notes

`agentLocked` is covered by unit tests but was **not** exercised against a real agent-bound conversation — worth a look if you have an Agent thread handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
