### PR TITLE
feat: show OAuth connection state on tools

### DIFF
--- a/backend/src/apis/app_api/tools/service.py
+++ b/backend/src/apis/app_api/tools/service.py
@@ -135,6 +135,11 @@ class ToolCatalogService:
                     category=tool.category,
                     protocol=tool.protocol,
                     status=tool.status,
+                    # UserToolAccess has always declared this field; nothing ever
+                    # passed it, so every tool reported `requiresOauthProvider:
+                    # null` and the SPA had no way to tell that 13 of the 31
+                    # tools in prod need a connection before they will work.
+                    requires_oauth_provider=tool.requires_oauth_provider,
                     granted_by=granted_by,
                     enabled_by_default=tool.enabled_by_default,
                     user_enabled=user_enabled,

--- a/backend/tests/apis/app_api/tools/test_oauth_provider_surfaced.py
+++ b/backend/tests/apis/app_api/tools/test_oauth_provider_surfaced.py
@@ -1,0 +1,84 @@
+"""`requiresOauthProvider` must reach the user-facing /tools payload.
+
+`UserToolAccess` has always declared the field, but the service never passed it,
+so every tool reported ``requiresOauthProvider: null``. The SPA therefore had no
+way to tell that 13 of the 31 tools in prod need an OAuth connection before they
+will run — the user only found out when a turn failed mid-answer.
+
+Dependencies are mocked; the logic under test is pure.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from apis.app_api.tools.service import ToolCatalogService
+from apis.shared.auth.models import User
+from apis.shared.rbac.models import UserEffectivePermissions
+from apis.shared.tools.models import (
+    MCPServerConfig,
+    ToolDefinition,
+    ToolProtocol,
+    ToolStatus,
+    UserToolPreference,
+)
+
+
+def _user():
+    return User(user_id="u1", email="u@x.com", name="U", roles=["User"], raw_token="t")
+
+
+def _service(tools):
+    repo = MagicMock()
+    repo.list_tools = AsyncMock(return_value=tools)
+    repo.get_user_preferences = AsyncMock(
+        return_value=UserToolPreference(user_id="u1", tool_preferences={})
+    )
+    role_service = MagicMock()
+    role_service.resolve_user_permissions = AsyncMock(
+        return_value=UserEffectivePermissions(
+            user_id="u1",
+            app_roles=["User"],
+            tools=["*"],
+            models=["*"],
+            quota_tier=None,
+            resolved_at="2024-01-01T00:00:00Z",
+        )
+    )
+    return ToolCatalogService(repository=repo, app_role_service=role_service)
+
+
+def _tool(tool_id: str, provider: str | None):
+    return ToolDefinition(
+        tool_id=tool_id,
+        display_name=tool_id,
+        description="x",
+        protocol=ToolProtocol.MCP_EXTERNAL,
+        status=ToolStatus.ACTIVE,
+        requires_oauth_provider=provider,
+        mcp_config=MCPServerConfig(server_url="https://example.com/mcp", tools=[]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_reaches_the_user_payload():
+    service = _service([_tool("canvas_faculty", "canvas-faculty")])
+    tools = await service.get_user_accessible_tools(_user())
+    assert tools[0].requires_oauth_provider == "canvas-faculty"
+
+
+@pytest.mark.asyncio
+async def test_tool_without_a_provider_reports_none():
+    service = _service([_tool("calculator", None)])
+    tools = await service.get_user_accessible_tools(_user())
+    assert tools[0].requires_oauth_provider is None
+
+
+@pytest.mark.asyncio
+async def test_provider_survives_serialization_under_its_alias():
+    # The SPA reads `requiresOauthProvider`; a field that only exists under its
+    # snake_case name would be just as invisible as not being set at all.
+    service = _service([_tool("gmail_employee", "gmail-employee")])
+    tools = await service.get_user_accessible_tools(_user())
+    dumped = tools[0].model_dump(by_alias=True)
+    assert dumped["requiresOauthProvider"] == "gmail-employee"

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -646,11 +646,35 @@
                           >{{ monogram(tool) }}</span
                         >
                         <span class="block min-w-0 flex-1 overflow-hidden">
-                          <span
-                            [id]="'tool-label-' + tool.toolId"
-                            class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
-                            >{{ tool.displayName }}</span
-                          >
+                          <span class="flex min-w-0 items-center gap-1.5">
+                            <span
+                              [id]="'tool-label-' + tool.toolId"
+                              class="min-w-0 truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+                              >{{ tool.displayName }}</span
+                            >
+                            <!--
+                              Static chip, never a control: this sits inside the
+                              row's body button, and a button nested in a button
+                              is invalid and swallows its own activation. The
+                              chip reports; Connect lives in the detail pane.
+                              `unknown` draws nothing — a probe that failed is
+                              not evidence the user is disconnected.
+                            -->
+                            @switch (connectionState(tool)) {
+                              @case ('connected') {
+                                <span
+                                  class="shrink-0 rounded-sm bg-state-success-50 px-1.5 font-mono text-[10px]/5 font-medium text-state-success-700 dark:bg-state-success-900/30 dark:text-state-success-300"
+                                  >connected</span
+                                >
+                              }
+                              @case ('disconnected') {
+                                <span
+                                  class="shrink-0 rounded-sm bg-state-warning-50 px-1.5 font-mono text-[10px]/5 font-medium text-state-warning-700 dark:bg-state-warning-900/30 dark:text-state-warning-300"
+                                  >connect</span
+                                >
+                              }
+                            }
+                          </span>
                           <span
                             [id]="'tool-desc-' + tool.toolId"
                             class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -556,6 +556,35 @@
               <div class="text-sm/6 text-gray-500 dark:text-gray-400">No tools available</div>
             } @else {
               <!--
+                Search matches a server's own tool names as well as its title and
+                description, so "calendar" finds Google Calendar through
+                `suggest_time`. `matchedSubTools` then says which name matched —
+                without it a row appears in the results for no visible reason.
+              -->
+              <div class="relative mb-2 px-1">
+                <ng-icon
+                  name="heroMagnifyingGlass"
+                  class="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+                <input
+                  type="search"
+                  [value]="toolQuery()"
+                  (input)="onToolQueryInput($event)"
+                  placeholder="Search tools"
+                  aria-label="Search tools"
+                  [attr.aria-describedby]="isSearching() ? 'tools-result-count' : null"
+                  class="w-full rounded-2xl border border-gray-200 bg-gray-50 py-2 pr-3 pl-10 text-sm/6 text-gray-900 placeholder:text-gray-400 focus-visible:border-primary-500 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-500"
+                />
+              </div>
+
+              @if (toolRows().length === 0) {
+                <p class="px-2 py-6 text-center text-sm/6 text-gray-500 dark:text-gray-400">
+                  No tools match “{{ toolQuery() }}”.
+                </p>
+              }
+
+              <!--
                 Split row, matching agent-listing-row.component.ts: the body is
                 the way into the detail pane and the switch is its SIBLING, never
                 nested — a <button> inside a <button> is invalid and swallows its
@@ -563,75 +592,123 @@
                 hover, because a hover-only control does not exist on touch.
               -->
               <ul class="flex flex-col gap-0.5" role="group" aria-labelledby="tools-heading">
-                @for (tool of toolService.visibleTools(); track tool.toolId) {
-                  <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
-                    <button
-                      type="button"
-                      (click)="openToolDetail(tool.toolId)"
-                      class="flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-2xl px-2 py-2.5 text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
-                      [attr.aria-label]="'Open details for ' + tool.displayName"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
-                        >{{ monogram(tool) }}</span
-                      >
-                      <span class="block min-w-0 flex-1 overflow-hidden">
-                        <span
-                          [id]="'tool-label-' + tool.toolId"
-                          class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
-                          >{{ tool.displayName }}</span
+                @for (row of toolRows(); track row.kind + ':' + row.id) {
+                  @if (row.kind === 'header') {
+                    <li>
+                      @if (row.collapsible) {
+                        <button
+                          type="button"
+                          (click)="toggleCategory(row.id)"
+                          [attr.aria-expanded]="row.expanded"
+                          class="mt-2 flex w-full items-center gap-1.5 rounded-2xl px-2 py-1.5 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500 dark:hover:bg-white/5"
                         >
-                        <span
-                          [id]="'tool-desc-' + tool.toolId"
-                          class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
-                          >{{ subtitle(tool) }}</span
+                          <ng-icon
+                            [name]="row.expanded ? 'heroChevronDown' : 'heroChevronRight'"
+                            class="size-3.5 shrink-0 text-gray-400 dark:text-gray-500"
+                            aria-hidden="true"
+                          />
+                          <span
+                            class="flex-1 text-xs/5 font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                            >{{ row.label }}</span
+                          >
+                          <span class="font-mono text-xs/5 text-gray-400 tabular-nums dark:text-gray-500">{{
+                            row.count
+                          }}</span>
+                        </button>
+                      } @else {
+                        <p
+                          [id]="row.id === 'results' ? 'tools-result-count' : null"
+                          class="mt-2 flex items-center gap-1.5 px-2 py-1.5"
                         >
-                      </span>
-                    </button>
-                    <!--
-                      Agent-locked shows a lock instead of a disabled switch: a
-                      disabled toggle invites a click and then refuses it, where a
-                      lock says who decided. Same call as agent-listing-row.
-                    -->
-                    @if (toolService.agentLocked()) {
-                      <span
-                        class="grid size-8 shrink-0 place-items-center text-gray-400 dark:text-gray-500"
-                        [attr.title]="'Fixed by this agent'"
-                      >
-                        <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
-                        <span class="sr-only">{{ tool.displayName }} is fixed by this agent</span>
-                      </span>
-                    } @else {
+                          <span
+                            class="flex-1 text-xs/5 font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                            >{{ row.label }}</span
+                          >
+                          <span class="font-mono text-xs/5 text-gray-400 tabular-nums dark:text-gray-500">{{
+                            row.count
+                          }}</span>
+                        </p>
+                      }
+                    </li>
+                  }
+                  @if (row.kind === 'tool') {
+                    @let tool = row.tool;
+                    <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
                       <button
                         type="button"
-                        role="switch"
-                        [id]="'tool-toggle-' + tool.toolId"
-                        [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
-                        [attr.aria-labelledby]="'tool-label-' + tool.toolId"
-                        [attr.aria-describedby]="'tool-desc-' + tool.toolId"
-                        (click)="toggleTool(tool.toolId)"
-                        (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
-                        class="grid size-10 shrink-0 cursor-pointer place-items-center rounded-full focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        (click)="openToolDetail(tool.toolId)"
+                        class="flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-2xl px-2 py-2.5 text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        [attr.aria-label]="'Open details for ' + tool.displayName"
                       >
                         <span
                           aria-hidden="true"
-                          class="relative inline-flex h-6 w-11 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
-                          [class]="
-                            toolService.isToolShownEnabled(tool)
-                              ? 'bg-primary-600 dark:bg-primary-500'
-                              : 'bg-gray-200 dark:bg-gray-700'
-                          "
+                          class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+                          >{{ monogram(tool) }}</span
                         >
+                        <span class="block min-w-0 flex-1 overflow-hidden">
                           <span
-                            class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
-                            [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
-                            [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
-                          ></span>
+                            [id]="'tool-label-' + tool.toolId"
+                            class="block truncate text-sm/6 font-semibold text-gray-900 dark:text-white"
+                            >{{ tool.displayName }}</span
+                          >
+                          <span
+                            [id]="'tool-desc-' + tool.toolId"
+                            class="block truncate text-xs/5 text-gray-500 dark:text-gray-400"
+                            >{{ subtitle(tool) }}</span
+                          >
+                          @let matched = matchedSubTools(tool);
+                          @if (matched.length > 0) {
+                            <span
+                              class="block truncate font-mono text-xs/5 text-primary-600 dark:text-primary-400"
+                              >{{ matched.join(', ') }}</span
+                            >
+                          }
                         </span>
                       </button>
-                    }
-                  </li>
+                      <!--
+                        Agent-locked shows a lock instead of a disabled switch: a
+                        disabled toggle invites a click and then refuses it, where a
+                        lock says who decided. Same call as agent-listing-row.
+                      -->
+                      @if (toolService.agentLocked()) {
+                        <span
+                          class="grid size-8 shrink-0 place-items-center text-gray-400 dark:text-gray-500"
+                          [attr.title]="'Fixed by this agent'"
+                        >
+                          <ng-icon name="heroLockClosed" class="size-4" aria-hidden="true" />
+                          <span class="sr-only">{{ tool.displayName }} is fixed by this agent</span>
+                        </span>
+                      } @else {
+                        <button
+                          type="button"
+                          role="switch"
+                          [id]="'tool-toggle-' + tool.toolId"
+                          [attr.aria-checked]="toolService.isToolShownEnabled(tool)"
+                          [attr.aria-labelledby]="'tool-label-' + tool.toolId"
+                          [attr.aria-describedby]="'tool-desc-' + tool.toolId"
+                          (click)="toggleTool(tool.toolId)"
+                          (keydown.space)="$event.preventDefault(); toggleTool(tool.toolId)"
+                          class="grid size-10 shrink-0 cursor-pointer place-items-center rounded-full focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="relative inline-flex h-6 w-11 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
+                            [class]="
+                              toolService.isToolShownEnabled(tool)
+                                ? 'bg-primary-600 dark:bg-primary-500'
+                                : 'bg-gray-200 dark:bg-gray-700'
+                            "
+                          >
+                            <span
+                              class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                              [class.translate-x-5]="toolService.isToolShownEnabled(tool)"
+                              [class.translate-x-0]="!toolService.isToolShownEnabled(tool)"
+                            ></span>
+                          </span>
+                        </button>
+                      }
+                    </li>
+                  }
                 }
               </ul>
             }

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.spec.ts
@@ -39,9 +39,11 @@ describe('ModelSettings', () => {
     };
     mockToolService = {
       tools: signal<any[]>([]),
+      visibleTools: signal<any[]>([]),
       enabledTools: signal([]),
       toolsByCategory: signal(new Map()),
       categories: signal([]),
+      isToolShownEnabled: (tool: any) => tool.isEnabled,
       toggleTool: vi.fn(),
     };
 
@@ -203,12 +205,119 @@ describe('ModelSettings', () => {
       expect(component.subtitle(calculator as any)).toBe('Does sums');
     });
 
+    it('names which of a server’s tools matched the query', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('send_mess');
+      expect(component.matchedSubTools(gmail as any)).toEqual(['send_message']);
+    });
+
+    it('stays quiet when the row’s own text already explains the match', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('gmail');
+      expect(component.matchedSubTools(gmail as any)).toEqual([]);
+    });
+
     it('builds a monogram from the display name', async () => {
       const component = await createComponent();
       expect(component.monogram(gmail as any)).toBe('GF');
       expect(component.monogram({ displayName: 'Excalidraw' } as any)).toBe('E');
       expect(component.monogram({ displayName: '1Password' } as any)).toBe('P');
       expect(component.monogram({ displayName: '///' } as any)).toBe('?');
+    });
+  });
+
+  describe('search and grouping', () => {
+    const tool = (over: Partial<any>) => ({
+      toolId: 't',
+      displayName: 'T',
+      description: '',
+      category: 'utility',
+      icon: null,
+      protocol: 'local',
+      status: 'active',
+      grantedBy: [],
+      enabledByDefault: false,
+      userEnabled: null,
+      isEnabled: false,
+      ...over,
+    });
+
+    const calculator = tool({ toolId: 'calculator', displayName: 'Calculator', category: 'utility' });
+    const artifacts = tool({
+      toolId: 'create_artifact',
+      displayName: 'Artifacts',
+      category: 'utility',
+      isEnabled: true,
+    });
+    const github = tool({ toolId: 'github_repos', displayName: 'Github Repos', category: 'code' });
+    const calendar = tool({
+      toolId: 'google_calendar',
+      displayName: 'Google Calendar',
+      category: 'custom',
+      protocol: 'mcp_external',
+      serverTools: [
+        { name: 'suggest_time', enabled: true },
+        { name: 'list_events', enabled: true },
+      ],
+    });
+
+    beforeEach(() => {
+      mockToolService.tools.set([calculator, artifacts, github, calendar]);
+      mockToolService.visibleTools = signal([calculator, artifacts, github, calendar]);
+      mockToolService.isToolShownEnabled = (t: any) => t.isEnabled;
+    });
+
+    it('pins the enabled group above the categories', async () => {
+      const component = await createComponent();
+      const rows = component['toolRows']();
+      expect(rows[0]).toMatchObject({ kind: 'header', id: 'enabled', count: 1 });
+      expect(rows[1]).toMatchObject({ kind: 'tool', id: 'create_artifact' });
+    });
+
+    it('collapses categories by default so the list is headers, not 31 rows', async () => {
+      const component = await createComponent();
+      const rows = component['toolRows']();
+      const toolIds = rows.filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      // Only the enabled tool has a row; the other three sit behind headers.
+      expect(toolIds).toEqual(['create_artifact']);
+      expect(rows.filter((r: any) => r.kind === 'header' && r.collapsible).map((r: any) => r.label))
+        .toEqual(['Code & repositories', 'Custom', 'Utility']);
+    });
+
+    it('reveals a category’s tools when it is expanded', async () => {
+      const component = await createComponent();
+      component.toggleCategory('code');
+      const ids = component['toolRows']().filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      expect(ids).toContain('github_repos');
+    });
+
+    it('flattens to one ungrouped run while searching', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('calc');
+      const rows = component['toolRows']();
+      expect(rows[0]).toMatchObject({ kind: 'header', id: 'results', collapsible: false, count: 1 });
+      expect(rows[1]).toMatchObject({ kind: 'tool', id: 'calculator' });
+    });
+
+    it('matches a server through its own tool names', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('suggest_time');
+      const ids = component['toolRows']().filter((r: any) => r.kind === 'tool').map((r: any) => r.id);
+      expect(ids).toEqual(['google_calendar']);
+    });
+
+    it('emits no rows at all when nothing matches, so the empty state can show', async () => {
+      const component = await createComponent();
+      component['toolQuery'].set('zzzznope');
+      // A bare "Results 0" header would make toolRows() non-empty and silently
+      // suppress the empty state — that regression shipped once.
+      expect(component['toolRows']()).toEqual([]);
+    });
+
+    it('falls back to the raw slug for a category the frontend does not know', async () => {
+      const component = await createComponent();
+      expect(component.categoryLabel('utility')).toBe('Utility');
+      expect(component.categoryLabel('quantum_widgets')).toBe('quantum_widgets');
     });
   });
 });

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, inject, input, output, signal, computed, effect, ElementRef } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
 import { ToolDetailComponent } from './tool-detail/tool-detail.component';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService, Tool } from '../../services/tool/tool.service';
@@ -13,6 +13,22 @@ import {
   ModelParamSpec,
   ModelProvider,
 } from '../../admin/manage-models/models/managed-model.model';
+
+/**
+ * One line of the tools picker — a group header or a tool row. Headers and rows
+ * share one list so the template loops once rather than repeating the split-row
+ * markup per group.
+ */
+export type ToolPickerRow =
+  | {
+      kind: 'header';
+      id: string;
+      label: string;
+      count: number;
+      collapsible: boolean;
+      expanded: boolean;
+    }
+  | { kind: 'tool'; id: string; tool: Tool };
 
 /** Resolved row the template renders for a single inference param. */
 interface AdvancedParamRow {
@@ -42,7 +58,7 @@ interface AdvancedParamRow {
   selector: 'app-model-settings',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, ToolDetailComponent],
-  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed })],
+  providers: [provideIcons({ heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed, heroMagnifyingGlass })],
   host: {
     '(document:click)': 'onDocumentClick($event)',
     '(document:keydown.escape)': 'onEscape($event)',
@@ -312,6 +328,180 @@ export class ModelSettings {
     const id = this.detailToolId();
     return id ? (this.toolService.tools().find((t) => t.toolId === id) ?? null) : null;
   });
+
+  /** Free-text filter over the tool list. */
+  protected readonly toolQuery = signal('');
+
+  /** Which category groups are expanded. Empty = all collapsed. */
+  private readonly expandedCategories = signal<Set<string>>(new Set());
+
+  /**
+   * Human labels for the catalog's `category` values. The catalog carries a
+   * category on every record and the drawer never used it; these are the same
+   * slugs the admin tool form offers.
+   *
+   * An unmapped slug falls back to the raw value rather than being dropped —
+   * an admin can introduce a category without a frontend release, and a tool
+   * that vanished from the picker would be a far worse bug than an ugly header.
+   */
+  private static readonly CATEGORY_LABELS: Record<string, string> = {
+    browser: 'Browser',
+    code: 'Code & repositories',
+    custom: 'Custom',
+    data: 'Data & spreadsheets',
+    document: 'Documents',
+    finance: 'Finance',
+    gateway: 'Gateway',
+    research: 'Research',
+    search: 'Search',
+    utility: 'Utility',
+    visualization: 'Diagrams & charts',
+  };
+
+  categoryLabel(category: string): string {
+    return ModelSettings.CATEGORY_LABELS[category] ?? category;
+  }
+
+  /**
+   * Which of a server's own tools matched the query. Surfacing this is the
+   * difference between search that works and search that looks broken: typing
+   * "calendar" matches Google Calendar's `suggest_time`, and without this the
+   * row gives no hint why it is in the results.
+   */
+  matchedSubTools(tool: Tool): string[] {
+    const query = this.toolQuery().trim().toLowerCase();
+    if (!query) return [];
+    // Already explained by the row's own text — don't repeat it underneath.
+    if (`${tool.displayName} ${tool.description}`.toLowerCase().includes(query)) return [];
+    return (tool.serverTools ?? [])
+      .filter((sub) => sub.name.toLowerCase().includes(query))
+      .map((sub) => sub.name)
+      .slice(0, 3);
+  }
+
+  private matches(tool: Tool, query: string): boolean {
+    if (!query) return true;
+    const haystack = [
+      tool.displayName,
+      tool.description,
+      tool.toolId,
+      ...(tool.serverTools ?? []).map((sub) => sub.name),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(query);
+  }
+
+  /** Everything the picker may show, after the query. */
+  private readonly matchingTools = computed(() => {
+    const query = this.toolQuery().trim().toLowerCase();
+    return this.toolService.visibleTools().filter((tool) => this.matches(tool, query));
+  });
+
+  /** True while a query is narrowing the list. */
+  protected readonly isSearching = computed(() => this.toolQuery().trim().length > 0);
+
+  private byName = (a: Tool, b: Tool) => a.displayName.localeCompare(b.displayName);
+
+  /**
+   * Headers and rows flattened into one list, so the template keeps a single
+   * loop instead of repeating the split-row markup for results, the enabled
+   * group, and every category.
+   *
+   * Searching flattens to one ungrouped "Results" run: with a query the user is
+   * looking for a specific tool, and making them expand the right category to
+   * find it would defeat the search.
+   */
+  protected readonly toolRows = computed<ToolPickerRow[]>(() => {
+    const tools = this.matchingTools();
+    const rows: ToolPickerRow[] = [];
+
+    if (this.isSearching()) {
+      // No header for an empty result set — "RESULTS 0" above blank space says
+      // less than the empty state does, and the template keys that state off
+      // this list being empty.
+      if (tools.length === 0) return rows;
+      rows.push({
+        kind: 'header',
+        id: 'results',
+        label: 'Results',
+        count: tools.length,
+        collapsible: false,
+        expanded: true,
+      });
+      for (const tool of [...tools].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+      return rows;
+    }
+
+    const enabled = tools.filter((tool) => this.toolService.isToolShownEnabled(tool));
+    if (enabled.length > 0) {
+      rows.push({
+        kind: 'header',
+        id: 'enabled',
+        label: 'On in this conversation',
+        count: enabled.length,
+        collapsible: false,
+        expanded: true,
+      });
+      for (const tool of [...enabled].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+    }
+
+    const groups = new Map<string, Tool[]>();
+    for (const tool of tools) {
+      if (this.toolService.isToolShownEnabled(tool)) continue;
+      groups.set(tool.category, [...(groups.get(tool.category) ?? []), tool]);
+    }
+
+    const sorted = [...groups.entries()]
+      .map(([category, list]) => ({ category, label: this.categoryLabel(category), list }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    for (const group of sorted) {
+      const expanded = this.isCategoryExpanded(group.category);
+      rows.push({
+        kind: 'header',
+        id: group.category,
+        label: group.label,
+        count: group.list.length,
+        collapsible: true,
+        expanded,
+      });
+      if (!expanded) continue;
+      for (const tool of [...group.list].sort(this.byName)) {
+        rows.push({ kind: 'tool', id: tool.toolId, tool });
+      }
+    }
+
+    return rows;
+  });
+
+  isCategoryExpanded(category: string): boolean {
+    return this.expandedCategories().has(category);
+  }
+
+  toggleCategory(category: string): void {
+    this.expandedCategories.update((set) => {
+      const next = new Set(set);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }
+
+  clearToolQuery(): void {
+    this.toolQuery.set('');
+  }
+
+  onToolQueryInput(event: Event): void {
+    this.toolQuery.set((event.target as HTMLInputElement).value);
+  }
 
   toggleTool(toolId: string): void {
     this.toolService.toggleTool(toolId);

--- a/frontend/ai.client/src/app/components/model-settings/model-settings.ts
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.ts
@@ -2,6 +2,10 @@ import { Component, ChangeDetectionStrategy, inject, input, output, signal, comp
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroXMark, heroCheck, heroChevronDown, heroChevronRight, heroArrowPath, heroArrowLeft, heroLockClosed, heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
 import { ToolDetailComponent } from './tool-detail/tool-detail.component';
+import {
+  ConnectionState,
+  ConnectorStatusService,
+} from '../../settings/connectors/services/connector-status.service';
 import { ModelService } from '../../session/services/model/model.service';
 import { ToolService, Tool } from '../../services/tool/tool.service';
 import { SkillService } from '../../services/skill/skill.service';
@@ -72,6 +76,7 @@ export class ModelSettings {
   protected toolService = inject(ToolService);
   protected skillService = inject(SkillService);
   protected systemPromptsService = inject(SystemPromptsService);
+  protected connectorStatus = inject(ConnectorStatusService);
 
   // Input to control visibility
   isOpen = input<boolean>(false);
@@ -213,6 +218,16 @@ export class ModelSettings {
       // show what this conversation is carrying.
       if (!isOpen) {
         this.detailToolId.set(null);
+      }
+
+      // Probe connection state for the OAuth-gated tools this user can see, so
+      // the rows can say whether a tool will actually work. `ensure` skips
+      // providers it already knows, so reopening the drawer costs nothing.
+      if (isOpen) {
+        const providers = this.toolService
+          .visibleTools()
+          .map((tool) => tool.requiresOauthProvider);
+        void this.connectorStatus.ensure(providers);
       }
 
       // Load the skills picker lazily on first open. SkillService deliberately
@@ -493,6 +508,15 @@ export class ModelSettings {
       }
       return next;
     });
+  }
+
+  /**
+   * Connection state for a tool's OAuth provider, or 'none' when the tool
+   * needs no connection at all — most tools, so the row draws no chip.
+   */
+  connectionState(tool: Tool): ConnectionState | 'none' {
+    if (!tool.requiresOauthProvider) return 'none';
+    return this.connectorStatus.stateFor(tool.requiresOauthProvider);
   }
 
   clearToolQuery(): void {

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
@@ -18,6 +18,42 @@
     <p class="mt-3 text-sm/6 text-gray-600 dark:text-gray-300">{{ t.description }}</p>
   }
 
+  <!--
+    Connection. Only drawn for a tool that actually needs consent, and only
+    once we know the answer — `unknown` means the probe failed, and telling
+    someone to reconnect on that basis sends them through a flow they may not
+    need. Turning the tool on without connecting is still allowed: the agent
+    surfaces its own consent prompt mid-turn, and blocking the toggle here
+    would be a second, contradictory gate.
+  -->
+  @switch (connection()) {
+    @case ('disconnected') {
+      <div
+        class="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-state-warning-200 bg-state-warning-50 px-3 py-2 dark:border-state-warning-800 dark:bg-state-warning-900/20"
+      >
+        <span class="min-w-0 text-xs/5 text-state-warning-800 dark:text-state-warning-200">
+          Needs your {{ t.requiresOauthProvider }} account before it can run.
+        </span>
+        <button
+          type="button"
+          (click)="connect()"
+          [disabled]="connecting()"
+          class="shrink-0 rounded-2xl bg-primary-accessible px-3 py-1.5 text-xs/5 font-semibold text-white transition-[filter] hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ connecting() ? 'Waiting…' : 'Connect' }}
+        </button>
+      </div>
+    }
+    @case ('connected') {
+      <p
+        class="mt-3 flex items-center gap-1.5 text-xs/5 text-state-success-700 dark:text-state-success-300"
+      >
+        <ng-icon name="heroCheckCircle" class="size-3.5 shrink-0" aria-hidden="true" />
+        Connected as you
+      </p>
+    }
+  }
+
   <div
     class="mt-4 flex items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-3 py-2 dark:border-white/10 dark:bg-white/5"
   >

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
@@ -8,8 +8,10 @@ import {
   signal,
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroArrowPath, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { heroArrowPath, heroCheckCircle, heroLockClosed } from '@ng-icons/heroicons/outline';
 import { Tool, ToolService } from '../../../services/tool/tool.service';
+import { ConnectorStatusService } from '../../../settings/connectors/services/connector-status.service';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
 
 /** Which panel of the detail view is showing. */
 export type ToolDetailTab = 'tools' | 'about';
@@ -35,14 +37,46 @@ export type ToolDetailTab = 'tools' | 'about';
   selector: 'app-tool-detail',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon],
-  providers: [provideIcons({ heroArrowPath, heroLockClosed })],
+  providers: [provideIcons({ heroArrowPath, heroCheckCircle, heroLockClosed })],
   host: { class: 'flex h-full flex-col' },
   templateUrl: './tool-detail.component.html',
 })
 export class ToolDetailComponent {
   protected readonly toolService = inject(ToolService);
+  protected readonly connectorStatus = inject(ConnectorStatusService);
+  private readonly consent = inject(OAuthConsentService);
 
   readonly tool = input.required<Tool>();
+
+  /** The OAuth provider this tool needs, or null when it needs none. */
+  protected readonly providerId = computed(() => this.tool().requiresOauthProvider ?? null);
+
+  /** Connection state for that provider; 'none' when the tool needs no consent. */
+  protected readonly connection = computed(() => {
+    const provider = this.providerId();
+    return provider ? this.connectorStatus.stateFor(provider) : 'none';
+  });
+
+  protected readonly connecting = computed(() => {
+    const provider = this.providerId();
+    return provider ? this.consent.inFlightProviders().has(provider) : false;
+  });
+
+  /**
+   * Open the provider's consent popup. Reuses the same service the chat layer
+   * and settings page use, so popup blocking, COOP-severed openers and the
+   * completion broadcast are all already handled — and
+   * `ConnectorStatusService` flips the chip when that broadcast lands.
+   *
+   * `requestConsent` is called with no authorization URL on purpose: the
+   * service then fetches a fresh one, because AgentCore's URLs expire quickly.
+   */
+  protected connect(): void {
+    const provider = this.providerId();
+    if (!provider) return;
+    this.consent.requestConsent(provider, undefined);
+    void this.consent.openConsentPopup(provider);
+  }
 
   protected readonly isMcpServer = computed(() => {
     const protocol = this.tool().protocol;

--- a/frontend/ai.client/src/app/services/tool/tool.service.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.ts
@@ -56,6 +56,12 @@ export interface Tool {
   userEnabled: boolean | null;
   isEnabled: boolean;
   /**
+   * OAuth provider this tool needs the user to connect before it will work,
+   * or null/absent when it needs no per-user consent. Mirrors the catalog's
+   * `requiresOauthProvider`.
+   */
+  requiresOauthProvider?: string | null;
+  /**
    * For MCP-server tools, the individual tools the server exposes. Empty for
    * non-MCP tools or servers whose tools are discovered live.
    */

--- a/frontend/ai.client/src/app/settings/connectors/services/connector-status.service.spec.ts
+++ b/frontend/ai.client/src/app/settings/connectors/services/connector-status.service.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { ConnectorStatusService } from './connector-status.service';
+import { UserConnectorsService } from './user-connectors.service';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+
+describe('ConnectorStatusService', () => {
+  let getStatus: ReturnType<typeof vi.fn>;
+  let completion: ReturnType<typeof signal<any>>;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    getStatus = vi.fn().mockResolvedValue({ connected: true });
+    completion = signal<any>(null);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserConnectorsService, useValue: { getStatus } },
+        {
+          provide: OAuthConsentService,
+          useValue: { completion, inFlightProviders: signal(new Set<string>()) },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  const service = () => TestBed.inject(ConnectorStatusService);
+
+  it('reports unknown before anything has been probed', () => {
+    expect(service().stateFor('canvas-faculty')).toBe('unknown');
+  });
+
+  it('records a connected provider', async () => {
+    const s = service();
+    await s.ensure(['canvas-faculty']);
+    expect(s.stateFor('canvas-faculty')).toBe('connected');
+  });
+
+  it('records a disconnected provider', async () => {
+    getStatus.mockResolvedValue({ connected: false });
+    const s = service();
+    await s.ensure(['gmail-employee']);
+    expect(s.stateFor('gmail-employee')).toBe('disconnected');
+  });
+
+  it('leaves a failed probe as unknown rather than claiming disconnected', async () => {
+    // Telling someone they are disconnected because a status call timed out
+    // sends them into a consent flow they do not need.
+    getStatus.mockRejectedValue(new Error('timeout'));
+    const s = service();
+    await s.ensure(['canvas-faculty']);
+    expect(s.stateFor('canvas-faculty')).toBe('unknown');
+  });
+
+  it('probes each provider once even when several tools share it', async () => {
+    const s = service();
+    await s.ensure(['google-tasks', 'google-tasks', 'google-tasks', null, undefined]);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenCalledWith('google-tasks');
+  });
+
+  it('does not re-probe a provider it already knows', async () => {
+    const s = service();
+    await s.ensure(['canvas-faculty']);
+    await s.ensure(['canvas-faculty']);
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores tools with no provider', async () => {
+    const s = service();
+    await s.ensure([null, undefined, '']);
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('re-probes after invalidate', async () => {
+    const s = service();
+    await s.ensure(['canvas-faculty']);
+    s.invalidate('canvas-faculty');
+    await s.ensure(['canvas-faculty']);
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('flips to connected when a consent completes', async () => {
+    getStatus.mockResolvedValue({ connected: false });
+    const s = service();
+    await s.ensure(['gmail-employee']);
+    expect(s.stateFor('gmail-employee')).toBe('disconnected');
+
+    completion.set({ status: 'success', providerId: 'gmail-employee' });
+    TestBed.tick();
+
+    // Without this the chip still reads "connect" after the user just
+    // connected, which looks like the consent silently failed.
+    expect(s.stateFor('gmail-employee')).toBe('connected');
+  });
+
+  it('ignores a failed consent', async () => {
+    getStatus.mockResolvedValue({ connected: false });
+    const s = service();
+    await s.ensure(['gmail-employee']);
+
+    completion.set({ status: 'error', providerId: 'gmail-employee' });
+    TestBed.tick();
+
+    expect(s.stateFor('gmail-employee')).toBe('disconnected');
+  });
+});

--- a/frontend/ai.client/src/app/settings/connectors/services/connector-status.service.ts
+++ b/frontend/ai.client/src/app/settings/connectors/services/connector-status.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { UserConnectorsService } from './user-connectors.service';
+import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
+
+/** What we know about a provider's connection right now. */
+export type ConnectionState = 'unknown' | 'connected' | 'disconnected';
+
+/**
+ * Cached, side-effect-free connection state per OAuth provider.
+ *
+ * The tools picker needs to answer "will this tool actually work?" for every
+ * OAuth-gated tool at once — 13 of the 31 tools in prod. Three things make a
+ * cache the right shape rather than a per-row fetch:
+ *
+ * * `initiateConsent` is the wrong call for a badge: it records a pending
+ *   session server-side every time it hands back a URL. `getStatus` exists
+ *   precisely because a badge must not commit the user to a consent flow.
+ * * Several tools share one provider (Gmail, Calendar, Drive and Tasks are
+ *   four rows and one `google-*` connection each), so requests are keyed by
+ *   provider, not by tool.
+ * * A failed probe is deliberately recorded as `unknown`, not `disconnected`.
+ *   Telling someone they are disconnected because a status call timed out
+ *   sends them into a consent flow they do not need.
+ */
+@Injectable({ providedIn: 'root' })
+export class ConnectorStatusService {
+  private readonly connectors = inject(UserConnectorsService);
+  private readonly consent = inject(OAuthConsentService);
+
+  private readonly states = signal<Record<string, ConnectionState>>({});
+  /** Providers with a probe in flight — prevents duplicate concurrent fetches. */
+  private readonly inFlight = new Set<string>();
+
+  readonly statuses = this.states.asReadonly();
+
+  constructor() {
+    // A completed consent invalidates what we cached. Without this the chip
+    // still reads "Connect" after the user has just connected, which looks
+    // like the consent silently failed.
+    effect(() => {
+      const completion = this.consent.completion();
+      if (completion?.status === 'success' && completion.providerId) {
+        this.markConnected(completion.providerId);
+      }
+    });
+  }
+
+  stateFor(providerId: string | null | undefined): ConnectionState {
+    if (!providerId) return 'unknown';
+    return this.states()[providerId] ?? 'unknown';
+  }
+
+  /** Optimistic flip after a consent completes, so the UI reacts immediately. */
+  markConnected(providerId: string): void {
+    this.states.update((current) => ({ ...current, [providerId]: 'connected' }));
+  }
+
+  /** Drop a provider's cached state so the next `ensure` re-probes it. */
+  invalidate(providerId: string): void {
+    this.states.update((current) => {
+      if (!(providerId in current)) return current;
+      const next = { ...current };
+      delete next[providerId];
+      return next;
+    });
+  }
+
+  /**
+   * Probe any provider we have no state for yet. Already-known providers are
+   * left alone — this runs whenever the picker opens, and re-probing a dozen
+   * providers on every open would be a burst of requests for an answer that
+   * rarely changes within a session.
+   */
+  async ensure(providerIds: readonly (string | null | undefined)[]): Promise<void> {
+    const pending = [
+      ...new Set(
+        providerIds.filter(
+          (id): id is string =>
+            !!id && !(id in this.states()) && !this.inFlight.has(id),
+        ),
+      ),
+    ];
+    if (pending.length === 0) return;
+
+    for (const id of pending) this.inFlight.add(id);
+
+    await Promise.all(
+      pending.map(async (id) => {
+        try {
+          const response = await this.connectors.getStatus(id);
+          this.states.update((current) => ({
+            ...current,
+            [id]: response.connected ? 'connected' : 'disconnected',
+          }));
+        } catch {
+          // Left as `unknown` on purpose — see the class comment.
+          this.states.update((current) => ({ ...current, [id]: 'unknown' }));
+        } finally {
+          this.inFlight.delete(id);
+        }
+      }),
+    );
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Third in a stack — merge bottom-up.** #1030 → #1031 → this. Base here is `feature/tool-drawer-search-grouping`. **Retarget each to `develop` as the one below it merges.** #419 lost `gateway_target_service.py` to exactly this: the base merged first and the stacked commit stranded.

## The bug underneath

13 of the 31 tools in prod need the user to connect an account before they run, and nothing said so — the first sign was a turn failing mid-answer.

The cause was **a field that existed and was never filled**. `UserToolAccess` has always declared `requires_oauth_provider`, but `ToolCatalogService` never passed it when constructing the response, so every tool reported `requiresOauthProvider: null`. The SPA couldn't have shown connection state even if it wanted to. One line of backend; everything else here is surfacing it.

## What you get

- Rows draw a **`connected` / `connect`** chip.
- The detail pane shows a connection banner with a working **Connect**.

## Judgment calls worth review

**The chip is static, not a button.** It sits inside the row's body button, and a button nested in a button is invalid and swallows its own activation — the same rule the split row already follows. Connecting happens in the detail pane, which has room for it.

**Connect reuses `OAuthConsentService`** rather than reimplementing consent, so popup blocking, COOP-severed `window.opener`, and the completion broadcast are already handled. `ConnectorStatusService` listens for that broadcast and flips the chip — without it the row still reads "connect" right after a successful consent, which looks like the consent failed.

**Status is cached per provider, not per tool.** Gmail, Calendar, Drive and Tasks are four rows and one `google-*` connection each. Probed with the side-effect-free `getStatus`, never `initiateConsent` — the latter records a pending session server-side every time it hands back a URL.

**A failed probe stays `unknown` and draws no chip.** Telling someone they are disconnected because a status call timed out sends them into a consent flow they do not need.

**Turning a tool on while disconnected is still allowed.** The agent surfaces its own consent prompt mid-turn; gating the toggle here would be a second, contradictory gate that disagrees with the runtime.

## Verification — read this before approving

**Tested:** `ng test` 2596 passing across 225 files (10 new); backend `tests/apis/app_api/tools/` 51 passing (3 new). I confirmed the backend test **fails without the fix** (2 of 3 red) rather than passing vacuously. I also re-drove the drawer in the browser to confirm no regression to PR-1/PR-2 behaviour.

**Not tested, and I want to be explicit:** I could not exercise the chip end-to-end against a live connection. The app-api on `localhost:8000` is the main checkout's process, so it serves the unfixed `/tools` payload, and I could not stand a second one up without taking over a port the SPA hardcodes. **The chip rendering path has unit coverage but has never rendered against real data.**

To check it yourself: run app-api from this worktree on 8000, then open Settings → Tools. Dev has exactly three OAuth-gated tools — `canvas_faculty` → `canvas-faculty`, `google_tasks` → `google-tasks`, `salesforce_oit` → `contract-salesforce` — so Canvas for Faculty is the row to watch. (Prod has 13.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
