### PR TITLE
feat(agents): scoped tool ids on Agent tool bindings

### DIFF
--- a/backend/src/apis/app_api/agent_designer/services/binding_validation.py
+++ b/backend/src/apis/app_api/agent_designer/services/binding_validation.py
@@ -8,8 +8,11 @@ Resolution scope:
 - ``model``          → must exist + author passes ``ModelAccessService.can_access_model``.
 - ``tool``           → author must have the tool in the ``/agents/bindable`` palette
   (``ToolCatalogService.get_user_accessible_tools``, the SAME source the picker fetches, so
-  "if the palette offers it, the write accepts it" — cf. the model check). Run-time then
-  re-resolves each bound tool against the *invoker* (``AppRoleService.can_access_tool``, D5).
+  "if the palette offers it, the write accepts it" — cf. the model check). A ref may be
+  *scoped* (``toolId::mcpToolName``) to bind a subset of an MCP server's tools: the base
+  id is checked against the palette and the tool name against that server's discovered
+  ``serverTools`` list. Run-time then re-resolves each bound tool against the *invoker*
+  (``AppRoleService.can_access_tool``, D5).
 - ``skill``          → feature-flagged; author must have the skill in the ``/agents/bindable``
   palette (``resolve_accessible_skill_ids``, the SAME source the picker fetches). Run-time then
   re-resolves each bound skill against the *invoker* (``resolve_invocable_skill_ids``, D5).
@@ -28,6 +31,7 @@ from apis.shared.feature_flags import memory_spaces_enabled, skills_enabled
 from apis.shared.memory.service import MemorySpaceService
 from apis.shared.models.managed_models import list_all_managed_models
 from apis.shared.skills.access import resolve_accessible_skill_ids
+from apis.shared.tools.scoped_ids import SCOPE_DELIMITER, parse_scoped_tool_id
 
 from apis.app_api.admin.services.model_access import ModelAccessService
 from apis.app_api.tools.service import ToolCatalogService
@@ -73,15 +77,22 @@ async def validate_agent_write(
         # kind is present, then validate each binding synchronously against those sets — the
         # same sources the palette uses, so the picker and the write agree (cf. the model
         # check). Each is fetched lazily (only when that kind is actually bound).
-        accessible_tool_ids: Optional[set] = None
+        # Tools map catalog id -> the server's discovered tool names (empty for a
+        # non-MCP tool, or an MCP server with no discovery snapshot), because a scoped
+        # ref has to be checked on both axes: base id in the palette, tool name exposed
+        # by that server.
+        accessible_tools: Optional[dict] = None
         if any(b.kind == "tool" for b in bindings):
             svc = tool_service or ToolCatalogService()
-            accessible_tool_ids = {t.tool_id for t in await svc.get_user_accessible_tools(user)}
+            accessible_tools = {
+                t.tool_id: {st.name for st in t.server_tools}
+                for t in await svc.get_user_accessible_tools(user)
+            }
         accessible_skill_ids: Optional[set] = None
         if skills_enabled() and any(b.kind == "skill" for b in bindings):
             accessible_skill_ids = set(await resolve_accessible_skill_ids(user))
         for binding in bindings:
-            _validate_binding(user, binding, mem, accessible_tool_ids, accessible_skill_ids)
+            _validate_binding(user, binding, mem, accessible_tools, accessible_skill_ids)
 
 
 async def _validate_model(user: User, cfg: AgentModelConfig, svc: ModelAccessService) -> None:
@@ -156,7 +167,7 @@ def _validate_binding(
     user: User,
     binding: AgentBinding,
     mem: MemorySpaceService,
-    accessible_tool_ids: Optional[set] = None,
+    accessible_tools: Optional[dict] = None,
     accessible_skill_ids: Optional[set] = None,
 ) -> None:
     kind = binding.kind
@@ -170,7 +181,7 @@ def _validate_binding(
         )
 
     if kind == "tool":
-        _validate_tool(binding, accessible_tool_ids or set())
+        _validate_tool(binding, accessible_tools or {})
         return
 
     if kind == "skill":
@@ -181,17 +192,49 @@ def _validate_binding(
         _validate_memory_space(user, binding, mem)
 
 
-def _validate_tool(binding: AgentBinding, accessible_tool_ids: set) -> None:
+def _validate_tool(binding: AgentBinding, accessible_tools: dict) -> None:
+    """Validate one ``tool`` binding, bare (whole server) or scoped (one tool of it).
+
+    Mirrors ``ToolCatalogService.save_user_preferences``, which validates the same
+    ``base::tool`` shape on the user-preference axis: the **base** id must be in the
+    author's palette (``get_user_accessible_tools`` — the exact source the Designer
+    picker fetches, so a bindable tool is always writable), and the tool name must be
+    one the server actually exposes.
+
+    A server with an empty ``serverTools`` list has simply never been discovered
+    ("Discover from server" on the admin tool page populates it); the name check is
+    skipped there rather than rejecting every scoped ref, exactly as the preference
+    path does. That cached list is a UI/validation aid only — it is never consulted at
+    run time, so it can gate what an author may *write* but is not the enforcement
+    point. Enforcement is the scoped id itself reaching ``collect_tool_name_filters``.
+    """
     ref = (binding.ref or "").strip()
     if not ref:
         raise BindingValidationError("tool binding requires a non-empty 'ref'.", status_code=400)
-    # The tool id must be in the author's palette (get_user_accessible_tools) — the exact
-    # source the Designer picker fetches, so a bindable tool is always writable. Run-time
-    # re-resolves against the invoker via AppRoleService.can_access_tool (D5).
-    if ref not in accessible_tool_ids:
+
+    base, tool_name = parse_scoped_tool_id(ref)
+    if tool_name is None and SCOPE_DELIMITER in ref:
+        # "canvas_faculty::" parses to a bare ref, so it would silently store as a
+        # whole-server binding — the opposite of what the author meant to narrow.
         raise BindingValidationError(
-            f"You do not have access to tool '{ref}'.", status_code=403
+            f"tool binding ref '{ref}' is missing a tool name after "
+            f"'{SCOPE_DELIMITER}'.",
+            status_code=400,
         )
+    # Run-time re-resolves against the invoker via AppRoleService.can_access_tool (D5),
+    # which likewise admits a scoped ref whose base server is granted.
+    if base not in accessible_tools:
+        raise BindingValidationError(
+            f"You do not have access to tool '{base}'.", status_code=403
+        )
+
+    if tool_name is not None:
+        server_names = accessible_tools[base]
+        if server_names and tool_name not in server_names:
+            raise BindingValidationError(
+                f"Tool '{base}' does not expose a tool named '{tool_name}'.",
+                status_code=400,
+            )
 
 
 def _validate_skill(binding: AgentBinding, accessible_skill_ids: set) -> None:

--- a/backend/src/apis/inference_api/chat/agent_binding_resolver.py
+++ b/backend/src/apis/inference_api/chat/agent_binding_resolver.py
@@ -20,6 +20,9 @@ Phase 3 lands incrementally:
   override): when an Agent binds tools they *are* its toolset, re-resolved per invoker via
   the same ``AppRoleService.can_access_tool`` gate; a bound tool the invoker lacks blocks the
   turn (D5). Absent tool bindings ⇒ the request's ``enabled_tools`` drive the turn as today.
+  A ref may be *scoped* (``toolId::mcpToolName``) to bind a subset of an MCP server's tools
+  rather than all of them; the scoped id rides through to the runtime, where
+  ``collect_tool_name_filters`` turns it into that server's ``allowed_tool_names``.
 - ``skill`` bindings → the effective skill set (**replace**, same shape as tools): when an
   Agent binds skills they *are* the turn's skills, re-resolved per invoker via the
   invoke-through predicate (§6/D7, ``resolve_invocable_skill_ids``); a bound skill the
@@ -42,6 +45,7 @@ from apis.shared.feature_flags import memory_spaces_enabled, skills_enabled
 from apis.shared.memory.service import MemorySpaceService
 from apis.shared.rbac.service import get_app_role_service
 from apis.shared.skills.access import resolve_invocable_skill_ids
+from apis.shared.tools.scoped_ids import base_tool_id
 
 _ROLE_RANK = {"viewer": 1, "editor": 2, "owner": 3}
 
@@ -94,6 +98,12 @@ class ResolvedTools:
     hand straight to the tool filter. An empty ``tool_ids`` is meaningful — the Agent
     deliberately runs with *no* tools — and is distinct from ``plan.tools is None`` (no tool
     binding, fall through to the request).
+
+    Ids are carried **verbatim**, scoping included: a scoped ``base::tool`` id must survive
+    into ``enabled_tools`` for ``collect_tool_name_filters`` to fold it into that server's
+    ``allowed_tool_names`` and build a filtered MCP client. Collapsing one to its base here
+    would silently restore the whole server — the exact bug the scoping exists to prevent,
+    and invisible from the outside because the turn would still work.
     """
 
     tool_ids: List[str]
@@ -223,6 +233,11 @@ async def _resolve_tools(assistant: Assistant, invoker: User) -> Optional[Resolv
     (block-with-message, no silent drop — D5). Returns ``None`` when the Agent binds no tools,
     leaving the request's ``enabled_tools`` in force. The RBAC service is fetched lazily (only
     when the Agent actually binds tools) — mirroring how ``_resolve_memory`` builds its own.
+
+    A ref may be **scoped** (``toolId::mcpToolName``) to bind a subset of an MCP server's
+    tools. Access is a property of the *server*, so the gate is keyed on the base id — which
+    is also what an administrator would grant, and so what the block message names. The
+    scoped id itself is preserved in the result; that is what narrows the turn.
     """
     tool_bindings = [b for b in (assistant.bindings or []) if b.kind == "tool"]
     if not tool_bindings:
@@ -230,13 +245,19 @@ async def _resolve_tools(assistant: Assistant, invoker: User) -> Optional[Resolv
 
     app_role_service = get_app_role_service()
     resolved: List[str] = []
+    # Access is per server, so check each base once: an Agent binding seven tools of one
+    # MCP server is the normal shape here, and it should cost one gate call, not seven.
+    checked_bases: set = set()
     for binding in tool_bindings:
         ref = binding.ref
-        if not await app_role_service.can_access_tool(invoker, ref):
-            raise AgentBindingBlockedError(
-                f"This agent uses the tool **{ref}**, which isn't available to your account. "
-                "Ask an administrator for access, or use a different agent."
-            )
+        base = base_tool_id(ref)
+        if base not in checked_bases:
+            if not await app_role_service.can_access_tool(invoker, ref):
+                raise AgentBindingBlockedError(
+                    f"This agent uses the tool **{base}**, which isn't available to your "
+                    "account. Ask an administrator for access, or use a different agent."
+                )
+            checked_bases.add(base)
         if ref not in resolved:
             resolved.append(ref)
 

--- a/backend/src/apis/shared/rbac/service.py
+++ b/backend/src/apis/shared/rbac/service.py
@@ -262,11 +262,17 @@ class AppRoleService:
         return granted | set(await get_public_tool_ids())
 
     async def can_access_tool(self, user: User, tool_id: str) -> bool:
-        """Check if user can access a specific tool.
+        """Check if user can access a specific tool, bare or scoped.
 
-        Exact-match on the id by design: callers pass a bare catalog id
-        (an Agent's ``binding.ref``, validated against the author's palette
-        at design time), never a scoped ``base::tool`` id.
+        ``tool_id`` may be a bare catalog id or a scoped ``base::tool`` id
+        referencing one tool within an MCP server (an Agent's ``binding.ref``
+        carries either). A scoped id is accessible when its **base server id**
+        is granted: scoping narrows a grant, it never widens one, so a role
+        that grants the whole server necessarily admits any subset of it.
+
+        This is the same predicate ``filter_requested_tools`` applies on the
+        ``enabled_tools`` axis — keep the two in agreement, or a subset the
+        picker admits will be denied on the bindings axis (and vice versa).
         """
         allowed = await self._tool_grant_set(user)
 
@@ -274,7 +280,7 @@ class AppRoleService:
         if "*" in allowed:
             return True
 
-        return tool_id in allowed
+        return tool_id in allowed or base_tool_id(tool_id) in allowed
 
     async def can_access_model(self, user: User, model_id: str) -> bool:
         """Check if user can access a specific model."""

--- a/backend/src/apis/shared/tools/freshness.py
+++ b/backend/src/apis/shared/tools/freshness.py
@@ -37,6 +37,7 @@ import logging
 import time
 from typing import Dict, FrozenSet, List, Optional, Tuple
 from apis.shared.timestamps import to_iso
+from apis.shared.tools.scoped_ids import base_tool_ids
 
 logger = logging.getLogger(__name__)
 
@@ -99,11 +100,19 @@ async def get_freshness_hash(tool_ids: List[str]) -> str:
 
     Changes when any of the given tools' config is edited. Empty list
     returns the empty string so callers can short-circuit.
+
+    Scoped ids (`base::tool`, selecting one tool of an MCP server) are
+    collapsed to their base first: freshness is a property of the catalog
+    record, and the catalog only holds the base. Hashing a scoped id
+    verbatim looks it up, misses, and pins that entry to a constant
+    `none` — so an admin edit to a server would never evict an agent that
+    had bound a subset of it. Collapsing also de-duplicates, so an agent
+    binding seven tools of one server costs one catalog read, not seven.
     """
     if not tool_ids:
         return ""
 
-    sorted_ids = sorted(tool_ids)
+    sorted_ids = sorted(base_tool_ids(tool_ids))
     values = await asyncio.gather(
         *(get_tool_updated_at(tid) for tid in sorted_ids)
     )

--- a/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
+++ b/backend/tests/apis/app_api/agent_designer/test_binding_validation.py
@@ -38,12 +38,25 @@ def _mem_svc(space, role) -> MagicMock:
     return svc
 
 
-def _tool_svc(*accessible_ids: str) -> MagicMock:
-    # Mirror the palette: get_user_accessible_tools returns objects carrying .tool_id.
+def _tool_svc(*accessible: object) -> MagicMock:
+    """Mirror the palette: ``get_user_accessible_tools`` returns ``UserToolAccess``.
+
+    Each entry is a bare id (a tool with no discovered per-tool list, the shape of a
+    local tool or an MCP server that has never been discovered) or a
+    ``(id, [tool names])`` pair carrying that server's ``server_tools`` — the field
+    ``_validate_tool`` checks a scoped ref's tool name against.
+    """
     svc = MagicMock()
-    svc.get_user_accessible_tools = AsyncMock(
-        return_value=[SimpleNamespace(tool_id=t) for t in accessible_ids]
-    )
+    items = []
+    for entry in accessible:
+        tool_id, names = entry if isinstance(entry, tuple) else (entry, ())
+        items.append(
+            SimpleNamespace(
+                tool_id=tool_id,
+                server_tools=[SimpleNamespace(name=n) for n in names],
+            )
+        )
+    svc.get_user_accessible_tools = AsyncMock(return_value=items)
     return svc
 
 
@@ -333,6 +346,79 @@ class TestToolValidation:
             tool_service=svc,
         )
         svc.get_user_accessible_tools.assert_not_awaited()
+
+    # -- scoped refs (``toolId::mcpToolName``) -----------------------------------
+    @pytest.mark.asyncio
+    async def test_scoped_ref_passes_when_base_accessible_and_name_exposed(self):
+        # The whole point: bind 2 of a 3-tool server. The base carries the grant, the
+        # discovered serverTools list carries the name.
+        svc = _tool_svc(("canvas_faculty", ["list_courses", "list_rubrics", "grade_submission"]))
+        await validate_agent_write(
+            _user(),
+            bindings=[
+                AgentBinding(kind="tool", ref="canvas_faculty::list_courses"),
+                AgentBinding(kind="tool", ref="canvas_faculty::list_rubrics"),
+            ],
+            tool_service=svc,
+        )
+        svc.get_user_accessible_tools.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_scoped_ref_403_when_base_inaccessible(self):
+        # Scoping narrows a grant; it can never conjure one.
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(
+                _user(),
+                bindings=[AgentBinding(kind="tool", ref="secret_server::peek")],
+                tool_service=_tool_svc(("canvas_faculty", ["list_courses"])),
+            )
+        assert ei.value.status_code == 403
+        # The message names the base — that is what an admin would grant.
+        assert "secret_server" in ei.value.message
+        assert "::" not in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_scoped_ref_400_when_name_not_exposed(self):
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(
+                _user(),
+                bindings=[AgentBinding(kind="tool", ref="canvas_faculty::no_such_tool")],
+                tool_service=_tool_svc(("canvas_faculty", ["list_courses"])),
+            )
+        assert ei.value.status_code == 400
+        assert "no_such_tool" in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_scoped_ref_allowed_when_server_never_discovered(self):
+        # An empty serverTools list means "never discovered", not "exposes nothing" —
+        # mirrors ToolCatalogService.save_user_preferences, which skips the name check
+        # in exactly this case rather than rejecting every scoped ref.
+        await validate_agent_write(
+            _user(),
+            bindings=[AgentBinding(kind="tool", ref="canvas_faculty::list_courses")],
+            tool_service=_tool_svc("canvas_faculty"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_ref_with_empty_tool_name_400(self):
+        # "base::" parses to a bare ref, so accepting it would store a whole-server
+        # binding under a ref the author wrote to narrow one.
+        with pytest.raises(BindingValidationError) as ei:
+            await validate_agent_write(
+                _user(),
+                bindings=[AgentBinding(kind="tool", ref="canvas_faculty::")],
+                tool_service=_tool_svc(("canvas_faculty", ["list_courses"])),
+            )
+        assert ei.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_bare_ref_still_binds_whole_server(self):
+        # Additive: a bare ref is unaffected by the discovered list.
+        await validate_agent_write(
+            _user(),
+            bindings=[AgentBinding(kind="tool", ref="canvas_faculty")],
+            tool_service=_tool_svc(("canvas_faculty", ["list_courses", "grade_submission"])),
+        )
 
 
 # --------------------------------------------------------------------------- KB

--- a/backend/tests/apis/inference_api/test_agent_binding_resolver.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_resolver.py
@@ -258,6 +258,77 @@ class TestToolResolution:
         args = svc.can_access_tool.await_args.args
         assert args[0].user_id == "u-bob" and args[1] == "web_search"
 
+    # -- scoped refs (``toolId::mcpToolName``) -----------------------------------
+    @pytest.mark.asyncio
+    async def test_scoped_refs_survive_resolution_verbatim(self, monkeypatch):
+        # The scoped id IS the enforcement: it must reach enabled_tools intact for
+        # collect_tool_name_filters to narrow the server. Collapsing it to the base
+        # here would silently restore all of the server's tools.
+        _patch_tool_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(
+            _assistant(
+                bindings=[
+                    _tool_binding("canvas_faculty::list_courses"),
+                    _tool_binding("canvas_faculty::list_rubrics"),
+                ]
+            ),
+            _user(),
+        )
+        assert plan.tools.tool_ids == [
+            "canvas_faculty::list_courses",
+            "canvas_faculty::list_rubrics",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_bare_ref_still_resolves_to_whole_server(self, monkeypatch):
+        # Additive: an existing whole-server binding is untouched.
+        _patch_tool_access(monkeypatch, True)
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_tool_binding("canvas_faculty")]), _user()
+        )
+        assert plan.tools.tool_ids == ["canvas_faculty"]
+
+    @pytest.mark.asyncio
+    async def test_scoped_ref_blocks_when_base_inaccessible(self, monkeypatch):
+        # Block-with-message, not a silent drop (D5). The gate answers on the base, so
+        # this asserts the real shape: the invoker is granted neither, and the message
+        # names the server an administrator would grant.
+        _patch_tool_access(monkeypatch, {"calculator"})
+        with pytest.raises(AgentBindingBlockedError) as ei:
+            await resolve_agent_invocation(
+                _assistant(bindings=[_tool_binding("canvas_faculty::list_courses")]),
+                _user(),
+            )
+        assert "canvas_faculty" in ei.value.message
+        assert "::" not in ei.value.message
+
+    @pytest.mark.asyncio
+    async def test_scoped_ref_allowed_when_base_server_granted(self, monkeypatch):
+        # A grant on the server admits any subset of it — the gate is handed the scoped
+        # id and AppRoleService.can_access_tool base-collapses it (tested against real
+        # role records in tests/shared/test_scoped_tool_grants.py).
+        _patch_tool_access(monkeypatch, {"canvas_faculty::list_courses"})
+        plan = await resolve_agent_invocation(
+            _assistant(bindings=[_tool_binding("canvas_faculty::list_courses")]), _user()
+        )
+        assert plan.tools.tool_ids == ["canvas_faculty::list_courses"]
+
+    @pytest.mark.asyncio
+    async def test_access_checked_once_per_server(self, monkeypatch):
+        # Seven tools of one server is the normal shape; it should cost one gate call.
+        svc = _patch_tool_access(monkeypatch, True)
+        await resolve_agent_invocation(
+            _assistant(
+                bindings=[
+                    _tool_binding("canvas_faculty::list_courses"),
+                    _tool_binding("canvas_faculty::list_rubrics"),
+                    _tool_binding("web_search"),
+                ]
+            ),
+            _user(),
+        )
+        assert svc.can_access_tool.await_count == 2
+
 
 class TestSkillResolution:
     @pytest.mark.asyncio

--- a/backend/tests/apis/inference_api/test_agent_binding_scoped_tools_e2e.py
+++ b/backend/tests/apis/inference_api/test_agent_binding_scoped_tools_e2e.py
@@ -1,0 +1,161 @@
+"""An Agent's scoped tool bindings must reach the MCP client as a name filter.
+
+The layers either side of this seam are each covered on their own — the resolver
+in ``test_agent_binding_resolver.py``, the client filter in
+``tests/agents/main_agent/integrations/test_external_mcp_client.py``. What neither
+proves is that they are *connected*: a resolver that collapsed a scoped ref to its
+base would pass its own tests and quietly hand the turn all 44 of a server's tools,
+which is invisible from outside because the agent still works. It just stops being
+fenced, and the tool definitions it does not need stay in the cacheable prefix on
+every turn for the life of the session.
+
+So this drives the real chain — ``Assistant.bindings`` → ``resolve_agent_invocation``
+→ ``enabled_tools`` → ``ToolFilter`` classification → ``load_external_tools`` — and
+asserts the filter that actually reaches ``create_external_mcp_client``. Only the
+catalog and the client constructor are stubbed.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agents.main_agent.integrations.external_mcp_client import ExternalMCPIntegration
+from agents.main_agent.tools.tool_filter import ToolFilter
+from apis.inference_api.chat.agent_binding_resolver import resolve_agent_invocation
+from apis.shared.assistants.models import AgentBinding, Assistant
+from apis.shared.auth.models import User
+
+RESOLVER = "apis.inference_api.chat.agent_binding_resolver"
+SERVER = "canvas_faculty"
+
+# The seven the Rubric Builder agent actually needs, of the forty-four the server has.
+BOUND = [
+    "list_courses",
+    "list_assignments",
+    "get_assignment_details",
+    "list_rubrics",
+    "get_rubric",
+    "create_rubric",
+    "associate_rubric",
+]
+# The ones its system prompt currently asks it not to call.
+UNBOUND = ["grade_submission", "bulk_grade_submissions", "create_assignment", "delete_rubric"]
+
+
+def _user() -> User:
+    return User(email="prof@x.edu", user_id="u-prof", name="Prof", roles=[])
+
+
+def _agent(refs) -> Assistant:
+    return Assistant(
+        assistantId="ast-rubric",
+        ownerId="u-alice",
+        ownerName="Alice",
+        name="Rubric Builder",
+        description="d",
+        instructions="i",
+        vectorIndexId="idx",
+        visibility="SHARED",
+        createdAt="t",
+        updatedAt="t",
+        status="COMPLETE",
+        bindings=[AgentBinding(kind="tool", ref=r) for r in refs],
+    )
+
+
+def _grant_whole_server(monkeypatch):
+    """The invoker's role grants the server; the binding decides the subset."""
+    svc = MagicMock()
+    svc.can_access_tool = AsyncMock(return_value=True)
+    monkeypatch.setattr(f"{RESOLVER}.get_app_role_service", lambda: svc)
+
+
+def _catalog_tool():
+    return SimpleNamespace(
+        tool_id=SERVER,
+        protocol="mcp_external",
+        mcp_config=SimpleNamespace(
+            server_url="https://example.com/mcp",
+            approval_required_names=lambda: set(),
+        ),
+        forward_auth_token=False,
+        requires_oauth_provider=None,
+        updated_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+async def _allowed_names_for(tool_ids):
+    """Run ``tool_ids`` through the runtime and return the client's name filter."""
+    integration = ExternalMCPIntegration()
+    repo = SimpleNamespace(get_tool=AsyncMock(return_value=_catalog_tool()))
+    client = SimpleNamespace(load_tools=AsyncMock(return_value=[]))
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository", return_value=repo
+    ), patch(
+        "agents.main_agent.integrations.external_mcp_client.create_external_mcp_client",
+        return_value=client,
+    ) as create_mock:
+        await integration.load_external_tools(tool_ids)
+    assert create_mock.call_count == 1, "one server ⇒ one client"
+    return create_mock.call_args.kwargs["allowed_tool_names"]
+
+
+class TestScopedBindingsNarrowTheTurn:
+    @pytest.mark.asyncio
+    async def test_scoped_bindings_yield_a_filtered_client(self, monkeypatch):
+        _grant_whole_server(monkeypatch)
+        plan = await resolve_agent_invocation(
+            _agent([f"{SERVER}::{name}" for name in BOUND]), _user()
+        )
+
+        allowed = await _allowed_names_for(plan.tools.tool_ids)
+
+        assert allowed == set(BOUND)
+        # The point of the exercise: the destructive tools are absent from the turn,
+        # not merely unused by it.
+        for name in UNBOUND:
+            assert name not in allowed
+
+    @pytest.mark.asyncio
+    async def test_bare_binding_still_loads_the_whole_server(self, monkeypatch):
+        """Additive — every Agent binding a server today keeps all of its tools."""
+        _grant_whole_server(monkeypatch)
+        plan = await resolve_agent_invocation(_agent([SERVER]), _user())
+
+        assert await _allowed_names_for(plan.tools.tool_ids) is None
+
+    @pytest.mark.asyncio
+    async def test_a_bare_binding_alongside_scoped_ones_wins(self, monkeypatch):
+        """Documented ``collect_tool_name_filters`` precedence, asserted end to end.
+
+        An author who binds the server *and* two of its tools has asked for the
+        server; the filter must not silently narrow to the two.
+        """
+        _grant_whole_server(monkeypatch)
+        plan = await resolve_agent_invocation(
+            _agent([SERVER, f"{SERVER}::list_courses", f"{SERVER}::get_rubric"]), _user()
+        )
+
+        assert await _allowed_names_for(plan.tools.tool_ids) is None
+
+    @pytest.mark.asyncio
+    async def test_scoped_ids_classify_as_external_mcp_tools(self, monkeypatch):
+        """The step between: ``ToolFilter`` must route a scoped id to the MCP loader.
+
+        It classifies on the *base* id, so a scoped ref that failed to match would
+        fall through to the "not a known tool id" warning and be dropped silently —
+        the agent would run with no Canvas tools at all.
+        """
+        _grant_whole_server(monkeypatch)
+        plan = await resolve_agent_invocation(
+            _agent([f"{SERVER}::{name}" for name in BOUND]), _user()
+        )
+
+        tool_filter = ToolFilter(registry=SimpleNamespace(has_tool=lambda _: False))
+        tool_filter.set_external_mcp_tools([SERVER])
+        result = tool_filter.filter_tools_extended(plan.tools.tool_ids)
+
+        assert result.external_mcp_tool_ids == plan.tools.tool_ids
+        assert result.local_tools == [] and result.gateway_tool_ids == []

--- a/backend/tests/shared/test_scoped_tool_grants.py
+++ b/backend/tests/shared/test_scoped_tool_grants.py
@@ -1,0 +1,128 @@
+"""A scoped tool id (``base::tool``) is granted by a grant on its **base** server.
+
+Scoping narrows a grant, it never widens one: an Agent binding
+``canvas_faculty::list_courses`` asks for strictly less than one binding
+``canvas_faculty``, so the same role grant must admit it. Before this, the
+binding gate ``AppRoleService.can_access_tool`` exact-matched the id, so a
+scoped binding was denied for every user — including one holding the whole
+server — while the sibling ``filter_requested_tools`` on the ``enabled_tools``
+axis already base-collapsed correctly. The two must stay in agreement, or the
+chat picker and the Agent Designer disagree about the same subset.
+
+Real ``AppRole`` records throughout (no predicate stubs), so these fail if the
+grant semantics move.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from apis.shared.tools import freshness
+
+GRANTED_SERVER = "canvas_faculty"
+PUBLIC_SERVER = "fetch_url_content"
+PRIVATE_SERVER = "gmail_employee"
+
+
+def _catalog_tool(tool_id: str, is_public: bool):
+    repo_tool = MagicMock()
+    repo_tool.tool_id = tool_id
+    repo_tool.is_public = is_public
+    return repo_tool
+
+
+@pytest.fixture(autouse=True)
+def _catalog():
+    freshness._reset_for_tests()
+    repo = MagicMock()
+    repo.list_tools = AsyncMock(
+        return_value=[
+            _catalog_tool(GRANTED_SERVER, is_public=False),
+            _catalog_tool(PUBLIC_SERVER, is_public=True),
+            _catalog_tool(PRIVATE_SERVER, is_public=False),
+        ]
+    )
+    with patch(
+        "apis.shared.tools.repository.get_tool_catalog_repository",
+        return_value=repo,
+    ):
+        yield
+    freshness._reset_for_tests()
+
+
+def _service(granted_tools):
+    from apis.shared.rbac.cache import AppRoleCache
+    from apis.shared.rbac.models import AppRole, EffectivePermissions
+    from apis.shared.rbac.service import AppRoleService
+
+    repo = AsyncMock()
+    repo.get_roles_for_jwt_role.return_value = ["faculty"]
+    repo.get_role.return_value = AppRole(
+        role_id="faculty",
+        display_name="faculty",
+        description="test",
+        jwt_role_mappings=["faculty"],
+        priority=10,
+        enabled=True,
+        effective_permissions=EffectivePermissions(tools=granted_tools, models=["*"]),
+    )
+    return AppRoleService(repository=repo, cache=AppRoleCache())
+
+
+@pytest.fixture
+def svc():
+    """A role granting one MCP server and nothing else."""
+    return _service([GRANTED_SERVER])
+
+
+def _user():
+    user = MagicMock()
+    user.user_id = "u1"
+    user.email = "prof@example.edu"
+    user.roles = ["faculty"]
+    return user
+
+
+class TestCanAccessTool:
+    """The gate an Agent's tool binding is re-resolved through (D5)."""
+
+    @pytest.mark.asyncio
+    async def test_scoped_id_admitted_by_a_grant_on_its_base_server(self, svc):
+        assert await svc.can_access_tool(_user(), f"{GRANTED_SERVER}::list_courses") is True
+
+    @pytest.mark.asyncio
+    async def test_bare_id_still_admitted(self, svc):
+        assert await svc.can_access_tool(_user(), GRANTED_SERVER) is True
+
+    @pytest.mark.asyncio
+    async def test_scoped_id_denied_when_its_base_is_not_granted(self, svc):
+        """Scoping narrows a grant; it cannot manufacture one."""
+        assert await svc.can_access_tool(_user(), f"{PRIVATE_SERVER}::send_mail") is False
+
+    @pytest.mark.asyncio
+    async def test_scoped_id_admitted_when_its_base_is_public(self, svc):
+        """A public tool is a grant, so it admits subsets like any other."""
+        assert await svc.can_access_tool(_user(), f"{PUBLIC_SERVER}::fetch") is True
+
+    @pytest.mark.asyncio
+    async def test_wildcard_admits_a_scoped_id(self):
+        assert await _service(["*"]).can_access_tool(_user(), f"{PRIVATE_SERVER}::send_mail") is True
+
+    @pytest.mark.asyncio
+    async def test_agrees_with_filter_requested_tools(self, svc):
+        """The bindings axis and the enabled_tools axis must answer alike.
+
+        They diverged before this change — the reason a subset the chat picker
+        happily sent was rejected as an Agent binding.
+        """
+        candidates = [
+            GRANTED_SERVER,
+            f"{GRANTED_SERVER}::list_courses",
+            PUBLIC_SERVER,
+            f"{PUBLIC_SERVER}::fetch",
+            PRIVATE_SERVER,
+            f"{PRIVATE_SERVER}::send_mail",
+        ]
+        by_filter = set(await svc.filter_requested_tools(_user(), candidates))
+        for tool_id in candidates:
+            assert await svc.can_access_tool(_user(), tool_id) is (tool_id in by_filter), tool_id

--- a/docs/specs/canvas-rubric-agent.md
+++ b/docs/specs/canvas-rubric-agent.md
@@ -89,10 +89,12 @@ Canvas, so any bearer value works.
   `memory_space` (`inference_api/chat/agent_binding_resolver.py`). The
   *"`tool` and `skill` are accepted and stored but inert until Phase 2/3"* comment in
   `apis/shared/assistants/models.py` is **stale**; ignore it.
-- **Tool bindings take bare catalog ids only.** `apis/shared/rbac/service.py` `can_access_tool`:
-  *"callers pass a bare catalog id … never a scoped `base::tool` id."* Binding `canvas_faculty`
-  therefore brings **all 42 tools** (~11.7k tokens of definitions). Trimming to the 5 rubric
-  tools would require accepting scoped refs in `binding.ref` — a platform change, out of scope.
+- **Tool bindings take bare catalog ids *or* scoped ones.** ~~`can_access_tool` exact-matched the
+  id, so binding `canvas_faculty` brought all 42 tools and trimming would need a platform
+  change.~~ **Superseded** — `binding.ref` now accepts `canvas_faculty::create_rubric`, and a
+  scoped ref is admitted by a grant on its base server. A bare ref still means the whole server,
+  so nothing about the shape above changed for an agent that wants all of it. Measured on this
+  agent in dev: bare = 44 tools and a 27,959-token prompt; the 7 scoped refs below = 9,981.
 - **Tool bindings replace** the request's `enabled_tools`; a bound tool the invoker cannot access
   raises `AgentBindingBlockedError` and blocks the turn with a message (no silent drop).
 - **Skills bind no tools.** `ChatAgent`: *"Skills are pure knowledge bundles … the tool universe
@@ -611,19 +613,29 @@ Ordered; each step has a different owner, which is why it is worth writing down.
 Steps 3 and 4 must not be separated by long — between them, rubric tools 401 with a message that
 tells the user a Canvas admin must act, which will already be done.
 
-### 8.3 Residual risk: the prompt fence is not a control
+### 8.3 Residual risk: the prompt fence is not a control — FIX SHIPPED
 
-The Agent binds `canvas_faculty` as a bare id, so it holds all 42 tools including
+The Agent bound `canvas_faculty` as a bare id, so it held all 44 tools including
 `grade_submission`, `bulk_grade_submissions`, `create_assignment` and `create_page`. Two of the
-42 are gated by approval; the rest are held back **only by the system prompt** (§7.1 Scope).
+44 were gated by approval; the rest were held back **only by the system prompt** (§7.1 Scope).
 That is a real fence for ordinary use and no fence at all against a determined prompt.
 
-The structural fix is scoped tool bindings (`binding.ref` accepting `canvas_faculty::create_rubric`),
-which `rbac/service.py` explicitly rejects today (§3.3). Until then, the mitigations available are:
-flag the genuinely destructive tools `needsApproval` as well, so the blast radius of a prompt
-that gets past the fence is still one click wide; and keep the Agent's visibility `SHARED`
-during the pilot so the population is known. Worth an explicit decision before the marketplace
-listing goes public.
+The structural fix — scoped tool bindings — has since shipped, so `binding.ref` accepts
+`canvas_faculty::create_rubric` and the runtime builds the MCP client restricted to the named
+tools (§3.3). **The agent is not rebound yet**; doing so is a one-click change in the Agent
+Designer (open the Tools chip's caret, leave on only the seven below).
+
+The seven it needs: `list_courses`, `list_assignments`, `get_assignment_details`, `list_rubrics`,
+`get_rubric`, `create_rubric`, `associate_rubric`.
+
+Verified in dev on the real agent: with those seven bound, the runtime logs the client as
+`(tools: associate_rubric, create_rubric, get_assignment_details, get_rubric, list_assignments,
+list_courses, list_rubrics)`, the whole turn prompt drops from 27,959 tokens to 9,981, and asked
+whether it can grade, the agent answers that it has no such tool — where the bare-bound run named
+`grade_submission`, `grade_with_rubric` and `bulk_grade_submissions` and declined by policy.
+
+Flagging the destructive tools `needsApproval` is still worth doing as defence in depth, and
+keeping the Agent's visibility limited during the pilot still bounds the population.
 
 ## 9. Open questions
 

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form-scoped-tools.spec.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form-scoped-tools.spec.ts
@@ -1,0 +1,248 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { provideRouter, ActivatedRoute } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Component, input, output } from '@angular/core';
+import { AgentFormPage } from './agent-form.page';
+import { AgentPreviewComponent } from './components/agent-preview.component';
+import { KnowledgeBaseSectionComponent } from '../../knowledge-base/knowledge-base-section.component';
+import { AgentService } from '../services/agent.service';
+import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ThemeService } from '../../components/topnav/components/theme-toggle/theme.service';
+import { ToastService } from '../../services/toast/toast.service';
+
+/**
+ * Binding a subset of an MCP server's tools.
+ *
+ * The selection model is the thing worth pinning down: `selectedToolRefs` holds the
+ * `binding.ref` values verbatim, and the invariant is that a fully-selected server is
+ * stored as the **bare** ref rather than as N scoped ones. Get that wrong and every
+ * existing agent's bindings silently rewrite themselves the first time someone opens
+ * the form — a different record, for no change the author made.
+ */
+
+@Component({ selector: 'app-agent-preview', template: '' })
+class StubPreviewComponent {
+  agentId = input<string | null>(null);
+  name = input('');
+  description = input('');
+  emoji = input('');
+  starters = input<string[]>([]);
+  modelId = input<string | null>(null);
+  isDirty = input(false);
+  saving = input(false);
+  canSave = input(false);
+  save = output<void>();
+  openFull = output<void>();
+}
+
+@Component({ selector: 'app-knowledge-base-section', template: '' })
+class StubKnowledgeBaseComponent {
+  entityId = input<string | null>(null);
+  userPermission = input('owner');
+  permissionResolved = input(false);
+  createDraft = input<unknown>(null);
+}
+
+const CANVAS = {
+  kind: 'tool',
+  ref: 'canvas_faculty',
+  label: 'Canvas Faculty',
+  description: 'Canvas LMS',
+  meta: {
+    protocol: 'mcp_external',
+    serverTools: [
+      { name: 'list_courses', description: 'List courses.\n\nArgs:\n  term: the term' },
+      { name: 'list_rubrics', description: 'List rubrics.' },
+      { name: 'grade_submission', description: 'Grade a submission.' },
+    ],
+  },
+};
+
+/** A local tool: nothing to narrow, so it must never offer the per-tool control. */
+const CALCULATOR = {
+  kind: 'tool',
+  ref: 'calculator',
+  label: 'Calculator',
+  description: 'Arithmetic',
+  meta: { protocol: 'direct', serverTools: [] },
+};
+
+async function settle(fixture: ComponentFixture<AgentFormPage>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  fixture.detectChanges();
+}
+
+async function mount(bindings: { kind: string; ref: string }[]): Promise<{
+  fixture: ComponentFixture<AgentFormPage>;
+  component: AgentFormPage;
+}> {
+  TestBed.resetTestingModule();
+  vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
+
+  const agentService = {
+    loadBindable: vi
+      .fn()
+      .mockImplementation((kind: string) =>
+        Promise.resolve(kind === 'tool' ? [CANVAS, CALCULATOR] : []),
+      ),
+    getAgent: vi.fn().mockResolvedValue({
+      agentId: 'agt-1',
+      name: 'Rubric Builder',
+      description: 'Builds rubrics',
+      instructions: 'You build rubrics.',
+      visibility: 'PRIVATE',
+      userPermission: 'owner',
+      bindings,
+    }),
+    createAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+    updateAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+  };
+
+  TestBed.configureTestingModule({
+    imports: [ReactiveFormsModule],
+    providers: [
+      provideRouter([{ path: 'agents', children: [] }]),
+      { provide: AgentService, useValue: agentService },
+      {
+        provide: ToastService,
+        useValue: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+      },
+      { provide: SidenavService, useValue: { hide: vi.fn(), show: vi.fn() } },
+      { provide: ThemeService, useValue: { isDark: () => false } },
+      { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => 'agt-1' } } } },
+    ],
+  });
+
+  TestBed.overrideComponent(AgentFormPage, {
+    remove: { imports: [AgentPreviewComponent, KnowledgeBaseSectionComponent] },
+    add: { imports: [StubPreviewComponent, StubKnowledgeBaseComponent] },
+  });
+
+  const fixture = TestBed.createComponent(AgentFormPage);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  await settle(fixture);
+  return { fixture, component: fixture.componentInstance };
+}
+
+/** The refs the form would submit, order-insensitive. */
+function refs(component: AgentFormPage): string[] {
+  return [...component.selectedToolRefs()].sort();
+}
+
+describe('AgentFormPage — scoped tool bindings', () => {
+  let fixture: ComponentFixture<AgentFormPage>;
+  let component: AgentFormPage;
+
+  describe('a whole-server binding', () => {
+    beforeEach(async () => {
+      ({ fixture, component } = await mount([{ kind: 'tool', ref: 'canvas_faculty' }]));
+    });
+
+    it('reads as selected with every tool on', () => {
+      expect(component.isToolSelected('canvas_faculty')).toBe(true);
+      expect(component.isWholeServerSelected(CANVAS)).toBe(true);
+      expect(component.isServerToolSelected('canvas_faculty', 'grade_submission')).toBe(true);
+    });
+
+    it('stays the bare ref when nothing is touched', () => {
+      expect(refs(component)).toEqual(['canvas_faculty']);
+    });
+
+    it('narrows to scoped refs when one tool is turned off', () => {
+      component.toggleServerTool(CANVAS, 'grade_submission');
+      expect(refs(component)).toEqual([
+        'canvas_faculty::list_courses',
+        'canvas_faculty::list_rubrics',
+      ]);
+      expect(component.isServerToolSelected('canvas_faculty', 'grade_submission')).toBe(false);
+      expect(component.selectedServerToolCount(CANVAS)).toBe(2);
+    });
+
+    it('collapses back to the bare ref when the last tool is turned on again', () => {
+      component.toggleServerTool(CANVAS, 'grade_submission');
+      component.toggleServerTool(CANVAS, 'grade_submission');
+      expect(refs(component)).toEqual(['canvas_faculty']);
+    });
+
+    it('deselects the server when its last tool is turned off', () => {
+      for (const name of ['list_courses', 'list_rubrics', 'grade_submission']) {
+        component.toggleServerTool(CANVAS, name);
+      }
+      expect(refs(component)).toEqual([]);
+      expect(component.isToolSelected('canvas_faculty')).toBe(false);
+    });
+  });
+
+  describe('a scoped binding', () => {
+    beforeEach(async () => {
+      ({ fixture, component } = await mount([
+        { kind: 'tool', ref: 'canvas_faculty::list_courses' },
+        { kind: 'tool', ref: 'canvas_faculty::list_rubrics' },
+      ]));
+    });
+
+    it('hydrates its refs verbatim', () => {
+      expect(refs(component)).toEqual([
+        'canvas_faculty::list_courses',
+        'canvas_faculty::list_rubrics',
+      ]);
+    });
+
+    it('shows the server as selected but not whole', () => {
+      expect(component.isToolSelected('canvas_faculty')).toBe(true);
+      expect(component.isWholeServerSelected(CANVAS)).toBe(false);
+      expect(component.selectedServerToolCount(CANVAS)).toBe(2);
+    });
+
+    it('leaves the unselected tool off', () => {
+      expect(component.isServerToolSelected('canvas_faculty', 'grade_submission')).toBe(false);
+    });
+
+    it('drops every scoped ref when the server chip is deselected', () => {
+      component.toggleTool('canvas_faculty');
+      expect(refs(component)).toEqual([]);
+    });
+
+    it('re-selecting the chip binds the whole server again', () => {
+      component.toggleTool('canvas_faculty');
+      component.toggleTool('canvas_faculty');
+      expect(refs(component)).toEqual(['canvas_faculty']);
+    });
+
+    it('renders the per-tool rows once expanded', async () => {
+      component.toggleToolExpanded('canvas_faculty');
+      fixture.detectChanges();
+      const switches = fixture.nativeElement.querySelectorAll('[role="switch"]');
+      expect(switches.length).toBe(3);
+      expect(fixture.nativeElement.textContent).toContain('grade_submission');
+      // `2 of 3` on the chip, so the narrowing is legible without expanding.
+      expect(fixture.nativeElement.textContent).toContain('2 of 3');
+    });
+
+    it('splits a docstring into summary and Args: detail, like the chat picker', () => {
+      const listCourses = component.serverTools(CANVAS)[0];
+      expect(listCourses.summary).toBe('List courses.');
+      expect(listCourses.detail).toContain('Args:');
+    });
+  });
+
+  describe('a tool with no discovered list', () => {
+    beforeEach(async () => {
+      ({ fixture, component } = await mount([{ kind: 'tool', ref: 'calculator' }]));
+    });
+
+    it('offers no per-tool control', () => {
+      expect(component.canScopeTool(CALCULATOR)).toBe(false);
+    });
+
+    it('toggles as a plain whole-tool binding', () => {
+      component.toggleTool('calculator');
+      expect(refs(component)).toEqual([]);
+      component.toggleTool('calculator');
+      expect(refs(component)).toEqual(['calculator']);
+    });
+  });
+});

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -363,12 +363,73 @@
         <p class="mt-0.5 text-xs/5 text-gray-500 dark:text-gray-400">Capabilities this agent can call.</p>
         <div class="mt-4 flex flex-wrap gap-2">
           @for (t of tools(); track t.ref) {
-            <button type="button" (click)="toggleTool(t.ref)" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition" [class.border-primary-500]="isToolSelected(t.ref)" [class.bg-primary-50]="isToolSelected(t.ref)" [class.text-primary-accessible]="isToolSelected(t.ref)" [class.dark:bg-primary-900/30]="isToolSelected(t.ref)" [class.dark:text-primary-accessible-dark]="isToolSelected(t.ref)" [class.border-gray-200]="!isToolSelected(t.ref)" [class.text-gray-700]="!isToolSelected(t.ref)" [class.dark:border-gray-700]="!isToolSelected(t.ref)" [class.dark:text-gray-300]="!isToolSelected(t.ref)" [appTooltip]="t.description" appTooltipPosition="top">
-              @if (isToolSelected(t.ref)) { <ng-icon name="heroCheck" class="size-3.5" /> }
-              {{ t.label }}
-            </button>
+            <!--
+              The chip selects the whole server, which is what a tool binding has always
+              meant. An MCP server with a discovered tool list gets a second control: the
+              caret opens its tools so the author can bind a subset instead. A server the
+              agent doesn't need every tool of is the common case — Rubric Builder wants
+              7 of canvas_faculty's 44 — and the ones it doesn't take sit in the model's
+              toolConfig on every turn.
+            -->
+            <span class="inline-flex items-stretch rounded-full border transition" [class.border-primary-500]="isToolSelected(t.ref)" [class.bg-primary-50]="isToolSelected(t.ref)" [class.dark:bg-primary-900/30]="isToolSelected(t.ref)" [class.border-gray-200]="!isToolSelected(t.ref)" [class.dark:border-gray-700]="!isToolSelected(t.ref)">
+              <button type="button" (click)="toggleTool(t.ref)" class="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm" [class.text-primary-accessible]="isToolSelected(t.ref)" [class.dark:text-primary-accessible-dark]="isToolSelected(t.ref)" [class.text-gray-700]="!isToolSelected(t.ref)" [class.dark:text-gray-300]="!isToolSelected(t.ref)" [appTooltip]="t.description" appTooltipPosition="top">
+                @if (isToolSelected(t.ref)) { <ng-icon name="heroCheck" class="size-3.5" /> }
+                {{ t.label }}
+                @if (isToolSelected(t.ref) && canScopeTool(t) && !isWholeServerSelected(t)) {
+                  <span class="text-xs/5 tabular-nums opacity-80">{{ selectedServerToolCount(t) }} of {{ serverTools(t).length }}</span>
+                }
+              </button>
+              @if (isToolSelected(t.ref) && canScopeTool(t)) {
+                <button type="button" (click)="toggleToolExpanded(t.ref)" [attr.aria-expanded]="isToolExpanded(t.ref)" [attr.aria-controls]="'agent-server-tools-' + t.ref" [attr.aria-label]="'Choose which ' + t.label + ' tools this agent can call'" class="inline-flex items-center rounded-r-full pr-2.5 pl-1 text-gray-500 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-gray-200">
+                  <ng-icon name="heroChevronDown" class="size-3.5 transition-transform" [class.rotate-180]="isToolExpanded(t.ref)" />
+                </button>
+              }
+            </span>
           }
         </div>
+
+        <!--
+          Per-tool selection, matching the chat tool picker's sub-tool rows (mono name,
+          first-paragraph summary, `Show details` for the Args: block, switch on the
+          right) rather than inventing a second pattern for the same decision.
+        -->
+        @for (t of tools(); track t.ref) {
+          @if (isToolSelected(t.ref) && canScopeTool(t) && isToolExpanded(t.ref)) {
+            <div [id]="'agent-server-tools-' + t.ref" class="mt-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10">
+              <p class="text-xs/5 text-gray-500 dark:text-gray-400">
+                <span class="font-medium text-gray-700 dark:text-gray-300">{{ t.label }}</span> —
+                @if (isWholeServerSelected(t)) {
+                  all {{ serverTools(t).length }} tools. Turn off the ones this agent doesn't need; only the tools left on are sent to the model.
+                } @else {
+                  {{ selectedServerToolCount(t) }} of {{ serverTools(t).length }} tools. Only the tools left on are sent to the model.
+                }
+              </p>
+              <ul class="mt-3 flex flex-col gap-2">
+                @for (sub of serverTools(t); track sub.name) {
+                  <li class="flex items-start justify-between gap-3 rounded-2xl border border-gray-200 px-3 py-2.5 dark:border-white/10">
+                    <div class="min-w-0 flex-1">
+                      <span [id]="'agent-subtool-' + t.ref + '-' + sub.name" class="block font-mono text-xs/5 font-medium text-gray-900 dark:text-white">{{ sub.name }}</span>
+                      @if (sub.summary) {
+                        <span class="mt-0.5 block text-xs/5 text-gray-500 dark:text-gray-400">{{ sub.summary }}</span>
+                      }
+                      @if (sub.detail) {
+                        <button type="button" (click)="toggleToolDetail(t.ref + '::' + sub.name)" [attr.aria-expanded]="isToolDetailExpanded(t.ref + '::' + sub.name)" [attr.aria-controls]="'agent-subtool-detail-' + t.ref + '-' + sub.name" class="mt-1 text-xs/5 font-medium text-primary-600 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-400">
+                          {{ isToolDetailExpanded(t.ref + '::' + sub.name) ? 'Hide details' : 'Show details' }}
+                        </button>
+                        @if (isToolDetailExpanded(t.ref + '::' + sub.name)) {
+                          <pre [id]="'agent-subtool-detail-' + t.ref + '-' + sub.name" class="mt-1.5 overflow-x-auto rounded-lg bg-gray-50 p-2 font-mono text-[11px]/5 whitespace-pre text-gray-600 dark:bg-white/5 dark:text-gray-300">{{ sub.detail }}</pre>
+                        }
+                      }
+                    </div>
+                    <button type="button" role="switch" [attr.aria-checked]="isServerToolSelected(t.ref, sub.name)" [attr.aria-labelledby]="'agent-subtool-' + t.ref + '-' + sub.name" (click)="toggleServerTool(t, sub.name)" (keydown.space)="$event.preventDefault(); toggleServerTool(t, sub.name)" class="relative mt-0.5 inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500" [class]="isServerToolSelected(t.ref, sub.name) ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'">
+                      <span aria-hidden="true" class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out" [class.translate-x-4]="isServerToolSelected(t.ref, sub.name)" [class.translate-x-0]="!isServerToolSelected(t.ref, sub.name)"></span>
+                    </button>
+                  </li>
+                }
+              </ul>
+            </div>
+          }
+        }
       </section>
     }
 

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -32,6 +32,7 @@ import {
   heroCircleStack,
   heroCheck,
   heroAdjustmentsHorizontal,
+  heroChevronDown,
 } from '@ng-icons/heroicons/outline';
 import { Dialog } from '@angular/cdk/dialog';
 import { PickerComponent } from '@ctrl/ngx-emoji-mart';
@@ -40,6 +41,7 @@ import { AgentService } from '../services/agent.service';
 import {
   AgentBinding,
   BindableItem,
+  BindableServerTool,
   MemorySpaceBindingConfig,
   ModelParamSpec,
   SupportedParams,
@@ -48,6 +50,7 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { ThemeService } from '../../components/topnav/components/theme-toggle/theme.service';
 import { ToastService } from '../../services/toast/toast.service';
 import { TooltipDirective } from '../../components/tooltip/tooltip.directive';
+import { splitToolDescription } from '../../shared/utils/tool-description';
 import { AgentPreviewComponent } from './components/agent-preview.component';
 import { AgentIconComponent } from '../components/agent-icon.component';
 import {
@@ -78,6 +81,13 @@ const PARAM_LABELS: Record<string, string> = {
   reasoning_effort: 'Reasoning effort',
   effort: 'Reasoning effort',
 };
+
+/** One of a server's tools with its docstring split for display, as the chat picker does. */
+interface DisplayServerTool {
+  name: string;
+  summary: string;
+  detail: string;
+}
 
 /** A memory-space selection with its per-binding config (access + alwaysLoad). */
 interface MemorySelection {
@@ -126,6 +136,7 @@ interface MemorySelection {
       heroCircleStack,
       heroCheck,
       heroAdjustmentsHorizontal,
+      heroChevronDown,
     }),
   ],
 })
@@ -191,6 +202,10 @@ export class AgentFormPage implements OnInit, OnDestroy {
    * selected model's `supportedParams`. Empty ⇒ omit `params` (today's default). */
   readonly modelParams = signal<Record<string, number | string>>({});
   readonly selectedToolRefs = signal<Set<string>>(new Set());
+  /** Which servers have their per-tool list open. Presentation only — never submitted. */
+  readonly expandedToolRefs = signal<Set<string>>(new Set());
+  /** Which sub-tools have their `Args:` reference detail open, keyed `serverRef::name`. */
+  readonly expandedToolDetails = signal<Set<string>>(new Set());
   readonly selectedSkillRefs = signal<Set<string>>(new Set());
   readonly memorySelections = signal<MemorySelection[]>([]);
 
@@ -469,14 +484,103 @@ export class AgentFormPage implements OnInit, OnDestroy {
     this.bindingsDirty.set(true);
   }
 
-  // ---- tools / skills (multi-select toggles) ---------------------------
+  // ---- tools (server toggle + per-tool scoping) -------------------------
+  /**
+   * `selectedToolRefs` holds `binding.ref` values verbatim, which may be a bare
+   * catalog id (the whole MCP server, and the only shape that existed before) or a
+   * scoped `serverId::toolName` selecting one of its tools. Everything below reads
+   * and writes that one set, so the refs the form submits are exactly what the
+   * backend validates — no parallel selection model to fall out of sync.
+   *
+   * The invariant: a server with *every* tool selected is stored as the bare ref, not
+   * as N scoped refs. That keeps an untouched agent byte-identical to what it had, and
+   * it is what `collect_tool_name_filters` means by whole-server anyway.
+   */
   toggleTool(ref: string): void {
-    this.selectedToolRefs.update((set) => toggle(set, ref));
+    this.selectedToolRefs.update((set) =>
+      this.isToolSelected(ref) ? withoutServer(set, ref) : toggle(set, ref),
+    );
     this.bindingsDirty.set(true);
   }
   isToolSelected(ref: string): boolean {
-    return this.selectedToolRefs().has(ref);
+    for (const selected of this.selectedToolRefs()) {
+      if (baseToolId(selected) === ref) return true;
+    }
+    return false;
   }
+
+  /** A selected server's tools, split for display like the chat tool picker's rows. */
+  serverTools(item: BindableItem): DisplayServerTool[] {
+    const subs = (item.meta?.['serverTools'] as BindableServerTool[] | undefined) ?? [];
+    return subs.map((sub) => ({ name: sub.name, ...splitToolDescription(sub.description ?? '') }));
+  }
+
+  /** Only an MCP server with a discovered tool list can be narrowed. */
+  canScopeTool(item: BindableItem): boolean {
+    return this.serverTools(item).length > 0;
+  }
+
+  isToolExpanded(ref: string): boolean {
+    return this.expandedToolRefs().has(ref);
+  }
+  toggleToolExpanded(ref: string): void {
+    this.expandedToolRefs.update((set) => toggle(set, ref));
+  }
+
+  isServerToolSelected(serverRef: string, name: string): boolean {
+    const refs = this.selectedToolRefs();
+    // The bare ref means every tool, including this one.
+    return refs.has(serverRef) || refs.has(scopedToolId(serverRef, name));
+  }
+
+  /**
+   * Turn one of a server's tools on or off, re-deriving the server's refs from the
+   * result: all on collapses to the bare ref, none on deselects the server entirely
+   * (an empty scoped set is not a thing the backend can store, and "selected but with
+   * nothing selected" is not a state worth inventing a third rendering for).
+   */
+  toggleServerTool(item: BindableItem, name: string): void {
+    const all = this.serverTools(item).map((sub) => sub.name);
+    const current = new Set(
+      all.filter((toolName) => this.isServerToolSelected(item.ref, toolName)),
+    );
+    if (current.has(name)) current.delete(name);
+    else current.add(name);
+
+    this.selectedToolRefs.update((set) => {
+      const next = withoutServer(set, item.ref);
+      if (current.size === 0) return next;
+      if (current.size === all.length) {
+        next.add(item.ref);
+        return next;
+      }
+      for (const toolName of all) {
+        if (current.has(toolName)) next.add(scopedToolId(item.ref, toolName));
+      }
+      return next;
+    });
+    this.bindingsDirty.set(true);
+  }
+
+  /** Every tool on (or the server not narrowed at all) — drives the "All" summary. */
+  isWholeServerSelected(item: BindableItem): boolean {
+    return this.selectedToolRefs().has(item.ref);
+  }
+
+  /** How many of a server's tools are on, for the chip's `5 of 44` count. */
+  selectedServerToolCount(item: BindableItem): number {
+    return this.serverTools(item).filter((sub) => this.isServerToolSelected(item.ref, sub.name))
+      .length;
+  }
+
+  isToolDetailExpanded(key: string): boolean {
+    return this.expandedToolDetails().has(key);
+  }
+  toggleToolDetail(key: string): void {
+    this.expandedToolDetails.update((set) => toggle(set, key));
+  }
+
+  // ---- skills (multi-select toggles) -----------------------------------
   toggleSkill(ref: string): void {
     this.selectedSkillRefs.update((set) => toggle(set, ref));
     this.bindingsDirty.set(true);
@@ -722,6 +826,28 @@ export class AgentFormPage implements OnInit, OnDestroy {
       });
     }
   }
+}
+
+/** The delimiter in a scoped tool id, mirroring `apis/shared/tools/scoped_ids.py`. */
+const SCOPE_DELIMITER = '::';
+
+function scopedToolId(serverRef: string, name: string): string {
+  return `${serverRef}${SCOPE_DELIMITER}${name}`;
+}
+
+/** The catalog id a (possibly scoped) ref refers to. */
+function baseToolId(ref: string): string {
+  const at = ref.indexOf(SCOPE_DELIMITER);
+  return at === -1 ? ref : ref.slice(0, at);
+}
+
+/** Drop every ref belonging to one server — the bare id and any scoped ones. */
+function withoutServer(set: Set<string>, serverRef: string): Set<string> {
+  const next = new Set<string>();
+  for (const ref of set) {
+    if (baseToolId(ref) !== serverRef) next.add(ref);
+  }
+  return next;
 }
 
 function toggle(set: Set<string>, ref: string): Set<string> {

--- a/frontend/ai.client/src/app/agents/models/agent.model.ts
+++ b/frontend/ai.client/src/app/agents/models/agent.model.ts
@@ -193,6 +193,23 @@ export interface BindableItem {
   meta: Record<string, unknown>;
 }
 
+/**
+ * One tool an MCP server exposes, as carried on a `kind: 'tool'` item's
+ * `meta.serverTools`. It is the server's last *discovery* snapshot (refreshed by
+ * "Discover from server" on the admin tool page), which is why an undiscovered
+ * server arrives with an empty list rather than a short one.
+ *
+ * This is what lets an author bind a subset: a selected name becomes the scoped
+ * ref `serverId::toolName`. Presentation and authoring only — the list is never
+ * consulted at run time, where the scoped ref itself does the narrowing.
+ */
+export interface BindableServerTool {
+  name: string;
+  description?: string;
+  needsApproval?: boolean;
+  enabled?: boolean;
+}
+
 export interface BindableListResponse {
   kind: string;
   items: BindableItem[];


### PR DESCRIPTION
An Agent's `binding.ref` accepted only a bare catalog id, so binding an MCP server loaded every one of its tools. The live **Rubric Builder** agent in dev needs 7 of `canvas_faculty`'s 44 and carried `grade_submission`, `bulk_grade_submissions`, `create_assignment` and `delete_rubric` — held back only by wording in its system prompt. `docs/specs/canvas-rubric-agent.md` §8.3 named that as the residual risk and this as the structural fix.

`binding.ref` now also accepts `canvas_faculty::create_rubric`. Bare refs are untouched — this is additive.

## Not built from scratch

`apis/shared/tools/scoped_ids.py` already owned the format and the runtime already honoured it (`collect_tool_name_filters` → `load_external_tools` → per-server `allowed_tool_names`, folded into the client cache key). User-facing tool selection has used that path all along. Three things blocked the **bindings** axis:

- **`AppRoleService.can_access_tool`** exact-matched the id, so a scoped ref was denied even for a user holding the whole server — while its sibling `filter_requested_tools` base-collapsed correctly on the `enabled_tools` axis. Scoping narrows a grant and can never widen one, so a grant on the base admits any subset. A test now asserts the two predicates agree tool-for-tool, since their divergence is what made a subset the chat picker happily sent illegal as a binding.
- **`_validate_tool`** required the ref verbatim in the author's palette. It now checks the base against the palette and the tool name against that server's discovered `serverTools`, mirroring `ToolCatalogService.save_user_preferences` — including skipping the name check for a server that has never been discovered, and rejecting a `base::` with no name (which would silently store as whole-server).
- **`get_freshness_hash`** looked a scoped id up in the catalog, missed, and pinned it to a constant `none`, so an admin edit to a server would never evict an agent that had bound a subset of it. Found while tracing, not in the brief. Ids are base-collapsed first, which also turns seven refs into one catalog read.

The resolver carries scoped ids through **verbatim** — that id *is* the enforcement — and gates on the base, checked once per server rather than once per binding.

## Agent Designer

The Tools chip still selects the whole server. An MCP server with a discovered tool list also gets a caret that opens its tools; the chip then reads `7 of 44`. The rows are the chat tool picker's sub-tool rows — mono name, first-paragraph summary, `Show details` for the `Args:` block, switch on the right — not a second pattern for the same decision. `serverTools` was already on the `/agents/bindable` payload.

The invariant that matters: a fully-selected server collapses to the **bare** ref. Without it, opening the form would rewrite every existing agent's bindings for a change the author never made.

## Verified in dev, on the real agent

Rebound Rubric Builder through the Agent Designer to the seven it needs, against a local stack on this branch pointed at dev data.

| | bare binding | 7 scoped refs |
|---|---|---|
| runtime MCP client | no filter | `(tools: associate_rubric, create_rubric, get_assignment_details, get_rubric, list_assignments, list_courses, list_rubrics)` |
| tools reaching the model | 44 | 7 |
| whole-turn prompt | **27,959** tokens | **9,981** |
| turn cost | $0.0958 | $0.0384 |

The rubric read flow (`list_courses` → `list_assignments` → `list_rubrics`) returned real Canvas data on both. Asked whether it could grade a submission, the scoped run answered that it has no tool that reads or scores submissions; the bare run named `grade_submission`, `grade_with_rubric` and `bulk_grade_submissions` and declined by policy. The conclusive evidence is the log line and the token delta, not the model's own account.

**The agent has been left on its original bare binding** — "changing any existing agent's bindings" was out of scope, and the rebind is now one click in the Designer.

## Tests

New: the RBAC gate against real `AppRole` records; scoped/bare/malformed refs through design-time validation; the resolver's verbatim pass-through and per-server gating; and an end-to-end seam test driving `Assistant.bindings` → resolver → `ToolFilter` → `load_external_tools` and asserting the filter that actually reaches `create_external_mcp_client`. That last one exists because a resolver that base-collapsed a ref would pass every layer's own tests and quietly hand the turn all 44 tools — invisible from outside, because the agent still works.

Backend 8213 passed / 3 skipped. SPA 2723 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)