### PR TITLE
docs(kb): refresh the migration handoff, land the chunk-inspector spec

### DIFF
--- a/.kiro/specs/kb-chunk-inspector/design.md
+++ b/.kiro/specs/kb-chunk-inspector/design.md
@@ -1,0 +1,105 @@
+# KB Chunk Inspector — Design
+
+**Status:** Draft · Reads only. Built entirely on the existing retrieval facade.
+
+## 1. The one hard constraint
+
+Bedrock managed knowledge bases have **no "list the chunks of a document" API**.
+The only read primitive is `Retrieve`, which is *query-driven* and *rank-bounded*
+by `numberOfResults` (`retrieval_configuration` in
+`backend/src/apis/shared/kb_backend/managed_backend.py` sets
+`managedSearchConfiguration.numberOfResults`). `GetKnowledgeBaseDocuments`/
+`ListKnowledgeBaseDocuments` list *documents*, not chunks.
+
+Consequence: we cannot promise a complete, in-order dump of a document's chunks
+on the managed engine. We can get "the top-N chunks `Retrieve` returns for this
+document, by relevance to a query, filtered to this document_id." That is more
+than enough to answer *"did my columns/headers/image survive?"* — you will see
+the vision descriptions and the flattened tables — but the spec (Req 3) requires
+we present it honestly as "up to N", not "all".
+
+This is why the feature is framed as an **inspector**, not an **exporter**.
+
+## 2. Reuse, don't invent
+
+Everything needed already exists:
+
+- **Facade search**, both engines:
+  `async backend.search(kb_ref, query, top_k, retrieval_filter=None) -> List[Chunk]`
+  (`protocol.py`; managed + legacy adapters). `Chunk` carries `text`, `metadata`
+  (incl. `document_id`, `filename`/`source`), `s3_key`, `relevance`.
+- **Per-document isolation filter**, already proven safe and used by the
+  retrievability probe: `{"equals": {"key": "document_id", "value": <id>}}`
+  (`equals` is in `ISOLATION_SAFE_FILTER_OPERATORS`).
+- **Engine resolution**: `resolve_engine_for(assistant_id, record=...)`.
+- **Permission gate**: `_require_edit_permission(assistant_id, current_user)` in
+  `backend/src/apis/app_api/documents/routes.py`.
+- **Citation display shape** on the frontend already renders
+  `{documentId, fileName, text}` — the inspector renders the same shape, longer.
+
+## 3. Backend — one new read endpoint
+
+`GET /assistants/{assistant_id}/documents/{document_id}/chunks`
+in `backend/src/apis/app_api/documents/routes.py`.
+
+1. `owner_id = await _require_edit_permission(assistant_id, current_user)`.
+2. Confirm the `DOC#` row exists and is `complete` (else 409 "still processing"
+   / 404).
+3. `engine, record = resolve_engine_for(...)`; get the backend via the resolver.
+4. Enumerate chunks (see §4), filtered to `document_id`.
+5. Return `{ documentId, fileName, engine, chunks: [{ text, page?, order, score? }],
+   complete: bool, returned: N, capReached: bool }`.
+
+Read-only, no writes, no new ingestion path (Req 5). Bounded `Retrieve` calls
+(Req 6).
+
+## 4. Enumerating chunks (the honest best-effort)
+
+`Retrieve` needs a query and returns top-N by relevance. To approximate "all
+chunks of this document":
+
+- **Query text:** use a neutral, document-anchored query — the filename, or the
+  document's own leading text — purely to give the reranker *something*; the
+  `document_id` `equals` filter is what actually scopes results. Ranking order is
+  not meaningful here, so the UI presents chunks as an unordered set (or by page
+  when metadata carries it), not as "chunk 1..N".
+- **`numberOfResults`:** request the backend maximum (Bedrock's documented ceiling
+  is 100 per call). If the count returned equals the ceiling, set
+  `capReached=true` and surface Req 3's "up to N / more may exist" note.
+- **De-dup** by chunk content hash across calls (a query-ranked API can repeat).
+- **Pagination:** only if we later find a reliable way to page distinct chunks;
+  v1 ships single-call, capped, honest.
+
+> Design note: because completeness is not guaranteed, do **not** compute
+> "missing header in chunk 2" server-side — just show what came back and let the
+> human eyeball it (matches the task-16.2 "guidance not code" decision).
+
+Legacy engine: the same facade call works; we own chunking there so results are
+closer to complete, but we keep the same "up to N" contract for a uniform shape.
+
+## 5. Frontend
+
+- On the document row / detail (where status already shows), add a **"View
+  extracted content"** action, enabled once status is `complete`.
+- Opens a panel listing each chunk's full text (monospace/pre for tables),
+  page/location when present, and a small header: *"This is what the knowledge
+  base extracted. If a table or image looks wrong here, the assistant will answer
+  from this — consider reformatting your source."* (the actionable nudge).
+- If `capReached`, show the "showing first N; more may exist" line.
+- Reuse the existing citation card component; the only new data is longer text
+  and the header/nudge.
+
+## 6. Testing
+
+- Route: owner sees chunks (managed + legacy), non-owner 403, non-`complete`
+  document 409, filter is `equals` on `document_id` (assert the exact filter —
+  mirrors the retrievability-probe test), `capReached` set when N == ceiling.
+- Use moto + a fake backend modeling `search(..., retrieval_filter=...)`
+  (the ingestion-consumer tests already have this fake to copy).
+- Mutation guard: dropping the `document_id` filter must fail a test that seeds a
+  second document's chunks and asserts they never appear.
+
+## 7. Effort
+
+Small–medium. One read endpoint + one resolver/facade call + a frontend panel
+reusing the citation card. No new pipeline, no infra, no legacy dependency.

--- a/.kiro/specs/kb-chunk-inspector/requirements.md
+++ b/.kiro/specs/kb-chunk-inspector/requirements.md
@@ -1,0 +1,81 @@
+# KB Chunk Inspector — Requirements
+
+**Status:** Draft · **Related:** `managed-kb-migration` (§5.41 diagram answer quality, task 16.2)
+
+## Problem
+
+The managed backend can extract content a user never sees and cannot verify. A
+flowchart or a two-column table is flattened by the vision/parse step at
+ingestion, so an answer about "semester 4" or a per-column total is *confidently
+wrong* with no signal to the user. The legacy backend failed **silently** (0
+chunks, no answer); the managed backend fails **invisibly** (wrong answer, no
+trace). We deliberately will not fix the managed parser (it is a managed service,
+and this is a self-service platform — see task 16.2's decision). Instead we make
+the extraction **visible**, so a user can look at what the knowledge base
+actually holds for their document and decide to change their input (convert a
+flowchart to a text table, re-export a scanned PDF, etc.).
+
+We already ship a *retrieval trace*: the chunks sent to the LLM for a given
+answer are streamed to the UI as `citation` events (assistantId, documentId,
+fileName, text — capped at 500 chars) from
+`backend/src/apis/inference_api/chat/routes.py`, and this already works for both
+engines via the facade. What is missing is an **upload-time, per-document,
+full-chunk view** that does not require asking a question and is not truncated to
+the retrieved top-k.
+
+## Requirements
+
+### Requirement 1 — Inspect a document's extracted chunks
+**User story:** As an assistant owner, I want to see the content the knowledge
+base extracted from a document I uploaded, so I can tell whether my file was
+parsed usefully before I rely on it.
+
+- WHEN an owner or editor opens a document that has reached `complete`, THEN the
+  system SHALL provide the chunks the knowledge base holds for that document,
+  each with its full extracted text and its source metadata (document id,
+  filename, and page/location when the backend supplies it).
+- WHEN a chunk was produced from a non-text element (an image or a diagram), THEN
+  its extracted text (the vision model's description) SHALL be shown verbatim, so
+  the user sees exactly what the model "read".
+- The excerpt SHALL NOT be truncated to the 500-character citation limit; the
+  inspector shows the full chunk text.
+
+### Requirement 2 — Engine-agnostic
+- WHEN the document belongs to a managed knowledge base, THEN chunks SHALL be
+  read through the managed backend; WHEN it belongs to a legacy knowledge base,
+  THEN through the legacy backend. The caller SHALL resolve the engine via
+  `resolve_engine_for` and never branch on it in the UI.
+- The response shape SHALL be identical across engines.
+
+### Requirement 3 — Honest completeness
+- Bedrock managed knowledge bases expose **no chunk-enumeration API**; `Retrieve`
+  is query-ranked and bounded by `numberOfResults`. WHERE the full set of chunks
+  cannot be guaranteed, the system SHALL label the view as "chunks the knowledge
+  base returned for this document (up to N)", and SHALL NOT claim to be a
+  complete or ordered dump.
+- WHEN more chunks may exist than were returned, THEN the UI SHALL say so rather
+  than imply the document has only N chunks.
+
+### Requirement 4 — Isolation and permission
+- The chunk query SHALL be filtered to the requested `document_id` using only an
+  isolation-safe operator (`equals`) — never a prefix/substring operator, which
+  over-matches (a filter for `DOC-1` must not admit `DOC-10`).
+- Access SHALL require owner or editor permission on the parent assistant
+  (reuse `_require_edit_permission`); a non-owner SHALL receive 403/404 exactly
+  as the other document endpoints do.
+
+### Requirement 5 — No new ingestion path, no legacy dependency
+- The inspector SHALL be read-only and SHALL reuse the existing retrieval facade
+  (`backend.search(...)`). It SHALL NOT introduce a new chunking, parsing, or
+  ingestion code path, and SHALL NOT depend on the legacy pipeline continuing to
+  exist (so it survives v1 deprecation).
+
+### Requirement 6 — Cost and latency are bounded
+- A single inspect request SHALL issue a bounded number of `Retrieve` calls
+  (one, plus pagination up to a hard cap), so opening the view cannot fan out
+  into an unbounded or expensive scan.
+
+## Out of scope
+- Fixing or re-parsing the document (managed owns parsing).
+- A per-question retrieval trace — that already exists (citations).
+- Editing/curating chunks.

--- a/.kiro/specs/kb-chunk-inspector/tasks.md
+++ b/.kiro/specs/kb-chunk-inspector/tasks.md
@@ -1,0 +1,87 @@
+# KB Chunk Inspector — Tasks
+
+**Status:** Not started · **Requirements:** `requirements.md` · **Design:** `design.md`
+**Why now:** it is the tooling half of the task-16.2 decision (`managed-kb-migration`
+§5.41). That decision was "guidance, not code" — this is what makes the guidance
+possible, because a user cannot act on advice about mangled tables if they cannot see
+that their table was mangled.
+
+**Effort:** small–medium. One read endpoint, one facade call, one frontend panel
+reusing the existing citation card. No new pipeline, no infra, no legacy dependency.
+
+---
+
+- [ ] 1. Backend read endpoint
+  - `GET /assistants/{assistant_id}/documents/{document_id}/chunks` in
+    `backend/src/apis/app_api/documents/routes.py`
+  - `_require_edit_permission` first, exactly as the sibling document endpoints do;
+    a non-owner gets the same 403/404 they already get elsewhere (Req 4)
+  - Confirm the `DOC#` row exists and is `complete`; 409 while it is still
+    processing, 404 when absent. **A born-managed first upload can be
+    `provisioning`** — that is a 409 too, not a 404, and its message should say the
+    knowledge base is still being created rather than implying the file is missing
+  - Resolve the engine with `resolve_engine_for` and get the backend from the
+    resolver; never branch on engine in the response shape (Req 2)
+  - _Requirements: 1, 2, 4, 5_
+
+- [ ] 2. Chunk enumeration, honest about completeness
+  - One `search(...)` call through the facade with the `document_id` `equals`
+    filter, `numberOfResults` at the backend ceiling (Bedrock documents 100)
+  - Neutral document-anchored query text (the filename, or the row's leading text)
+    purely to give the reranker something — the filter is what scopes the result
+  - De-duplicate by content hash: a query-ranked API can repeat a chunk
+  - Set `capReached=true` when the count returned equals the ceiling
+  - Present as an unordered set (or by page where metadata carries one), never as
+    "chunk 1..N" — ranking order is not document order, and implying otherwise is a
+    lie the UI would be telling
+  - **Do not** compute "the header is missing from chunk 2" server-side. Show what
+    came back and let the human judge it; that is the 16.2 decision, not laziness
+  - _Requirements: 1, 3, 6_
+
+- [ ] 3. Response contract
+  - `{ documentId, fileName, engine, chunks: [{ text, page?, order, score? }],
+    complete: bool, returned: N, capReached: bool }`
+  - Full chunk text, **not** truncated to the 500-character citation limit — that
+    truncation is the whole reason the existing citation trace cannot serve this
+  - _Requirements: 1, 2, 3_
+
+- [ ] 4. Frontend panel
+  - A "View extracted content" action on the document row, enabled at `complete`
+  - Panel lists each chunk's full text, monospace/`pre` so a flattened table's
+    damage is actually visible, with page/location when present
+  - Header carries the actionable nudge: *"This is what the knowledge base
+    extracted. If a table or image looks wrong here, the assistant will answer from
+    this — consider reformatting your source."*
+  - When `capReached`, say "showing the first N; more may exist" rather than
+    implying the document has exactly N chunks (Req 3)
+  - Reuse the citation card component; the only new data is longer text plus the
+    header
+  - _Requirements: 1, 3_
+
+- [ ] 5. Tests
+  - Route: owner sees chunks on **both** engines; non-owner 403; non-`complete`
+    document 409 (cover `provisioning` and `uploading` separately); `capReached`
+    set when the count equals the ceiling
+  - Assert the **exact** retrieval filter is `equals` on `document_id`, mirroring
+    the retrievability-probe test — `ISOLATION_SAFE_FILTER_OPERATORS` exists
+    because a prefix operator over-matches, and `DOC-1` admitting `DOC-10` is a
+    cross-document leak, not a display bug
+  - Fake backend modelling `search(..., retrieval_filter=...)`; copy the one in
+    `backend/tests/lambdas/test_kb_ingestion_consumer.py`
+  - **Mutation guard:** drop the `document_id` filter and a test that seeds a
+    second document's chunks must fail on those chunks appearing
+  - _Requirements: 4, 6_
+
+- [ ] 6. Verify against the real §5.41 corpus
+  - Open the inspector on the diagram documents that produced §5.41
+    (`4-yr-flowchart-v2026.pdf`, `sustainable-farming.pdf` on the dev retain
+    assistant) and confirm the flattening is *visible* to a human reader
+  - This is the acceptance test for the whole feature: if a user still cannot tell
+    from this panel why their per-semester answer was wrong, it has not delivered
+    what 16.2 promised
+  - _Requirements: 1_
+
+## Out of scope
+- Re-parsing or fixing a document — managed owns parsing.
+- A per-question retrieval trace — that already ships as citation events.
+- Editing or curating chunks.

--- a/.kiro/specs/managed-kb-migration/HANDOFF.md
+++ b/.kiro/specs/managed-kb-migration/HANDOFF.md
@@ -10,12 +10,18 @@ re-deriving anything. Read this, then `tasks.md`.
 
 ## 0. Read this first
 
+**Where this stands, in one line:** the build is finished and running in dev with the
+flags on there; production has every flag off, and what remains is the group-15
+probes plus turning the flags on. Ladder step 2 (born managed) is the next real
+move — see §6 "Do these first". If you read nothing else, read that table.
+
 Four things invalidate earlier versions of this document:
 
 1. **It is deployed.** The feature shipped to production in release 1.16.0 and the
    platform deploy succeeded on 2026-08-28, so `GSI7`, the Bedrock service role and
-   the four Lambdas exist in **both** dev and prod. Earlier revisions of this file
-   said "Nothing deployed"; that is no longer true.
+   the Lambdas exist in **both** dev and prod. Earlier revisions of this file
+   said "Nothing deployed"; that is no longer true. There are now **five** migration
+   Lambdas, not four — task 16.5 added the document reconciler.
 2. **Sixteen defects were found only by running it**, each reviewed clean and
    deployed clean. They are §5 items 25–41 and they are the most useful part of
    this document. Three clusters: 32–36 trace to the two engines never being made
@@ -47,12 +53,16 @@ Four things invalidate earlier versions of this document:
 
 | | |
 |---|---|
-| Spec | Complete. Requirement **8.5 was amended by measurement on 2026-08-31** — see §5.29 |
-| Implementation | Groups 1–14 except 14.5. A migration has completed `shadow → verify → promote → retain` in dev and serves from the managed backend |
-| Tests | 640 infra (jest) · ~6,840 backend (pytest) · 1,936 frontend (vitest) · 5 pre-existing unrelated Strands failures |
-| Deployed | **dev and prod.** Flags off in prod; `migrationEnabled` on in dev |
-| Open PRs | **#908** — the filtered retrievability probe (§5.38) and `TEXT_INDEXED` (§5.39), plus this document. · merged: #898 `ef2f4c9e`, #899, #900 `df93471c`, #901 `a4b660ba` |
+| Spec | Complete. Requirement **8.5 was amended by measurement on 2026-08-31** — see §5.29. Requirement 3.2 amended by task 16.1; Requirement 12.11 completed by the upload-time byte cap |
+| Implementation | **Build phase done.** Groups 1–14 except 14.4 (retry endpoint) and 14.5 (admin surface); all of group 16; born-managed provision-then-ingest. A migration has completed `shadow → verify → promote → retain` in dev and serves from the managed backend |
+| Tests | Counts drift with every merge — read the latest `develop` run rather than a number pasted here. CI is green on `develop` (backend pytest, frontend, infra jest, load suite, scan) |
+| Deployed | **dev and prod.** In dev: `migrationEnabled` on, everything else off. In prod: **every flag off**, so none of it can fire |
+| Open PRs | **none** for this feature. Last merged: **#1027** born-managed (`f1e11bd3`, 2026-09-10), **#1019** upload-time byte cap, **#1018** doc-reconciler flag forwarding, **#1017** task-16.2 docs |
 | Uncommitted | none |
+
+**What is left is not build work.** It is (a) the three pre-promotion probes in
+group 15, (b) turning flags on in prod, and (c) two deferred surfaces (14.4, 14.5).
+See §6.
 
 ### Flag state (GitHub Environment variables)
 
@@ -61,76 +71,104 @@ Four things invalidate earlier versions of this document:
 | `CDK_MANAGED_KB_MIGRATION_ENABLED` | `true` | `false` |
 | `CDK_MANAGED_KB_NEW_DEFAULT` | `false` | `false` |
 | `CDK_MANAGED_KB_RECONCILER_ARMED` | `false` | `false` |
+| `CDK_MANAGED_KB_DOC_RECONCILER_ARMED` | `false` | `false` |
 | `CDK_TAG_ENVIRONMENT` | `dev` | `prod` |
 
-`newDefault` has **no reader anywhere in `backend/src`** — "new knowledge bases are
-created managed" is design §14.7 steps 5–8, a follow-up spec. Setting it does
-nothing, which is worth knowing before someone flips it expecting an effect.
+`CDK_MANAGED_KB_DOC_RECONCILER_ARMED` is the fourth flag, added by task 16.5. It was
+settable only by hand-editing `cdk.context.json` until PR #1018 added the missing
+`platform.yml` line — the wiring existed end to end *except* for forwarding the
+GitHub variable.
+
+**`newDefault` now has a reader** (PR #1027). An earlier revision of this section
+said it had none anywhere in `backend/src` and that setting it did nothing; that was
+true then and is false now. Turning it on makes an agent's knowledge base provision
+on the managed backend **when its first document is uploaded** — not at agent
+creation, which would spend a Bedrock knowledge base on every prompt-only agent and
+abandoned draft. See `.kiro/specs/managed-kb-migration/born-managed-provision-then-ingest.md`
+for the flow, the failure/rollback path, and why the engine must be declared before
+the object lands.
 
 ⚠️ **Production carries every defect fixed after 1.16.0 shipped.** It cannot fire,
-because nothing enrols while `migrationEnabled` is false. Do not turn that flag on
-in prod until #898 and the uncommitted work have landed and shipped.
+because nothing enrols and nothing provisions while all four flags are false. The
+release-order rule still holds: ship the code, confirm the deploy, *then* consider a
+flag — never both in one motion.
 
 ### Commits
 
-**On `fix/kb-legacy-pipeline-engine-gate` — PR #900, open:**
+Deliberately **not** an exhaustive log any more. It had drifted into listing
+branches that merged weeks ago as "open", which is worse than having no list — a
+reader trusts it and then chases a PR that no longer exists. `git log --oneline
+origin/develop -- .kiro/specs/managed-kb-migration backend/src/apis/app_api/kb_migration
+backend/src/apis/shared/kb_backend` is authoritative and never stale.
 
-```
-e3398f30  propagate document deletion to the managed knowledge base       (§5.36)
-8a35dbc6  the legacy pipeline stands down for a promoted knowledge base   (§5.32, §5.34)
-```
+The landmarks worth knowing by number, newest first:
 
-**Merged as `ef2f4c9e` (was PR #898):**
+| PR | What |
+|---|---|
+| **#1027** `f1e11bd3` | Born-managed: provision on first upload, `MANAGED_KB_NEW_DEFAULT` gets a reader |
+| **#1019** | Byte cap enforced at document upload time — completes Req 12.11 |
+| **#1018** | Forward `CDK_MANAGED_KB_DOC_RECONCILER_ARMED` through `platform.yml` |
+| **#1007 / #1008** | Dead-letter document reconciler (task 16.5) — backend, then Lambda + nightly schedule + IAM |
+| **#1006** | Engine visibility: Managed/Classic badge, engine-aware status vocabulary (task 16.4) |
+| **#998** | Fail-closed status filter (§5.33) |
+| **#997** | Engine-aware context cap, managed 8,000 / legacy 2,000 (task 16.1, §5.40) |
+| **#900** `df93471c` | Legacy pipeline stands down for a promoted KB; deletion propagates (§5.32, §5.34, §5.36) |
+| **#898** `ef2f4c9e` | `bedrock:StartIngestionJob` grant, defer-verify, record the KB id first (§5.28–§5.31) |
 
-```
-fdf15d21  grant bedrock:StartIngestionJob, which authorizes direct ingestion  (§5.31)
-6420f148  drop the embedding pin, defer verify, complete a migration in dev   (§5.29, §5.30)
-7542d907  record the knowledge base id before anything else can fail          (§5.28)
-```
-
-**Already merged (16, on develop):**
-
-```
-45239838  one source of truth for the managed KB tag contract
-4acaa8f2  handoff reflects group 14 backend half and three more defects
-e59f771c  register the managed backend, fleet metrics, tagged teardown  (group 14 backend)
-d5e56f31  handoff reflects group 13 and four more defects
-ee091971  migration dispatcher and the shadow/verify/promote/retain worker (group 13)
-53476544  handoff reflects groups 11-12 and two new defects
-a361fdd4  opt-in dual-read pilot that legacy always wins                (group 12)
-a43d80bf  app-side authorization, IAM-enforced sharing, publication      (group 11)
-58f0c6b6  handoff document and accurate task-list state
-8079f7e2  tombstone deletion sagas and the report-only reconciler        (group 10)
-e6936b0b  ingestion consumer with exclusive engine routing              (group 9)
-620fa49c  managed KB provisioning, retrieval and direct ingestion        (group 8)
-d433d6f1  per-owner byte cap with atomic reserve/commit/release          (group 7)
-f2e86afe  clamp retrieval queries and fail closed on status              (groups 5, 6)
-24689de1  backend abstraction seam behind the retrieval entry point      (group 4)
-ffa7a408  KB_Record data layer with conditional state transitions        (group 3)
-5f2c98b1  spec, schema and worker platform                              (groups 1, 2)
-```
-
-**Working tree: clean.** An earlier revision listed the 14.3 upgrade surface and
-then the 8.5 amendment as uncommitted; both have landed. `apis/app_api/kb_upgrade/`
-is merged — see §7 for the file map and §2 for how to run it.
+**Working tree: clean.**
 
 ### Is the feature reachable yet?
 
-**Yes, end to end, once the flag is on — except that nothing performs the work.**
-Group 14.3 closed the last gap in the *control* path: a user can now enrol a
-knowledge base, which writes a `KB#` record in `shadow` with the GSI7 work keys.
-Before it, nothing wrote either, so every group could have been finished with the
-feature unreachable (§5 defect 21).
+**Yes, end to end, and the work actually happens.** Two paths reach the managed
+backend now:
 
-The worker's image **is deployed** — PR #886 shipped `Dockerfile.kb-migration` and
-all four Lambdas run real handlers. An earlier revision of this section said the
-image was undeployed and a `shadow` record would sit forever; that is no longer
-true. The dispatcher's rule is `ENABLED` and ticking every 15 minutes in dev.
+1. **Upgrade** (opt-in, existing corpus). A user enrols; the record enters `shadow`
+   with GSI7 work keys; the dispatcher hands it to the worker, which runs
+   `shadow → verify → promote → retain`. Gated on `MANAGED_KB_MIGRATION_ENABLED`.
+2. **Born managed** (new agent, no corpus). The first document upload declares the
+   engine managed and queues a provisioning job; the worker builds the knowledge
+   base and ingests the waiting document itself. Gated on `MANAGED_KB_NEW_DEFAULT`.
 
-⚠️ **That tick is a hazard while #898 is unmerged.** The deployed worker predates
-it, so an enrolled record can be picked up by pre-fix code and failed at `verify`.
-Always drive a local migration with `--break-lease`, which defers `dueAt` 20 minutes
-out so the deployed dispatcher skips it.
+The dispatcher's rule is enabled when **either** flag is on, and the Python gates
+each work state on its own flag — so step 2 of the rollout ladder provisions new
+agents without touching a single existing knowledge base.
+
+All five Lambdas run real handlers from `Dockerfile.kb-migration`. The dispatcher
+ticks every 15 minutes in dev.
+
+⚠️ **That 15-minute tick is also born-managed's pickup latency.** A first upload can
+sit at "Provisioning knowledge base…" for up to a whole interval before the real
+47–124 s create even begins. It is recorded as a known cost, not a bug, with the fix
+(provision inline in the ingestion consumer, keeping the queue as the fallback)
+written up in the born-managed spec.
+
+When driving a migration by hand, still use `--break-lease`: it defers `dueAt` 20
+minutes out so the deployed dispatcher does not race your local run.
+
+### The production rollout ladder
+
+Four flags, four rungs, in this order. Each is a GitHub per-environment Variable fed
+through `platform.yml`; all default OFF and unset means off. **Deploy, confirm the
+deploy, then set a variable — never both in one motion.**
+
+| Rung | Flag | What changes | Risk |
+|---|---|---|---|
+| **1** | *none* — just deploy | Everything dark. Both reconcilers run report-only, which is deliberate: Req 14.7 makes report-only the initial deployed mode so their judgement can be audited against real data before either is allowed to act | none |
+| **2** | `CDK_MANAGED_KB_NEW_DEFAULT` | New agents are born managed on their **first document upload**. No existing knowledge base is touched | **low** — each agent is independent, so a problem affects one agent |
+| **3** | `CDK_MANAGED_KB_MIGRATION_ENABLED` | The Upgrade card appears, and the background worker migrates enrolled knowledge bases `shadow → verify → promote → retain` | **medium** — touches existing corpora. Needs 15.2 and 14.5 first |
+| **4a** | `CDK_MANAGED_KB_RECONCILER_ARMED` | The KB reconciler starts **deleting** orphaned knowledge bases instead of reporting them | **high** — only after a clean report-only period you have actually read |
+| **4b** | `CDK_MANAGED_KB_DOC_RECONCILER_ARMED` | The document reconciler starts correcting stranded `DOC#` rows instead of reporting them | medium — after an audit |
+
+Rung 2 is deliberately reachable on its own: the dispatcher's schedule is enabled by
+*either* flag and the Python gates each work state on its own, so `NEW_DEFAULT` alone
+provisions new agents and migrates nothing.
+
+**The intended end state**, and the one genuinely dangerous step: once the fleet is
+fully migrated, retire the legacy pipeline. That step needs a hard **zero-legacy-
+knowledge-bases gate**, because the legacy code does not merely *create* old
+knowledge bases — it also **serves retrieval** for every un-migrated one. Removing it
+early breaks every agent that has not moved. For a public repo with forks that sync,
+make it a loud version boundary with a long deprecation window, never a quiet sync.
 
 ### What works today, verified live in dev
 
@@ -537,11 +575,13 @@ saying why that number is a property of AWS rather than a knob.
     `app-api-environment.test.ts`. The mutation — deleting the line, which is
     precisely what the defect was — is caught.
 
-    ⚠️ `managedKb.newDefault` has **no reader anywhere in `backend/src`**. It is
-    set on the Lambdas' environment and consumed by nothing, because
-    "new knowledge bases are created managed" is a follow-up spec (design §14.7
-    steps 5–8), not this phase. Leave it off; turning it on is a no-op that reads
-    like a behaviour change.
+    ⚠️ **Superseded 2026-09-10.** This warning used to read that
+    `managedKb.newDefault` had *no reader anywhere in `backend/src`*, so setting it
+    was a no-op that read like a behaviour change. That was true when written and is
+    now false: PR #1027 gave it a reader plus the app-api environment thread it was
+    also missing. It now has a real effect — an agent's knowledge base provisions on
+    the managed backend at its **first document upload**. See
+    `born-managed-provision-then-ingest.md` and the rollout ladder in §1.
 
 ---
 
@@ -980,25 +1020,36 @@ answer than legacy** on a question it retrieves *better*. Both are open.
 
 ### Do these first
 
+The build is done. What remains is proving it against prod's constraints and then
+turning flags on. In order:
+
 | | |
 |---|---|
-| **Merge #900** | Engine exclusivity, both halves. Triggers `backend.yml` (rebuilds rag-ingestion **and** kb-sync — the content hash moves because `kb_backend` was added to both images' `SOURCE_DIRS`) and `platform.yml` (the two new IAM grants). Wait for the platform deploy before testing a deletion on a promoted assistant, or the delete fails on IAM and the `DOC#` row is deliberately kept |
-| **Then re-add a document in dev** | `DOC#DOC-dc8b65658e29` is parked at `failed` from §5.31 and is not retried retroactively — there is no reprocess endpoint (task 14.4). Re-upload; that path works |
-| **Then drive a migration from the *deployed* dispatcher, not the local driver** | §5.31 is the proof that the local driver cannot see IAM defects: its SSO identity is broader than either Lambda role. Every remaining unknown in this feature is of that class |
+| **1. Task 15.1 — the live SDK probe** | The only item that can invalidate the whole feature in prod. The *static* half passes (`boto3==1.43.68` carries `MANAGED`, the embedding members, `FLOAT32`, all four document ops, with no `AWS_DATA_PATH`), and a real create → ingest → retrieve → promote has succeeded in dev. What is missing is doing it deliberately, with the checked-in environment and **no** side-loaded service model, and recording the result. If this fails, managed knowledge bases do not work in prod at all |
+| **2. Flip `CDK_MANAGED_KB_NEW_DEFAULT` in prod** | Ladder step 2. New agents are born managed on their first document; not one existing knowledge base is touched. Lowest-blast-radius rung: each agent is independent, so a problem affects that agent and no other. Deploy first, confirm the deploy, *then* set the variable — never both in one motion |
+| **3. Task 15.2 — the ingestion-concurrency probe** | Gates ladder step 3 (`MIGRATION_ENABLED`), **not** step 2. The quota page lists no account-level ingestion-concurrency limit, which is not evidence there is none. Do not size a wide fleet migration before this is answered |
+| **4. Task 14.5 — the admin surface** | Also gates step 3 rather than step 2. The moment existing knowledge bases start migrating you have a mixed fleet and no view of who is on which engine — and "how many are affected?" is the first question anyone asks when something goes wrong |
+| **5. Task 15.3 — full matrix in the dev container** | Housekeeping; CI already covers most of it |
+
+⚠️ **Before flipping anything, re-read §5.41.** Managed is *worse* than legacy for
+column-structured diagrams and two-dimensional tables: legacy returned nothing,
+managed returns a confident wrong answer. Born-managed makes managed the default for
+every new agent, so that trade stops being opt-in. The agreed mitigation is guidance,
+not code — and the `kb-chunk-inspector` spec is the tooling half of that guidance.
 
 ### Open, in rough order
 
 | Group | Notes |
 |---|---|
 | ~~**§5.40** the 2,000-char cap~~ ✅ DONE (PR #997) | Engine-aware cap: managed **8,000**, legacy 2,000 (`rag_service.resolve_context_cap`, keyed on `resolve_engine_for`). Requirement 3.2 amended; validated end-to-end on the KINES advising corpus in dev; mutation-tested |
-| ~~**§5.41** diagram answers~~ ✅ DONE (task 16.2) | Understood: the vision model flattens the 2-D layout, chunks carry no column coordinates, and the 16.1 cap fix does not rescue it (re-measured 2026-09-08: 14 credits vs the chart's 19 at both caps, mis-columned `ENGR 220` persists). Closed as a **product/training matter, not code** — this is a self-service platform, and users won't know to convert a diagram to text. Guidance: demo as *retrievable where previously impossible*, never precise per-column answers |
+| ~~**§5.41** diagram answers~~ ✅ DONE (task 16.2) | Understood: the vision model flattens the 2-D layout, chunks carry no column coordinates, and the 16.1 cap fix does not rescue it (re-measured 2026-09-08: 14 credits vs the chart's 19 at both caps, mis-columned `ENGR 220` persists). Closed as a **product/training matter, not code** — this is a self-service platform, and users won't know to convert a diagram to text. Guidance: demo as *retrievable where previously impossible*, never precise per-column answers. **The tooling half of that guidance is specced:** `.kiro/specs/kb-chunk-inspector/` (requirements + design written, no tasks yet) makes the extraction *visible* — an owner can see for themselves that a table came out mangled or an image description is wrong, instead of finding out via a confidently wrong answer. That is the difference between "managed fails invisibly" and "managed fails visibly", which is the most this decision can buy without touching a managed parser |
 | ~~**§5.33** the one fail-open line~~ ✅ DONE (PR #998) | `if not doc_ids: return vectors` now returns `[]` + `METRIC_STATUS_FILTER_FAIL_CLOSED` when a non-empty batch carries no `document_id`; an empty input stays an empty result with no metric. Guard `test_filter_fails_closed_when_no_chunk_carries_a_document_id`, mutation-tested |
 | ~~**engine visibility**~~ ✅ DONE (task 16.4) | The facade now logs one INFO line per query naming the served engine (`engine=managed (Managed)` / `engine=s3vectors (Classic)`), read from the same KB_Record `resolve_backend` uses. The knowledge base section carries a `Managed`/`Classic` badge, fed by a new `engine` field on `UpgradeStatusResponse` (defaults `classic`), and its per-document status vocabulary is engine-aware — `uploading → processing → ready` for managed, `chunking`/`embedding` kept for legacy. Mutation-tested. Branch `feat/kb-engine-visibility` |
-| **14.4** one-click document retry | Req 21.2. Ingestion is S3-event-triggered and there is no reprocess endpoint, so this needs new backend against a live pipeline. The card currently directs the user to re-upload, which works today. Close it by building the endpoint **or** by amending Req 21.2 to accept re-upload |
-| **14.5** admin surface | not started. Filter by engine, stored bytes, document counts, bulk migrate, per-KB retry |
-| **15.1** packaged-SDK probe | the *static* half is done and passing (`boto3==1.43.68` carries `MANAGED`, the embedding members, `FLOAT32`, all four document ops, no `AWS_DATA_PATH`). The live half has now effectively been done by hand — a real create → ingest → retrieve → promote succeeded in dev |
-| **15.2** ingestion-concurrency probe | unanswered. Do not size a wide fleet migration before it |
-| **15.3** full matrix | run it once the above land |
+| **14.4** one-click document retry | Req 21.2. Ingestion is S3-event-triggered and there is no reprocess endpoint, so this needs new backend against a live pipeline. The card currently directs the user to re-upload, which works today. Close it by building the endpoint **or** by amending Req 21.2 to accept re-upload. Note task 16.5's document reconciler already performs the *scheduled* form of this |
+| **14.5** admin surface | Not started. Req 23.9: list knowledge bases filterable by engine, with stored bytes and document counts, bulk migrate, per-KB retry. Gates ladder **step 3**, not step 2. Two gaps it does *not* close, worth knowing before someone assumes it does: it reads our own `KB#` records, so it cannot see AWS-only orphans (the reconciler's job — and those still consume the account's knowledge-base quota); and it carries no control for granting the elevated byte tier, which remains a hand-edited `elevatedByteCap` attribute with no API or UI writer anywhere |
+| **15.1** packaged-SDK probe | The *static* half is done and passing (`boto3==1.43.68` carries `MANAGED`, the embedding members, `FLOAT32`, all four document ops, no `AWS_DATA_PATH`). The live half has effectively happened by hand — a real create → ingest → retrieve → promote succeeded in dev — but has not been run deliberately with the checked-in environment and recorded. **Do this one first:** it is the only remaining item that can invalidate the feature in prod |
+| **15.2** ingestion-concurrency probe | Unanswered. Gates a wide fleet migration (step 3), **not** born-managed (step 2), which provisions one knowledge base at a time as agents are created |
+| **15.3** full matrix | Run it once the above land |
 
 ### RESOLVED — the `document_id` / `relevance` "known unknown" was a false alarm
 


### PR DESCRIPTION
Documentation only. No code, no behaviour change.

## Why

`HANDOFF.md` §1 had drifted far enough to actively mislead. It listed PRs **#900** and **#908** as open (both merged weeks ago), stated that `MANAGED_KB_NEW_DEFAULT` has **no reader anywhere in `backend/src`** (PR #1027 gave it one), said "nothing performs the work", and instructed the reader to merge #900 first. A stale handoff is worse than no handoff — someone trusts it and goes chasing a pull request that no longer exists.

## What changed in the handoff

- **§0** now opens with where this actually stands, so a fresh reader orients in one line instead of five sections.
- **§1** status table, flag table (the fourth flag, `CDK_MANAGED_KB_DOC_RECONCILER_ARMED`, was missing entirely), and the reachability section — which now describes **both** paths to managed: opt-in Upgrade for an existing corpus, born-managed for a new agent.
- **The hand-maintained commit log is gone**, replaced by landmark PRs plus the `git log` command that is authoritative and cannot rot. Enumerating branches by hand is precisely what decayed last time.
- **New: the production rollout ladder in one place.** Four flags, four rungs, risk per rung, why rung 2 is reachable on its own, and the zero-legacy-knowledge-bases gate that must precede retiring the v1 pipeline — legacy code does not merely *create* old knowledge bases, it still **serves retrieval** for every un-migrated one, so removing it early breaks every agent that has not moved. That matters especially for forks that sync.
- **§6 "Do these first"** now reflects reality. Task **15.1** (the live packaged-SDK probe) is the only remaining item that can invalidate the feature in production. Tasks **15.2** and **14.5** gate rung **3**, not rung 2 — previously these were conflated, which made born-managed look more blocked than it is.
- The 15-minute born-managed pickup latency is recorded where an operator will actually meet it, not only in the feature spec.
- The superseded `newDefault` warning in the §5 defect log is **corrected in place rather than deleted**, so the history of the decision survives.

## What is added

`.kiro/specs/kb-chunk-inspector/` — which was sitting **untracked** on one machine, one `git clean` from being lost.

It is the tooling half of the task-16.2 decision. 16.2 concluded "guidance, not code" for §5.41 diagram answers, and that decision is only honest if users can act on it — which they cannot, because a flattened table produces a *confidently wrong answer with no trace*. The inspector makes the extraction visible: you open a document and read exactly what the knowledge base holds for it, including the vision model's image descriptions, untruncated.

Requirements and design were already written. This adds the missing `tasks.md`, including three things the drafts did not cover:

- the **isolation-filter mutation guard** (`equals` on `document_id`; a prefix operator would let `DOC-1` admit `DOC-10`, which is a cross-document leak, not a display bug)
- the **409-on-`provisioning`** case that born-managed newly introduces, with a message about the knowledge base being built rather than one implying the file is missing
- an **acceptance step against the real §5.41 corpus** — if a user still cannot tell from the panel why their per-semester answer was wrong, the feature has not delivered what 16.2 promised

Nothing here is scheduled. It is specced so it stops being tribal knowledge.