### PR TITLE
feat(frontend): show MCP prompts and resources in the tool detail pane

### DIFF
--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.html
@@ -190,6 +190,116 @@
         }
       }
     </div>
+  } @else if (tab() === 'prompts') {
+    <div
+      role="tabpanel"
+      id="tool-detail-panel-prompts"
+      aria-labelledby="tool-detail-tab-prompts"
+      tabindex="0"
+    >
+      @if (capabilitiesLoading()) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading…</p>
+      } @else if (neverDiscovered()) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          Nobody has asked this server what prompts it offers yet. An administrator can
+          refresh it.
+        </p>
+      } @else if (!capabilities()?.supportsPrompts) {
+        <!--
+          Distinct from "has none": this server answered prompts/list with
+          "method not found", so prompts are not part of what it does.
+        -->
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          This server doesn’t offer prompts.
+        </p>
+      } @else if (prompts().length === 0) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          This server offers prompts, but none right now.
+        </p>
+      } @else {
+        <ul class="flex flex-col gap-2">
+          @for (prompt of prompts(); track prompt.name) {
+            <li class="rounded-2xl border border-gray-200 px-3 py-2.5 dark:border-white/10">
+              <span class="block font-mono text-xs/5 font-medium text-gray-900 dark:text-white">{{
+                prompt.title || prompt.name
+              }}</span>
+              @if (prompt.description) {
+                <span class="mt-0.5 block text-xs/5 text-gray-500 dark:text-gray-400">{{
+                  prompt.description
+                }}</span>
+              }
+              @if (prompt.arguments.length > 0) {
+                <span class="mt-1 block font-mono text-[11px]/5 text-gray-400 dark:text-gray-500"
+                  >arguments: {{ prompt.arguments.join(', ') }}</span
+                >
+              }
+            </li>
+          }
+        </ul>
+      }
+    </div>
+  } @else if (tab() === 'resources') {
+    <div
+      role="tabpanel"
+      id="tool-detail-panel-resources"
+      aria-labelledby="tool-detail-tab-resources"
+      tabindex="0"
+    >
+      @if (capabilitiesLoading()) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">Loading…</p>
+      } @else if (neverDiscovered()) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          Nobody has asked this server what resources it offers yet. An administrator can
+          refresh it.
+        </p>
+      } @else if (!capabilities()?.supportsResources) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          This server doesn’t offer resources.
+        </p>
+      } @else if (resources().length === 0) {
+        <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+          This server offers resources, but none right now.
+        </p>
+      } @else {
+        <ul class="flex flex-col gap-2">
+          @for (resource of resources(); track resource.uri) {
+            <li class="rounded-2xl border border-gray-200 px-3 py-2.5 dark:border-white/10">
+              <span class="flex items-start gap-1.5">
+                <span
+                  class="min-w-0 flex-1 font-mono text-xs/5 font-medium break-all text-gray-900 dark:text-white"
+                  >{{ resource.uri }}</span
+                >
+                @if (resource.uriTemplate) {
+                  <!--
+                    A template is a pattern, not a readable URI — the
+                    placeholders have to be filled before anything can read it.
+                  -->
+                  <span
+                    class="shrink-0 rounded-sm bg-gray-100 px-1.5 font-mono text-[10px]/5 text-gray-600 dark:bg-white/10 dark:text-gray-300"
+                    >template</span
+                  >
+                }
+              </span>
+              @if (resource.name || resource.description) {
+                <span class="mt-0.5 block text-xs/5 text-gray-500 dark:text-gray-400">{{
+                  resource.description || resource.name
+                }}</span>
+              }
+              @if (resource.mimeType) {
+                <span class="mt-1 block font-mono text-[11px]/5 text-gray-400 dark:text-gray-500">{{
+                  resource.mimeType
+                }}</span>
+              }
+            </li>
+          }
+        </ul>
+      }
+      @if (capabilities()?.truncated) {
+        <p class="mt-3 text-xs/5 text-gray-400 dark:text-gray-500">
+          This server exposes more than we store; the list above is capped.
+        </p>
+      }
+    </div>
   } @else {
     <div
       role="tabpanel"

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
@@ -3,6 +3,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { ToolDetailComponent } from './tool-detail.component';
 import { Tool, ToolService } from '../../../services/tool/tool.service';
+import { ToolCapabilityService } from '../../../services/tool-capability/tool-capability.service';
 
 /**
  * Rendered rather than instantiated: the point of this component is what the
@@ -11,6 +12,7 @@ import { Tool, ToolService } from '../../../services/tool/tool.service';
  */
 describe('ToolDetailComponent', () => {
   let mockToolService: any;
+  let mockCapabilityService: any;
   let fixture: ComponentFixture<ToolDetailComponent>;
 
   const mcpServer: Tool = {
@@ -57,9 +59,26 @@ describe('ToolDetailComponent', () => {
       discoverServerTools: vi.fn().mockResolvedValue(undefined),
     };
 
+    mockCapabilityService = {
+      snapshots: {} as Record<string, any>,
+      loading: new Set<string>(),
+      ensure: vi.fn().mockResolvedValue(undefined),
+      capabilitiesFor(toolId: string) {
+        return this.snapshots[toolId] ?? null;
+      },
+      isLoading(toolId: string) {
+        return this.loading.has(toolId);
+      },
+      hasFailed: () => false,
+      invalidate: vi.fn(),
+    };
+
     TestBed.configureTestingModule({
       imports: [ToolDetailComponent],
-      providers: [{ provide: ToolService, useValue: mockToolService }],
+      providers: [
+        { provide: ToolService, useValue: mockToolService },
+        { provide: ToolCapabilityService, useValue: mockCapabilityService },
+      ],
     });
   });
 
@@ -83,12 +102,25 @@ describe('ToolDetailComponent', () => {
     expect(text()).toContain('Search the mailbox.');
   });
 
-  it('shows a tab strip with the tool count for an MCP server', () => {
+  it('shows Tools, Prompts, Resources and About for an external MCP server', () => {
     render(mcpServer);
-    const tabs = fixture.nativeElement.querySelectorAll('[role="tab"]');
-    expect(tabs.length).toBe(2);
-    expect(tabs[0].textContent).toContain('Tools');
-    expect(tabs[0].textContent).toContain('2');
+    const tabs = [...fixture.nativeElement.querySelectorAll('[role="tab"]')];
+    expect(tabs.map((t: any) => t.textContent.replace(/\s+/g, ' ').trim())).toEqual([
+      'Tools 2',
+      'Prompts 0',
+      'Resources 0',
+      'About',
+    ]);
+  });
+
+  it('offers no prompts or resources tab for a Gateway target', () => {
+    // A Gateway target exposes tools only — there is no server to ask.
+    render({ ...mcpServer, protocol: 'mcp' });
+    const labels = [...fixture.nativeElement.querySelectorAll('[role="tab"]')].map(
+      (t: any) => t.textContent.trim()
+    );
+    expect(labels.some((l: string) => l.startsWith('Prompts'))).toBe(false);
+    expect(labels.some((l: string) => l.startsWith('Resources'))).toBe(false);
   });
 
   it('gives a plain tool no tab strip and opens it on About', () => {
@@ -162,13 +194,116 @@ describe('ToolDetailComponent', () => {
     expect(fixture.componentInstance['tab']()).toBe('tools');
   });
 
-  it('moves between tabs with the arrow keys', () => {
+  it('moves between tabs with the arrow keys and wraps', () => {
     render(mcpServer);
-    const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-    fixture.componentInstance['onTabKeydown'](event);
-    expect(fixture.componentInstance['tab']()).toBe('about');
+    const right = () =>
+      fixture.componentInstance['onTabKeydown'](
+        new KeyboardEvent('keydown', { key: 'ArrowRight' })
+      );
 
-    fixture.componentInstance['onTabKeydown'](new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    right();
+    expect(fixture.componentInstance['tab']()).toBe('prompts');
+    right();
+    expect(fixture.componentInstance['tab']()).toBe('resources');
+    right();
+    expect(fixture.componentInstance['tab']()).toBe('about');
+    right();
     expect(fixture.componentInstance['tab']()).toBe('tools');
+  });
+
+  describe('prompts and resources', () => {
+    const snapshot = (over: Partial<any> = {}) => ({
+      toolId: 'gmail_employee',
+      prompts: [],
+      resources: [],
+      supportsPrompts: false,
+      supportsResources: false,
+      discoveredAt: '2026-09-01T00:00:00Z',
+      discoveredBy: 'admin',
+      error: null,
+      truncated: false,
+      ...over,
+    });
+
+    it('loads the snapshot for the tool being shown', () => {
+      render(mcpServer);
+      expect(mockCapabilityService.ensure).toHaveBeenCalledWith('gmail_employee');
+    });
+
+    it('lists prompts with their arguments', () => {
+      mockCapabilityService.snapshots['gmail_employee'] = snapshot({
+        supportsPrompts: true,
+        prompts: [
+          {
+            name: 'summarise_unread',
+            title: null,
+            description: 'Group unread mail by thread.',
+            arguments: ['since'],
+          },
+        ],
+      });
+      render(mcpServer);
+      fixture.componentInstance['tab'].set('prompts');
+      fixture.detectChanges();
+
+      expect(text()).toContain('summarise_unread');
+      expect(text()).toContain('Group unread mail by thread.');
+      expect(text()).toContain('since');
+    });
+
+    it('separates "offers no prompts" from "never asked"', () => {
+      // The server answered prompts/list with "method not found".
+      mockCapabilityService.snapshots['gmail_employee'] = snapshot({
+        supportsPrompts: false,
+      });
+      render(mcpServer);
+      fixture.componentInstance['tab'].set('prompts');
+      fixture.detectChanges();
+      expect(text()).toContain('doesn’t offer prompts');
+
+      // Nobody has run a discovery against it at all.
+      mockCapabilityService.snapshots['gmail_employee'] = snapshot({
+        discoveredAt: null,
+      });
+      fixture.componentRef.setInput('tool', { ...mcpServer });
+      fixture.componentInstance['tab'].set('prompts');
+      fixture.detectChanges();
+      expect(text()).toContain('Nobody has asked this server');
+    });
+
+    it('marks a resource template as a pattern rather than a readable URI', () => {
+      mockCapabilityService.snapshots['gmail_employee'] = snapshot({
+        supportsResources: true,
+        resources: [
+          {
+            uri: 'canvas://courses/{course_id}/syllabus',
+            name: null,
+            description: null,
+            mimeType: null,
+            uriTemplate: true,
+          },
+        ],
+      });
+      render(mcpServer);
+      fixture.componentInstance['tab'].set('resources');
+      fixture.detectChanges();
+
+      expect(text()).toContain('canvas://courses/{course_id}/syllabus');
+      expect(text()).toContain('template');
+    });
+
+    it('says when the stored list was capped', () => {
+      mockCapabilityService.snapshots['gmail_employee'] = snapshot({
+        supportsResources: true,
+        truncated: true,
+        resources: [
+          { uri: 'x://1', name: null, description: null, mimeType: null, uriTemplate: false },
+        ],
+      });
+      render(mcpServer);
+      fixture.componentInstance['tab'].set('resources');
+      fixture.detectChanges();
+      expect(text()).toContain('capped');
+    });
   });
 });

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   input,
   linkedSignal,
@@ -10,9 +11,10 @@ import {
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroArrowPath, heroLockClosed } from '@ng-icons/heroicons/outline';
 import { Tool, ToolService } from '../../../services/tool/tool.service';
+import { ToolCapabilityService } from '../../../services/tool-capability/tool-capability.service';
 
 /** Which panel of the detail view is showing. */
-export type ToolDetailTab = 'tools' | 'about';
+export type ToolDetailTab = 'tools' | 'prompts' | 'resources' | 'about';
 
 /**
  * The second pane of the tools drawer: everything about one tool that a row
@@ -25,11 +27,16 @@ export type ToolDetailTab = 'tools' | 'about';
  * detail gets the drawer's full width, and the list keeps its scroll position
  * underneath.
  *
- * Deliberately absent: MCP **prompts** and **resources**. The backend only ever
- * calls `tools/list` (see `app_api/tools/discovery.py`); there is no
- * `prompts/list` or `resources/list` call anywhere in the stack, so a tab for
- * either would be an empty promise. The strip is built to take them once
- * discovery exists.
+ * Prompts and resources come from the stored capability snapshot, never a live
+ * probe: probing opens an MCP session per server, and a 3LO server cannot be
+ * reached without a consent token the browser does not hold. An admin refreshes
+ * the snapshot; this pane reads it.
+ *
+ * They are read-only here. Acting on them needs two MCP methods the backend
+ * does not expose yet — `prompts/get` to expand a template's arguments into
+ * real text, and `resources/read` to fetch a resource's contents — so an
+ * "Insert" that pasted a prompt's *name* into the composer would be a worse
+ * answer than none.
  */
 @Component({
   selector: 'app-tool-detail',
@@ -41,8 +48,18 @@ export type ToolDetailTab = 'tools' | 'about';
 })
 export class ToolDetailComponent {
   protected readonly toolService = inject(ToolService);
+  private readonly capabilityService = inject(ToolCapabilityService);
 
   readonly tool = input.required<Tool>();
+
+  constructor() {
+    // Load the snapshot when a tool is shown. Keyed on the id so drilling into
+    // a second server fetches its own; `ensure` is a no-op for one already
+    // cached, so re-opening the same tool costs nothing.
+    effect(() => {
+      void this.capabilityService.ensure(this.tool().toolId);
+    });
+  }
 
   protected readonly isMcpServer = computed(() => {
     const protocol = this.tool().protocol;
@@ -69,10 +86,41 @@ export class ToolDetailComponent {
 
   protected readonly subTools = computed(() => this.tool().serverTools ?? []);
 
-  protected readonly tabs = computed(() => [
-    { id: 'tools' as const, label: 'Tools', count: this.subTools().length },
-    { id: 'about' as const, label: 'About', count: null },
-  ]);
+  /** The stored snapshot for this tool, or null while loading / on failure. */
+  protected readonly capabilities = computed(() =>
+    this.capabilityService.capabilitiesFor(this.tool().toolId),
+  );
+
+  protected readonly capabilitiesLoading = computed(() =>
+    this.capabilityService.isLoading(this.tool().toolId),
+  );
+
+  protected readonly prompts = computed(() => this.capabilities()?.prompts ?? []);
+  protected readonly resources = computed(() => this.capabilities()?.resources ?? []);
+
+  /** Never discovered — distinct from "discovered and offers nothing". */
+  protected readonly neverDiscovered = computed(() => {
+    const snapshot = this.capabilities();
+    return !!snapshot && !snapshot.discoveredAt;
+  });
+
+  /**
+   * Prompts and resources are only offered for an external MCP server. A local
+   * tool has no server to ask, and a Gateway target exposes tools only.
+   */
+  protected readonly tabs = computed(() => {
+    const tabs: { id: ToolDetailTab; label: string; count: number | null }[] = [
+      { id: 'tools', label: 'Tools', count: this.subTools().length },
+    ];
+    if (this.tool().protocol === 'mcp_external') {
+      tabs.push(
+        { id: 'prompts', label: 'Prompts', count: this.prompts().length },
+        { id: 'resources', label: 'Resources', count: this.resources().length },
+      );
+    }
+    tabs.push({ id: 'about', label: 'About', count: null });
+    return tabs;
+  });
 
   /** Initials, so a row reads as an object rather than a line of text. */
   protected readonly monogram = computed(() => {

--- a/frontend/ai.client/src/app/services/tool-capability/tool-capability.service.spec.ts
+++ b/frontend/ai.client/src/app/services/tool-capability/tool-capability.service.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { ToolCapabilityService } from './tool-capability.service';
+import { ConfigService } from '../config.service';
+
+describe('ToolCapabilityService', () => {
+  let get: ReturnType<typeof vi.fn>;
+
+  const snapshot = (over: Partial<any> = {}) => ({
+    toolId: 'canvas_faculty',
+    prompts: [],
+    resources: [],
+    supportsPrompts: false,
+    supportsResources: false,
+    discoveredAt: '2026-09-01T00:00:00Z',
+    discoveredBy: 'admin',
+    error: null,
+    truncated: false,
+    ...over,
+  });
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    get = vi.fn().mockReturnValue(of(snapshot()));
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: { get } },
+        { provide: ConfigService, useValue: { appApiUrl: () => 'http://api' } },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  const service = () => TestBed.inject(ToolCapabilityService);
+
+  it('returns null before anything is loaded', () => {
+    expect(service().capabilitiesFor('canvas_faculty')).toBeNull();
+  });
+
+  it('loads and caches a snapshot', async () => {
+    const s = service();
+    await s.ensure('canvas_faculty');
+    expect(s.capabilitiesFor('canvas_faculty')?.toolId).toBe('canvas_faculty');
+    expect(get).toHaveBeenCalledWith('http://api/tools/canvas_faculty/capabilities');
+  });
+
+  it('fetches each tool once', async () => {
+    const s = service();
+    await s.ensure('canvas_faculty');
+    await s.ensure('canvas_faculty');
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a failed read on every render', async () => {
+    // The detail pane re-reads this on each change detection; retrying there
+    // would turn one dead endpoint into a request loop.
+    get.mockReturnValue(throwError(() => new Error('404')));
+    const s = service();
+    await s.ensure('canvas_faculty');
+    await s.ensure('canvas_faculty');
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(s.hasFailed('canvas_faculty')).toBe(true);
+    expect(s.capabilitiesFor('canvas_faculty')).toBeNull();
+  });
+
+  it('re-reads after invalidate', async () => {
+    const s = service();
+    await s.ensure('canvas_faculty');
+    s.invalidate('canvas_faculty');
+    await s.ensure('canvas_faculty');
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('encodes the tool id in the URL', async () => {
+    await service().ensure('weird/id');
+    expect(get).toHaveBeenCalledWith('http://api/tools/weird%2Fid/capabilities');
+  });
+
+  it('ignores an empty tool id', async () => {
+    await service().ensure('');
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ai.client/src/app/services/tool-capability/tool-capability.service.ts
+++ b/frontend/ai.client/src/app/services/tool-capability/tool-capability.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../config.service';
+
+/** A prompt template an MCP server exposes (`prompts/list`). */
+export interface McpPrompt {
+  name: string;
+  title?: string | null;
+  description?: string | null;
+  arguments: string[];
+}
+
+/**
+ * A resource an MCP server exposes. `uriTemplate` marks entries that came from
+ * `resources/templates/list` — those are patterns like
+ * `canvas://courses/{course_id}/syllabus`, not readable URIs.
+ */
+export interface McpResource {
+  uri: string;
+  name?: string | null;
+  description?: string | null;
+  mimeType?: string | null;
+  uriTemplate: boolean;
+}
+
+/**
+ * What a server last told us it offers.
+ *
+ * `supportsPrompts` / `supportsResources` are separate from `error` on purpose:
+ * a server that answers `prompts/list` with "method not found" offers no
+ * prompts, which is a different fact from one we could not reach at all. The
+ * two states read differently in the UI.
+ */
+export interface ToolCapabilities {
+  toolId: string;
+  prompts: McpPrompt[];
+  resources: McpResource[];
+  supportsPrompts: boolean;
+  supportsResources: boolean;
+  discoveredAt?: string | null;
+  discoveredBy?: string | null;
+  error?: string | null;
+  truncated: boolean;
+}
+
+type Entry =
+  | { state: 'loading' }
+  | { state: 'loaded'; value: ToolCapabilities }
+  | { state: 'failed' };
+
+/**
+ * Reads the stored capability snapshot for a tool.
+ *
+ * Deliberately a read of what an admin last discovered, never a live probe:
+ * probing opens an MCP session per server, and a 3LO server cannot be reached
+ * without a consent token the browser does not hold.
+ *
+ * Cached per tool for the life of the page — a snapshot only changes when an
+ * admin refreshes it, so re-fetching every time the detail pane opens would be
+ * a request per drill-in for an answer that rarely moves.
+ */
+@Injectable({ providedIn: 'root' })
+export class ToolCapabilityService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  private readonly entries = signal<Record<string, Entry>>({});
+
+  private url(toolId: string): string {
+    return `${this.config.appApiUrl()}/tools/${encodeURIComponent(toolId)}/capabilities`;
+  }
+
+  /** Snapshot for a tool, or null while loading / if the read failed. */
+  capabilitiesFor(toolId: string): ToolCapabilities | null {
+    const entry = this.entries()[toolId];
+    return entry?.state === 'loaded' ? entry.value : null;
+  }
+
+  isLoading(toolId: string): boolean {
+    return this.entries()[toolId]?.state === 'loading';
+  }
+
+  hasFailed(toolId: string): boolean {
+    return this.entries()[toolId]?.state === 'failed';
+  }
+
+  /**
+   * Fetch once per tool. A failed read is remembered rather than retried on
+   * every render — the detail pane re-reads this on each change detection, and
+   * retrying there would turn one dead endpoint into a request loop.
+   */
+  async ensure(toolId: string): Promise<void> {
+    if (!toolId || this.entries()[toolId]) return;
+    this.entries.update((current) => ({ ...current, [toolId]: { state: 'loading' } }));
+    try {
+      const value = await firstValueFrom(
+        this.http.get<ToolCapabilities>(this.url(toolId)),
+      );
+      this.entries.update((current) => ({
+        ...current,
+        [toolId]: { state: 'loaded', value },
+      }));
+    } catch {
+      this.entries.update((current) => ({ ...current, [toolId]: { state: 'failed' } }));
+    }
+  }
+
+  /** Drop a cached snapshot so the next `ensure` re-reads it. */
+  invalidate(toolId: string): void {
+    this.entries.update((current) => {
+      if (!(toolId in current)) return current;
+      const next = { ...current };
+      delete next[toolId];
+      return next;
+    });
+  }
+}


### PR DESCRIPTION
> Based on **`develop`**, not stacked. It touches `tool-detail.component.*`, which #1032 also touches — different regions, so expect at most a trivial import-block resolution for whichever lands second. After #1031 stranded I would rather resolve three lines by hand than risk another stack.
>
> **Needs #1035 deployed to show anything.** That PR adds `GET /tools/{id}/capabilities`. Without it every tab renders its "never discovered" state, which is correct behaviour but not a demo.

## What you get

An external MCP server's detail pane gains **Prompts** and **Resources** beside Tools and About — the thing a 320px row could never hold, and the reason this whole sequence started.

## Four states, deliberately not collapsed

Each tab distinguishes:

1. **Never discovered** — "Nobody has asked this server yet."
2. **Doesn't implement the listing** — the server answered `prompts/list` with "method not found".
3. **Implements it, has none.**
4. **Here's the list.**

Collapsing these into one empty message would tell someone their server offers nothing when in fact nobody has asked it. That distinction is why #1035 records `supportsPrompts` separately from `error`.

## Other judgment calls

**Read from the stored snapshot, never a live probe.** Probing opens an MCP session per server, and a 3LO server can't be reached without a consent token the browser doesn't hold. Cached per tool for the life of the page.

**A failed read is remembered, not retried.** The pane re-reads this on every change detection; retrying there turns one dead endpoint into a request loop. There's a test for it.

**Resource templates are labelled.** `canvas://courses/{course_id}/syllabus` is a pattern, not something anything can read — showing it as a plain resource invites a click that can't work.

**Gateway targets get neither tab.** The Gateway exposes tools only; there's no server on the other end to ask.

## What is *not* here, and why

**Prompts and resources are read-only. There is no Insert and no Attach.**

Acting on them needs two MCP methods the backend doesn't expose: `prompts/get`, to expand a template's arguments into actual text, and `resources/read`, to fetch contents. An MCP prompt is a *template* — inserting its `name` into the composer would paste `summarise_unread`, which is not a prompt. There's also no shared composer-draft service; `chat-input` keeps its text in a local signal.

I'd rather ship the listing honestly than a button that pastes an identifier. That's the natural next PR, and it's backend-first.

## Verification

`ng test` — **2592 passing across 225 files**. Two existing tab tests were updated rather than worked around: the strip is now four tabs for `mcp_external`, and `ArrowRight` from Tools lands on Prompts.

**Not verified in a browser.** The route it reads doesn't exist until #1035 deploys, so every pane would currently render the "never discovered" state. Once #1035 is on dev, `canvas_faculty` and `excalidraw` are the tools to check — and that's also the first real exercise of #1035's `list_resource_templates_sync` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
