### PR TITLE
feat(frontend): search and category grouping in the tools drawer

### DIFF
--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -556,6 +556,35 @@
               <div class="text-sm/6 text-gray-500 dark:text-gray-400">No tools available</div>
             } @else {
               <!--
+                Search matches a server's own tool names as well as its title and
+                description, so "calendar" finds Google Calendar through
+                `suggest_time`. `matchedSubTools` then says which name matched —
+                without it a row appears in the results for no visible reason.
+              -->
+              <div class="relative mb-2 px-1">
+                <ng-icon
+                  name="heroMagnifyingGlass"
+                  class="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+                <input
+                  type="search"
+                  [value]="toolQuery()"
+                  (input)="onToolQueryInput($event)"
+                  placeholder="Search tools"
+                  aria-label="Search tools"
+                  [attr.aria-describedby]="isSearching() ? 'tools-result-count' : null"
+                  class="w-full rounded-2xl border border-gray-200 bg-gray-50 py-2 pr-3 pl-10 text-sm/6 text-gray-900 placeholder:text-gray-400 focus-visible:border-primary-500 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-500"
+                />
+              </div>
+
+              @if (toolRows().length === 0) {
+                <p class="px-2 py-6 text-center text-sm/6 text-gray-500 dark:text-gray-400">
+                  No tools match “{{ toolQuery() }}”.
+                </p>
+              }
+
+              <!--
                 Split row, matching agent-listing-row.component.ts: the body is
                 the way into the detail pane and the switch is its SIBLING, never
                 nested — a <button> inside a <button> is invalid and swallows its
@@ -563,75 +592,123 @@
                 hover, because a hover-only control does not exist on touch.
               -->
               <ul class="flex flex-col gap-0.5" role="group" aria-labelledby="tools-heading">
-                @for (tool of toolService.visibleTools(); track tool.toolId) {
-                  <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
-                    <button
-                      type="button"
-                      (click)="openToolDetail(tool.toolId)"
-                      class="flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-2xl px-2 py-2.5 text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
-                      [attr.aria-label]="'Open details for ' + tool.displayName"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
-                        >{{ monogram(tool) }}</span
-                      >
-                      <span class="block min-w-0 flex-1 overflow-hidden">
-                        <span
-                          [id]="'tool-label-' + tool.toolId"
-                          class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
-                          >{{ tool.displayName }}</span
+                @for (row of toolRows(); track row.kind + ':' + row.id) {
+                  @if (row.kind === 'header') {
+                    <li>
+                      @if (row.collapsible) {
+                        <button
+                          type="button"
+                          (click)="toggleCategory(row.id)"
+                          [attr.aria-expanded]="row.expanded"
+                          class="mt-2 flex w-full items-center gap-1.5 rounded-2xl px-2 py-1.5 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500 dark:hover:bg-white/5"
                         >
-                        <span
-                          [id]="'tool-desc-' + tool.toolId"
-                          class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
-                          >{{ subtitle(tool) }}</span
+                          <ng-icon
+                            [name]="row.expanded ? 'heroChevronDown' : 'heroChevronRight'"
+                            class="size-3.5 shrink-0 text-gray-400 dark:text-gray-500"
+                            aria-hidden="true"
+                          />
+                          <span
+                            class="flex-1 text-xs/5 font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                            >{{ row.label }}</span
+                          >
+                          <span class="font-mono text-xs/5 text-gray-400 tabular-nums dark:text-gray-500">{{
+                            row.count
+                          }}</span>
+                        </button>
+                      } @else {
+                        <p
+                          [id]="row.id === 'results' ? 'tools-result-count' : null"
+                          class="mt-2 flex items-center gap-1.5 px-2 py-1.5"
                         >
-                      </span>
-                    </button>
-                    <!--
-                      Agent-locked shows a lock instead of a disabled switch: a
-                      disabled toggle invites a click and then refuses it, where a
-                      lock says who decided. Same call as agent-listing-row.
-                    -->
-                    @if (toolService.agentLocked()) {
-                      <span
-                        class="grid size-8 shrink-0 place-items-center text-gray-400 dark:text-gray-500"
-                        [attr.title]="'Fixed by this agent'"
-                      >
-                        <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
-                        <span class="sr-only">{{ tool.displayName }} is fixed by this agent</span>
-                      </span>
-                    } @else {
+                          <span
+                            class="flex-1 text-xs/5 font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                            >{{ row.label }}</span
+                          >
+                          <span class="font-mono text-xs/5 text-gray-400 tabular-nums dark:text-gray-500">{{
+                            row.count
+                          }}</span>
+                        </p>
+                      }
+                    </li>
+                  }
+                  @if (row.kind === 'tool') {
+                    @let tool = row.tool;
+                    <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
                       <button
                         type="button"
-                        role="switch"
-                        [id]="'tool-toggle-' + tool.toolId"
-                        [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
-                        [attr.aria-labelledby]="'tool-label-' + tool.toolId"
-                        [attr.aria-describedby]="'tool-desc-' + tool.toolId"
-                        (click)="toggleTool(tool.toolId)"
-                        (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
-                        class="grid size-10 shrink-0 cursor-pointer place-items-center rounded-full focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        (click)="openToolDetail(tool.toolId)"
+                        class="flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-2xl px-2 py-2.5 text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        [attr.aria-label]="'Open details for ' + tool.displayName"
                       >
                         <span
                           aria-hidden="true"
-                          class="relative inline-flex h-6 w-11 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
-                          [class]="
-                            toolService.isToolShownEnabled(tool)
-                              ? 'bg-primary-600 dark:bg-primary-500'
-                              : 'bg-gray-200 dark:bg-gray-700'
-                          "
+                          class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+                          >{{ monogram(tool) }}</span
                         >
+                        <span class="block min-w-0 flex-1 overflow-hidden">
                           <span
-                            class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                            [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
-                            [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
-                          ></span>
+                            [id]="'tool-label-' + tool.toolId"
+                            class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+                            >{{ tool.displayName }}</span
+                          >
+                          <span
+                            [id]="'tool-desc-' + tool.toolId"
+                            class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
+                            >{{ subtitle(tool) }}</span
+                          >
+                          @let matched = matchedSubTools(tool);
+                          @if (matched.length > 0) {
+                            <span
+                              class="block truncate font-mono text-xs/5 text-primary-600 dark:text-primary-400"
+                              >{{ matched.join(', ') }}</span
+                            >
+                          }
                         </span>
                       </button>
-                    }
-                  </li>
+                      <!--
+                        Agent-locked shows a lock instead of a disabled switch: a
+                        disabled toggle invites a click and then refuses it, where a
+                        lock says who decided. Same call as agent-listing-row.
+                      -->
+                      @if (toolService.agentLocked()) {
+                        <span
+                          class="grid size-8 shrink-0 place-items-center text-gray-400 dark:text-gray-500"
+                          [attr.title]="'Fixed by this agent'"
+                        >
+                          <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
+                          <span class="sr-only">{{ tool.displayName }} is fixed by this agent</span>
+                        </span>
+                      } @else {
+                        <button
+                          type="button"
+                          role="switch"
+                          [id]="'tool-toggle-' + tool.toolId"
+                          [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
+                          [attr.aria-labelledby]="'tool-label-' + tool.toolId"
+                          [attr.aria-describedby]="'tool-desc-' + tool.toolId"
+                          (click)="toggleTool(tool.toolId)"
+                          (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
+                          class="grid size-10 shrink-0 cursor-pointer place-items-center rounded-full focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="relative inline-flex h-6 w-11 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
+                            [class]="
+                              toolService.isToolShownEnabled(tool)
+                                ? 'bg-primary-600 dark:bg-primary-500'
+                                : 'bg-gray-200 dark:bg-gray-700'
+                            "
+                          >
+                            <span
+                              class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                              [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
+                              [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
+                            ></span>
+                          </span>
+                        </button>
+                      }
+                    </li>
+                  }
                 }
               </ul>
             }

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
@@ -39,9 +39,11 @@ describe('ModelSettings', () => {
     };
     mockToolService = {
       tools: signal<any[]>([]),
+      visibleTools: signal<any[]>([]),
       enabledTools: signal([]),
       toolsByCategory: signal(new Map()),
       categories: signal([]),
+      isToolShownEnabled: (tool: any) => tool.isEnabled,
       toggleTool: vi.fn(),
     };
 
@@ -203,12 +205,119 @@ describe('ModelSettings', () => {
       expect(component.subtitle(calculator as any)).toBe('Does sums');
     });
 
+    it('names which of a server’s tools matched the query', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('send_mess');
+      expect(component.matchedSubTools(gmail as any)).toEqual(['send_message']);
+    });
+
+    it('stays quiet when the row’s own text already explains the match', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('gmail');
+      expect(component.matchedSubTools(gmail as any)).toEqual([]);
+    });
+
     it('builds a monogram from the display name', async () => {
       const component = await createComponent();
       expect(component.monogram(gmail as any)).toBe('GF');
       expect(component.monogram({ displayName: 'Excalidraw' } as any)).toBe('E');
       expect(component.monogram({ displayName: '1Password' } as any)).toBe('P');
       expect(component.monogram({ displayName: '///' } as any)).toBe('?');
+    });
+  });
+
+  describe('search and grouping', () => {
+    const tool = (over: Partial<any>) => ({
+      toolId: 't',
+      displayName: 'T',
+      description: '',
+      category: 'utility',
+      icon: null,
+      protocol: 'local',
+      status: 'active',
+      grantedBy: [],
+      enabledByDefault: false,
+      userEnabled: null,
+      isEnabled: false,
+      ...over,
+    });
+
+    const calculator = tool({ toolId: 'calculator', displayName: 'Calculator', category: 'utility' });
+    const artifacts = tool({
+      toolId: 'create_artifact',
+      displayName: 'Artifacts',
+      category: 'utility',
+      isEnabled: true,
+    });
+    const github = tool({ toolId: 'github_repos', displayName: 'Github Repos', category: 'code' });
+    const calendar = tool({
+      toolId: 'google_calendar',
+      displayName: 'Google Calendar',
+      category: 'custom',
+      protocol: 'mcp_external',
+      serverTools: [
+        { name: 'suggest_time', enabled: true },
+        { name: 'list_events', enabled: true },
+      ],
+    });
+
+    beforeEach(() => {
+      mockToolService.tools.set([calculator, artifacts, github, calendar]);
+      mockToolService.visibleTools = signal([calculator, artifacts, github, calendar]);
+      mockToolService.isToolShownEnabled = (t: any) => t.isEnabled;
+    });
+
+    it('pins the enabled group above the categories', async () => {
+      const component = await createComponent();
+      const rows = component['toolRows']();
+      expect(rows[0]).toMatchObject({ kind: 'header', id: 'enabled', count: 1 });
+      expect(rows[1]).toMatchObject({ kind: 'tool', id: 'create_artifact' });
+    });
+
+    it('collapses categories by default so the list is headers, not 31 rows', async () => {
+      const component = await createComponent();
+      const rows = component['toolRows']();
+      const toolIds = rows.filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      // Only the enabled tool has a row; the other three sit behind headers.
+      expect(toolIds).toEqual(['create_artifact']);
+      expect(rows.filter((r: any) => r.kind === 'header' && r.collapsible).map((r: any) => r.label))
+        .toEqual(['Code & repositories', 'Custom', 'Utility']);
+    });
+
+    it('reveals a category’s tools when it is expanded', async () => {
+      const component = await createComponent();
+      component.toggleCategory('code');
+      const ids = component['toolRows']().filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      expect(ids).toContain('github_repos');
+    });
+
+    it('flattens to one ungrouped run while searching', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('calc');
+      const rows = component['toolRows']();
+      expect(rows[0]).toMatchObject({ kind: 'header', id: 'results', collapsible: false, count: 1 });
+      expect(rows[1]).toMatchObject({ kind: 'tool', id: 'calculator' });
+    });
+
+    it('matches a server through its own tool names', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('suggest_time');
+      const ids = component['toolRows']().filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      expect(ids).toEqual(['google_calendar']);
+    });
+
+    it('emits no rows at all when nothing matches, so the empty state can show', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('zzzznope');
+      // A bare "Results 0" header would make toolRows() non-empty and silently
+      // suppress the empty state — that regression shipped once.
+      expect(component['toolRows']()).toEqual([]);
+    });
+
+    it('falls back to the raw slug for a category the frontend does not know', async () => {
+      const component = await createComponent();
+      expect(component.categoryLabel('utility')).toBe('Utility');
+      expect(component.categoryLabel('quantum_widgets')).toBe('quantum_widgets');
     });
   });
 });

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, inject, input, output, signal, computed, effect, ElementRef } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
 import { ToolDetailComponent } from './tool-detail/tool-detail.component';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService, Tool } from '../../services/tool/tool.service';
@@ -13,6 +13,22 @@ import {
   ModelParamSpec,
   ModelProvider,
 } from '../../admin/manage-models/models/managed-model.model';
+
+/**
+ * One line of the tools picker — a group header or a tool row. Headers and rows
+ * share one list so the template loops once rather than repeating the split-row
+ * markup per group.
+ */
+export type ToolPickerRow =
+  | {
+      kind: 'header';
+      id: string;
+      label: string;
+      count: number;
+      collapsible: boolean;
+      expanded: boolean;
+    }
+  | { kind: 'tool'; id: string; tool: Tool };
 
 /** Resolved row the template renders for a single inference param. */
 interface AdvancedParamRow {
@@ -42,7 +58,7 @@ interface AdvancedParamRow {
   selector: 'app-model-settings',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, ToolDetailComponent],
-  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed })],
+  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed, heroMagnifyingGlass })],
   host: {
     '(document:click)': 'onDocumentClick($event)',
     '(document:keydown.escape)': 'onEscape($event)',
@@ -312,6 +328,180 @@ export class ModelSettings {
     const id = this.detailToolId();
     return id ? (this.toolService.tools().find((t) => t.toolId === id) ?? null) : null;
   });
+
+  /** Free-text filter over the tool list. */
+  protected readonly toolQuery = signal('');
+
+  /** Which category groups are expanded. Empty = all collapsed. */
+  private readonly expandedCategories = signal<Set<string>>(new Set());
+
+  /**
+   * Human labels for the catalog's `category` values. The catalog carries a
+   * category on every record and the drawer never used it; these are the same
+   * slugs the admin tool form offers.
+   *
+   * An unmapped slug falls back to the raw value rather than being dropped —
+   * an admin can introduce a category without a frontend release, and a tool
+   * that vanished from the picker would be a far worse bug than an ugly header.
+   */
+  private static readonly CATEGORY_LABELS: Record<string, string> = {
+    browser: 'Browser',
+    code: 'Code & repositories',
+    custom: 'Custom',
+    data: 'Data & spreadsheets',
+    document: 'Documents',
+    finance: 'Finance',
+    gateway: 'Gateway',
+    research: 'Research',
+    search: 'Search',
+    utility: 'Utility',
+    visualization: 'Diagrams & charts',
+  };
+
+  categoryLabel(category: string): string {
+    return ModelSettings.CATEGORY_LABELS[category] ?? category;
+  }
+
+  /**
+   * Which of a server's own tools matched the query. Surfacing this is the
+   * difference between search that works and search that looks broken: typing
+   * "calendar" matches Google Calendar's `suggest_time`, and without this the
+   * row gives no hint why it is in the results.
+   */
+  matchedSubTools(tool: Tool): string[] {
+    const query = this.toolQuery().trim().toLowerCase();
+    if (!query) return [];
+    // Already explained by the row's own text — don't repeat it underneath.
+    if (`${tool.displayName} ${tool.description}`.toLowerCase().includes(query)) return [];
+    return (tool.serverTools ?? [])
+      .filter((sub) => sub.name.toLowerCase().includes(query))
+      .map((sub) => sub.name)
+      .slice(0, 3);
+  }
+
+  private matches(tool: Tool, query: string): boolean {
+    if (!query) return true;
+    const haystack = [
+      tool.displayName,
+      tool.description,
+      tool.toolId,
+      ...(tool.serverTools ?? []).map((sub) => sub.name),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  }
+
+  /** Everything the picker may show, after the query. */
+  private readonly matchingTools = computed(() => {
+    const query = this.toolQuery().trim().toLowerCase();
+    return this.toolService.visibleTools().filter((tool) => this.matches(tool, query));
+  });
+
+  /** True while a query is narrowing the list. */
+  protected readonly isSearching = computed(() => this.toolQuery().trim().length > 0);
+
+  private byName = (a: Tool, b: Tool) => a.displayName.localeCompare(b.displayName);
+
+  /**
+   * Headers and rows flattened into one list, so the template keeps a single
+   * loop instead of repeating the split-row markup for results, the enabled
+   * group, and every category.
+   *
+   * Searching flattens to one ungrouped "Results" run: with a query the user is
+   * looking for a specific tool, and making them expand the right category to
+   * find it would defeat the search.
+   */
+  protected readonly toolRows = computed<ToolPickerRow[]>(() => {
+    const tools = this.matchingTools();
+    const rows: ToolPickerRow[] = [];
+
+    if (this.isSearching()) {
+      // No header for an empty result set — "RESULTS 0" above blank space says
+      // less than the empty state does, and the template keys that state off
+      // this list being empty.
+      if (tools.length === 0) return rows;
+      rows.push({
+        kind: 'header',
+        id: 'results',
+        label: 'Results',
+        count: tools.length,
+        collapsible: false,
+        expanded: true,
+      });
+      for (const tool of [...tools].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+      return rows;
+    }
+
+    const enabled = tools.filter((tool) => this.toolService.isToolShownEnabled(tool));
+    if (enabled.length > 0) {
+      rows.push({
+        kind: 'header',
+        id: 'enabled',
+        label: 'On in this conversation',
+        count: enabled.length,
+        collapsible: false,
+        expanded: true,
+      });
+      for (const tool of [...enabled].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+    }
+
+    const groups = new Map<string, Tool[]>();
+    for (const tool of tools) {
+      if (this.toolService.isToolShownEnabled(tool)) continue;
+      groups.set(tool.category, [...(groups.get(tool.category) ?? []), tool]);
+    }
+
+    const sorted = [...groups.entries()]
+      .map(([category, list]) => ({ category, label: this.categoryLabel(category), list }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    for (const group of sorted) {
+      const expanded = this.isCategoryExpanded(group.category);
+      rows.push({
+        kind: 'header',
+        id: group.category,
+        label: group.label,
+        count: group.list.length,
+        collapsible: true,
+        expanded,
+      });
+      if (!expanded) continue;
+      for (const tool of [...group.list].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+    }
+
+    return rows;
+  });
+
+  isCategoryExpanded(category: string): boolean {
+    return this.expandedCategories().has(category);
+  }
+
+  toggleCategory(category: string): void {
+    this.expandedCategories.update((set) => {
+      const next = new Set(set);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }
+
+  clearToolQuery(): void {
+    this.toolQuery.set('');
+  }
+
+  onToolQueryInput(event: Event): void {
+    this.toolQuery.set((event.target as HTMLInputElement).value);
+  }
 
   toggleTool(toolId: string): void {
     this.toolService.toggleTool(toolId);


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #1030 — merge order matters.** Base is `feature/tool-drawer-drill-down`, not `develop`, because this builds directly on that PR's row markup. **Retarget this to `develop` once #1030 merges, before merging this.** We lost `gateway_target_service.py` to exactly this hazard on #419: the base merged to develop first, and the stacked PR's commit stranded on the now-merged base.

## Why

31 catalog entries, one flat unsorted list, no search. `category` is on every catalog record and the drawer never used it, so the only way to find a tool was to scroll past the other thirty.

## What changed

**An "On in this conversation" group pinned to the top.** "What is this conversation carrying?" was previously unanswerable without reading every row.

**Category headers below it, collapsed.** Seven headers instead of twenty-four rows, on the live dev catalog.

**Search across servers *and* their own tool names.** `gpa` finds Student MyBoiseState through `get_current_gpa`; `suggest_time` finds Google Calendar. The row then names which tool matched — without that it appears in the results for no visible reason. A query flattens the list to one ungrouped run, because at that point the user wants a specific tool and making them guess its category would defeat the search.

Headers and rows are flattened into a single `toolRows()` computed, so the template loops once instead of repeating the split-row markup three times.

## Judgment calls worth a look

- **Unknown category slugs fall back to the raw value** rather than being dropped. An admin can add a category without a frontend release; a tool silently missing from the picker is a far worse bug than an ugly header.
- **Categories start collapsed.** Open-by-default would reproduce the wall this PR exists to remove. The enabled group is always open.
- **Search is substring, not fuzzy.** Fuzzy matching over ~128 leaf names invites false positives; substring is predictable and was enough in testing.

## Verified on dev against the live catalog

Not only unit tests — driven in the browser:

- 7 enabled pinned on top, then Code & repositories 4 / Custom 1 / Data & spreadsheets 1 / Documents 1 / Research 1 / Search 3 / Utility 6
- Expanding a header adds exactly its rows (7 → 11 for Code & repositories); `aria-expanded` tracks
- `gpa` → one result, Student MyBoiseState, with `get_current_gpa` named underneath
- Nonsense query → "No tools match" ; clearing restores the grouped view

**One bug the browser caught:** the empty state never rendered. I keyed it off `toolRows().length === 0`, but the `Results` header is itself a row, so the list was never empty — the user got a bare "RESULTS 0" above blank space. Now a search with no matches emits no rows at all. There's a regression test for it.

`ng test`: **2586 passing across 224 files**, 9 new.

## Not in this PR

Connection chips (`GET /connectors/{id}/status` fan-out) and MCP prompts/resources (no `prompts/list` or `resources/list` exists in the backend). Both are on the roadmap after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
