### PR TITLE
chore(frontend): remove dead ToolProgress stream-parser plumbing

### DIFF
--- a/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
+++ b/frontend/ai.client/src/app/assistants/assistant-form/services/preview-chat.service.ts
@@ -151,7 +151,6 @@ export class PreviewChatService {
       // Unused callbacks for preview - just ignore these events
       onContentBlockStart: () => {},
       onContentBlockStop: () => {},
-      onToolProgress: () => {},
       onMetadata: () => {},
       onReasoning: () => {},
       onCitation: () => {},

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -44,7 +44,6 @@ import {
   type ContentBlockBuilder,
   type MessageBuilder,
   type SteeringAppliedEvent,
-  type ToolProgress,
   type ContentBlockDeltaEvent,
   type ContentBlockStartEvent,
   type ToolResultEventData,
@@ -59,9 +58,6 @@ enum StreamState {
   Completed = 'completed',
   Error = 'error',
 }
-
-// Re-export ToolProgress for backwards compatibility
-export type { ToolProgress };
 
 /**
  * Tools whose `content` input is a long document worth surfacing live (as a
@@ -109,9 +105,6 @@ interface ParserSessionState {
    * here instead and are folded in, in order, when that message finalizes.
    */
   steeringMessages: WritableSignal<Message[]>;
-
-  /** Tool progress indicator state */
-  toolProgress: WritableSignal<ToolProgress>;
 
   /**
    * Epoch ms of the last event received on this stream. Stamped on EVERY
@@ -187,7 +180,6 @@ export class StreamParserService {
   /** Stable per-session accessor signals (cached so callers can hold them). */
   private readonly allMessagesCache = new Map<string, Signal<Message[]>>();
   private readonly streamingMessageIdCache = new Map<string, Signal<string | null>>();
-  private readonly toolProgressCache = new Map<string, Signal<ToolProgress>>();
   private readonly modelRetryCache = new Map<string, Signal<ModelRetryEvent | null>>();
   private readonly lastEventAtCache = new Map<string, Signal<number>>();
   private readonly citationsCache = new Map<string, Signal<Citation[]>>();
@@ -213,11 +205,6 @@ export class StreamParserService {
    */
   streamingMessageIdFor(sessionId: string): Signal<string | null> {
     return this.cachedAccessor(this.streamingMessageIdCache, sessionId, (state) => state.streamingMessageId(), null);
-  }
-
-  /** Tool progress indicator state for a session. */
-  toolProgressFor(sessionId: string): Signal<ToolProgress> {
-    return this.cachedAccessor(this.toolProgressCache, sessionId, (state) => state.toolProgress(), { visible: false });
   }
 
   /**
@@ -421,7 +408,6 @@ export class StreamParserService {
       currentMessageBuilder,
       completedMessages,
       steeringMessages,
-      toolProgress: signal<ToolProgress>({ visible: false }),
       modelRetry: signal<ModelRetryEvent | null>(null),
       lastEventAt: signal<number>(Date.now()),
       error: signal<string | null>(null),
@@ -511,14 +497,12 @@ export class StreamParserService {
       onContentBlockDelta: (data) => this.handleContentBlockDelta(state, data),
       onContentBlockStop: (data) => this.handleContentBlockStop(state, data),
 
-      onToolUse: (data) => {
+      onToolUse: () => {
         // This turn has tool boundaries, so a follow-up typed from here can
         // land mid-turn. Drives the composer's placeholder wording.
         this.steering.markToolUsed(state.sessionId);
-        this.handleToolUseProgress(state, data);
       },
       onToolResult: (data) => this.handleToolResult(state, data),
-      onToolProgress: (progress) => state.toolProgress.set(progress),
 
       onModelRetry: (data: ModelRetryEvent) => {
         // Not viewed-session-scoped on purpose: this signal is read per
@@ -753,17 +737,6 @@ export class StreamParserService {
 
       return { ...builder, contentBlocks: newBlocks };
     });
-
-    // Show tool progress for tool_use blocks
-    if (blockType === 'tool_use' && data.toolUse) {
-      state.toolProgress.set({
-        visible: true,
-        toolName: data.toolUse.name,
-        toolUseId: data.toolUse.toolUseId,
-        message: `Running ${data.toolUse.name}...`,
-        startTime: Date.now(),
-      });
-    }
   }
 
   private handleContentBlockDelta(state: ParserSessionState, data: ContentBlockDeltaEvent): void {
@@ -843,26 +816,11 @@ export class StreamParserService {
 
       block.isComplete = true;
 
-      if (block.type === 'tool_use') {
-        state.toolProgress.set({ visible: false });
-      }
-
       const newBlocks = new Map(builder.contentBlocks);
       newBlocks.set(data.contentBlockIndex, { ...block });
 
       return { ...builder, contentBlocks: newBlocks };
     });
-  }
-
-  private handleToolUseProgress(state: ParserSessionState, data: {
-    tool_use: { name: string; tool_use_id: string; input: string };
-  }): void {
-    state.toolProgress.update((progress) => ({
-      ...progress,
-      visible: true,
-      toolName: data.tool_use.name,
-      toolUseId: data.tool_use.tool_use_id,
-    }));
   }
 
   private handleToolResult(state: ParserSessionState, data: ToolResultEventData): void {
@@ -914,8 +872,6 @@ export class StreamParserService {
 
       return { ...builder, contentBlocks: newBlocks };
     });
-
-    state.toolProgress.set({ visible: false });
   }
 
   private handleMessageStop(state: ParserSessionState, data: { stopReason: string }): void {
@@ -941,7 +897,6 @@ export class StreamParserService {
   private handleDone(state: ParserSessionState): void {
     this.finalizeCurrentMessage(state);
     state.isStreamComplete.set(true);
-    state.toolProgress.set({ visible: false });
     state.modelRetry.set(null);
     state.streamState = StreamState.Completed;
 
@@ -1102,7 +1057,6 @@ export class StreamParserService {
   private setError(state: ParserSessionState, message: string): void {
     state.error.set(message);
     state.isStreamComplete.set(true);
-    state.toolProgress.set({ visible: false });
     state.streamState = StreamState.Error;
   }
 

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/index.ts
@@ -103,5 +103,4 @@ export type {
   ContentBlockBuilder,
   MessageBuilder,
   ToolResultContent,
-  ToolProgress,
 } from './stream-parser-types';

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.spec.ts
@@ -623,8 +623,7 @@ describe('stream-parser-core', () => {
         onDone: vi.fn(),
         onError: vi.fn(),
         onMetadata: vi.fn(),
-        onReasoning: vi.fn(),
-        onToolProgress: vi.fn()
+        onReasoning: vi.fn()
       };
     });
 
@@ -645,21 +644,15 @@ describe('stream-parser-core', () => {
       expect(callbacks.onContentBlockDelta).toHaveBeenCalledWith(data);
     });
 
-    it('should call onToolUse and onToolProgress for valid tool_use', () => {
+    it('should call onToolUse for valid tool_use', () => {
       const data = { tool_use: { name: 'search', tool_use_id: 'id123' } };
       processStreamEvent('tool_use', data, callbacks);
       expect(callbacks.onToolUse).toHaveBeenCalledWith(data);
-      expect(callbacks.onToolProgress).toHaveBeenCalledWith({
-        visible: true,
-        toolName: 'search',
-        toolUseId: 'id123'
-      });
     });
 
-    it('should call onDone and hide tool progress for done event', () => {
+    it('should call onDone for done event', () => {
       processStreamEvent('done', null, callbacks);
       expect(callbacks.onDone).toHaveBeenCalled();
-      expect(callbacks.onToolProgress).toHaveBeenCalledWith({ visible: false });
     });
 
     it('should call onParseError for invalid event type', () => {

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-core.ts
@@ -46,7 +46,6 @@ import type {
   SessionTitleEvent,
   SteeringAppliedEvent,
   ModelRetryEvent,
-  ToolProgress,
 } from './stream-parser-types';
 import type { MetadataEvent } from '../../../session/services/models/content-types';
 
@@ -74,7 +73,6 @@ export interface StreamParserCallbacks {
   // Tool events
   onToolUse?: (data: ToolUseEvent) => void;
   onToolResult?: (data: ToolResultEventData) => void;
-  onToolProgress?: (progress: ToolProgress) => void;
 
   // Metadata and auxiliary events
   onMetadata?: (data: MetadataEvent) => void;
@@ -656,17 +654,6 @@ export function processStreamEvent(
       case 'content_block_start':
         if (validateContentBlockStartEvent(data)) {
           callbacks.onContentBlockStart?.(data);
-
-          // Emit tool progress for tool_use blocks
-          if (data.type === 'tool_use' && data.toolUse) {
-            callbacks.onToolProgress?.({
-              visible: true,
-              toolName: data.toolUse.name,
-              toolUseId: data.toolUse.toolUseId,
-              message: `Running ${data.toolUse.name}...`,
-              startTime: Date.now(),
-            });
-          }
         } else {
           callbacks.onParseError?.('content_block_start: invalid data structure');
         }
@@ -691,11 +678,6 @@ export function processStreamEvent(
       case 'tool_use':
         if (validateToolUseEvent(data)) {
           callbacks.onToolUse?.(data);
-          callbacks.onToolProgress?.({
-            visible: true,
-            toolName: data.tool_use.name,
-            toolUseId: data.tool_use.tool_use_id,
-          });
         } else {
           callbacks.onParseError?.('tool_use: invalid data structure');
         }
@@ -704,7 +686,6 @@ export function processStreamEvent(
       case 'tool_result':
         if (validateToolResultEvent(data)) {
           callbacks.onToolResult?.(data);
-          callbacks.onToolProgress?.({ visible: false });
         } else {
           callbacks.onParseError?.('tool_result: invalid data structure');
         }
@@ -720,7 +701,6 @@ export function processStreamEvent(
 
       case 'done':
         callbacks.onDone?.();
-        callbacks.onToolProgress?.({ visible: false });
         break;
 
       case 'error':

--- a/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
+++ b/frontend/ai.client/src/app/shared/utils/stream-parser/stream-parser-types.ts
@@ -488,14 +488,3 @@ export interface MessageBuilder {
   createdAt: string;
   isComplete: boolean;
 }
-
-/**
- * Tool progress state for UI feedback
- */
-export interface ToolProgress {
-  visible: boolean;
-  message?: string;
-  toolName?: string;
-  toolUseId?: string;
-  startTime?: number;
-}


### PR DESCRIPTION
## What

Removes the `ToolProgress` plumbing from the SPA stream parser. It was never wired to any UI.

`StreamParserService.toolProgressFor(sessionId)` had **no consumer anywhere outside its own spec** — no template bound it. So the ~6 `state.toolProgress.set(...)` writes in the service and the four `onToolProgress` emit sites in `stream-parser-core.ts` (emitting `Running ${toolName}...`) were feeding a signal nobody read.

It is also **superseded**, not merely unused: the live "Using `list_assignments`" status line and per-tool durations are driven by the `agent_status` SSE event and `ToolInsightService`. `toolProgress` was an earlier attempt at the same thing, and keeping both invites someone to wire up the wrong one.

## Changes

| File | Change |
|---|---|
| `stream-parser-types.ts` | Delete the `ToolProgress` interface |
| `stream-parser/index.ts` | Drop its barrel re-export |
| `stream-parser-core.ts` | Drop `onToolProgress` from `StreamParserCallbacks` + all 4 emit sites (`content_block_start`, `tool_use`, `tool_result`, `done`) |
| `stream-parser.service.ts` | Drop `toolProgressFor`, `toolProgressCache`, the `toolProgress` field on `ParserSessionState`, every write to it, and `handleToolUseProgress` (which existed only to write that signal) |
| `preview-chat.service.ts` | Drop the `onToolProgress: () => {}` stub |
| `stream-parser-core.spec.ts` | Drop the two `onToolProgress` assertions; the `tool_use` / `done` tests stay and still assert `onToolUse` / `onDone` |

### On deleting the exported type

The task flagged `ToolProgress` as needing an importer check before removal. A repo-wide grep finds **zero** importers outside the plumbing being deleted — including the `export type { ToolProgress }` in `stream-parser.service.ts` labelled "for backwards compatibility", which nothing consumed. So the type goes too. After this change `grep -rn "ToolProgress\|toolProgress"` over the repo returns nothing.

No behavior change: the signal had no readers.

## Verification

- `npx tsc --noEmit -p tsconfig.app.json` — clean (exit 0)
- `npx ng test` — **224 files / 2579 tests passed**, identical to the `develop` baseline measured on `7bbc8f98`

## Notes for the reviewer

- **Overlaps open PR #1034.** That PR (`feat(chat): condense tool calls and narrate what the agent is doing`) is the one that *adds* `agent_status` + `ToolInsightService`, and it is **still open against `develop`** — neither exists in `develop` yet. It also touches all four of the stream-parser files this PR edits (keeping the `toolProgress` lines as untouched context), so **whichever of the two merges second will need a conflict resolution** in `stream-parser.service.ts`, `stream-parser-core.ts`, `stream-parser-types.ts` and `index.ts`. The resolution is mechanical in either direction — take #1034's additions, drop the `toolProgress` lines — but merging #1034 first and rebasing this PR on top is the lower-friction order. The dead-code case here stands on its own regardless of #1034's fate.
- Two incidental tidy-ups that fall out of the deletion: `handleToolUseProgress` is gone, so the `onToolUse` handler now keeps only its `steering.markToolUsed(...)` call and no longer needs its `data` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)