### PR TITLE
feat(models): register GPT-6 Astra at the 272K short-context cap

### DIFF
--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
@@ -265,7 +265,7 @@ describe('ModelCatalogPage', () => {
     });
   });
 
-  describe('curated bedrock-responses (GPT-5.6) entries', () => {
+  describe('curated bedrock-responses (OpenAI family) entries', () => {
     it('renders them on their own tab', () => {
       const page = createComponent();
       page.selectTab('bedrock-responses');
@@ -308,6 +308,34 @@ describe('ModelCatalogPage', () => {
       // silently block params the model actually accepts.
       for (const model of CURATED_BEDROCK_RESPONSES_MODELS) {
         expect(model.template.supportedParams ?? null).toBeNull();
+      }
+    });
+
+    it('curates GPT-6 Astra on the Short Context rate card', () => {
+      // The 272K cap is covered by the family loop above; this pins the rates
+      // that cap keeps correct. Geo CRIS Short Context is $11.00 / $55.00 —
+      // Long Context (1.05M) is $22.00 / $82.50, and the tier is chosen by the
+      // request's actual token count, so nothing but the cap keeps a single
+      // flat rate per bucket true.
+      const astra = CURATED_BEDROCK_RESPONSES_MODELS.find(m => m.key === 'gpt-6-astra');
+
+      expect(astra?.template.modelId).toBe('us.openai.gpt-6-astra');
+      expect(astra?.template.inputPricePerMillionTokens).toBeCloseTo(11.0, 6);
+      expect(astra?.template.outputPricePerMillionTokens).toBeCloseTo(55.0, 6);
+    });
+
+    it('declares Astra\'s published output cap and cutoff, which its siblings lack', () => {
+      // Astra's card publishes `Max output tokens: 128,000` and an April 30,
+      // 2026 cutoff; every GPT-5.6 card states neither, which is why the
+      // family default is null for both. Inheriting the default here would
+      // discard two numbers AWS actually publishes.
+      const astra = CURATED_BEDROCK_RESPONSES_MODELS.find(m => m.key === 'gpt-6-astra');
+
+      expect(astra?.template.maxOutputTokens).toBe(128_000);
+      expect(astra?.template.knowledgeCutoffDate).toBe('2026-04-30');
+
+      for (const sibling of CURATED_BEDROCK_RESPONSES_MODELS.filter(m => m.key !== 'gpt-6-astra')) {
+        expect(`${sibling.key}:${sibling.template.maxOutputTokens}`).toBe(`${sibling.key}:null`);
       }
     });
   });

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -401,11 +401,30 @@ const bedrockResponsesDefaults = (): Pick<
 });
 
 /**
- * GPT-5.6 on `bedrock-runtime` via the Responses API.
+ * The OpenAI family on `bedrock-runtime` via the Responses API.
  *
  * Rates are the **Geo CRIS, Short Context (272K)** row from each model card —
  * Geo CRIS is the tier the `us.*` inference profiles resolve to, and these
- * models are inference-profile-only (no ON_DEMAND). Verified 2026-09-06.
+ * models are inference-profile-only (no ON_DEMAND). Verified 2026-09-06,
+ * re-verified for GPT-6 Astra 2026-09-11.
+ *
+ * **Every card in this family publishes two price tables, and the tier is
+ * selected by the ACTUAL token count of the request** — not by a declared
+ * window, and not by a separate model id. Settled 2026-09-11 (see
+ * `docs/kaizen/review-queue.md`): the Price List API encodes `-long-ctx` as a
+ * value of `tokenType` under an identical `model` attribute, GPT-5.6 Terra
+ * declares a 1M window against a single model id yet still publishes a
+ * reachable Short Context table, and our own Cost Explorer rows bill
+ * `_standard` and never `-long-ctx` while calling those 1M-window ids. There
+ * is no field in which a window could be declared: `maxInputTokens` below is
+ * ours, is read only for compaction and telemetry, and never reaches a
+ * Bedrock request.
+ *
+ * That is exactly why `maxInputTokens: 272_000` is load-bearing. It does not
+ * protect us from being over-charged — nothing here does. It keeps the single
+ * flat rate per bucket that `CuratedModel` can hold **arithmetically true**,
+ * because a request that crosses 272K bills input at 2x, output at 1.5x and
+ * both cache buckets at 2x. Raising it silently UNDER-charges every long turn.
  *
  * `supportedParams` is deliberately absent. AWS publishes no parameter table
  * for these models (`model-parameters-openai.html` documents only the
@@ -415,6 +434,39 @@ const bedrockResponsesDefaults = (): Pick<
  * only from published or measured evidence.
  */
 export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
+  {
+    key: 'gpt-6-astra',
+    tagline: 'Frontier model for the hardest end-to-end work — reasoning, coding and research.',
+    capabilities: ['Reasoning', 'Vision', 'Long context', 'Prompt caching'],
+    pricingTier: 'regional',
+    template: {
+      ...bedrockResponsesDefaults(),
+      // UNVERIFIED, and the one thing here worth re-checking before anyone
+      // banks cache savings on this row: Astra's card lists Implicit and
+      // Explicit Prompt Caching under `bedrock-mantle` ONLY. Caching appears
+      // in neither column of its `bedrock-runtime` feature table, where every
+      // GPT-5.6 card lists it under both endpoints — and this row routes over
+      // `bedrock-runtime`. `supportsCaching` still inherits `true`, which is
+      // the safe stance either way: `false` would zero the cache-rate fields
+      // and price cached tokens at $0.00 while AWS bills them in full. If
+      // caching turns out not to fire here the cost is a stale capability
+      // chip, not a mispriced bill.
+      modelId: 'us.openai.gpt-6-astra',
+      modelName: 'GPT-6 Astra',
+      // Geo CRIS Short Context: $11.00 / $55.00. Global CRIS is $10.00 /
+      // $50.00. Long Context (1.05M) would be $22.00 / $82.50 — unreachable
+      // while maxInputTokens stays pinned at the 272K boundary.
+      ...ratesWithDerivedCache(11.0, 55.0),
+      // Astra departs from its GPT-5.6 siblings here: its card publishes a
+      // real cap (`Max output tokens: 128,000`) where theirs say N/A, so this
+      // overrides the family default of `null`. Declaring the published
+      // number beats inheriting "unknown".
+      maxOutputTokens: 128_000,
+      // Published on the card as April 30, 2026 — again unlike the GPT-5.6
+      // cards, which state none.
+      knowledgeCutoffDate: '2026-04-30',
+    },
+  },
   {
     key: 'gpt-5-6-sol',
     tagline: 'OpenAI\'s most capable model — frontier reasoning and agentic work.',


### PR DESCRIPTION
Adds `us.openai.gpt-6-astra` to `CURATED_BEDROCK_RESPONSES_MODELS`, executing the catalog half of **Proposal #4** now that the blocking question is answered ([#1054](https://github.com/Boise-State-Development/agentcore-public-stack/pull/1054)).

## The row

| field | value | source |
|---|---|---|
| `modelId` | `us.openai.gpt-6-astra` | Geo CRIS; `global.*` is SCP-denied in dev |
| `maxInputTokens` | `272_000` (inherited) | Short Context boundary |
| input / output | $11.00 / $55.00 | card, Geo CRIS Short Context |
| cache write / read | $13.75 / $1.10 | derived at 1.25× / 0.1×, matches card exactly |
| `maxOutputTokens` | `128_000` | **override** — card publishes a real cap |
| `knowledgeCutoffDate` | `2026-04-30` | **override** — card publishes one |

## Why the cap is load-bearing — and why the old reason was wrong

The tier is selected by the **actual token count of the request**, not a declared window. So the cap does *not* protect us from being over-charged — nothing does. What it protects is **arithmetic**: `CuratedModel` holds one flat rate per bucket, and a request crossing 272K bills input at 2×, output at 1.5× and both cache buckets at 2×. Raising it silently **under-charges** every long turn.

That reasoning now sits in the docblock above the array, not only in the kaizen queue, since this is the file where someone would actually be tempted to raise it.

## Two deviations from the family defaults

Both are card-backed. `bedrockResponsesDefaults()` sets `maxOutputTokens: null` because the GPT-5.6 cards say `N/A` — Astra's says **128,000**, and inheriting the default would discard a number AWS publishes. Same for the cutoff.

## What I deliberately did *not* do

- **No `supportedParams`.** The ref repo sets `rejectsTemperature: true`, but it is single-source and set family-wide (Astra, all three GPT-5.6 models, Opus 5, Sonnet 5, Grok) rather than being an Astra-specific finding, and **no model card in this family has a parameter table at all**. Per #915 a declared spec flips the guard from permissive to restrictive, so a wrong entry silently blocks a parameter the model accepts. The existing spec asserts this stays null family-wide, and it still does.
- **No role grants / no deploy.** `allowedAppRoles` and `availableToRoles` stay `[]` like every sibling; this is a curated *template*, and registration happens from the admin UI.

## ⚠️ One unverified thing, flagged in-line

**Astra's card lists prompt caching under `bedrock-mantle` only.** Caching appears in *neither* column of its `bedrock-runtime` feature table, where every GPT-5.6 card lists it under both — and this row routes over `bedrock-runtime`.

`supportsCaching` stays `true`, which is the safe stance either way: `false` would zero the cache-rate fields and price cached tokens at $0.00 while AWS bills them in full. If caching turns out not to fire here, the cost is a stale capability chip, not a mispriced bill. Worth a live check before anyone banks cache savings on this model.

## Tests

The four existing family-wide loops now cover Astra automatically (272K cap, `supportsCaching`, `apiMode`/`provider`, null `supportedParams`), as do the pricing-tier and cache-multiplier guards. Added two focused specs for the rate card and the two deviations, mirroring the existing GPT-5.4 test.

Frontend deps aren't installed in this worktree and I left the suite to CI per the standing local-OOM warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)