### PR TITLE
build(deps): constrain the transitive `mcp` dependency below 2.x

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -106,6 +106,34 @@ all = [
     "agentcore-stack[agentcore,bidi,dev]",
 ]
 
+[tool.uv]
+# Guard rail on a TRANSITIVE dependency — this is not a loosened pin.
+#
+# `mcp` arrives only via `strands-agents`; we do not depend on it directly and
+# deliberately do not promote it to a direct dependency. `strands-agents==1.55.0`
+# — the version pinned above, today — already declares `mcp>=1.23.0,<2.2`, so
+# the resolver is free to cross into `mcp` 2.x whenever it gets the chance.
+#
+# The ONLY thing holding us on the 1.x line right now is incidental: `mcp` 2.x
+# pulls `httpx2>=2.5.0`, which needs `idna>=3.18`, and we pin `idna==3.15` for
+# an unrelated Dependabot alert. A routine security bump of `idna` would quietly
+# unblock the major crossing — nobody would be choosing it, and nothing in the
+# diff would say "MCP".
+#
+# That crossing lands under `src/agents/main_agent/integrations/mcp_apps.py`,
+# which substitutes `strands.tools.mcp.mcp_client.ClientSession` with
+# `_UIExtensionClientSession` to advertise the MCP Apps UI extension (SEP-1865)
+# on `initialize`. That seam reaches through a Strands internal into an MCP SDK
+# class and has never been exercised against 2.x — where the transport
+# dependency itself changed (httpx -> httpx2) and the types moved to a separate
+# `mcp-types` distribution. The failure mode is silent: MCP App frame headers
+# degrade to a generic glyph rather than raising an ImportError.
+#
+# A constraint, not a dependency: it bounds the version IF `mcp` is in the
+# resolution graph, without adding it to our own dependency metadata. Lift it
+# deliberately, together with a test pass over that `ClientSession` patch.
+constraint-dependencies = ["mcp<2"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+constraints = [{ name = "mcp", specifier = "<2" }]
+
 [[package]]
 name = "agentcore-stack"
 version = "1.20.0"


### PR DESCRIPTION
Kaizen review 2026-09-11, Proposal #9(a). A one-line guard rail, and the reason it is worth having.

## The hazard

`mcp` reaches us only through `strands-agents` — we do not depend on it directly. `strands-agents==1.55.0` already declares **`mcp>=1.23.0,<2.2`**, so the resolver is free to cross into `mcp` 2.x at any time. `uv.lock` currently sits at **1.28.1**; latest on PyPI is **2.2.0**.

**The only thing holding us on the 1.x line today is incidental.** `mcp` 2.x pulls `httpx2>=2.5.0`, which needs `idna>=3.18` — and we pin `idna==3.15` for an unrelated Dependabot alert. A routine security bump of `idna` would quietly unblock the major crossing. Nobody would be choosing it, and nothing in that diff would mention MCP.

## Why that crossing is not safe to take by accident

It lands under `integrations/mcp_apps.py`, which substitutes `strands.tools.mcp.mcp_client.ClientSession` with `_UIExtensionClientSession` to advertise the MCP Apps UI extension (SEP-1865) on `initialize`.

That seam reaches **through a Strands internal into an MCP SDK class**, and it has never been exercised against 2.x — where the transport dependency itself changed (`httpx` → `httpx2`) and the types moved to a separate `mcp-types` distribution. The failure mode is silent: App frame headers degrade to a generic glyph rather than raising an `ImportError`.

Strands is also actively churning that client — an httpx2 adapter (#4183), the floor relaxation (#4151), SEP-2663 tasks (#4125) and changed `load_servers` defaults (#4177), all in one week.

## The mechanism

`[tool.uv] constraint-dependencies = ["mcp<2"]` — it bounds the version **if** `mcp` is in the resolution graph, without adding it to our own dependency metadata. The alternative, adding `mcp<2` to `dependencies`, would promote a transitive dep to a direct one, which is a larger claim than we want to make.

⚠️ **On the exact-pins rule:** this repo requires exact version pins with no `^`, `~` or `>=`. This is not a loosened pin — it is an upper bound on a transitive dependency we do not pin at all today, and its purpose is to make a major crossing a deliberate act rather than a side effect. Lift it together with a test pass over the `ClientSession` patch.

## Verification — the resolved version does not move

| | before | after |
|---|---|---|
| `mcp` resolved | 1.28.1 | **1.28.1** |
| version lines changed in `uv.lock` | — | **0** |

The entire `uv.lock` diff is three lines: the `[manifest] constraints` stanza and nothing else. `uv sync --extra agentcore --extra dev` leaves the lock clean, confirming the constraint is a genuine no-op on the current resolution.

## Not in scope

**`strands-agents` 1.55.0 → 1.55.1 is deliberately not bumped here**, though the review named it as a natural rider. Adding a constraint that changes nothing is a guard; a version bump is an upgrade, and this repo requires explicit approval for those.

`mcp_apps.py` and the monkeypatch are untouched — retiring it is Proposal #9(b), deferred pending verification that the MCP servers we actually call emit `io.modelcontextprotocol/serverInfo` in result `_meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)