### PR TITLE
feat(kb): chunk inspector — show owners what their knowledge base extracted

### DIFF
--- a/.kiro/specs/kb-chunk-inspector/requirements.md
+++ b/.kiro/specs/kb-chunk-inspector/requirements.md
@@ -47,6 +47,29 @@ parsed usefully before I rely on it.
   `resolve_engine_for` and never branch on it in the UI.
 - The response shape SHALL be identical across engines.
 
+> **AMENDED BY IMPLEMENTATION 2026-09-11 — managed only.** The clause above assumed
+> `backend.search(..., retrieval_filter=...)` was part of the protocol. It is not:
+> `retrieval_filter` exists **only** on `ManagedKbBackend.search`. The legacy
+> adapter's signature is `search(kb_ref, query, top_k)`, it accepts no filter, and it
+> ignores `top_k` — it always asks its index for a fixed five results across the
+> **whole** knowledge base.
+>
+> So on legacy there is no way to scope a retrieval to one document. Running it anyway
+> would return five whole-knowledge-base chunks, most or all belonging to *other*
+> documents, rendered under this document's filename. That is a cross-document leak —
+> exactly what Requirement 4 exists to prevent — not a cosmetic defect to tidy later.
+>
+> Teaching the legacy adapter to filter was rejected on Requirement 5's own grounds:
+> the inspector must not depend on the legacy pipeline continuing to exist, and that
+> pipeline is being deprecated. New capability there has a negative lifespan.
+>
+> **As built:** a legacy document returns `available=false` with an owner-facing
+> `reason`, as a **200 rather than an error** — the owner asked a reasonable question
+> and "your knowledge base is on the classic engine, which cannot show this" is an
+> answer. The response shape is identical either way, so the second clause above holds
+> and the UI still never branches on engine, which is what this requirement was
+> actually protecting.
+
 ### Requirement 3 — Honest completeness
 - Bedrock managed knowledge bases expose **no chunk-enumeration API**; `Retrieve`
   is query-ranked and bounded by `numberOfResults`. WHERE the full set of chunks

--- a/.kiro/specs/kb-chunk-inspector/tasks.md
+++ b/.kiro/specs/kb-chunk-inspector/tasks.md
@@ -1,6 +1,6 @@
 # KB Chunk Inspector — Tasks
 
-**Status:** Not started · **Requirements:** `requirements.md` · **Design:** `design.md`
+**Status:** Built (tasks 1-5); task 6 is a manual check against dev · **Requirements:** `requirements.md` · **Design:** `design.md`
 **Why now:** it is the tooling half of the task-16.2 decision (`managed-kb-migration`
 §5.41). That decision was "guidance, not code" — this is what makes the guidance
 possible, because a user cannot act on advice about mangled tables if they cannot see
@@ -11,7 +11,7 @@ reusing the existing citation card. No new pipeline, no infra, no legacy depende
 
 ---
 
-- [ ] 1. Backend read endpoint
+- [x] 1. Backend read endpoint
   - `GET /assistants/{assistant_id}/documents/{document_id}/chunks` in
     `backend/src/apis/app_api/documents/routes.py`
   - `_require_edit_permission` first, exactly as the sibling document endpoints do;
@@ -24,7 +24,7 @@ reusing the existing citation card. No new pipeline, no infra, no legacy depende
     resolver; never branch on engine in the response shape (Req 2)
   - _Requirements: 1, 2, 4, 5_
 
-- [ ] 2. Chunk enumeration, honest about completeness
+- [x] 2. Chunk enumeration, honest about completeness
   - One `search(...)` call through the facade with the `document_id` `equals`
     filter, `numberOfResults` at the backend ceiling (Bedrock documents 100)
   - Neutral document-anchored query text (the filename, or the row's leading text)
@@ -38,14 +38,14 @@ reusing the existing citation card. No new pipeline, no infra, no legacy depende
     came back and let the human judge it; that is the 16.2 decision, not laziness
   - _Requirements: 1, 3, 6_
 
-- [ ] 3. Response contract
+- [x] 3. Response contract
   - `{ documentId, fileName, engine, chunks: [{ text, page?, order, score? }],
     complete: bool, returned: N, capReached: bool }`
   - Full chunk text, **not** truncated to the 500-character citation limit — that
     truncation is the whole reason the existing citation trace cannot serve this
   - _Requirements: 1, 2, 3_
 
-- [ ] 4. Frontend panel
+- [x] 4. Frontend panel
   - A "View extracted content" action on the document row, enabled at `complete`
   - Panel lists each chunk's full text, monospace/`pre` so a flattened table's
     damage is actually visible, with page/location when present
@@ -58,7 +58,7 @@ reusing the existing citation card. No new pipeline, no infra, no legacy depende
     header
   - _Requirements: 1, 3_
 
-- [ ] 5. Tests
+- [x] 5. Tests
   - Route: owner sees chunks on **both** engines; non-owner 403; non-`complete`
     document 409 (cover `provisioning` and `uploading` separately); `capReached`
     set when the count equals the ceiling

--- a/backend/src/apis/app_api/documents/models.py
+++ b/backend/src/apis/app_api/documents/models.py
@@ -185,3 +185,46 @@ class ImportDocumentsResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     documents: List[DocumentResponse] = Field(..., description="Created document records, each in 'uploading' state")
+
+
+class ExtractedChunkResponse(BaseModel):
+    """One passage as the knowledge base actually holds it.
+
+    ``text`` is the FULL extracted text, deliberately not truncated. The existing
+    per-answer citation trace caps excerpts at 500 characters, which is exactly why it
+    cannot serve this purpose: a flattened table's damage is usually past the cut, so a
+    truncated excerpt of a mangled table reads like a fine excerpt of a fine table.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    text: str = Field(..., description="Full extracted text of this chunk, untruncated")
+    order: int = Field(..., description="Position in the returned set — NOT the document's own order")
+    score: Optional[float] = Field(None, description="Relevance as the backend reported it; higher is better")
+    page: Optional[int] = Field(None, description="Page number when the backend supplied one; never inferred")
+
+
+class ExtractedChunksResponse(BaseModel):
+    """What the knowledge base extracted from one document.
+
+    ``available`` is false, with a ``reason``, for a document the inspector cannot
+    show — a classic knowledge base cannot scope a retrieval to a single document. The
+    shape is identical either way so the client never branches on the engine.
+
+    ``capReached`` is honesty rather than a paging hint. Bedrock exposes no
+    chunk-enumeration API, so a complete set is never guaranteed and the UI must say
+    "up to N" instead of implying the document has exactly N chunks.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    documentId: str = Field(..., description="Document identifier", alias="documentId")
+    fileName: str = Field(..., description="Original filename", alias="fileName")
+    engine: str = Field(..., description="Engine serving this knowledge base: 'managed' or 's3vectors'")
+    available: bool = Field(..., description="False when this engine cannot show a single document's chunks")
+    reason: Optional[str] = Field(None, description="Owner-facing explanation when available is false")
+    chunks: List[ExtractedChunkResponse] = Field(default_factory=list, description="The chunks returned, unordered")
+    returned: int = Field(0, description="How many chunks are in this response")
+    capReached: bool = Field(
+        False, description="True when the per-call ceiling was hit, so more chunks may exist", alias="capReached"
+    )

--- a/backend/src/apis/app_api/documents/routes.py
+++ b/backend/src/apis/app_api/documents/routes.py
@@ -14,10 +14,16 @@ from apis.app_api.documents.models import (
     DocumentResponse,
     DocumentsListResponse,
     DownloadUrlResponse,
+    ExtractedChunkResponse,
+    ExtractedChunksResponse,
     ImportDocumentsRequest,
     ImportDocumentsResponse,
     ReportUploadFailureRequest,
     UploadUrlResponse,
+)
+from apis.app_api.documents.services.chunk_inspector import (
+    DocumentNotInspectable,
+    inspect_document_chunks,
 )
 from apis.app_api.documents.services.document_service import _generate_document_id, create_document, list_assistant_documents, update_document_status, release_reservation_if_managed
 from apis.app_api.documents.services.document_service import get_document as get_document_service
@@ -463,6 +469,76 @@ async def get_download_url(
     except Exception as e:
         logger.error(f"Error generating download URL: {e}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to generate download URL: {str(e)}")
+
+
+@router.get(
+    "/{document_id}/chunks",
+    response_model=ExtractedChunksResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_document_chunks(
+    assistant_id: str, document_id: str, current_user: User = Depends(get_current_user_from_session)
+) -> ExtractedChunksResponse:
+    """Show what the knowledge base actually extracted from this document.
+
+    The tooling half of the task-16.2 decision on managed-kb-migration §5.41. The
+    managed backend flattens a column-structured diagram or a 2-D table at ingestion,
+    so a per-column question gets a *confident wrong answer with no trace*. We do not
+    fix the parser — it is a managed service and this is a self-service platform — so
+    instead the extraction is made visible and the owner can decide to reformat their
+    source. Guidance nobody can verify is not guidance.
+
+    Owners and editors only, the same gate as every other document endpoint. Read-only:
+    no chunking, parsing or ingestion path is touched (Requirement 5).
+    """
+    try:
+        assistant_owner_id = await _require_edit_permission(assistant_id, current_user)
+        document = await get_document_service(assistant_id, document_id, assistant_owner_id)
+
+        if not document or document.status == "deleting":
+            # A soft-deleted document is being removed on purpose; surfacing its
+            # content would resurrect it in the one place the user is told it is gone.
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Document not found: {document_id}"
+            )
+
+        result = await inspect_document_chunks(
+            assistant_id,
+            document_id,
+            file_name=document.filename,
+            status=document.status,
+        )
+
+        return ExtractedChunksResponse(
+            documentId=result.document_id,
+            fileName=result.file_name,
+            engine=result.engine,
+            available=result.available,
+            reason=result.reason,
+            chunks=[
+                ExtractedChunkResponse(
+                    text=chunk.text, order=chunk.order, score=chunk.score, page=chunk.page
+                )
+                for chunk in result.chunks
+            ],
+            returned=result.returned,
+            capReached=result.cap_reached,
+        )
+
+    except DocumentNotInspectable as e:
+        # 409 rather than 404: the document exists, it simply has no content in the
+        # knowledge base yet. The carried copy is written for the owner, not an
+        # operator — `provisioning` in particular gets its own sentence, because a
+        # born-managed first upload is waiting on the knowledge base itself.
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=e.reason)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error inspecting document chunks: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to read extracted content: {str(e)}",
+        )
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/apis/app_api/documents/services/chunk_inspector.py
+++ b/backend/src/apis/app_api/documents/services/chunk_inspector.py
@@ -1,0 +1,277 @@
+"""Show an owner the content their knowledge base actually extracted from a document.
+
+Feature: `kb-chunk-inspector`. The tooling half of the task-16.2 decision on
+`managed-kb-migration` §5.41.
+
+Why this exists
+---------------
+The two backends fail differently, and the managed one fails worse:
+
+* **Legacy** failed **silently** — a column-structured flowchart produced 0 chunks,
+  so a question about it got no answer. Bad, but visible.
+* **Managed** fails **invisibly** — the vision/parse step flattens a 2-D layout at
+  ingestion, so a question about "semester 4" or a per-column total gets a
+  *confident wrong answer* with no trace of why.
+
+Task 16.2 decided not to fix the parser: it is a managed service, and this is a
+self-service platform where owners upload their own documents. The mitigation is
+guidance. But guidance is useless if the user cannot see the problem — nobody can act
+on "reformat your flowchart as a text table" without first believing their flowchart
+came out wrong. This module is what lets them look.
+
+Read-only. No new chunking, parsing or ingestion path (Requirement 5).
+
+Managed-only, and that is a correction to the design
+----------------------------------------------------
+The design document assumed ``backend.search(..., retrieval_filter=...)`` was part of
+the protocol and that the inspector could therefore be engine-agnostic. It is not:
+``retrieval_filter`` exists **only** on ``ManagedKbBackend.search``. The legacy
+adapter's signature is ``search(kb_ref, query, top_k)``, it accepts no filter, and it
+ignores ``top_k`` — it always asks its index for a fixed five results across the
+*whole* knowledge base.
+
+So on legacy there is no way to scope a retrieval to one document. Running it anyway
+would return the top five chunks of the entire knowledge base, most or all of them
+belonging to **other documents** — the user opens "view extracted content" on their
+syllabus and reads somebody else's handbook. That is a cross-document leak, which is
+precisely what Requirement 4 and ``ISOLATION_SAFE_FILTER_OPERATORS`` exist to
+prevent; it is not a cosmetic problem to be tidied up later.
+
+Teaching the legacy adapter to filter was rejected: Requirement 5 says the inspector
+must not depend on the legacy pipeline continuing to exist, and that pipeline is being
+deprecated. Building new capability into it would be work with a negative lifespan.
+
+So a legacy document returns ``available=False`` with a reason, as a **200 rather than
+an error**: the owner asked a reasonable question and "your knowledge base is on the
+classic engine, which cannot show this" is an answer, not a fault. The response shape
+is identical either way, so the UI never branches on the engine — which is what
+Requirement 2 was actually protecting.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Chunks requested in one `Retrieve`. Bedrock documents 100 as the ceiling for
+#: `numberOfResults`, and the inspector wants as complete a picture as one bounded
+#: call can give — unlike a real query, where 5 is the answer-quality choice.
+#:
+#: One call, not a pagination loop (Requirement 6). `Retrieve` is query-ranked with no
+#: cursor, so "page 2" is not a thing it offers; repeating the call with a different
+#: query would return an overlapping arbitrary subset and cost another 662–695 ms for
+#: no guarantee of new content.
+INSPECT_TOP_K = 100
+
+#: Statuses that can be inspected. Only `complete` — the retrieval facade serves only
+#: `complete`, so anything else has no chunks in the knowledge base to show.
+INSPECTABLE_STATUS = "complete"
+
+#: Why a document cannot be inspected yet, in the owner's language. Keyed on the
+#: `DOC#` status. `provisioning` is born-managed's leading status (the knowledge base
+#: itself is still being created), and it gets its own sentence because "not found"
+#: would be a lie and "still processing" would understate the wait.
+_NOT_READY_REASONS = {
+    "provisioning": (
+        "This assistant's knowledge base is still being created. The extracted "
+        "content will be available once the first document has finished processing."
+    ),
+    "uploading": "This document is still being processed. Check back shortly.",
+    "chunking": "This document is still being processed. Check back shortly.",
+    "embedding": "This document is still being processed. Check back shortly.",
+    "failed": (
+        "This document could not be processed, so the knowledge base holds no "
+        "content for it. Upload it again, or convert it to a different format."
+    ),
+}
+
+_NOT_READY_FALLBACK = "This document is not ready to inspect yet."
+
+LEGACY_UNAVAILABLE_REASON = (
+    "This assistant uses the classic knowledge base, which cannot list the "
+    "extracted content for a single document. Upgrading the assistant's knowledge "
+    "base makes this view available."
+)
+
+
+class DocumentNotInspectable(Exception):
+    """The document exists but has no content to show yet. Carries owner-safe copy."""
+
+    def __init__(self, reason: str, status: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.status = status
+
+
+@dataclass
+class InspectedChunk:
+    """One passage as the knowledge base holds it.
+
+    ``text`` is deliberately **not** truncated. The existing citation trace caps
+    excerpts at 500 characters, which is the whole reason it cannot serve this
+    purpose: a flattened table's damage is frequently past the cut, and a truncated
+    excerpt of a mangled table looks like a fine excerpt of a fine table.
+    """
+
+    text: str
+    order: int
+    score: Optional[float] = None
+    page: Optional[int] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class InspectionResult:
+    document_id: str
+    file_name: str
+    engine: str
+    available: bool
+    chunks: List[InspectedChunk] = field(default_factory=list)
+    returned: int = 0
+    cap_reached: bool = False
+    reason: Optional[str] = None
+
+
+def document_filter(document_id: str) -> Dict[str, Any]:
+    """The retrieval filter scoping results to exactly one document.
+
+    ``equals``, never a prefix or substring operator. This is the same filter the
+    ingestion consumer's retrievability probe and the document reconciler use, and it
+    is in ``ISOLATION_SAFE_FILTER_OPERATORS`` for a reason worth restating: a prefix
+    match for ``DOC-1`` also admits ``DOC-10``, ``DOC-11`` and so on, so the operator
+    choice is the isolation boundary rather than a query-tuning detail.
+    """
+    return {"equals": {"key": "document_id", "value": document_id}}
+
+
+def _page_of(metadata: Dict[str, Any]) -> Optional[int]:
+    """Page number when the backend supplied one, else ``None``.
+
+    Never invented. A fabricated page number would be indistinguishable from a real
+    one and would make an unordered result set look authoritatively ordered.
+    """
+    for key in ("page", "pageNumber", "page_number", "x-amz-bedrock-kb-document-page-number"):
+        raw = metadata.get(key)
+        if raw is None:
+            continue
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _dedupe(chunks: List[Any]) -> List[Any]:
+    """Drop repeated passages, preserving first-seen order.
+
+    ``Retrieve`` is query-ranked rather than a cursor over a set, so the same passage
+    can legitimately come back more than once. Showing an owner the same mangled
+    table three times would make them think it was ingested three times.
+    """
+    seen = set()
+    unique = []
+    for chunk in chunks:
+        fingerprint = hash(chunk.text)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        unique.append(chunk)
+    return unique
+
+
+async def inspect_document_chunks(
+    assistant_id: str,
+    document_id: str,
+    *,
+    file_name: str,
+    status: str,
+) -> InspectionResult:
+    """The content the knowledge base holds for one document.
+
+    Raises :class:`DocumentNotInspectable` when the document exists but has nothing
+    to show; the caller turns that into a 409 with the carried copy.
+    """
+    from apis.shared.kb_backend import resolver
+    from apis.shared.kb_backend.query_guard import clamp_query
+    from apis.shared.kb_backend.records import ENGINE_MANAGED
+
+    if status != INSPECTABLE_STATUS:
+        raise DocumentNotInspectable(
+            _NOT_READY_REASONS.get(status, _NOT_READY_FALLBACK), status
+        )
+
+    record = resolver.load_record(assistant_id)
+    engine = resolver.resolve_engine_for(assistant_id, record=record)
+
+    if engine != ENGINE_MANAGED:
+        # See the module docstring: legacy cannot scope a retrieval to one document,
+        # and returning the whole knowledge base's top chunks would leak other
+        # documents' content into this view.
+        return InspectionResult(
+            document_id=document_id,
+            file_name=file_name,
+            engine=engine,
+            available=False,
+            reason=LEGACY_UNAVAILABLE_REASON,
+        )
+
+    backend = resolver.resolve_backend(assistant_id, record=record)
+
+    # The filter is what scopes the result; this text exists only because `Retrieve`
+    # requires a query. The filename is the most document-anchored string available
+    # without reading the object, and clamp_query is reused rather than reinvented so
+    # an absurd filename cannot become an absurd query.
+    query, _ = clamp_query(file_name or document_id)
+
+    chunks = await backend.search(
+        assistant_id,
+        query,
+        INSPECT_TOP_K,
+        retrieval_filter=document_filter(document_id),
+    )
+
+    # Defence in depth. The filter should make this a no-op, and if it ever is not,
+    # the failure must not be "the owner reads another document's content".
+    scoped = [chunk for chunk in chunks if chunk.document_id == document_id]
+    if len(scoped) != len(chunks):
+        logger.error(
+            f"chunk inspector: {len(chunks) - len(scoped)} chunk(s) for a document "
+            f"other than {document_id} came back through a document-scoped filter; "
+            f"dropped them"
+        )
+
+    unique = _dedupe(scoped)
+
+    inspected = [
+        InspectedChunk(
+            text=chunk.text,
+            order=index,
+            score=chunk.relevance,
+            page=_page_of(chunk.metadata or {}),
+            metadata={},
+        )
+        for index, chunk in enumerate(unique)
+    ]
+
+    # `capReached` is honesty, not a paging hint (Requirement 3). Bedrock exposes no
+    # chunk-enumeration API, so a full result set is never guaranteed and the UI must
+    # say "up to N" rather than implying the document has exactly N chunks.
+    cap_reached = len(chunks) >= INSPECT_TOP_K
+
+    logger.info(
+        f"chunk inspector: assistant={assistant_id} document={document_id} "
+        f"engine={engine} returned={len(inspected)} capReached={cap_reached}"
+    )
+
+    return InspectionResult(
+        document_id=document_id,
+        file_name=file_name,
+        engine=engine,
+        available=True,
+        chunks=inspected,
+        returned=len(inspected),
+        cap_reached=cap_reached,
+    )

--- a/backend/tests/routes/test_document_chunk_inspector.py
+++ b/backend/tests/routes/test_document_chunk_inspector.py
@@ -1,0 +1,375 @@
+"""The chunk inspector: show an owner what the knowledge base actually extracted.
+
+Feature: `kb-chunk-inspector`. Tooling half of the task-16.2 decision on
+`managed-kb-migration` §5.41.
+
+The failure this endpoint exists to make visible is not a crash — it is a *confident
+wrong answer*. The managed backend flattens a column-structured diagram at ingestion,
+so "how many credits in semester 4" comes back plausible and wrong with no trace. 16.2
+decided against fixing the parser and in favour of user guidance; guidance the user
+cannot verify is not guidance, so this endpoint is what lets them look.
+
+Two things here are security properties rather than features, and both are mutation-
+guarded below:
+
+**The document filter is the isolation boundary.** It must be `equals` on
+`document_id`. A prefix or substring operator matching `DOC-1` also admits `DOC-10`,
+which means one owner's inspector renders another document's content. That is a leak,
+not a display bug — hence `ISOLATION_SAFE_FILTER_OPERATORS`.
+
+**A classic knowledge base must refuse rather than approximate.** The legacy adapter
+accepts no filter and ignores `top_k`; it always returns five results from the *whole*
+knowledge base. Running it anyway would show the owner other documents' chunks under
+the heading of theirs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apis.app_api.documents.routes import router
+from apis.app_api.documents.services import chunk_inspector as ci
+from apis.shared.auth import get_current_user_from_session
+from apis.shared.auth.models import User
+from apis.shared.kb_backend.managed_backend import ISOLATION_SAFE_FILTER_OPERATORS
+from apis.shared.kb_backend.protocol import Chunk
+
+ROUTES_MODULE = "apis.app_api.documents.routes"
+INSPECTOR_MODULE = "apis.app_api.documents.services.chunk_inspector"
+RESOLVER_MODULE = "apis.shared.kb_backend.resolver"
+ASSISTANT_ID = "ast-insp01"
+DOCUMENT_ID = "DOC-insp01"
+OTHER_DOCUMENT_ID = "DOC-insp01-other"
+USER_ID = "user-insp"
+FILENAME = "4-yr-flowchart-v2026.pdf"
+
+
+@pytest.fixture()
+def app():
+    _app = FastAPI()
+    _app.include_router(router)
+    _app.dependency_overrides[get_current_user_from_session] = lambda: User(
+        user_id=USER_ID, email=f"{USER_ID}@example.com", name="Test User", roles=["User"]
+    )
+    return _app
+
+
+def _owner():
+    return (SimpleNamespace(owner_id=USER_ID), "owner")
+
+
+def _viewer():
+    return (SimpleNamespace(owner_id="somebody-else"), "viewer")
+
+
+def _document(status="complete", filename=FILENAME):
+    return SimpleNamespace(
+        document_id=DOCUMENT_ID, filename=filename, status=status, s3_key="k"
+    )
+
+
+def _chunk(text, document_id=DOCUMENT_ID, relevance=0.5, metadata=None):
+    return Chunk(
+        text=text,
+        relevance=relevance,
+        document_id=document_id,
+        metadata=metadata or {},
+        key=f"{document_id}#0",
+    )
+
+
+class _FakeBackend:
+    """Records the retrieval filter it was handed and returns canned chunks.
+
+    Modelling the filter is the whole point: the isolation guarantee lives in the
+    argument, not in the response, so a fake that ignored it could not tell a scoped
+    query from an unscoped one.
+
+    ``honour_filter=False`` models a backend that accepts the filter and does not
+    apply it — a service-side regression, or an adapter that drops the argument. That
+    is not hypothetical enough to skip: it is the failure the post-filter exists for,
+    and it is silent.
+    """
+
+    def __init__(self, chunks, honour_filter=True):
+        self._chunks = chunks
+        self._honour_filter = honour_filter
+        self.calls = []
+
+    async def search(self, kb_ref, query, top_k=5, retrieval_filter=None):
+        self.calls.append(
+            {"kb_ref": kb_ref, "query": query, "top_k": top_k, "filter": retrieval_filter}
+        )
+        if not retrieval_filter or not self._honour_filter:
+            # Model the real world: unfiltered, the index returns everything it has,
+            # including other documents. A fake that returned only the "right" chunks
+            # would hide exactly the bug being guarded against.
+            return self._chunks
+        wanted = retrieval_filter.get("equals", {}).get("value")
+        return [c for c in self._chunks if c.document_id == wanted]
+
+
+def _get(app):
+    return TestClient(app).get(
+        f"/assistants/{ASSISTANT_ID}/documents/{DOCUMENT_ID}/chunks"
+    )
+
+
+def _inspect(app, *, document, engine="managed", backend=None, record=None):
+    """Drive the endpoint with the resolver and document lookup stubbed."""
+    return (
+        patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_owner(),
+        ),
+        patch(
+            f"{ROUTES_MODULE}.get_document_service",
+            new_callable=AsyncMock,
+            return_value=document,
+        ),
+        # Patched on the resolver module, not on the inspector: the inspector imports
+        # it function-locally (stdlib-only module scope is the house rule for anything
+        # the size-constrained Lambda images touch), so there is no module attribute
+        # to patch on this side.
+        patch(f"{RESOLVER_MODULE}.load_record", return_value=record or {}),
+        patch(f"{RESOLVER_MODULE}.resolve_engine_for", return_value=engine),
+        patch(f"{RESOLVER_MODULE}.resolve_backend", return_value=backend),
+    )
+
+
+class TestTheHappyPath:
+    def test_an_owner_sees_the_full_extracted_text(self, app):
+        backend = _FakeBackend(
+            [
+                _chunk("Semester 1 | ENGL 101 | 3 credits", metadata={"page": "1"}),
+                _chunk("x" * 900),  # longer than the 500-char citation cap
+            ]
+        )
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is True
+        assert body["engine"] == "managed"
+        assert body["returned"] == 2
+        assert body["capReached"] is False
+        # NOT truncated to 500 — the whole reason the citation trace cannot serve this.
+        assert len(body["chunks"][1]["text"]) == 900
+        assert body["chunks"][0]["page"] == 1
+
+    def test_the_filter_sent_to_the_backend_scopes_to_one_document(self, app):
+        """MUTATION GUARD: drop `retrieval_filter=document_filter(...)` from
+        `inspect_document_chunks` and this fails.
+
+        This is the guard for the filter itself, asserted on the ARGUMENT rather than
+        on the response, and that distinction was earned the hard way. The obvious
+        guard — seed a second document's chunks and assert they do not appear — passes
+        with the filter removed, because the post-filter in `inspect_document_chunks`
+        catches them on the way out. A test that green-lights the mutated code is not
+        a guard, however sensible it reads. See
+        `test_a_backend_that_ignores_the_filter_still_cannot_leak` for the other layer.
+        """
+        backend = _FakeBackend([_chunk("only mine")])
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            _get(app)
+
+        call = backend.calls[0]
+        assert call["query"] == FILENAME
+        assert call["top_k"] == ci.INSPECT_TOP_K
+        assert call["filter"] == {
+            "equals": {"key": "document_id", "value": DOCUMENT_ID}
+        }
+
+    def test_repeated_passages_are_collapsed(self, app):
+        """`Retrieve` is query-ranked, not a cursor, so it can return a passage twice.
+        Showing a mangled table three times would read as three bad ingestions."""
+        backend = _FakeBackend([_chunk("same text"), _chunk("same text"), _chunk("other")])
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        assert [c["text"] for c in body["chunks"]] == ["same text", "other"]
+
+    def test_cap_reached_is_reported_when_the_ceiling_is_hit(self, app):
+        """Honesty, not paging (Req 3). Bedrock has no chunk-enumeration API, so the
+        UI must say 'up to N' rather than 'this document has N chunks'."""
+        backend = _FakeBackend([_chunk(f"chunk {i}") for i in range(ci.INSPECT_TOP_K)])
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        assert body["capReached"] is True
+        assert body["returned"] == ci.INSPECT_TOP_K
+
+    def test_a_page_number_is_never_invented(self, app):
+        """A fabricated page would be indistinguishable from a real one and would make
+        an unordered set look authoritatively ordered."""
+        backend = _FakeBackend([_chunk("no page metadata", metadata={"junk": "x"})])
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        assert body["chunks"][0]["page"] is None
+
+
+class TestIsolation:
+    def test_a_backend_that_ignores_the_filter_still_cannot_leak(self, app):
+        """MUTATION GUARD for the SECOND layer: delete the `scoped = [...]` post-filter
+        in `inspect_document_chunks` and this fails.
+
+        The fake here deliberately ignores the filter it is handed, modelling a backend
+        that stops honouring it — a service-side regression, or a future adapter that
+        accepts the argument and drops it. Neither would raise. The response would just
+        quietly start carrying another document's content under this document's
+        filename, and nothing else in the system would notice.
+
+        Belt and braces is the right call here precisely because the failure is silent
+        and the blast radius is one owner reading another's document.
+        """
+        backend = _FakeBackend(
+            [
+                _chunk("mine", document_id=DOCUMENT_ID),
+                _chunk("SOMEBODY ELSE'S CONTENT", document_id=OTHER_DOCUMENT_ID),
+            ],
+            honour_filter=False,
+        )
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        texts = [c["text"] for c in body["chunks"]]
+        assert texts == ["mine"]
+        assert "SOMEBODY ELSE'S CONTENT" not in texts
+
+    def test_only_the_requested_document_reaches_the_owner(self, app):
+        """The observable guarantee, through whichever layer delivers it. Both the
+        filter and the post-filter would have to fail for this to break."""
+        backend = _FakeBackend(
+            [
+                _chunk("mine", document_id=DOCUMENT_ID),
+                _chunk("SOMEBODY ELSE'S CONTENT", document_id=OTHER_DOCUMENT_ID),
+            ]
+        )
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        assert [c["text"] for c in body["chunks"]] == ["mine"]
+
+    def test_the_filter_operator_is_isolation_safe(self):
+        """The operator choice IS the isolation boundary. A prefix match for `DOC-1`
+        admits `DOC-10`, so this asserts the operator rather than trusting it."""
+        built = ci.document_filter(DOCUMENT_ID)
+        assert list(built) == ["equals"]
+        assert set(built) <= ISOLATION_SAFE_FILTER_OPERATORS
+        assert built["equals"] == {"key": "document_id", "value": DOCUMENT_ID}
+
+    def test_a_prefix_style_document_id_cannot_over_match(self, app):
+        """`DOC-insp01` must not admit `DOC-insp01-other`, which is exactly what a
+        substring operator would do. Driven through a filter-honouring fake so this
+        exercises the real `equals` semantics rather than the post-filter."""
+        backend = _FakeBackend(
+            [
+                _chunk("mine", document_id=DOCUMENT_ID),
+                _chunk("longer id, must not match", document_id=OTHER_DOCUMENT_ID),
+            ]
+        )
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            body = _get(app).json()
+
+        assert [c["text"] for c in body["chunks"]] == ["mine"]
+
+    def test_a_viewer_is_refused(self, app):
+        with patch(
+            f"{ROUTES_MODULE}.resolve_assistant_permission",
+            new_callable=AsyncMock,
+            return_value=_viewer(),
+        ):
+            resp = _get(app)
+        assert resp.status_code == 403
+
+
+class TestWhatCannotBeInspected:
+    def test_a_classic_knowledge_base_refuses_rather_than_approximating(self, app):
+        """MUTATION GUARD: let the legacy engine through to `search` and this fails.
+        The legacy adapter takes no filter and ignores top_k — it returns five results
+        from the WHOLE knowledge base — so 'approximating' means rendering other
+        documents' content under this document's name."""
+        backend = _FakeBackend([_chunk("whole-KB result", document_id=OTHER_DOCUMENT_ID)])
+        p, d, lr, re_, rb = _inspect(
+            app, document=_document(), engine="s3vectors", backend=backend
+        )
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+
+        assert resp.status_code == 200  # an answer, not an error
+        body = resp.json()
+        assert body["available"] is False
+        assert body["chunks"] == []
+        assert "classic" in body["reason"].lower()
+        # The decisive assertion: the backend was never asked.
+        assert backend.calls == []
+
+    @pytest.mark.parametrize(
+        "status", ["uploading", "chunking", "embedding", "provisioning"]
+    )
+    def test_a_document_still_processing_is_409_not_404(self, app, status):
+        """It exists; it simply has no content yet. A 404 would tell the owner their
+        file is missing, which is both wrong and alarming."""
+        p, d, lr, re_, rb = _inspect(app, document=_document(status=status))
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+
+        assert resp.status_code == 409
+
+    def test_provisioning_says_the_knowledge_base_is_being_created(self, app):
+        """Born-managed's leading status. 'Still processing' would understate it — the
+        wait is on the knowledge base itself, not on this file."""
+        p, d, lr, re_, rb = _inspect(app, document=_document(status="provisioning"))
+        with p, d, lr, re_, rb:
+            detail = _get(app).json()["detail"]
+
+        assert "knowledge base" in detail.lower()
+        assert "being created" in detail.lower()
+
+    def test_a_failed_document_explains_itself(self, app):
+        p, d, lr, re_, rb = _inspect(app, document=_document(status="failed"))
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+
+        assert resp.status_code == 409
+        assert "could not be processed" in resp.json()["detail"].lower()
+
+    def test_a_missing_document_is_404(self, app):
+        p, d, lr, re_, rb = _inspect(app, document=None)
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+        assert resp.status_code == 404
+
+    def test_a_soft_deleted_document_is_404_not_its_content(self, app):
+        """`deleting` means removal is under way on purpose. Rendering its content is
+        resurrecting it in the one place the user was told it is gone."""
+        p, d, lr, re_, rb = _inspect(app, document=_document(status="deleting"))
+        with p, d, lr, re_, rb:
+            resp = _get(app)
+        assert resp.status_code == 404
+
+
+class TestBoundedCost:
+    def test_exactly_one_retrieve_per_request(self, app):
+        """Req 6. `Retrieve` was measured at 662–695 ms p50 and offers no cursor, so a
+        second call would cost that again for an overlapping arbitrary subset."""
+        backend = _FakeBackend([_chunk("a"), _chunk("b")])
+        p, d, lr, re_, rb = _inspect(app, document=_document(), backend=backend)
+        with p, d, lr, re_, rb:
+            _get(app)
+
+        assert len(backend.calls) == 1

--- a/frontend/ai.client/src/app/assistants/components/extracted-content-dialog.component.ts
+++ b/frontend/ai.client/src/app/assistants/components/extracted-content-dialog.component.ts
@@ -1,0 +1,183 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroXMark, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { DialogDismissDirective } from '../../components/dialog/dialog-dismiss.directive';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+import { DocumentService } from '../services/document.service';
+import { ExtractedChunk } from '../models/document.model';
+
+export interface ExtractedContentDialogData {
+  assistantId: string;
+  documentId: string;
+  filename: string;
+}
+
+/**
+ * Shows the content the knowledge base actually extracted from one document.
+ *
+ * Why this exists (managed-kb-migration §5.41, task 16.2): the managed backend's
+ * vision/parse step flattens a column-structured flowchart or a two-dimensional table
+ * at ingestion. A question about "semester 4" then gets a *confident wrong answer* with
+ * nothing to indicate why. The decision was not to fix the parser — it is a managed
+ * service, and on a self-service platform the mitigation is guidance — but guidance
+ * nobody can verify is not guidance. This panel is where an owner sees that their table
+ * came out as one long line, and decides to reformat their source.
+ *
+ * Three deliberate presentation choices:
+ *
+ * - **Monospace, whitespace preserved.** A flattened table rendered as flowing prose
+ *   looks fine. The damage is only visible when the alignment is shown as-is.
+ * - **No chunk numbering.** `Retrieve` is query-ranked, so the order here is not the
+ *   document's order. Numbering them 1..N would assert a sequence that does not exist.
+ * - **The "up to N" note when capped.** Bedrock exposes no chunk-enumeration API, so a
+ *   complete set is never guaranteed and claiming one would be a lie the UI tells.
+ */
+@Component({
+  selector: 'app-extracted-content-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogDismissDirective, NgIcon, SpinnerComponent],
+  providers: [provideIcons({ heroXMark, heroExclamationTriangle })],
+  host: {
+    class: 'block',
+    '(keydown.escape)': 'close()',
+  },
+  template: `
+    <div class="dialog-backdrop fixed inset-0 bg-gray-500/75 dark:bg-gray-900/80" aria-hidden="true"></div>
+
+    <div
+      class="fixed inset-0 z-10 flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+      appDialogDismiss
+      (dismissed)="close()"
+    >
+      <div
+        class="dialog-panel relative flex max-h-[85vh] w-full transform flex-col overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl sm:my-8 sm:max-w-3xl sm:p-6 dark:bg-gray-800 dark:outline dark:-outline-offset-1 dark:outline-white/10"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="extracted-title"
+      >
+        <div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+          <button
+            type="button"
+            (click)="close()"
+            class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-primary-600 dark:bg-gray-800 dark:hover:text-gray-300 dark:focus:outline-white"
+            aria-label="Close dialog"
+          >
+            <span class="sr-only">Close</span>
+            <ng-icon name="heroXMark" class="size-6" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div class="shrink-0 pr-8">
+          <h3 id="extracted-title" class="text-base/7 font-semibold text-gray-900 dark:text-white">
+            Extracted content
+          </h3>
+          <p class="mt-1 truncate text-sm/6 text-gray-500 dark:text-gray-400">{{ data.filename }}</p>
+        </div>
+
+        @if (loading()) {
+          <div class="flex grow items-center justify-center py-12">
+            <app-spinner />
+          </div>
+        } @else if (reason()) {
+          <!-- Not an error state: the owner asked a fair question and this is the
+               answer. A classic knowledge base cannot scope a retrieval to one
+               document; a still-processing document has nothing yet. -->
+          <div class="mt-4 flex grow items-start gap-3 rounded-md bg-gray-50 p-4 dark:bg-white/5">
+            <ng-icon
+              name="heroExclamationTriangle"
+              class="size-5 shrink-0 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <p class="text-sm/6 text-gray-600 dark:text-gray-300">{{ reason() }}</p>
+          </div>
+        } @else {
+          <!-- The actionable nudge. Without it this panel is a curiosity; with it,
+               it tells the owner what to do about what they are looking at. -->
+          <p class="mt-3 shrink-0 text-sm/6 text-gray-600 dark:text-gray-300">
+            This is what the knowledge base extracted. The assistant answers from
+            <em>this</em>, not from your original layout &mdash; so if a table or an image
+            description looks wrong here, consider reformatting your source.
+          </p>
+
+          @if (capReached()) {
+            <p class="mt-2 shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">
+              Showing the first {{ returned() }} passages. More may exist &mdash; this
+              knowledge base cannot list them all.
+            </p>
+          } @else {
+            <p class="mt-2 shrink-0 text-xs/5 text-gray-500 dark:text-gray-400">
+              {{ returned() }} {{ returned() === 1 ? 'passage' : 'passages' }}. Order is not
+              the document's own order.
+            </p>
+          }
+
+          <div class="mt-4 grow space-y-3 overflow-y-auto">
+            @for (chunk of chunks(); track chunk.order) {
+              <div class="rounded-md bg-gray-50 p-3 dark:bg-white/5">
+                @if (chunk.page !== null && chunk.page !== undefined) {
+                  <p class="mb-1.5 text-xs/5 font-medium text-gray-500 dark:text-gray-400">
+                    Page {{ chunk.page }}
+                  </p>
+                }
+                <!-- Monospace and whitespace-preserved on purpose: a flattened table
+                     rendered as prose looks perfectly fine, which is the bug. -->
+                <pre
+                  class="overflow-x-auto font-mono text-xs/5 whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+                  >{{ chunk.text }}</pre
+                >
+              </div>
+            } @empty {
+              <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                The knowledge base returned no content for this document. If it finished
+                processing, the file may contain nothing the parser could read &mdash; a
+                scanned image with no text layer, for instance.
+              </p>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class ExtractedContentDialogComponent {
+  readonly data = inject<ExtractedContentDialogData>(DIALOG_DATA);
+  private readonly dialogRef = inject<DialogRef<void>>(DialogRef);
+  private readonly documents = inject(DocumentService);
+
+  readonly loading = signal(true);
+  readonly chunks = signal<ExtractedChunk[]>([]);
+  readonly returned = signal(0);
+  readonly capReached = signal(false);
+  readonly reason = signal<string | null>(null);
+
+  constructor() {
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    try {
+      const result = await this.documents.getExtractedChunks(
+        this.data.assistantId,
+        this.data.documentId,
+      );
+      if (!result.available) {
+        this.reason.set(result.reason ?? 'This content cannot be shown.');
+        return;
+      }
+      this.chunks.set(result.chunks);
+      this.returned.set(result.returned);
+      this.capReached.set(result.capReached);
+    } catch {
+      // Resolve rather than reject into a toast: the panel is already open and an
+      // explanation inside it is more useful than an error banner behind it.
+      this.reason.set('Could not read the extracted content. Please try again.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/ai.client/src/app/assistants/models/document.model.ts
+++ b/frontend/ai.client/src/app/assistants/models/document.model.ts
@@ -96,3 +96,43 @@ export interface DownloadUrlResponse {
   expiresIn: number;
 }
 
+/**
+ * One passage as the knowledge base actually holds it.
+ *
+ * `text` is the FULL extracted text. The per-answer citation trace caps excerpts at
+ * 500 characters, which is precisely why it cannot serve this purpose: a flattened
+ * table's damage is usually past the cut, so a truncated excerpt of a mangled table
+ * reads like a fine excerpt of a fine table.
+ */
+export interface ExtractedChunk {
+  text: string;
+  /** Position in the returned set — NOT the document's own order. */
+  order: number;
+  score?: number | null;
+  /** Page when the backend supplied one. Never inferred. */
+  page?: number | null;
+}
+
+/**
+ * Response from GET /assistants/{assistantId}/documents/{documentId}/chunks
+ *
+ * `available` is false with a `reason` when the engine cannot show a single
+ * document's chunks — a classic knowledge base cannot scope a retrieval to one
+ * document, and approximating would render other documents' content under this
+ * document's name. The shape is identical either way so the UI never branches on
+ * engine.
+ *
+ * `capReached` is honesty rather than a paging hint: Bedrock exposes no
+ * chunk-enumeration API, so a complete set is never guaranteed.
+ */
+export interface ExtractedChunksResponse {
+  documentId: string;
+  fileName: string;
+  engine: string;
+  available: boolean;
+  reason?: string | null;
+  chunks: ExtractedChunk[];
+  returned: number;
+  capReached: boolean;
+}
+

--- a/frontend/ai.client/src/app/assistants/services/document.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/document.service.ts
@@ -8,6 +8,7 @@ import {
   Document,
   DocumentsListResponse,
   DownloadUrlResponse,
+  ExtractedChunksResponse,
   STALE_DOCUMENT_THRESHOLD_MS,
 } from '../models/document.model';
 import { parseIso } from '../../utils/date';
@@ -227,6 +228,46 @@ export class DocumentService {
       );
     } catch (err) {
       throw this.handleApiError(err, 'Failed to get download URL');
+    }
+  }
+
+  /**
+   * Read the content the knowledge base actually extracted from a document.
+   *
+   * The tooling half of the §5.41 decision: the managed backend flattens a
+   * column-structured diagram at ingestion, so a per-column question gets a
+   * confident wrong answer with no trace. This is how an owner sees that for
+   * themselves and decides to reformat their source.
+   *
+   * A 409 means the document exists but has nothing to show yet (still processing,
+   * or its knowledge base is still being created). That is surfaced as a `reason`
+   * rather than thrown, because it is an answer to the user's question, not a fault
+   * they need to see as an error.
+   */
+  async getExtractedChunks(
+    assistantId: string,
+    documentId: string,
+  ): Promise<ExtractedChunksResponse> {
+    try {
+      return await firstValueFrom(
+        this.http.get<ExtractedChunksResponse>(
+          `${this.baseUrl()}/${assistantId}/documents/${documentId}/chunks`,
+        ),
+      );
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 409) {
+        return {
+          documentId,
+          fileName: '',
+          engine: '',
+          available: false,
+          reason: err.error?.detail ?? 'This document is not ready to inspect yet.',
+          chunks: [],
+          returned: 0,
+          capReached: false,
+        };
+      }
+      throw this.handleApiError(err, 'Failed to read extracted content');
     }
   }
 

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
@@ -568,6 +568,15 @@
             @if (doc.status === 'complete') {
               <button
                 type="button"
+                (click)="viewExtractedContent(doc)"
+                title="View extracted content"
+                [attr.aria-label]="'View the content extracted from ' + doc.filename"
+                class="flex size-8 shrink-0 items-center justify-center rounded-2xl text-gray-400 hover:bg-primary-50 hover:text-primary-accessible focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-500 dark:hover:bg-primary-500/10 dark:hover:text-primary-accessible-dark"
+              >
+                <ng-icon name="heroMagnifyingGlass" class="size-4" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
                 (click)="downloadDocument(doc.documentId)"
                 title="Download document"
                 [attr.aria-label]="'Download ' + doc.filename"

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
@@ -18,6 +18,7 @@ import {
   heroExclamationTriangle,
   heroGlobeAlt,
   heroLink,
+  heroMagnifyingGlass,
   heroPlus,
   heroSparkles,
   heroTrash,
@@ -40,6 +41,10 @@ import {
   WebSourceDialogComponent,
   WebSourceDialogData,
 } from '../assistants/components/web-source-dialog.component';
+import {
+  ExtractedContentDialogComponent,
+  ExtractedContentDialogData,
+} from '../assistants/components/extracted-content-dialog.component';
 import { FileSourceService } from '../assistants/services/file-source.service';
 import { WebSourceService } from '../assistants/services/web-source.service';
 import { SyncPolicyService } from '../assistants/services/sync-policy.service';
@@ -93,6 +98,7 @@ import { parseIso } from '../utils/date';
       heroExclamationTriangle,
       heroGlobeAlt,
       heroLink,
+      heroMagnifyingGlass,
       heroPlus,
       heroSparkles,
       heroTrash,
@@ -1061,8 +1067,30 @@ export class KnowledgeBaseSectionComponent implements OnDestroy {
     }
   }
 
-  async downloadDocument(documentId: string): Promise<void> {
+  /**
+   * Open the extracted-content panel for a document (§5.41, task 16.2).
+   *
+   * The assistant answers from what the knowledge base extracted, not from the file's
+   * original layout, and on the managed engine those can differ badly — a
+   * column-structured flowchart is flattened at ingestion. This is where an owner sees
+   * the difference instead of inferring it from a wrong answer.
+   */
+  async viewExtractedContent(doc: Document): Promise<void> {
     const recordId = this.id();
+    if (!recordId) {
+      return;
+    }
+    this.dialog.open<void, ExtractedContentDialogData>(ExtractedContentDialogComponent, {
+      data: {
+        assistantId: recordId,
+        documentId: doc.documentId,
+        filename: doc.filename,
+      },
+      hasBackdrop: false,
+    });
+  }
+
+  async downloadDocument(documentId: string): Promise<void> {    const recordId = this.id();
     if (!recordId) {
       return;
     }


### PR DESCRIPTION
Builds `kb-chunk-inspector`. The tooling half of the task-16.2 decision on `managed-kb-migration` §5.41.

## Why

16.2 concluded **"guidance, not code"** for diagram answer quality: the managed backend's vision step flattens a column-structured flowchart or a two-dimensional table at ingestion, so a question about "semester 4" gets a *confident wrong answer with no trace*, and fixing a managed parser is not on the table.

The trouble is that guidance nobody can verify is not guidance. An owner cannot act on "convert your flowchart to a text table" without first believing their flowchart came out wrong — and right now nothing tells them. The two engines fail differently, and the managed one fails worse:

| | How it fails |
|---|---|
| **Classic** | **silently** — 0 chunks, no answer. Bad, but visible |
| **Managed** | **invisibly** — a wrong answer, confidently, with no trace of why |

This endpoint is where they look.

## What

`GET /assistants/{assistant_id}/documents/{document_id}/chunks` — owner/editor only, read-only, one bounded `Retrieve`, no new chunking/parsing/ingestion path.

Frontend: a **View extracted content** action on completed documents opens a panel listing each passage.

Three presentation choices are deliberate:

- **Monospace, whitespace preserved.** A flattened table rendered as flowing prose looks perfectly fine — the broken alignment *is* the evidence.
- **No chunk numbering.** `Retrieve` is query-ranked, so this is not the document's order; numbering 1..N would assert a sequence that does not exist.
- **"Showing the first N, more may exist"** when the ceiling is hit. Bedrock exposes no chunk-enumeration API, so claiming completeness would be a lie the UI tells.

Plus the actionable nudge, which is the entire point: *"The assistant answers from this, not from your original layout — so if a table or an image description looks wrong here, consider reformatting your source."*

## Spec amended: managed only

Requirement 2 assumed `backend.search(..., retrieval_filter=...)` was part of the protocol. **It is not** — `retrieval_filter` exists only on `ManagedKbBackend.search`. The legacy adapter is `search(kb_ref, query, top_k)`: no filter, and it ignores `top_k`, always returning five results from the **whole** knowledge base.

So on classic there is no way to scope a retrieval to one document. Running it anyway would render *other documents'* content under this document's filename — a cross-document leak, which is what Requirement 4 exists to prevent, not a cosmetic defect to tidy up later.

Teaching the legacy adapter to filter was rejected on Requirement 5's own grounds: the inspector must not depend on the legacy pipeline continuing to exist, and that pipeline is being deprecated, so new capability there has a negative lifespan.

**As built:** a classic document returns `available=false` with an owner-facing reason, as a **200 rather than an error** — they asked a reasonable question and "your knowledge base is on the classic engine, which cannot show this" is an answer. The response shape is identical either way, so the UI still never branches on engine, which is what Req 2 was actually protecting. Recorded in `requirements.md` rather than quietly implemented differently.

## Isolation

Two layers, because the failure is silent and its blast radius is one owner reading another owner's document:

1. The retrieval filter is **`equals`** on `document_id`, never a prefix operator. A prefix match for `DOC-1` also admits `DOC-10`, so the operator choice *is* the isolation boundary.
2. A post-filter drops any chunk whose `document_id` is not the requested one, in case a backend ever stops honouring the filter it accepted.

## Tests

20 new. Three mutation guards, each verified by mutating the source and watching the named test fail:

| Mutation | Fails |
|---|---|
| drop `retrieval_filter=document_filter(...)` | `test_the_filter_sent_to_the_backend_scopes_to_one_document` |
| drop the `scoped = [...]` post-filter | `test_a_backend_that_ignores_the_filter_still_cannot_leak` |
| let the legacy engine through to `search` | `test_a_classic_knowledge_base_refuses_rather_than_approximating` |

**One finding worth flagging to a reviewer.** The obvious isolation test — seed a second document's chunks, assert they do not appear — **passes with the filter removed**, because the post-filter catches them on the way out. A test that green-lights the mutated code is not a guard, however sensible it reads. So the filter is asserted on the **argument**, and the post-filter has its own test driven by a fake that deliberately ignores the filter it is handed. Both layers are now independently guarded rather than one shadowing the other.

Also covered: born-managed's `provisioning` status gets its own 409 message (the wait is on the knowledge base being created, so "still processing" understates it and 404 would wrongly imply the file is missing), and a soft-deleted document is 404 rather than having its content resurrected in the one place the user was told it is gone.

49 backend tests green across the document suites · `ruff` clean · `tsc --noEmit` clean.

## Not done

Task 6 — open the panel on the actual §5.41 flowchart PDFs in dev and confirm the flattening is visible to a human. It needs the deployed endpoint, and it is the real acceptance test for whether this delivered what 16.2 promised. Left unticked in `tasks.md`.

Nothing deployed.