### PR TITLE
fix(chat): drop the prose margin under the tool batch summary

### DIFF
--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.css
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.css
@@ -2,6 +2,14 @@
   display: block;
 }
 
+/* The rail renders inside `.message-block`, whose global prose rule
+   (styles.css) gives every <p> a 16px margin-bottom. The batch summary is a
+   banded row in an accordion, not a prose paragraph — the margin punched a
+   gap between it and the calls it summarizes. */
+.batch-summary {
+  margin-bottom: 0;
+}
+
 /* Status dot base */
 .status-dot {
   width: 6px;

--- a/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
+++ b/frontend/ai.client/src/app/session/components/message-list/components/tool-rail/tool-rail.component.html
@@ -73,7 +73,7 @@
              contains several rounds and each did something different. -->
         @if (batch.summary) {
           <p
-            class="bg-gray-100/70 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:bg-white/5 dark:text-gray-300"
+            class="batch-summary bg-gray-100/70 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:bg-white/5 dark:text-gray-300"
           >
             {{ batch.summary }}
           </p>


### PR DESCRIPTION
## What

The tool rail's batch-summary line had a 16px gap under it, separating it from the very call rows it summarizes.

`ToolRailComponent` renders inside `.message-block`, the app's markdown/prose stylesheet. That sheet's `p { margin-bottom: 1rem }` rule (`frontend/ai.client/src/styles.css:136`) applies to the batch summary, which is a `<p>`. The gap only showed when call rows followed the summary — `p:last-child` already zeroes the margin, so a trailing summary looked fine, which is why it read as a one-off rather than a global rule leaking in.

## How

Scoped a `.batch-summary` class onto that `<p>` and zeroed its `margin-bottom` in the component stylesheet.

This is the same override pattern `tool-approval-prompt` and `oauth-consent-prompt` already use against this exact global rule. It works on specificity: Angular's emulated encapsulation rewrites the component selector to `.batch-summary[_ngcontent-…]` (two classes), which outranks `.message-block p` (one class + one element) — and both live in the same unlayered origin, so specificity decides. A bare Tailwind `mb-0` would *not* have worked here, since utilities sit in a layer that the unlayered `.message-block` block beats regardless of specificity.

## Base branch

Opened against `develop`, not `main`, per `CLAUDE.md`: PRs target `develop`; `main` is updated via squash-merge releases only.

## Reviewer notes

- CSS-only + one class attribute; no TypeScript, no behavior, no contract change.
- Not browser-verified. Reproducing it live needs a running local stack plus a real turn that produces a `tool_group_summary`, which I didn't stand up for a one-property override. The specificity reasoning and the two in-repo precedents are the basis for the fix — worth an eyeball on dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)