### PR TITLE
fix(chat): scope the tool rail's hover to the rail

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
@@ -1,11 +1,19 @@
 <!-- Collapsed header: one line saying what the agent did, whatever the group's
      size. It stays collapsed while the tools run — the old behaviour force-
      expanded on any pending call, which meant the rail was at its tallest
-     exactly while the user was watching it. -->
+     exactly while the user was watching it.
+
+     The group is NAMED (`group/rail`). An unnamed `group-hover:` matches ANY
+     ancestor carrying `group`, and the assistant message card is one — so the
+     bare version lit this headline up whenever the pointer was anywhere in
+     the message, including over the answer text. Since a turn's tool calls
+     now share a single card, that meant hovering one row lightened every
+     rail's headline at once. Every group modifier in this file must stay
+     named for the same reason. -->
 <button
   type="button"
   (click)="toggleExpanded()"
-  class="flex items-center gap-2 cursor-pointer group w-full text-left"
+  class="flex items-center gap-2 cursor-pointer group/rail w-full text-left"
   [attr.aria-expanded]="isExpanded()"
   [attr.aria-label]="isExpanded() ? 'Hide tool call details' : 'Show tool call details'"
 >
@@ -21,7 +29,7 @@
   </svg>
 
   <span
-    class="text-xs text-gray-500 dark:text-gray-400 group-hover:text-gray-700 dark:group-hover:text-gray-200 min-w-0 truncate"
+    class="text-xs text-gray-500 dark:text-gray-400 group-hover/rail:text-gray-700 dark:group-hover/rail:text-gray-200 min-w-0 truncate"
     [class.text-shimmer]="isRunning()"
   >
     {{ headline() }}


### PR DESCRIPTION
## The bug

Hovering anywhere in an assistant message lightened **every** tool rail headline in that message, not the one under the pointer.

Tailwind's unnamed `group-hover:` matches **any** ancestor carrying `group`, and there are two in this tree: the rail's own header button, and the assistant message card in `message-list.component.html`. So the headline's `group-hover:text-gray-700` fired whenever the pointer was anywhere in the card — over the answer text, over a table cell, over another rail entirely.

Measured on deployed dev, pointer over the answer table and demonstrably **not** over the rail (`rail.matches(':hover') === false`, `card.matches(':hover') === true`):

```
at rest           oklch(0.707 0.022 261.325)
hovering answer   oklch(0.928 0.006 264.531)
```

The card merge in #1034 made this worse rather than causing it: when every tool call had its own card the blast radius was a single rail; now a turn's rails share one card.

## The fix

Name the group — `group/rail` on the header button, `group-hover/rail:` on the headline. Named groups only match the correspondingly named ancestor.

Verified after, same method: hovering the answer leaves the headline at `oklch(0.707)` (unchanged from rest), hovering the rail still lightens it to `oklch(0.928)`. The expanded per-call rows were already correct — they use the named `group/call`, and only the row under the pointer changes colour or gains its background tint.

## No unit test, deliberately

The rail spec overrides `templateUrl` (not resolvable in this test runner) with a stand-in template, so any class assertion there would be testing the stand-in rather than the shipped markup — circular. The spec environment also has no `fs`, so a file-content guard asserting "no bare `group-hover:` in this file" can't run either.

This class of bug is only observable in a browser, which is where it was both found and verified. The template now carries a comment stating that every group modifier in the file must stay named, and why.

2706 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
