### PR TITLE
feat(backend): discover and persist MCP prompts and resources

### DIFF
--- a/backend/src/apis/app_api/admin/tools/routes.py
+++ b/backend/src/apis/app_api/admin/tools/routes.py
@@ -20,7 +20,10 @@ from apis.shared.oauth.provider_repository import (
     get_provider_repository,
 )
 from apis.app_api.tools.service import get_tool_catalog_service
-from apis.app_api.tools.discovery import discover_tools_for_saved_tool
+from apis.app_api.tools.discovery import (
+    discover_capabilities_for_saved_tool,
+    discover_tools_for_saved_tool,
+)
 from apis.shared.tools.gateway_target_service import (
     GatewayTargetConflictError,
     GatewayTargetNotFoundError,
@@ -40,6 +43,7 @@ from apis.shared.tools.models import (
     DiscoveredMCPTool,
     GatewayTargetStatusResponse,
     MCPAuthType,
+    ToolCapabilitySnapshot,
 )
 
 logger = logging.getLogger(__name__)
@@ -734,3 +738,94 @@ async def remove_roles_from_tool(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.post(
+    "/{tool_id}/capabilities/refresh", response_model=ToolCapabilitySnapshot
+)
+async def admin_refresh_tool_capabilities(
+    tool_id: str,
+    admin: User = Depends(require_tools_admin),
+    provider_repo: OAuthProviderRepository = Depends(get_provider_repository),
+):
+    """Ask a saved MCP server what prompts and resources it exposes, and store it.
+
+    An admin action rather than a user one: probing opens a live MCP session, so
+    doing it per user per page view would hammer every server in the catalog.
+    Users read the stored snapshot.
+
+    A 3LO server is probed with the **admin's own** vaulted token, exactly as
+    ``POST /admin/tools/discover`` does. The snapshot therefore reflects what the
+    admin's connection can see — for providers that scope-filter by grant, a user
+    with narrower scopes may see less. That is the same caveat the tool listing
+    has always carried, and it is far better than the alternative: six servers in
+    prod currently expose nothing at all because discovery runs without a token.
+
+    A failed probe is **not** written over a good snapshot. Losing a working
+    listing because a server was briefly down would be a worse outcome than
+    showing a slightly stale one, so the previous snapshot is returned with the
+    error attached.
+    """
+    service = get_tool_catalog_service()
+    tool = await service.repository.get_tool(tool_id)
+    if tool is None:
+        raise HTTPException(status_code=404, detail="Tool not found")
+
+    oauth_token: Optional[str] = None
+    if tool.requires_oauth_provider:
+        provider = await provider_repo.get_provider(tool.requires_oauth_provider)
+        if provider is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown OAuth provider '{tool.requires_oauth_provider}'.",
+            )
+        identity = get_agentcore_identity_client()
+        try:
+            result = await identity.get_token_for_user(
+                provider_name=provider.provider_id,
+                scopes=provider.scopes,
+                user_id=admin.user_id,
+                # customParameters are part of the AgentCore vault key — omitting
+                # them would falsely report consent-required for a vaulted token.
+                custom_parameters=custom_parameters_for(provider.custom_parameters),
+            )
+        except (WorkloadTokenUnavailableError, CallbackUrlUnavailableError) as err:
+            logger.warning("Capability discovery token unavailable: %s", err)
+            raise HTTPException(status_code=503, detail=str(err))
+        if result.requires_consent or not result.access_token:
+            raise HTTPException(
+                status_code=409,
+                detail=f"You haven't connected '{provider.display_name}' yet. "
+                "Connect it in your connector settings, then retry.",
+            )
+        oauth_token = result.access_token
+    elif getattr(tool, "forward_auth_token", False):
+        if not admin.raw_token:
+            raise HTTPException(
+                status_code=400,
+                detail="Forward-auth discovery needs your session token, which "
+                "this request didn't carry.",
+            )
+        oauth_token = admin.raw_token
+
+    snapshot = await discover_capabilities_for_saved_tool(
+        tool, oauth_token=oauth_token, discovered_by=admin.user_id
+    )
+
+    if snapshot.error:
+        previous = await service.repository.get_capabilities(tool_id)
+        if previous is not None:
+            previous.error = snapshot.error
+            return previous
+        return snapshot
+
+    return await service.repository.put_capabilities(snapshot)
+
+
+@router.get("/{tool_id}/capabilities", response_model=ToolCapabilitySnapshot)
+async def admin_get_tool_capabilities(
+    tool_id: str,
+    admin: User = Depends(require_tools_admin),
+):
+    """The stored snapshot, without probing. Empty when never discovered."""
+    service = get_tool_catalog_service()
+    snapshot = await service.repository.get_capabilities(tool_id)
+    return snapshot or ToolCapabilitySnapshot(tool_id=tool_id)

--- a/backend/src/apis/app_api/tools/discovery.py
+++ b/backend/src/apis/app_api/tools/discovery.py
@@ -20,9 +20,19 @@ NOTE: importing MCP-client construction from ``agents`` mirrors the existing
 
 import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import List, Optional
 
-from apis.shared.tools.models import DiscoveredMCPTool, ToolDefinition
+from apis.shared.tools.models import (
+    MAX_CAPABILITY_ENTRIES,
+    MAX_CAPABILITY_PAGES,
+    DiscoveredMCPTool,
+    MCPPromptEntry,
+    MCPResourceEntry,
+    ToolCapabilitySnapshot,
+    ToolDefinition,
+    _clip,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,3 +110,180 @@ async def discover_tools_for_saved_tool(
             DiscoveredMCPTool(name=name, description=getattr(spec, "description", None))
         )
     return discovered
+
+
+# =============================================================================
+# Capability discovery (prompts + resources)
+# =============================================================================
+
+
+def _paginate(list_page, extract) -> tuple[list, bool]:
+    """Walk an MCP listing's cursor, capped by entries and by pages.
+
+    Returns ``(entries, truncated)``. Two caps, because they fail differently:
+    a server with thousands of resources would blow the DynamoDB item, and a
+    server with a broken cursor would loop forever.
+    """
+    entries: list = []
+    cursor = None
+    truncated = False
+    for _ in range(MAX_CAPABILITY_PAGES):
+        result = list_page(cursor)
+        entries.extend(extract(result))
+        if len(entries) >= MAX_CAPABILITY_ENTRIES:
+            entries = entries[:MAX_CAPABILITY_ENTRIES]
+            truncated = True
+            break
+        cursor = getattr(result, "nextCursor", None)
+        if not cursor:
+            break
+    else:
+        truncated = True
+    return entries, truncated
+
+
+def _prompt_entries(result) -> List[MCPPromptEntry]:
+    out: List[MCPPromptEntry] = []
+    for prompt in getattr(result, "prompts", None) or []:
+        name = getattr(prompt, "name", None)
+        if not name:
+            continue
+        out.append(
+            MCPPromptEntry(
+                name=name,
+                title=_clip(getattr(prompt, "title", None)),
+                description=_clip(getattr(prompt, "description", None)),
+                arguments=[
+                    getattr(arg, "name", "")
+                    for arg in (getattr(prompt, "arguments", None) or [])
+                    if getattr(arg, "name", None)
+                ],
+            )
+        )
+    return out
+
+
+def _resource_entries(result, *, templates: bool) -> List[MCPResourceEntry]:
+    out: List[MCPResourceEntry] = []
+    source = (
+        getattr(result, "resourceTemplates", None)
+        if templates
+        else getattr(result, "resources", None)
+    ) or []
+    for resource in source:
+        # A template carries `uriTemplate`; a concrete resource carries `uri`.
+        uri = getattr(resource, "uriTemplate", None) if templates else None
+        uri = uri or getattr(resource, "uri", None)
+        if not uri:
+            continue
+        out.append(
+            MCPResourceEntry(
+                uri=str(uri),
+                name=_clip(getattr(resource, "name", None)),
+                description=_clip(getattr(resource, "description", None)),
+                mime_type=getattr(resource, "mimeType", None),
+                uri_template=templates,
+            )
+        )
+    return out
+
+
+async def discover_capabilities_for_saved_tool(
+    tool: ToolDefinition,
+    oauth_token: Optional[str] = None,
+    discovered_by: Optional[str] = None,
+) -> ToolCapabilitySnapshot:
+    """Ask a saved MCP tool what prompts and resources it exposes.
+
+    Each listing is attempted independently and its failure is swallowed into
+    ``supports_*=False``. A server that implements tools but not prompts answers
+    ``prompts/list`` with a JSON-RPC "method not found", which is normal and must
+    not cost us the resources listing — or the whole snapshot.
+
+    A transport-level failure (server unreachable, auth rejected) is different:
+    nothing was learned, so the snapshot records ``error`` and the caller can
+    keep showing the previous one rather than replacing it with emptiness.
+
+    Gateway (``mcp``) tools are not probed. The AgentCore Gateway enumerates a
+    target's *tools* at registration and exposes no prompt or resource surface,
+    so there is nothing on the other end to ask.
+    """
+    snapshot = ToolCapabilitySnapshot(
+        tool_id=tool.tool_id,
+        discovered_at=datetime.now(timezone.utc).isoformat(),
+        discovered_by=discovered_by,
+    )
+
+    if tool.protocol != "mcp_external" or not tool.mcp_config:
+        snapshot.error = "This tool is not an external MCP server."
+        return snapshot
+
+    from agents.main_agent.integrations.external_mcp_client import (
+        create_external_mcp_client,
+    )
+
+    forward = bool(getattr(tool, "forward_auth_token", False))
+    client = create_external_mcp_client(
+        config=tool.mcp_config,
+        tool_definition=tool,
+        oauth_token=oauth_token if (forward or tool.requires_oauth_provider) else None,
+    )
+    if client is None:
+        snapshot.error = "Could not build a client for this server."
+        return snapshot
+
+    def _probe() -> ToolCapabilitySnapshot:
+        # One session for both listings — a second connect would double the
+        # handshake cost and, for a 3LO server, the token round-trip with it.
+        with client:
+            try:
+                prompts, prompts_truncated = _paginate(
+                    lambda cursor: client.list_prompts_sync(pagination_token=cursor),
+                    _prompt_entries,
+                )
+                snapshot.prompts = prompts
+                snapshot.supports_prompts = True
+                snapshot.truncated = snapshot.truncated or prompts_truncated
+            except Exception as exc:  # noqa: BLE001 - unsupported is the common case
+                logger.debug("prompts/list unavailable for %s: %s", tool.tool_id, exc)
+
+            resources: List[MCPResourceEntry] = []
+            supports_resources = False
+            try:
+                listed, listed_truncated = _paginate(
+                    lambda cursor: client.list_resources_sync(pagination_token=cursor),
+                    lambda result: _resource_entries(result, templates=False),
+                )
+                resources.extend(listed)
+                supports_resources = True
+                snapshot.truncated = snapshot.truncated or listed_truncated
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("resources/list unavailable for %s: %s", tool.tool_id, exc)
+
+            try:
+                templated, templated_truncated = _paginate(
+                    lambda cursor: client.list_resource_templates_sync(
+                        pagination_token=cursor
+                    ),
+                    lambda result: _resource_entries(result, templates=True),
+                )
+                resources.extend(templated)
+                supports_resources = True
+                snapshot.truncated = snapshot.truncated or templated_truncated
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "resources/templates/list unavailable for %s: %s",
+                    tool.tool_id,
+                    exc,
+                )
+
+            snapshot.resources = resources[:MAX_CAPABILITY_ENTRIES]
+            snapshot.supports_resources = supports_resources
+            return snapshot
+
+    try:
+        return await asyncio.to_thread(_probe)
+    except Exception as exc:  # noqa: BLE001 - surfaced to the caller as `error`
+        logger.warning("Capability discovery failed for %s: %s", tool.tool_id, exc)
+        snapshot.error = f"Could not reach the MCP server: {exc}"
+        return snapshot

--- a/backend/src/apis/app_api/tools/routes.py
+++ b/backend/src/apis/app_api/tools/routes.py
@@ -25,6 +25,7 @@ from apis.shared.tools.models import (
     UserToolsResponse,
     ToolPreferencesRequest,
     MCPDiscoverResponse,
+    ToolCapabilitySnapshot,
 )
 
 logger = logging.getLogger(__name__)
@@ -163,6 +164,34 @@ async def discover_my_tool_tools(
         raise HTTPException(status_code=502, detail=str(exc))
 
     return MCPDiscoverResponse(tools=tools)
+
+
+@router.get("/{tool_id}/capabilities", response_model=ToolCapabilitySnapshot)
+async def get_my_tool_capabilities(
+    tool_id: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """The stored prompts/resources snapshot for a tool the user can access.
+
+    Reads the persisted snapshot rather than probing the server. A detail view
+    has to render immediately, a 3LO server cannot be probed without the user's
+    consent token, and a catalogue of thirty servers opening a session each
+    would be unusable. Refreshing is an admin action.
+
+    A tool that has never been discovered returns an empty snapshot with
+    ``discoveredAt: null`` rather than a 404 — "nobody has asked this server
+    yet" is a state the UI should render, not an error.
+    """
+    service = get_tool_catalog_service()
+
+    # RBAC: same gate as the per-tool discover route — the user must already
+    # have access to this catalog tool.
+    accessible = await service.get_user_accessible_tools(user)
+    if not any(t.tool_id == tool_id for t in accessible):
+        raise HTTPException(status_code=404, detail="Tool not found or not accessible")
+
+    snapshot = await service.repository.get_capabilities(tool_id)
+    return snapshot or ToolCapabilitySnapshot(tool_id=tool_id)
 
 
 # =============================================================================

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -1469,3 +1469,164 @@ class GatewayTargetStatusResponse(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+
+
+# =============================================================================
+# MCP capability snapshot
+# =============================================================================
+#
+# An MCP server exposes three listings: tools, prompts and resources. The stack
+# has only ever called ``tools/list``, so prompts and resources were invisible
+# to every surface in the product.
+#
+# The snapshot is stored beside the catalog row (``PK=TOOL#<id>, SK=CAPABILITIES``)
+# rather than inside it, on purpose. The catalog row is read on the agent build
+# path; prompts and resources are of no use to the agent today, and folding a few
+# KB of prompt text into an item read on every turn would be a latency and cost
+# regression for a feature the agent does not consume.
+
+
+# A single stored snapshot is bounded well under the 400KB DynamoDB item limit.
+# Servers are free to expose hundreds of resources, and a description can be a
+# whole docstring, so both the per-entry text and the entry counts are capped.
+MAX_CAPABILITY_ENTRIES = 200
+MAX_CAPABILITY_TEXT = 500
+# Guards against a server that paginates forever.
+MAX_CAPABILITY_PAGES = 20
+
+
+def _clip(value: Optional[str]) -> Optional[str]:
+    """Bound a single description/title so one verbose entry can't blow the item."""
+    if value is None:
+        return None
+    text = value.strip()
+    if len(text) <= MAX_CAPABILITY_TEXT:
+        return text
+    return text[: MAX_CAPABILITY_TEXT - 1] + "…"
+
+
+class MCPPromptEntry(BaseModel):
+    """A prompt template exposed by an MCP server (``prompts/list``)."""
+
+    name: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    arguments: List[str] = Field(
+        default_factory=list,
+        description="Argument names the prompt accepts, in the order the server listed them.",
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "arguments": self.arguments,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MCPPromptEntry":
+        return cls(
+            name=data.get("name", ""),
+            title=data.get("title"),
+            description=data.get("description"),
+            arguments=list(data.get("arguments") or []),
+        )
+
+
+class MCPResourceEntry(BaseModel):
+    """A resource exposed by an MCP server (``resources/list``).
+
+    ``uri_template`` is set for entries that came from
+    ``resources/templates/list`` — those are patterns such as
+    ``canvas://courses/{course_id}/syllabus`` rather than concrete URIs, and a
+    caller has to fill the placeholders before reading one.
+    """
+
+    uri: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    mime_type: Optional[str] = Field(None, alias="mimeType")
+    uri_template: bool = Field(default=False, alias="uriTemplate")
+
+    model_config = {"populate_by_name": True}
+
+    def to_dict(self) -> dict:
+        return {
+            "uri": self.uri,
+            "name": self.name,
+            "description": self.description,
+            "mimeType": self.mime_type,
+            "uriTemplate": self.uri_template,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MCPResourceEntry":
+        return cls(
+            uri=data.get("uri", ""),
+            name=data.get("name"),
+            description=data.get("description"),
+            mime_type=data.get("mimeType"),
+            uri_template=bool(data.get("uriTemplate", False)),
+        )
+
+
+class ToolCapabilitySnapshot(BaseModel):
+    """What one MCP server told us it offers, and when it said so.
+
+    Persisted so a detail view never has to open a live MCP session to render.
+    A 31-card catalogue opening one session per server would be unusable, and
+    OAuth-gated servers cannot be reached at all without a consent token.
+
+    ``supports_prompts`` / ``supports_resources`` record whether the server
+    answered the listing at all. A server that does not implement prompts
+    returns a JSON-RPC "method not found", which is a different fact from a
+    server that implements prompts and has none — and the UI should say
+    different things about each.
+    """
+
+    tool_id: str = Field(..., alias="toolId")
+    prompts: List[MCPPromptEntry] = Field(default_factory=list)
+    resources: List[MCPResourceEntry] = Field(default_factory=list)
+    supports_prompts: bool = Field(default=False, alias="supportsPrompts")
+    supports_resources: bool = Field(default=False, alias="supportsResources")
+    discovered_at: Optional[str] = Field(None, alias="discoveredAt")
+    discovered_by: Optional[str] = Field(None, alias="discoveredBy")
+    #: Set when the last attempt failed, so the UI can distinguish "this server
+    #: offers nothing" from "we could not ask".
+    error: Optional[str] = None
+    #: True when a listing was cut short by the entry cap above.
+    truncated: bool = Field(default=False)
+
+    model_config = {"populate_by_name": True}
+
+    def to_dynamo_item(self) -> dict:
+        return {
+            "PK": f"TOOL#{self.tool_id}",
+            "SK": "CAPABILITIES",
+            "toolId": self.tool_id,
+            "prompts": [p.to_dict() for p in self.prompts],
+            "resources": [r.to_dict() for r in self.resources],
+            "supportsPrompts": self.supports_prompts,
+            "supportsResources": self.supports_resources,
+            "discoveredAt": self.discovered_at,
+            "discoveredBy": self.discovered_by,
+            "error": self.error,
+            "truncated": self.truncated,
+        }
+
+    @classmethod
+    def from_dynamo_item(cls, item: dict) -> "ToolCapabilitySnapshot":
+        return cls(
+            tool_id=item.get("toolId", ""),
+            prompts=[MCPPromptEntry.from_dict(p) for p in item.get("prompts") or []],
+            resources=[
+                MCPResourceEntry.from_dict(r) for r in item.get("resources") or []
+            ],
+            supports_prompts=bool(item.get("supportsPrompts", False)),
+            supports_resources=bool(item.get("supportsResources", False)),
+            discovered_at=item.get("discoveredAt"),
+            discovered_by=item.get("discoveredBy"),
+            error=item.get("error"),
+            truncated=bool(item.get("truncated", False)),
+        )

--- a/backend/src/apis/shared/tools/repository.py
+++ b/backend/src/apis/shared/tools/repository.py
@@ -13,7 +13,12 @@ from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
 
-from .models import ToolDefinition, UserToolPreference, ToolStatus
+from .models import (
+    ToolCapabilitySnapshot,
+    ToolDefinition,
+    UserToolPreference,
+    ToolStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +67,53 @@ class ToolCatalogRepository:
             return ToolDefinition.from_dynamo_item(item)
         except ClientError as e:
             logger.error(f"Error getting tool {tool_id}: {e}")
+            raise
+
+    # =========================================================================
+    # MCP capability snapshots (PK=TOOL#{id}, SK=CAPABILITIES)
+    # =========================================================================
+
+    async def get_capabilities(
+        self, tool_id: str
+    ) -> Optional["ToolCapabilitySnapshot"]:
+        """The stored prompts/resources snapshot for a tool, or None if never discovered."""
+        try:
+            response = self._table.get_item(
+                Key={"PK": f"TOOL#{tool_id}", "SK": "CAPABILITIES"}
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return ToolCapabilitySnapshot.from_dynamo_item(item)
+        except ClientError as e:
+            logger.error(f"Error getting capabilities for {tool_id}: {e}")
+            raise
+
+    async def put_capabilities(
+        self, snapshot: "ToolCapabilitySnapshot"
+    ) -> "ToolCapabilitySnapshot":
+        """Write a capability snapshot, replacing any previous one.
+
+        Replace rather than merge: the snapshot is a point-in-time answer from
+        the server, and merging would keep prompts the server has since removed.
+        """
+        try:
+            self._table.put_item(Item=snapshot.to_dynamo_item())
+            return snapshot
+        except ClientError as e:
+            logger.error(
+                f"Error writing capabilities for {snapshot.tool_id}: {e}"
+            )
+            raise
+
+    async def delete_capabilities(self, tool_id: str) -> None:
+        """Drop a tool's snapshot — used when the tool itself is deleted."""
+        try:
+            self._table.delete_item(
+                Key={"PK": f"TOOL#{tool_id}", "SK": "CAPABILITIES"}
+            )
+        except ClientError as e:
+            logger.error(f"Error deleting capabilities for {tool_id}: {e}")
             raise
 
     async def list_tools(

--- a/backend/tests/apis/app_api/tools/test_capability_discovery.py
+++ b/backend/tests/apis/app_api/tools/test_capability_discovery.py
@@ -1,0 +1,264 @@
+"""Capability discovery: prompts + resources from a saved MCP server.
+
+The stack only ever called ``tools/list``. These cover the part that is easy to
+get wrong — a server that implements *some* of the three listings. Answering
+"method not found" to ``prompts/list`` is normal and must not cost us the
+resources listing, or the snapshot.
+
+The MCP client is stubbed; the logic under test is the guarding, pagination and
+capping around it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apis.app_api.tools.discovery import discover_capabilities_for_saved_tool
+from apis.shared.tools.models import (
+    MAX_CAPABILITY_ENTRIES,
+    MCPServerConfig,
+    ToolDefinition,
+    ToolProtocol,
+    ToolStatus,
+)
+
+
+class _StubClient:
+    """Stands in for strands' MCPClient as a context manager."""
+
+    def __init__(self, prompts=None, resources=None, templates=None):
+        self._prompts = prompts
+        self._resources = resources
+        self._templates = templates
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def _answer(self, payload, kind):
+        if payload is None:
+            # What a server that doesn't implement the method actually does.
+            raise RuntimeError(f"Method not found: {kind}")
+        return payload
+
+    def list_prompts_sync(self, pagination_token=None):
+        return self._answer(self._prompts, "prompts/list")
+
+    def list_resources_sync(self, pagination_token=None):
+        return self._answer(self._resources, "resources/list")
+
+    def list_resource_templates_sync(self, pagination_token=None):
+        return self._answer(self._templates, "resources/templates/list")
+
+
+def _tool(tool_id="canvas_faculty", protocol=ToolProtocol.MCP_EXTERNAL):
+    return ToolDefinition(
+        tool_id=tool_id,
+        display_name=tool_id,
+        description="x",
+        protocol=protocol,
+        status=ToolStatus.ACTIVE,
+        mcp_config=MCPServerConfig(server_url="https://example.com/mcp", tools=[]),
+    )
+
+
+def _prompts(*names):
+    return SimpleNamespace(
+        prompts=[
+            SimpleNamespace(
+                name=n,
+                title=None,
+                description=f"desc for {n}",
+                arguments=[SimpleNamespace(name="course_id")],
+            )
+            for n in names
+        ],
+        nextCursor=None,
+    )
+
+
+def _resources(*uris):
+    return SimpleNamespace(
+        resources=[
+            SimpleNamespace(uri=u, name=None, description=None, mimeType="text/plain")
+            for u in uris
+        ],
+        nextCursor=None,
+    )
+
+
+def _templates(*uris):
+    return SimpleNamespace(
+        resourceTemplates=[
+            SimpleNamespace(
+                uriTemplate=u, name=None, description=None, mimeType=None
+            )
+            for u in uris
+        ],
+        nextCursor=None,
+    )
+
+
+async def _run(tool, client):
+    """Patch at the source module: discovery imports it inside the function."""
+    with patch(
+        "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+        return_value=client,
+    ):
+        return await discover_capabilities_for_saved_tool(tool)
+
+
+@pytest.mark.asyncio
+async def test_collects_prompts_and_resources():
+    snapshot = await _run(
+        _tool(),
+        _StubClient(
+            prompts=_prompts("grade_summary"),
+            resources=_resources("canvas://a"),
+            templates=_templates("canvas://courses/{id}/syllabus"),
+        ),
+    )
+    assert snapshot.supports_prompts is True
+    assert snapshot.supports_resources is True
+    assert [p.name for p in snapshot.prompts] == ["grade_summary"]
+    assert snapshot.prompts[0].arguments == ["course_id"]
+    assert {r.uri for r in snapshot.resources} == {
+        "canvas://a",
+        "canvas://courses/{id}/syllabus",
+    }
+    # A template is not a readable URI — the UI has to say so.
+    assert [r.uri_template for r in snapshot.resources if "{id}" in r.uri] == [True]
+    assert snapshot.error is None
+
+
+@pytest.mark.asyncio
+async def test_a_server_without_prompts_still_yields_resources():
+    # The regression this guards: one unsupported listing taking the whole
+    # snapshot down with it.
+    snapshot = await _run(
+        _tool(),
+        _StubClient(prompts=None, resources=_resources("x://1"), templates=None),
+    )
+    assert snapshot.supports_prompts is False
+    assert snapshot.prompts == []
+    assert snapshot.supports_resources is True
+    assert len(snapshot.resources) == 1
+    assert snapshot.error is None
+
+
+@pytest.mark.asyncio
+async def test_a_server_with_neither_is_not_an_error():
+    snapshot = await _run(_tool(), _StubClient())
+    assert snapshot.supports_prompts is False
+    assert snapshot.supports_resources is False
+    # "Offers nothing" and "we couldn't ask" are different facts.
+    assert snapshot.error is None
+
+
+@pytest.mark.asyncio
+async def test_unreachable_server_records_an_error():
+    class _Boom(_StubClient):
+        def __enter__(self):
+            raise RuntimeError("connection refused")
+
+    snapshot = await _run(_tool(), _Boom())
+    assert snapshot.error is not None
+    assert "connection refused" in snapshot.error
+
+
+@pytest.mark.asyncio
+async def test_gateway_tools_are_not_probed():
+    # A Gateway target exposes no prompt or resource surface to ask.
+    snapshot = await _run(_tool(protocol=ToolProtocol.MCP_GATEWAY), _StubClient(prompts=_prompts("p")))
+    assert snapshot.prompts == []
+    assert snapshot.error is not None
+
+
+@pytest.mark.asyncio
+async def test_entries_are_capped_so_one_server_cannot_blow_the_item():
+    many = _resources(*[f"x://{i}" for i in range(MAX_CAPABILITY_ENTRIES + 50)])
+    snapshot = await _run(_tool(), _StubClient(resources=many))
+    assert len(snapshot.resources) == MAX_CAPABILITY_ENTRIES
+    assert snapshot.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_pagination_follows_the_cursor():
+    pages = [
+        SimpleNamespace(
+            resources=[
+                SimpleNamespace(
+                    uri="x://1", name=None, description=None, mimeType=None
+                )
+            ],
+            nextCursor="c1",
+        ),
+        SimpleNamespace(
+            resources=[
+                SimpleNamespace(
+                    uri="x://2", name=None, description=None, mimeType=None
+                )
+            ],
+            nextCursor=None,
+        ),
+    ]
+
+    class _Paged(_StubClient):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def list_resources_sync(self, pagination_token=None):
+            page = pages[self.calls]
+            self.calls += 1
+            return page
+
+        def list_prompts_sync(self, pagination_token=None):
+            raise RuntimeError("no prompts")
+
+        def list_resource_templates_sync(self, pagination_token=None):
+            raise RuntimeError("no templates")
+
+    snapshot = await _run(_tool(), _Paged())
+    assert {r.uri for r in snapshot.resources} == {"x://1", "x://2"}
+
+
+@pytest.mark.asyncio
+async def test_a_broken_cursor_cannot_loop_forever():
+    class _Endless(_StubClient):
+        def list_resources_sync(self, pagination_token=None):
+            return SimpleNamespace(
+                resources=[
+                    SimpleNamespace(
+                        uri="x://same", name=None, description=None, mimeType=None
+                    )
+                ],
+                nextCursor="always",
+            )
+
+        def list_prompts_sync(self, pagination_token=None):
+            raise RuntimeError("no prompts")
+
+        def list_resource_templates_sync(self, pagination_token=None):
+            raise RuntimeError("no templates")
+
+    snapshot = await _run(_tool(), _Endless())
+    assert snapshot.truncated is True
+
+
+@pytest.mark.asyncio
+async def test_long_descriptions_are_clipped():
+    long_desc = "x" * 5000
+    payload = SimpleNamespace(
+        prompts=[
+            SimpleNamespace(
+                name="p", title=None, description=long_desc, arguments=[]
+            )
+        ],
+        nextCursor=None,
+    )
+    snapshot = await _run(_tool(), _StubClient(prompts=payload))
+    assert len(snapshot.prompts[0].description) < 600


### PR DESCRIPTION
> Backend only, and **based on `develop`** — not stacked on the drawer PRs. Nothing here depends on them, and after #1031 stranded I did not want another stack.

## Why

An MCP server exposes three listings — **tools, prompts and resources** — and this stack has only ever called `tools/list`. Grepping the backend for `prompts/list` or `resources/list` returns nothing. Two thirds of what our servers offer has been invisible to every surface in the product.

This is the unlock for the Prompts/Resources tabs in the tool detail pane; that frontend work is a separate PR and has no data until this lands.

## Design decisions worth reviewing

**Each listing is guarded independently.** A server that implements tools but not prompts answers `prompts/list` with a JSON-RPC "method not found". That is normal. One unsupported listing must not cost us the other one, or the whole snapshot — there's a test named after exactly that regression.

**"Offers nothing" and "we couldn't ask" are different facts.** `supports_prompts` / `supports_resources` record whether the server answered at all, separately from `error`, which records a transport failure. The UI has to say different things about each.

**The snapshot lives beside the catalog row, not inside it** (`SK=CAPABILITIES`). The catalog row is read on the agent build path. Prompts and resources are of no use to the agent today, and folding a few KB of prompt text into an item read on every turn would be a latency and cost regression for a feature the agent doesn't consume.

**Two independent caps, because they fail differently.** Entry and text caps keep one chatty server well under the 400KB item limit; a separate page cap stops a server with a broken cursor from looping forever. Both are tested.

**3LO servers are probed with the admin's own vaulted token**, the same pattern `POST /admin/tools/discover` already uses. This is the fix for the six prod servers — Github Orgs, Github Repos, Travel Auth among them — that expose *nothing at all* today because discovery runs without a token. Caveat, unchanged from the existing tool listing: the snapshot reflects the admin's connection, and a provider that scope-filters by grant may show a user less.

**A failed probe is never written over a good snapshot.** Losing a working listing because a server was briefly down is worse than showing a slightly stale one, so the previous snapshot is returned with the error attached.

**Refresh is an admin action; users read the stored snapshot.** Probing per user per page view would open a live MCP session against every server in the catalog on every page load.

## Routes

| | |
|---|---|
| `POST /admin/tools/{id}/capabilities/refresh` | probe + persist |
| `GET /admin/tools/{id}/capabilities` | stored, no probe |
| `GET /tools/{id}/capabilities` | stored, RBAC-gated to tools the user can access |

A tool never discovered returns an empty snapshot with `discoveredAt: null` rather than a 404 — "nobody has asked this server yet" is a state to render, not an error.

## Deliberately not here

**Scheduled refresh.** It needs EventBridge plus a Lambda and belongs in its own change. Until then a snapshot is as fresh as the last admin refresh, which `discoveredAt` reports.

## Verification

`pytest tests/` — **8117 passed, 3 skipped**. 9 new tests covering partial support, unreachable servers, pagination, the cursor loop guard, entry caps and text clipping. Architecture boundary and admin-scope-coverage suites pass, so the new admin routes are properly scoped.

**Not verified against a live MCP server.** The MCP client is stubbed in tests; no server in dev has been probed for prompts or resources yet, because that needs this code deployed and an admin refresh. The first real run may turn up shape mismatches in what servers actually return — `list_resource_templates_sync` in particular is the least-exercised path. Worth a manual refresh against `canvas_faculty` or `excalidraw` on dev before this reaches prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
