### PR TITLE
fix(frontend): run the tool row's hover highlight the full drawer width

### DIFF
--- a/frontend/ai.client/src/app/components/model-settings/model-settings.html
+++ b/frontend/ai.client/src/app/components/model-settings/model-settings.html
@@ -633,7 +633,18 @@
                   }
                   @if (row.kind === 'tool') {
                     @let tool = row.tool;
-                    <li class="flex items-center gap-1 rounded-2xl pr-1 hover:bg-gray-50 dark:hover:bg-white/5">
+                    <!--
+                    The hover highlight runs the full width of the drawer
+                    (`-mx-2` cancels the list's own padding), matching the
+                    section headers above it. Inset, it ended 4px past the
+                    switch while 8px of unhighlighted gutter sat beyond — the
+                    switch looked crowded against its own row's edge. `pl-2`
+                    keeps the text exactly where it was; `pr-4` is what buys
+                    the switch its breathing room.
+                  -->
+                  <li
+                    class="-mx-2 flex items-center gap-1 pr-4 pl-2 hover:bg-gray-50 dark:hover:bg-white/5"
+                  >
                       <button
                         type="button"
                         (click)="openToolDetail(tool.toolId)"


### PR DESCRIPTION
The tool row's hover highlight was inset by the list's own padding. In a 320px drawer that left it ending **4px past the switch**, while 8px of *unhighlighted* gutter sat beyond — so the switch read as crowded against the edge of its own row.

The highlight now runs the full width of the drawer, matching the Model / Skills / Tools section headers directly above it.

## One line, three parts

- `-mx-2` cancels the list's padding so the row highlights edge to edge
- `pr-4` gives the switch 16px inside the highlight instead of 4
- `pl-2` keeps the icon and text exactly where they were, so nothing else on the row moves

## Measured at 320px

| | before | after |
|---|---|---|
| highlight width | 304px (inset) | **320px (full panel)** |
| switch → highlight right edge | 4px | **16px** |
| text left edge | 1088px | 1088px (unchanged) |

Checked by hovering a row on a local build, not just by reading the CSS. `ng test` — 2690 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
