### PR TITLE
fix(ci): anchor filesystem-reading specs to the project root, and let PR CI see them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
     with:
       run_backend: true
       run_frontend: true
+      # The frontend suite again under --coverage — the nightly's invocation.
+      # Coverage changes how the specs are built (see tests.yml), so specs can
+      # pass here and fail there. Only the PR gate pays for it; the deploy
+      # workflows keep running the plain suite.
+      run_frontend_coverage: true
       run_infra: true
       # Pure-logic tests for tests/load. Deliberately only on the PR gate: the
       # deploy workflows run test suites to protect a deploy, and the load

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_frontend_coverage:
+        description: 'Run the frontend suite a second time under --coverage (the nightly invocation)'
+        required: false
+        default: false
+        type: boolean
       run_infra:
         description: 'Run infrastructure jest suite'
         required: false
@@ -81,6 +86,51 @@ jobs:
       - name: Run tests
         working-directory: frontend/ai.client
         run: npm run test:ci
+
+  # The SAME frontend suite, run the way the nightly runs it: `ng test
+  # --no-watch --coverage`, via the very script nightly.yml invokes.
+  #
+  # Why this is a separate gate rather than a flag on `test:ci`: under
+  # --coverage, @angular/build's unit-test builder bundles each spec into a
+  # flattened chunk emitted at the PROJECT ROOT instead of handing Vitest the
+  # spec at its own source path. `import.meta.url` and the `__dirname` shim
+  # move with it, so every filesystem-reading spec resolves relative paths
+  # from a different directory than it does without coverage. That is a real
+  # failure mode with no watered-down version — a doc-presence spec reads the
+  # wrong README and a hygiene guard walks generated CSS and "finds"
+  # violations — and until this job existed NOTHING on a pull request ever
+  # passed --coverage, so the class could only be discovered by the nightly,
+  # after merge. It went undetected for seven consecutive nights.
+  #
+  # It is its own job, and enabled only on the PR gate (ci.yml), because the
+  # deploy workflows run `test-frontend` to protect a deploy and gain nothing
+  # from paying for instrumentation there. Running in parallel with
+  # test-frontend costs no extra wall-clock on the PR.
+  #
+  # Coverage artifacts are deliberately NOT uploaded here: the nightly owns
+  # coverage *reporting* (analyze-coverage compares runs over time). This job
+  # only cares that the suite passes under the instrumented build.
+  test-frontend-coverage:
+    if: ${{ inputs.run_frontend_coverage }}
+    name: Test frontend (coverage build)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/ai.client/package-lock.json
+      - name: Install
+        working-directory: frontend/ai.client
+        run: npm ci --prefer-offline
+      - name: Run tests with coverage
+        run: bash scripts/frontend/test.sh
 
   test-infra:
     if: ${{ inputs.run_infra }}

--- a/frontend/ai.client/src/app/color-tokens.spec.ts
+++ b/frontend/ai.client/src/app/color-tokens.spec.ts
@@ -30,6 +30,7 @@
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fromProjectRoot } from '../testing/project-root';
 
 describe('color token hygiene', () => {
   it('src/app should not use raw Tailwind palettes (ratchet enforcement)', () => {
@@ -101,7 +102,7 @@ describe('color token hygiene', () => {
     const commentPatterns = [/\/\/.*/g, /\/\*[\s\S]*?\*\//g, /<!--[\s\S]*?-->/g];
 
     // Scan files.
-    const appDir = path.join(__dirname);
+    const appDir = fromProjectRoot('src/app');
     const files: string[] = [];
 
     function walkDir(dir: string): void {

--- a/frontend/ai.client/src/app/surface-literal-guard.spec.ts
+++ b/frontend/ai.client/src/app/surface-literal-guard.spec.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fromProjectRoot } from '../testing/project-root';
 
 describe('surface literal hygiene', () => {
   it('src/app should not use literal white/black/hex values in background declarations (Prism okaidia exempted)', () => {
@@ -41,7 +42,7 @@ describe('surface literal hygiene', () => {
 
     const commentPatterns = [/\/\/.*/g, /\/\*[\s\S]*?\*\//g, /<!--[\s\S]*?-->/g];
 
-    const appDir = path.join(__dirname);
+    const appDir = fromProjectRoot('src/app');
     const files: string[] = [];
 
     function walkDir(dir: string): void {

--- a/frontend/ai.client/src/app/tailwind-theme-import-guard.spec.ts
+++ b/frontend/ai.client/src/app/tailwind-theme-import-guard.spec.ts
@@ -21,13 +21,14 @@
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fromProjectRoot } from '../testing/project-root';
 
 describe('tailwind theme-import hygiene', () => {
   it('only styles/theme.css may @import "tailwindcss"; every other stylesheet must @reference the shared theme', () => {
     // The single allowed owner of `@import "tailwindcss"`, relative to src/.
     const ALLOWED_TAILWIND_IMPORTER = path.normalize('styles/theme.css');
 
-    const srcDir = path.resolve(__dirname, '..');
+    const srcDir = fromProjectRoot('src');
     const styleFiles: string[] = [];
 
     // Both standalone `.css` stylesheets AND `.ts` components with an inline

--- a/frontend/ai.client/src/branding/brand-theme-golden.spec.ts
+++ b/frontend/ai.client/src/branding/brand-theme-golden.spec.ts
@@ -11,14 +11,12 @@
 // branding. See design.md "Snapshot / golden regression tests".
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fromProjectRoot } from '../testing/project-root';
 import { generateBrandTheme } from '../../scripts/branding/generate-brand-theme';
 import { BRAND_CONFIG } from './brand.config';
 import { DEFAULT_SURFACES } from './brand.defaults';
 
-const SPEC_DIR = dirname(fileURLToPath(import.meta.url));
-const GOLDEN_CSS_PATH = resolve(SPEC_DIR, '../styles/generated/brand-theme.css');
+const GOLDEN_CSS_PATH = fromProjectRoot('src/styles/generated/brand-theme.css');
 
 /**
  * Extract just the declaration lines from the committed brand-theme.css:

--- a/frontend/ai.client/src/branding/prestart-generator-parity.spec.ts
+++ b/frontend/ai.client/src/branding/prestart-generator-parity.spec.ts
@@ -18,12 +18,10 @@
 // generator is missing from a hook, not when the count changes.
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fromProjectRoot } from '../testing/project-root';
 
-const SPEC_DIR = dirname(fileURLToPath(import.meta.url));
-const PACKAGE_JSON_PATH = resolve(SPEC_DIR, '../../package.json');
-const GENERATORS_DIR = resolve(SPEC_DIR, '../../scripts/branding');
+const PACKAGE_JSON_PATH = fromProjectRoot('package.json');
+const GENERATORS_DIR = fromProjectRoot('scripts/branding');
 
 // Every generator is named generate-*.ts. color-math.ts and any other
 // helper module is intentionally excluded: only entry-point generators

--- a/frontend/ai.client/src/branding/rebranding-guide.doc-presence.spec.ts
+++ b/frontend/ai.client/src/branding/rebranding-guide.doc-presence.spec.ts
@@ -8,11 +8,9 @@
 // without breaking this test. See requirements.md Requirement 9.
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fromProjectRoot } from '../testing/project-root';
 
-const SPEC_DIR = dirname(fileURLToPath(import.meta.url));
-const README_PATH = resolve(SPEC_DIR, './README.md');
+const README_PATH = fromProjectRoot('src/branding/README.md');
 
 const readmeContent = readFileSync(README_PATH, 'utf8');
 

--- a/frontend/ai.client/src/branding/surface-theme-golden.spec.ts
+++ b/frontend/ai.client/src/branding/surface-theme-golden.spec.ts
@@ -13,14 +13,12 @@
 // value.
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fromProjectRoot } from '../testing/project-root';
 import { generateSurfaceTheme } from '../../scripts/branding/generate-surface-theme';
 import { BRAND_CONFIG } from './brand.config';
 import { DEFAULT_SURFACES } from './brand.defaults';
 
-const SPEC_DIR = dirname(fileURLToPath(import.meta.url));
-const GOLDEN_CSS_PATH = resolve(SPEC_DIR, '../styles/generated/surface-theme.css');
+const GOLDEN_CSS_PATH = fromProjectRoot('src/styles/generated/surface-theme.css');
 
 /** Mirrors brand-theme-golden.spec.ts's extractThemeDeclarations. */
 function extractThemeDeclarations(fileContents: string): string {

--- a/frontend/ai.client/src/testing/project-root.ts
+++ b/frontend/ai.client/src/testing/project-root.ts
@@ -1,0 +1,66 @@
+// project-root.ts — the one stable filesystem anchor for specs that read
+// real files off disk.
+//
+// WHY THIS EXISTS
+//
+// A handful of specs are filesystem guards rather than unit tests: they read
+// README.md, package.json, the committed styles/generated/*.css goldens, or
+// walk src/app looking for banned CSS. They need to know where the project
+// root is. The obvious anchors do not survive `--coverage`:
+//
+//   Without --coverage, @angular/build's unit-test builder hands each spec to
+//   Vitest at its own source path, so `import.meta.url` and the `__dirname`
+//   shim both point at the spec's own directory:
+//
+//     import.meta.url  file:///…/frontend/ai.client/src/branding/foo.spec.ts
+//     __dirname        /…/frontend/ai.client/src/branding
+//
+//   With --coverage the builder bundles instead, emitting one flattened chunk
+//   per spec AT THE PROJECT ROOT, and both anchors move with it:
+//
+//     import.meta.url  file:///…/frontend/ai.client/spec-branding-foo.js
+//     __dirname        /…/frontend/ai.client
+//
+// This is an absolute relocation to the project root, not a fixed-depth
+// shift — a spec nested four levels deep resolves to the project root just
+// like one nested two levels deep. So every `resolve(SPEC_DIR, '../..')`
+// silently changed meaning under coverage, which is why these specs passed in
+// PR CI (`ng test --watch=false`) and failed every night in the coverage job.
+//
+// `process.cwd()` is stable ACROSS the two modes but is not pinned by the
+// builder — it is whatever directory `ng` was invoked from, which may be a
+// subdirectory of the project. So we walk up from it looking for
+// `angular.json`, which is exactly how the Angular CLI locates the workspace
+// itself; by construction this helper agrees with the tool that is running it.
+//
+// RULE: filesystem-reading specs must anchor on `fromProjectRoot()`. Do not
+// reintroduce `import.meta.url` or `__dirname` for path resolution in a spec.
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+function findProjectRoot(): string {
+  let dir = process.cwd();
+
+  for (;;) {
+    if (existsSync(resolve(dir, 'angular.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `Could not locate the Angular project root: no angular.json found in ${process.cwd()} ` +
+          'or any parent directory. Filesystem-reading specs must be run via `ng test` from ' +
+          'within frontend/ai.client.',
+      );
+    }
+    dir = parent;
+  }
+}
+
+/** Absolute path to the Angular project root (the directory holding angular.json). */
+export const PROJECT_ROOT = findProjectRoot();
+
+/** Resolve a path relative to the Angular project root, e.g. `fromProjectRoot('src', 'app')`. */
+export function fromProjectRoot(...segments: string[]): string {
+  return resolve(PROJECT_ROOT, ...segments);
+}

--- a/frontend/ai.client/tsconfig.app.json
+++ b/frontend/ai.client/tsconfig.app.json
@@ -10,6 +10,7 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/testing/**/*.ts"
   ]
 }

--- a/frontend/ai.client/tsconfig.spec.json
+++ b/frontend/ai.client/tsconfig.spec.json
@@ -12,6 +12,7 @@
   "include": [
     "src/**/*.d.ts",
     "src/**/*.spec.ts",
-    "src/test-setup.ts"
+    "src/test-setup.ts",
+    "src/testing/**/*.ts"
   ]
 }


### PR DESCRIPTION
Fixes the nightly, which has been **red for seven consecutive nights** (2026-09-05 → 2026-09-11) after being green the five before. Two commits: the actual fix, and the reason nobody caught it.

## Root cause

Six filesystem-reading specs failed **only under `--coverage`** — which the nightly passes (`scripts/frontend/test.sh` → `ng test --no-watch --coverage`) and PR CI does not (`npm run test:ci` → `ng test --watch=false`).

Under `--coverage`, `@angular/build`'s unit-test builder **bundles** each spec into a flattened chunk emitted at the **project root**, instead of handing Vitest the spec at its own source path. Both anchors move with it:

| | without `--coverage` | with `--coverage` |
|---|---|---|
| `import.meta.url` | `…/src/branding/foo.spec.ts` | `…/spec-branding-foo.js` |
| `__dirname` | `…/src/branding` | `…/frontend/ai.client` |

This is an **absolute relocation to the project root, not a fixed-depth shift** — a spec nested four levels deep lands in the same place as one nested two. So every `resolve(SPEC_DIR, '../..')` silently changed meaning:

- `rebranding-guide.doc-presence.spec.ts` read `frontend/ai.client/README.md` (`# AiClient…`) instead of `src/branding/README.md` (`# Rebranding Guide`).
- `prestart-generator-parity.spec.ts` ENOENT'd at **collection**.
- The two hygiene guards walked the whole package — including generated Tailwind CSS, which is full of literal hex and contains a direct `@import "tailwindcss"` — so they *found violations* rather than finding nothing.

## The fix

`src/testing/project-root.ts` walks up from `process.cwd()` to the directory holding `angular.json` — the same way the Angular CLI locates the workspace, so the helper agrees **by construction** with the tool running it. `process.cwd()` is stable across both modes; `import.meta.url`/`__dirname` are not.

`color-tokens.spec.ts` was not in the original failing set but shares the pattern and is converted too, so the rule holds uniformly.

## The structural half — the more important one

Nothing on a pull request has **ever** passed `--coverage`, so this class could only be found by the nightly, after merge. New `test-frontend-coverage` job invokes `scripts/frontend/test.sh` — *the very script `nightly.yml` runs* — so the gate matches the nightly rather than approximating it. Enabled only from `ci.yml`; runs in parallel with `test-frontend` so it costs no extra wall-clock; uploads no artifacts, since the nightly still owns coverage reporting over time.

## Verification

Both invocations run locally, identical results:

| invocation | result |
|---|---|
| `npm run test:ci` (no coverage) | **230 files / 2723 tests passed** |
| `bash scripts/frontend/test.sh` (coverage) | **230 files / 2723 tests passed** |

**The guards were checked for vacuous passes, not just for green.** A literal `background: #abcdef` and a stray `@import "tailwindcss"` were planted under `src/app` and the coverage run was repeated: exactly **2 failed / 2721 passed**, both the planted violations, each naming the right guard. Probes removed.

## Not in scope

- **vitest 4→5** — deliberately not attempted; the suite was not a trustworthy migration baseline until it was green.
- **`nightly-develop-PlatformStack`**, wedged in `DELETE_FAILED` — the nightly's *other*, independent root cause. It is a dev-ai console task and will keep the `deploy` track red until someone with access reads `StackStatusReason` and clears the retained resource. **This PR does not fix that, and the nightly deploy job will still fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)