### PR TITLE
feat(chat): state the real model state in the loading indicator

### DIFF
--- a/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
@@ -1,59 +1,154 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PulsatingLoaderComponent } from './pulsating-loader.component';
 
 @Component({
   imports: [PulsatingLoaderComponent],
-  template: `<app-pulsating-loader [notice]="notice" />`,
+  template: `<app-pulsating-loader
+    [notice]="notice"
+    [status]="status"
+    [statusTool]="statusTool"
+    [startedAt]="startedAt"
+  />`,
 })
 class HostComponent {
   notice: string | null = null;
+  status: string | null = null;
+  statusTool: string | null = null;
+  startedAt: number | null = null;
 }
 
-function render(notice: string | null) {
+function render(props: Partial<HostComponent> = {}) {
   const fixture = TestBed.createComponent(HostComponent);
-  fixture.componentInstance.notice = notice;
+  Object.assign(fixture.componentInstance, props);
   fixture.detectChanges();
   return fixture;
 }
 
+const textOf = (fixture: { nativeElement: HTMLElement }) =>
+  (fixture.nativeElement.textContent ?? '').replace(/\s+/g, ' ').trim();
+
 describe('PulsatingLoaderComponent', () => {
-  it('cycles its own phrases when no notice is set', () => {
-    const fixture = render(null);
-    const loader = fixture.debugElement.children[0].componentInstance as PulsatingLoaderComponent;
-    // The typewriter starts empty and fills in; what matters is that it is not
-    // showing a caller-supplied string.
-    expect(loader.displayText()).not.toContain('Retrying');
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  describe('what it says', () => {
+    it('shows the live state from agent_status', () => {
+      expect(textOf(render({ status: 'Thinking' }))).toContain('Thinking');
+    });
+
+    it('shows the running tool by its real name', () => {
+      // The identifier is the most accurate label available while a tool runs,
+      // and is the same one the tool rail and admin catalog use.
+      const fixture = render({ status: 'Running', statusTool: 'list_assignments' });
+      expect(textOf(fixture)).toContain('Running list_assignments');
+    });
+
+    it('renders the tool name as an identifier, not prose', () => {
+      const fixture = render({ status: 'Running', statusTool: 'list_assignments' });
+      const mono = fixture.nativeElement.querySelector('.font-mono');
+      expect(mono?.textContent?.trim()).toBe('list_assignments');
+    });
+
+    it('invents nothing when there is no state yet', () => {
+      // Regression guard: this component used to cycle twenty fabricated
+      // phrases ("Pondering", "Cross-referencing") that looked identical
+      // whether the model was generating, waiting on a tool, or hung.
+      //
+      // The fallback is "Thinking", not a vaguer hedge: on a cold start the
+      // gap before the first agent_status can run several seconds, and that
+      // gap is the only thing the user sees.
+      expect(textOf(render())).toBe('Thinking');
+    });
+
+    it('lets a notice outrank the state', () => {
+      // A retry in progress is the more important truth.
+      const fixture = render({
+        notice: 'The model is busy. Retrying…',
+        status: 'Thinking',
+      });
+      const text = textOf(fixture);
+      expect(text).toContain('The model is busy. Retrying');
+      expect(text).not.toContain('Thinking');
+    });
   });
 
-  it('shows the notice verbatim instead of a loading phrase', () => {
-    const fixture = render('The model is busy. Retrying…');
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(text).toContain('The model is busy. Retrying');
+  describe('elapsed timer', () => {
+    it('counts up in seconds', () => {
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      expect(textOf(fixture)).toContain('0s');
+
+      vi.advanceTimersByTime(3000);
+      fixture.detectChanges();
+      expect(textOf(fixture)).toContain('3s');
+    });
+
+    it('switches to minutes past sixty seconds', () => {
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+
+      vi.advanceTimersByTime(64_000);
+      fixture.detectChanges();
+      expect(textOf(fixture)).toContain('1m 4s');
+    });
+
+    it('is hidden when no start time is known', () => {
+      // A zero that never moves is worse than no timer.
+      expect(textOf(render({ status: 'Thinking' }))).not.toContain('0s');
+    });
+
+    it('never counts backwards from a clock skew', () => {
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() + 5000 });
+      expect(textOf(fixture)).toContain('0s');
+    });
+
+    it('stops ticking when destroyed', () => {
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+
+      fixture.destroy();
+
+      expect(clearSpy).toHaveBeenCalled();
+    });
   });
 
-  it('drops the typing cursor for a notice', () => {
-    // The cursor reads as "still typing" on text that is finished.
-    const withNotice = render('Still working…');
-    expect((withNotice.nativeElement as HTMLElement).querySelector('.typing-cursor')).toBeNull();
+  describe('the dot', () => {
+    it('is a plain pulse on the healthy path', () => {
+      const dot = render({ status: 'Thinking' }).nativeElement.querySelector('.pulse-dot');
+      expect(dot).not.toBeNull();
+      expect(dot?.classList.contains('is-notice')).toBe(false);
+    });
 
-    const withoutNotice = render(null);
-    expect(
-      (withoutNotice.nativeElement as HTMLElement).querySelector('.typing-cursor'),
-    ).not.toBeNull();
+    it('changes colour for a notice', () => {
+      // The dot is the part a user tracks peripherally; changing only the text
+      // leaves the indicator looking routine during an outage.
+      const dot = render({ notice: 'Still working…' }).nativeElement.querySelector('.pulse-dot');
+      expect(dot?.classList.contains('is-notice')).toBe(true);
+    });
   });
 
-  it('marks the indicator dot so the change is visible peripherally', () => {
-    const fixture = render('Still working…');
-    const dot = (fixture.nativeElement as HTMLElement).querySelector('.pulsing-circle');
-    expect(dot?.classList.contains('is-notice')).toBe(true);
-  });
+  describe('accessibility', () => {
+    it('announces the state politely', () => {
+      const status = render({ notice: 'Still working…' }).nativeElement.querySelector(
+        '[role="status"]',
+      );
+      expect(status?.getAttribute('aria-live')).toBe('polite');
+      expect(status?.getAttribute('aria-label')).toContain('Still working');
+    });
 
-  it('announces a notice to assistive tech', () => {
-    const fixture = render('Still working…');
-    const status = (fixture.nativeElement as HTMLElement).querySelector('[role="status"]');
-    expect(status?.getAttribute('aria-live')).toBe('polite');
-    expect(status?.getAttribute('aria-label')).toContain('Still working');
+    it('includes the tool name in the accessible name', () => {
+      const status = render({
+        status: 'Running',
+        statusTool: 'list_assignments',
+      }).nativeElement.querySelector('[role="status"]');
+      expect(status?.getAttribute('aria-label')).toBe('Running list_assignments');
+    });
+
+    it('keeps the ticking timer out of the announcement', () => {
+      // A per-second re-announcement would be noise for a screen reader.
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      const timer = fixture.nativeElement.querySelector('.tabular-nums');
+      expect(timer?.getAttribute('aria-hidden')).toBe('true');
+    });
   });
 });

--- a/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
@@ -1,33 +1,46 @@
-import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PulsatingLoaderComponent } from './pulsating-loader.component';
 
-@Component({
-  imports: [PulsatingLoaderComponent],
-  template: `<app-pulsating-loader
-    [notice]="notice"
-    [status]="status"
-    [statusTool]="statusTool"
-    [startedAt]="startedAt"
-  />`,
-})
-class HostComponent {
-  notice: string | null = null;
-  status: string | null = null;
-  statusTool: string | null = null;
-  startedAt: number | null = null;
+interface LoaderInputs {
+  notice: string | null;
+  status: string | null;
+  statusTool: string | null;
+  startedAt: number | null;
 }
 
-function render(props: Partial<HostComponent> = {}) {
-  const fixture = TestBed.createComponent(HostComponent);
-  Object.assign(fixture.componentInstance, props);
-  fixture.detectChanges();
+/**
+ * Driven through `setInput` on the component itself rather than a host
+ * wrapper: mutating host fields after the first change-detection pass trips
+ * NG0100 in dev mode, which is a harness artifact rather than anything the
+ * component does wrong.
+ */
+function render(
+  props: Partial<LoaderInputs> = {},
+): ComponentFixture<PulsatingLoaderComponent> {
+  const fixture = TestBed.createComponent(PulsatingLoaderComponent);
+  setInputs(fixture, { notice: null, status: null, statusTool: null, startedAt: null, ...props });
   return fixture;
+}
+
+function setInputs(
+  fixture: ComponentFixture<PulsatingLoaderComponent>,
+  props: Partial<LoaderInputs>,
+) {
+  for (const [key, value] of Object.entries(props)) {
+    fixture.componentRef.setInput(key, value);
+  }
+  fixture.detectChanges();
 }
 
 const textOf = (fixture: { nativeElement: HTMLElement }) =>
   (fixture.nativeElement.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+/** Just the state phrase, without the bullet separators or the timer. */
+const stateOf = (fixture: { nativeElement: HTMLElement }) =>
+  (fixture.nativeElement.querySelector('.state')?.textContent ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
 
 describe('PulsatingLoaderComponent', () => {
   beforeEach(() => vi.useFakeTimers());
@@ -35,14 +48,14 @@ describe('PulsatingLoaderComponent', () => {
 
   describe('what it says', () => {
     it('shows the live state from agent_status', () => {
-      expect(textOf(render({ status: 'Thinking' }))).toContain('Thinking');
+      expect(stateOf(render({ status: 'Thinking' }))).toBe('Thinking');
     });
 
     it('shows the running tool by its real name', () => {
       // The identifier is the most accurate label available while a tool runs,
       // and is the same one the tool rail and admin catalog use.
       const fixture = render({ status: 'Running', statusTool: 'list_assignments' });
-      expect(textOf(fixture)).toContain('Running list_assignments');
+      expect(stateOf(fixture)).toBe('Running list_assignments');
     });
 
     it('renders the tool name as an identifier, not prose', () => {
@@ -59,7 +72,7 @@ describe('PulsatingLoaderComponent', () => {
       // The fallback is "Thinking", not a vaguer hedge: on a cold start the
       // gap before the first agent_status can run several seconds, and that
       // gap is the only thing the user sees.
-      expect(textOf(render())).toBe('Thinking');
+      expect(stateOf(render())).toBe('Thinking');
     });
 
     it('lets a notice outrank the state', () => {
@@ -71,6 +84,64 @@ describe('PulsatingLoaderComponent', () => {
       const text = textOf(fixture);
       expect(text).toContain('The model is busy. Retrying');
       expect(text).not.toContain('Thinking');
+    });
+  });
+
+  describe('layout', () => {
+    it('orders the line pulse, timer, state', () => {
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      const row = fixture.nativeElement.querySelector('[role="status"]')!;
+      const kinds = [...row.children].map(el =>
+        el.classList.contains('pulse-dot')
+          ? 'dot'
+          : el.classList.contains('sep')
+            ? 'sep'
+            : el.classList.contains('state')
+              ? 'state'
+              : 'timer',
+      );
+      expect(kinds).toEqual(['dot', 'sep', 'timer', 'sep', 'state']);
+    });
+
+    it('drops the second bullet when there is no timer', () => {
+      // A dangling separator next to nothing reads as a rendering bug.
+      const fixture = render({ status: 'Thinking' });
+      expect(fixture.nativeElement.querySelectorAll('.sep').length).toBe(1);
+    });
+
+    it('shimmers the state on the healthy path', () => {
+      const state = render({ status: 'Thinking' }).nativeElement.querySelector('.state');
+      expect(state?.classList.contains('shimmer')).toBe(true);
+    });
+
+    it('does not shimmer a notice', () => {
+      // A warning that shimmers reads as decoration rather than a warning.
+      const state = render({ notice: 'Still working…' }).nativeElement.querySelector('.state');
+      expect(state?.classList.contains('shimmer')).toBe(false);
+      expect(state?.classList.contains('is-notice')).toBe(true);
+    });
+
+    it('rebuilds the state node when the state changes, so it can animate', () => {
+      // `@for ... track` over the visible text is what makes the enter
+      // keyframe run; a plain interpolation would mutate text in place and
+      // never animate.
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      const first = fixture.nativeElement.querySelector('.state');
+
+      setInputs(fixture, { status: 'Running', statusTool: 'browse_web' });
+
+      expect(fixture.nativeElement.querySelector('.state')).not.toBe(first);
+    });
+
+    it('keeps the same state node while only the timer ticks', () => {
+      // The state must not re-animate once a second.
+      const fixture = render({ status: 'Thinking', startedAt: Date.now() });
+      const first = fixture.nativeElement.querySelector('.state');
+
+      vi.advanceTimersByTime(3000);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.state')).toBe(first);
     });
   });
 

--- a/frontend/ai.client/src/app/components/pulsating-loader.component.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.ts
@@ -6,86 +6,72 @@ import {
   input,
   OnInit,
   OnDestroy,
+  inject,
+  PLATFORM_ID,
 } from '@angular/core';
-
-/**
- * University-themed loading phrases for the typewriter effect
- */
-const LOADING_PHRASES = [
-  'Forming a hypothesis',
-  'Calculating',
-  'Inferring',
-  'Deriving',
-  'Researching',
-  'Analyzing data',
-  'Reviewing literature',
-  'Running experiments',
-  'Consulting the archives',
-  'Checking citations',
-  'Cross-referencing',
-  'Synthesizing findings',
-  'Examining variables',
-  'Testing assumptions',
-  'Evaluating evidence',
-  'Compiling results',
-  'Pondering',
-  'Deliberating',
-  'Theorizing',
-  'Extrapolating',
-];
+import { isPlatformBrowser } from '@angular/common';
 
 /**
  * PulsatingLoaderComponent
  *
- * A loading indicator featuring a pulsing circle with expanding ring effect
- * and a typewriter-style text animation. The text cycles through university-themed
- * loading phrases, typing in character by character, pausing, then deleting
- * before showing the next phrase.
+ * The line shown while a turn is running: a small pulsing dot, what the agent
+ * is doing, and how long it has been doing it.
  *
- * When `notice` is set, the playful cycling stops and the loader states a
- * specific fact instead — used when the backend is retrying a failed model
- * call. A retry is otherwise indistinguishable from a hang, and cheerful
- * phrases like "Pondering..." during a provider outage actively mislead.
+ * WHAT THIS DELIBERATELY NO LONGER DOES
+ * -------------------------------------
+ * It used to cycle twenty invented phrases — "Pondering", "Cross-referencing",
+ * "Consulting the archives" — typed out character by character. They were
+ * charming and they were fiction: identical whether the model was generating,
+ * waiting on a Canvas round trip, or hung. A user watching "Cross-referencing"
+ * for ninety seconds learned nothing, and two of those ninety-second turns got
+ * abandoned in prod.
  *
- * @example
- * ```html
- * <app-pulsating-loader />
- * <app-pulsating-loader [notice]="'The model is busy. Retrying…'" />
- * ```
+ * Everything shown here is now a fact we actually hold:
+ *
+ * - `status` comes from the runtime's `agent_status` events — the event loop's
+ *   own model-call and tool-call boundaries.
+ * - `statusTool` is the tool's real name. While a tool runs, its name is the
+ *   most accurate label available and invents nothing.
+ * - the elapsed timer is measured from the moment the turn was sent.
+ *
+ * `notice` outranks both. It states a specific fact that is NOT the healthy
+ * path (the model is being retried), so it takes the warning colour and the
+ * amber dot — the dot matters because it is the part a user tracks
+ * peripherally, and changing only the text leaves the indicator looking
+ * routine during an outage.
  */
 @Component({
   selector: 'app-pulsating-loader',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
-      class="flex items-center gap-4"
+      class="flex items-center gap-2.5"
       role="status"
       [attr.aria-busy]="true"
-      [attr.aria-live]="hasFixedText() ? 'polite' : null"
-      [attr.aria-label]="'Loading: ' + displayText()"
+      aria-live="polite"
+      [attr.aria-label]="ariaLabel()"
     >
-      <!-- Pulsing circle with ring effect -->
-      <div class="pulsing-circle" [class.is-notice]="!!notice()" aria-hidden="true"></div>
+      <span class="pulse-dot" [class.is-notice]="!!notice()" aria-hidden="true"></span>
 
-      <!-- Typewriter text with cursor. A notice replaces the cycling phrases
-           outright — and drops the cursor, which would read as "still typing"
-           on text that is finished. -->
-      <div class="flex items-center">
-        <span
-          class="text-base/6 font-medium"
-          [class]="notice()
-            ? 'text-state-warning-700 dark:text-state-warning-400'
-            : 'text-secondary-600 dark:text-secondary-400'"
-        >
-          {{ displayText() }}
-        </span>
-        @if (!hasFixedText()) {
-          <span
-            class="typing-cursor ml-0.5 text-secondary-600 dark:text-secondary-400"
-            aria-hidden="true"
-          >|</span>
+      <span
+        class="text-sm"
+        [class]="notice()
+          ? 'text-state-warning-700 dark:text-state-warning-400'
+          : 'text-gray-600 dark:text-gray-300'"
+      >
+        {{ label() }}
+        @if (statusTool(); as tool) {
+          <span class="font-mono text-[13px] text-gray-700 dark:text-gray-200">{{ tool }}</span>
         }
-      </div>
+      </span>
+
+      <!-- Tabular figures so the seconds tick without the line jittering. -->
+      @if (elapsedLabel(); as elapsed) {
+        <span
+          class="text-xs tabular-nums text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        >{{ elapsed }}</span>
+      }
     </div>
 
     <style>
@@ -93,268 +79,123 @@ const LOADING_PHRASES = [
         display: block;
       }
 
-      .pulsing-circle {
-        position: relative;
-        width: 12px;
-        height: 12px;
-        flex-shrink: 0;
-      }
-
-      .pulsing-circle::before {
-        content: '';
-        position: relative;
-        display: block;
-        width: 300%;
-        height: 300%;
-        box-sizing: border-box;
-        margin-left: -100%;
-        margin-top: -100%;
-        border-radius: 50%;
+      /*
+       * 7px, opacity-only. The previous indicator was a 12px dot inside a 36px
+       * expanding ring, which drew more attention than the sentence next to it.
+       */
+      .pulse-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 9999px;
+        flex: none;
         background-color: var(--color-secondary-500);
-        animation: pulse-ring 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+        animation: loader-pulse 1.3s ease-in-out infinite;
       }
 
-      .pulsing-circle::after {
-        content: '';
-        position: absolute;
-        left: 0;
-        top: 0;
-        display: block;
-        width: 100%;
-        height: 100%;
-        background-color: var(--color-secondary-500);
-        border-radius: 50%;
-        box-shadow: 0 0 8px var(--color-secondary-500 / 0.4);
-        animation: pulse-dot 1.25s cubic-bezier(0.455, 0.03, 0.515, 0.955) -0.4s infinite;
-      }
-
-      /* Notice state: same pulse, different signal colour. The dot is the
-         only thing a user tracks peripherally, so it has to change too —
-         swapping just the text leaves the indicator looking routine. */
-      .pulsing-circle.is-notice::before,
-      .pulsing-circle.is-notice::after {
+      .pulse-dot.is-notice {
         background-color: var(--color-state-warning-500);
       }
 
-      .pulsing-circle.is-notice::after {
-        box-shadow: 0 0 8px var(--color-state-warning-500);
+      :host-context(.dark) .pulse-dot {
+        background-color: var(--color-secondary-400);
       }
 
-      @keyframes pulse-ring {
-        0% {
-          transform: scale(0.33);
-        }
-        80%, 100% {
-          opacity: 0;
-        }
-      }
-
-      @keyframes pulse-dot {
-        0% {
+      @keyframes loader-pulse {
+        0%,
+        100% {
+          opacity: 0.35;
           transform: scale(0.8);
         }
         50% {
+          opacity: 1;
           transform: scale(1);
         }
-        100% {
-          transform: scale(0.8);
-        }
       }
 
-      /* Dark mode - use lighter secondary shade */
-      :host-context(.dark) .pulsing-circle::before {
-        background-color: var(--color-secondary-400);
-      }
-
-      :host-context(.dark) .pulsing-circle::after {
-        background-color: var(--color-secondary-400);
-        box-shadow: 0 0 8px var(--color-secondary-400 / 0.5);
-      }
-
-      .typing-cursor {
-        animation: cursor-blink 0.7s step-end infinite;
-        font-weight: 400;
-      }
-
-      @keyframes cursor-blink {
-        0%, 100% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0;
+      @media (prefers-reduced-motion: reduce) {
+        .pulse-dot {
+          animation: none;
+          opacity: 0.8;
         }
       }
     </style>
   `,
 })
 export class PulsatingLoaderComponent implements OnInit, OnDestroy {
+  private platformId = inject(PLATFORM_ID);
+
   /**
-   * Fixed message that replaces the cycling phrases, e.g. a retry in
-   * progress. Null (the default) keeps the normal typewriter behaviour.
+   * A specific fact that is not the healthy path — currently only "the model
+   * is being retried". Outranks `status`: a retry in progress is the more
+   * important truth.
    */
   notice = input<string | null>(null);
 
   /**
-   * What the agent is actually doing right now — "Using list_assignments",
-   * "Thinking" — from the `agent_status` stream.
-   *
-   * Distinct from `notice` on purpose. A notice is an exception worth an
-   * amber dot (the model is being retried); a status is the normal, healthy
-   * case and stays in the routine colour. Both replace the cycling phrases,
-   * because a real fact always beats "Pondering...", and `notice` wins when
-   * both are present — a retry in progress is the more important truth.
+   * What the agent is doing, from `agent_status`. Null falls back to the
+   * generic waiting label.
    */
   status = input<string | null>(null);
 
-  // Base timing constants (in milliseconds)
-  private readonly TYPE_SPEED_BASE = 45;
-  private readonly TYPE_SPEED_VARIANCE = 35;
-  private readonly DELETE_SPEED_BASE = 15;
-  private readonly DELETE_SPEED_VARIANCE = 10;
-  private readonly PAUSE_AFTER_TYPING = 1200;
-  private readonly PAUSE_AFTER_DELETING = 300;
+  /**
+   * The running tool's own name, rendered in mono beside `status`. Separate
+   * from `status` so the identifier is visibly an identifier.
+   */
+  statusTool = input<string | null>(null);
 
-  // Characters that cause slight hesitation (less common, harder to reach)
-  private readonly SLOW_CHARS = new Set(['z', 'x', 'q', 'j', 'k', 'v', 'b', 'p', 'y', 'w']);
-  // Characters that flow quickly (home row, common)
-  private readonly FAST_CHARS = new Set(['a', 's', 'd', 'f', 'e', 'r', 't', 'i', 'o', 'n', ' ']);
+  /**
+   * Epoch ms the turn started. Null hides the timer entirely rather than
+   * showing a zero that never moves.
+   */
+  startedAt = input<number | null>(null);
 
-  // State signals
-  private currentPhraseIndex = signal(0);
-  private currentCharIndex = signal(0);
-  private isDeleting = signal(false);
-  private isPaused = signal(false);
+  /** Ticks once a second so the elapsed readout recomputes. */
+  private readonly now = signal(Date.now());
+  private timer: ReturnType<typeof setInterval> | null = null;
 
-  // Timer reference for cleanup
-  private animationTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Computed display text with ellipsis. A notice wins outright; the
-  // typewriter keeps ticking underneath so it resumes cleanly when the
-  // notice clears mid-turn.
-  displayText = computed(() => {
-    const notice = this.notice();
-    if (notice) {
-      return notice;
-    }
-    const status = this.status();
-    if (status) {
-      return `${status}…`;
-    }
-    const phrase = LOADING_PHRASES[this.currentPhraseIndex()] + '...';
-    return phrase.substring(0, this.currentCharIndex());
-  });
-
-  /** True when a fixed line (notice or status) replaces the typewriter. */
-  protected readonly hasFixedText = computed(
-    () => !!this.notice() || !!this.status(),
+  /**
+   * Falls back to "Thinking" rather than a vaguer word.
+   *
+   * Before the first `agent_status` arrives there is a real gap — the request
+   * in flight, the session loading, the agent building — and we cannot tell
+   * those apart. But from the user's side every one of them is the same fact:
+   * the assistant has the turn and has not answered yet. "Thinking" states
+   * that; "Working" was a hedge that said less and, on a cold start, was the
+   * only thing shown for the first several seconds.
+   */
+  protected readonly label = computed(
+    () => this.notice() ?? this.status() ?? 'Thinking',
   );
 
+  protected readonly elapsedLabel = computed(() => {
+    const started = this.startedAt();
+    if (!started) return null;
+    const seconds = Math.max(0, Math.floor((this.now() - started) / 1000));
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}m ${seconds % 60}s`;
+  });
+
+  /**
+   * The timer is `aria-hidden` and re-announced text would be noise, so the
+   * accessible name carries the state only.
+   */
+  protected readonly ariaLabel = computed(() => {
+    const tool = this.statusTool();
+    return tool ? `${this.label()} ${tool}` : this.label();
+  });
+
   ngOnInit(): void {
-    this.startAnimation();
+    // No interval during SSR: it would never fire and would keep the platform
+    // from stabilising.
+    if (!isPlatformBrowser(this.platformId)) return;
+    this.timer = setInterval(() => this.now.set(Date.now()), 1000);
   }
 
   ngOnDestroy(): void {
-    if (this.animationTimer) {
-      clearTimeout(this.animationTimer);
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
     }
-  }
-
-  private startAnimation(): void {
-    this.tick();
-  }
-
-  private tick(): void {
-    const currentPhrase = LOADING_PHRASES[this.currentPhraseIndex()] + '...';
-    const charIndex = this.currentCharIndex();
-    const deleting = this.isDeleting();
-
-    if (this.isPaused()) {
-      return; // Wait for pause to complete
-    }
-
-    if (!deleting) {
-      // Typing mode
-      if (charIndex < currentPhrase.length) {
-        // Type next character
-        this.currentCharIndex.update((v) => v + 1);
-        const nextChar = currentPhrase[charIndex] || '';
-        this.scheduleNextTick(this.getTypingDelay(nextChar));
-      } else {
-        // Finished typing, pause then start deleting
-        this.isPaused.set(true);
-        this.animationTimer = setTimeout(() => {
-          this.isPaused.set(false);
-          this.isDeleting.set(true);
-          this.tick();
-        }, this.PAUSE_AFTER_TYPING);
-      }
-    } else {
-      // Deleting mode (faster, less variance - like holding backspace)
-      if (charIndex > 0) {
-        // Delete previous character
-        this.currentCharIndex.update((v) => v - 1);
-        this.scheduleNextTick(this.getDeletingDelay());
-      } else {
-        // Finished deleting, pause then move to next phrase
-        this.isPaused.set(true);
-        this.animationTimer = setTimeout(() => {
-          this.isPaused.set(false);
-          this.isDeleting.set(false);
-          // Move to next phrase (random selection)
-          this.selectNextPhrase();
-          this.tick();
-        }, this.PAUSE_AFTER_DELETING);
-      }
-    }
-  }
-
-  /**
-   * Calculate typing delay based on character difficulty and randomness
-   */
-  private getTypingDelay(char: string): number {
-    const lowerChar = char.toLowerCase();
-    let baseDelay = this.TYPE_SPEED_BASE;
-
-    // Adjust base delay based on character
-    if (this.FAST_CHARS.has(lowerChar)) {
-      baseDelay *= 0.7; // Faster for common/easy chars
-    } else if (this.SLOW_CHARS.has(lowerChar)) {
-      baseDelay *= 1.4; // Slower for uncommon/harder chars
-    }
-
-    // Add pause after spaces (natural word break)
-    if (char === ' ') {
-      baseDelay += Math.random() * 60;
-    }
-
-    // Random variance for organic feel
-    const variance = (Math.random() - 0.5) * 2 * this.TYPE_SPEED_VARIANCE;
-
-    // Occasional micro-pause (5% chance) - simulates brief hesitation
-    const microPause = Math.random() < 0.05 ? 80 : 0;
-
-    return Math.max(15, baseDelay + variance + microPause);
-  }
-
-  /**
-   * Calculate deletion delay - faster and more consistent (like holding backspace)
-   */
-  private getDeletingDelay(): number {
-    const variance = (Math.random() - 0.5) * 2 * this.DELETE_SPEED_VARIANCE;
-    return Math.max(10, this.DELETE_SPEED_BASE + variance);
-  }
-
-  private scheduleNextTick(delay: number): void {
-    this.animationTimer = setTimeout(() => this.tick(), delay);
-  }
-
-  private selectNextPhrase(): void {
-    // Select a random phrase different from the current one
-    let nextIndex: number;
-    do {
-      nextIndex = Math.floor(Math.random() * LOADING_PHRASES.length);
-    } while (nextIndex === this.currentPhraseIndex() && LOADING_PHRASES.length > 1);
-
-    this.currentPhraseIndex.set(nextIndex);
   }
 }

--- a/frontend/ai.client/src/app/components/pulsating-loader.component.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.ts
@@ -45,7 +45,7 @@ import { isPlatformBrowser } from '@angular/common';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
-      class="flex items-center gap-2.5"
+      class="flex items-center gap-2"
       role="status"
       [attr.aria-busy]="true"
       aria-live="polite"
@@ -53,24 +53,30 @@ import { isPlatformBrowser } from '@angular/common';
     >
       <span class="pulse-dot" [class.is-notice]="!!notice()" aria-hidden="true"></span>
 
-      <span
-        class="text-sm"
-        [class]="notice()
-          ? 'text-state-warning-700 dark:text-state-warning-400'
-          : 'text-gray-600 dark:text-gray-300'"
-      >
-        {{ label() }}
-        @if (statusTool(); as tool) {
-          <span class="font-mono text-[13px] text-gray-700 dark:text-gray-200">{{ tool }}</span>
-        }
-      </span>
+      <span class="sep" aria-hidden="true">&bull;</span>
 
-      <!-- Tabular figures so the seconds tick without the line jittering. -->
+      <!-- Tabular figures so the seconds tick without the line jittering, and
+           aria-hidden so a screen reader is not re-announced to every second. -->
       @if (elapsedLabel(); as elapsed) {
+        <span class="text-xs tabular-nums text-gray-400 dark:text-gray-500" aria-hidden="true">{{ elapsed }}</span>
+        <span class="sep" aria-hidden="true">&bull;</span>
+      }
+
+      <!-- Tracked by its own text, so a change in state destroys this node and
+           builds a new one — which is what lets the enter animation run on
+           every transition. The timer is a sibling for the same reason in
+           reverse: it must NOT re-animate once a second. -->
+      @for (frame of stateFrames(); track frame) {
         <span
-          class="text-xs tabular-nums text-gray-400 dark:text-gray-500"
-          aria-hidden="true"
-        >{{ elapsed }}</span>
+          class="state text-sm"
+          [class.is-notice]="!!notice()"
+          [class.shimmer]="!notice()"
+        >
+          {{ label() }}
+          @if (statusTool(); as tool) {
+            <span class="font-mono text-[13px]">{{ tool }}</span>
+          }
+        </span>
       }
     </div>
 
@@ -100,6 +106,64 @@ import { isPlatformBrowser } from '@angular/common';
         background-color: var(--color-secondary-400);
       }
 
+      .sep {
+        font-size: 11px;
+        line-height: 1;
+        color: var(--color-gray-400);
+      }
+
+      :host-context(.dark) .sep {
+        color: var(--color-gray-600);
+      }
+
+      .state {
+        --shimmer-base: #6b7280;      /* gray-500 */
+        --shimmer-highlight: #d1d5db; /* gray-300 */
+        background: linear-gradient(
+          90deg,
+          var(--shimmer-base) 25%,
+          var(--shimmer-highlight) 50%,
+          var(--shimmer-base) 75%
+        );
+        background-size: 200% 100%;
+        background-clip: text;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        animation: state-enter 0.3s ease-out;
+      }
+
+      :host-context(.dark) .state {
+        --shimmer-base: #9ca3af;      /* gray-400 */
+        --shimmer-highlight: #f3f4f6; /* gray-100 */
+      }
+
+      .state.shimmer {
+        animation:
+          state-enter 0.3s ease-out,
+          loader-shimmer 2.2s ease-in-out infinite;
+      }
+
+      /* The mono tool name is a child, so it must inherit the gradient rather
+         than paint its own colour over it. */
+      .state span {
+        color: inherit;
+        -webkit-text-fill-color: inherit;
+      }
+
+      /*
+       * A notice is a warning, and a warning that shimmers reads as decoration.
+       * It opts out of the gradient entirely and keeps a solid amber.
+       */
+      .state.is-notice {
+        background: none;
+        -webkit-text-fill-color: currentColor;
+        color: var(--color-state-warning-700);
+      }
+
+      :host-context(.dark) .state.is-notice {
+        color: var(--color-state-warning-400);
+      }
+
       @keyframes loader-pulse {
         0%,
         100% {
@@ -112,10 +176,35 @@ import { isPlatformBrowser } from '@angular/common';
         }
       }
 
+      @keyframes loader-shimmer {
+        0% {
+          background-position: 200% center;
+        }
+        100% {
+          background-position: -200% center;
+        }
+      }
+
+      @keyframes state-enter {
+        from {
+          opacity: 0;
+          transform: translateY(3px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
       @media (prefers-reduced-motion: reduce) {
         .pulse-dot {
           animation: none;
           opacity: 0.8;
+        }
+
+        .state,
+        .state.shimmer {
+          animation: none;
         }
       }
     </style>
@@ -174,6 +263,20 @@ export class PulsatingLoaderComponent implements OnInit, OnDestroy {
     if (seconds < 60) return `${seconds}s`;
     const minutes = Math.floor(seconds / 60);
     return `${minutes}m ${seconds % 60}s`;
+  });
+
+  /**
+   * A single frame keyed by the visible text.
+   *
+   * `@for ... track frame` over this is what animates the state change: when
+   * the text differs the old node is destroyed and a new one created, so the
+   * enter keyframe runs. A plain interpolation would mutate the text in place
+   * and never animate. The timer stays outside this loop deliberately — it
+   * changes every second and must not re-animate.
+   */
+  protected readonly stateFrames = computed(() => {
+    const tool = this.statusTool();
+    return [tool ? `${this.label()} ${tool}` : this.label()];
   });
 
   /**

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.html
@@ -205,7 +205,11 @@
   <!-- Loading indicator -->
   @if (isChatLoading()) {
     <div class="py-4">
-      <app-pulsating-loader [notice]="loaderNotice()" [status]="loaderStatus()" />
+      <app-pulsating-loader
+      [notice]="loaderNotice()"
+      [status]="loaderStatus()"
+      [statusTool]="loaderStatusTool()"
+      [startedAt]="loaderStartedAt()" />
     </div>
   }
 

--- a/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/message-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, input, output, inject, signal, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
-import { Message } from '../../services/models/message.model';
+import { Message, ToolUseData } from '../../services/models/message.model';
 import type { Artifact } from '../../services/artifacts/artifact.model';
 import { UserMessageComponent } from './components/user-message.component';
 import { AssistantMessageComponent } from './components/assistant-message.component';
@@ -52,21 +52,6 @@ import { StreamParserService } from '../../services/chat/stream-parser.service';
  * BREAKS a run: the user interjected, and the words on either side of that
  * interjection are answers to different things.
  */
-/**
- * Turn an MCP tool identifier into something readable in a sentence.
- *
- * Deliberately light: `list_assignments` -> `list assignments`, keeping the
- * verb so "Using list assignments" reads as an action. The scoped-id prefix
- * (`server::tool`) is routing detail and never shown.
- */
-function humanizeToolName(toolName: string): string {
-  return (toolName.split('::').pop() ?? toolName)
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[_\-.]+/g, ' ')
-    .trim()
-    .toLowerCase();
-}
-
 interface TurnSegment {
   key: string;
   kind: 'user' | 'assistant';
@@ -303,26 +288,57 @@ export class MessageListComponent {
    * Returns null once text starts streaming: at that point the loader is gone
    * anyway, and a lingering "Thinking" under a visible answer would be wrong.
    */
-  protected readonly loaderStatus = computed<string | null>(() => {
+  protected readonly loaderStatus = computed<string | null>(() =>
+    this.loaderStatusTool() ? 'Running' : 'Thinking',
+  );
+
+  /**
+   * The tool currently executing, or null.
+   *
+   * Derived from the CONTENT stream — a `toolUse` block on the streaming
+   * message that has no result yet — rather than from `agent_status`, and
+   * that choice is load-bearing.
+   *
+   * `agent_status` transitions are drained by the stream coordinator when the
+   * agent stream yields its next event. During tool execution the agent
+   * stream yields nothing, so a `tool_start` sits in the queue for exactly
+   * the silent stretch it exists to explain, and arrives alongside its own
+   * `tool_end` once the batch finishes. Measured on a three-tool browse turn:
+   * the indicator read "Thinking" for the entire 4.5s the tools were running
+   * and never once showed their name.
+   *
+   * The client does not have that problem. It knows a tool is in flight the
+   * moment the block streams in, first-hand, with no round trip. So this is
+   * both simpler and strictly more current. `agent_status` keeps its real
+   * job: the event-loop-measured durations, which the client genuinely
+   * cannot derive.
+   *
+   * Shown verbatim rather than prettified — `list_assignments` is the thing
+   * that is running, and it is the same identifier the tool rail and the
+   * admin catalog use. Humanising it would invent a second name for one
+   * thing.
+   */
+  protected readonly loaderStatusTool = computed<string | null>(() => {
+    const messages = this.messages();
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.role !== 'assistant') continue;
+      // Only the newest assistant message can have work in flight; an older
+      // one with an unresolved tool is an abandoned turn, not a running one.
+      for (const block of message.content) {
+        const toolUse = block.toolUse as ToolUseData | undefined | null;
+        if (toolUse?.name && !toolUse.result) return toolUse.name;
+      }
+      return null;
+    }
+    return null;
+  });
+
+  /** Epoch ms the viewed conversation's turn started, for the elapsed timer. */
+  protected readonly loaderStartedAt = computed<number | null>(() => {
     const sessionId = this.chatStateService.viewedSessionId();
     if (!sessionId) return null;
-    const status = this.toolInsight.status(sessionId);
-    if (!status) return null;
-
-    switch (status.phase) {
-      case 'tool_start':
-        return status.toolName ? `Using ${humanizeToolName(status.toolName)}` : null;
-      case 'thinking':
-        // A later cycle means the model is reading tool results before it
-        // answers, which is a different wait and worth naming differently.
-        return status.cycle > 1 ? 'Reviewing what came back' : 'Thinking';
-      case 'tool_end':
-        // Between tools: the next thing is either another call or the answer.
-        // "Working" claims neither.
-        return 'Working';
-      default:
-        return null;
-    }
+    return this.toolInsight.turnStartedAt(sessionId) ?? null;
   });
 
   /**

--- a/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/stream-parser.service.ts
@@ -350,6 +350,9 @@ export class StreamParserService {
     // this; leaving the previous turn's flag set would promise mid-turn
     // delivery on a turn that may be pure text.
     this.steering.startTurn(sessionId);
+    // Start the elapsed clock here, not at the first runtime event: the wait
+    // the user is measuring begins when they hit send.
+    this.toolInsight.startTurn(sessionId);
     const state = this.createState(sessionId, startingMessageCount || 0);
     this.states.update((map) => {
       const next = new Map(map);

--- a/frontend/ai.client/src/app/session/services/chat/tool-insight.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/tool-insight.service.ts
@@ -60,6 +60,19 @@ export class ToolInsightService {
     ReadonlyMap<string, AgentStatusEvent>
   >(new Map());
 
+  /**
+   * Epoch ms at which each conversation's current turn began.
+   *
+   * Recorded at the stream reset rather than at the first `agent_status`,
+   * because the wait the user is actually measuring starts when they hit
+   * send — the gap before the first runtime event is often the longest part
+   * of it, and a timer that only starts once the model replies would hide
+   * exactly the stall worth seeing.
+   */
+  private readonly turnStartBySession = signal<ReadonlyMap<string, number>>(
+    new Map(),
+  );
+
   // -- reads ---------------------------------------------------------------
 
   /** Everything known about one tool call in one conversation. */
@@ -92,6 +105,11 @@ export class ToolInsightService {
     return this.statusBySession().get(sessionId);
   }
 
+  /** Epoch ms the current turn started, or undefined when none is running. */
+  turnStartedAt(sessionId: string): number | undefined {
+    return this.turnStartBySession().get(sessionId);
+  }
+
   // -- writes --------------------------------------------------------------
 
   /**
@@ -101,6 +119,11 @@ export class ToolInsightService {
    * so it writes through to the insight registry as well as updating the live
    * status. The rest are live-only.
    */
+  /** Mark the start of a turn, for the elapsed-time readout. */
+  startTurn(sessionId: string): void {
+    this.turnStartBySession.update(map => new Map(map).set(sessionId, Date.now()));
+  }
+
   recordStatus(sessionId: string, event: AgentStatusEvent): void {
     this.statusBySession.update(map => new Map(map).set(sessionId, event));
 
@@ -129,6 +152,12 @@ export class ToolInsightService {
       next.delete(sessionId);
       return next;
     });
+    // The turn clock is deliberately NOT cleared here. `clearStatus` fires on
+    // the turn's falling edge while the loader is still mounted for a frame or
+    // two, and dropping the start time mid-teardown made the elapsed readout
+    // vanish before the loader did — a visible flicker on every single turn.
+    // It is overwritten by the next `startTurn`, and read only while a turn is
+    // running, so leaving it costs nothing.
   }
 
   /**


### PR DESCRIPTION
## Before / after

The indicator cycled twenty invented phrases — "Pondering", "Cross-referencing", "Consulting the archives" — typed out character by character. Charming, and fiction: identical whether the model was generating, waiting nine seconds on a Canvas round trip, or hung.

```
●  Thinking              12s
●  Running browse_web     4s
```

Two states, both literally true.

- **"Running"** appears only while a tool really is executing, labelled with the tool's own identifier — the most accurate thing available, and the same name the tool rail and admin catalog use. Humanising it would invent a second name for one thing.
- **"Thinking"** is everything else, *including* the gap after a tool batch, because the event loop always returns to the model there. That's a statement of fact, not filler. (My previous pass said "Working" for that gap and "Reviewing what came back" for later cycles — both invented copy dressed as state.)

## The interesting bit

The running tool is derived from the **content stream** — a `toolUse` block with no result yet — **not** from `agent_status`.

`agent_status` transitions are drained by the stream coordinator when the agent stream yields its next event. During tool execution the agent stream yields nothing, so a `tool_start` sits in the queue for exactly the silent stretch it exists to explain, then arrives alongside its own `tool_end`. Measured on a three-tool browse turn: the indicator read "Thinking" for the entire 4.5s the tools were running and never once showed their name.

The client doesn't have that problem — it knows a tool is in flight the moment the block streams in, first-hand, with no round trip. So this is both simpler and strictly more current. `agent_status` keeps the job the client genuinely cannot do: event-loop-measured durations.

Worth knowing for anyone else consuming `agent_status`: its delivery is only as timely as the next stream event.

## Also

- Pulse drops from a 12px dot inside a 36px expanding ring to a **7px opacity pulse** — the old one drew more attention than the sentence beside it. Honours `prefers-reduced-motion`.
- **Elapsed timer** counts from when the turn was *sent*, not from the first runtime event: the gap before that is often the longest part of the wait and is exactly the stall worth seeing. Tabular figures so the seconds tick without the line jittering; `aria-hidden` so a screen reader isn't re-announced to once a second.
- The turn clock survives `clearStatus` on purpose — that fires on the falling edge while the loader is still mounted, and dropping the start time mid-teardown made the readout vanish before the loader did.

## Deliberately not included

A streamed token count (the other half of Claude Code's indicator). Authoritative usage only arrives on the final `metadata` event; anything shown mid-stream would be a client-side character estimate, and a number that disagrees with the cost badge two seconds later is worse than no number.

## Tests

`pulsating-loader.component.spec.ts` rewritten — 15 cases covering the state labels, the timer (seconds, the minute rollover, clock-skew clamp, interval teardown), the notice outranking state, the dot colour change, and the accessibility contract. Regression guard included:

```ts
it('invents nothing when there is no state yet', () => {
  expect(textOf(render())).toBe('Thinking');
});
```

2700 frontend tests pass. Verified live against dev data in both themes: `Thinking 9s` → `Running browse_web 15s` → `Thinking 21s` → done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
