### PR TITLE
fix(kb): deleting a document mid-upload leaked bytes and spammed 404 dialogs

### DIFF
--- a/backend/src/apis/app_api/documents/services/document_service.py
+++ b/backend/src/apis/app_api/documents/services/document_service.py
@@ -759,10 +759,26 @@ async def soft_delete_document(
 
         if 'Attributes' in response:
             try:
-                return Document.model_validate(response['Attributes'])
+                document = Document.model_validate(response['Attributes'])
             except Exception as e:
                 logger.warning(f"Failed to parse document from DynamoDB response: {e}")
                 return None
+
+            # Deleting a document that never finished ingesting leaves its
+            # request-time byte reservation stranded. Nothing else settles it: the
+            # release paths are ingestion reaching a terminal state, a
+            # client-reported upload failure, and the stale sweep — and a deleted
+            # document reaches none of them.
+            #
+            # Left unreleased the leak is invisible and cumulative. Every cancelled
+            # upload permanently shaves bytes off that assistant's allowance until
+            # uploads start failing for no reason the owner can see, months after
+            # the deletes that caused it. `settle_once` makes this exactly-once
+            # against the other paths, so releasing here cannot double-credit a
+            # document that some other path also settles.
+            await release_reservation_if_managed(document)
+
+            return document
 
         return None
 

--- a/backend/tests/routes/test_document_delete_releases_bytes.py
+++ b/backend/tests/routes/test_document_delete_releases_bytes.py
@@ -1,0 +1,204 @@
+"""Deleting a document mid-upload must not strand its byte reservation.
+
+Feature: managed-kb-migration Requirement 12.6 (release on every abandon path).
+
+Found by deleting an `uploading` document in dev. Three defects surfaced; this file
+covers the byte-cap one, which is the invisible and cumulative one.
+
+The request-time reservation is taken when the upload URL is issued, and it is
+released by whichever terminal path the document reaches: a client-reported upload
+failure, the stale sweep, or the ingestion consumer's own terminal paths. **A deleted
+document reaches none of them.** Its row goes to `deleting` and nothing settles the
+bytes.
+
+Left unfixed the leak has the worst possible shape: silent, cumulative, and delayed.
+Every cancelled upload permanently shaves bytes off that assistant's allowance, and it
+presents months later as "uploads stopped working" with no failure anywhere near the
+deletes that caused it — precisely what `byte_cap.release`'s own docstring warns about.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from apis.app_api.documents.services.document_service import soft_delete_document
+
+REGION = "us-east-1"
+TABLE = "test-delete-releases-bytes"
+ASSISTANT_ID = "ast-del01"
+DOCUMENT_ID = "DOC-del01"
+OWNER = "user-del01"
+SIZE = 4096
+
+
+@pytest.fixture()
+def table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("DYNAMODB_ASSISTANTS_TABLE_NAME", TABLE)
+
+    with mock_aws():
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+@pytest.fixture()
+def owned(table):
+    """`soft_delete_document` verifies ownership via `assistants.service.get_assistant`.
+
+    Patched rather than seeded: that lookup reads the assistant METADATA row and its
+    own permission model, none of which this suite is about. Stubbing it keeps the
+    test aimed at the byte accounting.
+    """
+    with patch(
+        "apis.shared.assistants.service.get_assistant",
+        new_callable=AsyncMock,
+        return_value=SimpleNamespace(assistant_id=ASSISTANT_ID, owner_id=OWNER),
+    ):
+        yield table
+
+
+def _seed(table, *, engine="managed", status="uploading", size=SIZE, reserved=SIZE):
+    """A managed KB holding a reservation, plus the uploading document that took it."""
+    item = {
+        "PK": f"AST#{ASSISTANT_ID}",
+        "SK": f"KB#{ASSISTANT_ID}",
+        "appKbId": ASSISTANT_ID,
+        "ownerUserId": OWNER,
+        "storedBytes": 0,
+        "reservedBytes": reserved,
+        "totalBytes": reserved,
+    }
+    if engine == "managed":
+        item["retrievalEngine"] = "managed"
+    table.put_item(Item=item)
+    table.put_item(
+        Item={
+            "PK": f"AST#{ASSISTANT_ID}",
+            "SK": f"DOC#{DOCUMENT_ID}",
+            "documentId": DOCUMENT_ID,
+            "assistantId": ASSISTANT_ID,
+            "filename": "half-uploaded.pdf",
+            "contentType": "application/pdf",
+            "sizeBytes": size,
+            "s3Key": f"assistants/{ASSISTANT_ID}/documents/{DOCUMENT_ID}/half-uploaded.pdf",
+            "status": status,
+            "createdAt": "2026-09-11T00:00:00Z",
+            "updatedAt": "2026-09-11T00:00:00Z",
+        }
+    )
+
+
+def _kb(table):
+    return table.get_item(
+        Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"KB#{ASSISTANT_ID}"}
+    )["Item"]
+
+
+def _doc(table):
+    return table.get_item(
+        Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"DOC#{DOCUMENT_ID}"}
+    )["Item"]
+
+
+class TestDeleteReleasesTheReservation:
+    @pytest.mark.asyncio
+    async def test_deleting_an_uploading_document_returns_its_bytes(self, owned, table):
+        """MUTATION GUARD: remove the `release_reservation_if_managed` call from
+        `soft_delete_document` and this fails with reservedBytes still at 4096 — the
+        allowance permanently smaller for a document that never stored a byte."""
+        _seed(table)
+
+        document = await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+
+        assert document is not None
+        assert _doc(table)["status"] == "deleting"
+        assert int(_kb(table)["reservedBytes"]) == 0
+        assert int(_kb(table)["totalBytes"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_the_release_is_exactly_once(self, owned, table):
+        """A second settlement would over-credit the allowance, letting an owner
+        exceed their cap by deleting repeatedly. `settle_once` stamps the DOC# row, so
+        a re-delete (idempotent by design) releases nothing further."""
+        _seed(table)
+
+        await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+        await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+
+        assert int(_kb(table)["reservedBytes"]) == 0
+        assert int(_kb(table)["totalBytes"]) == 0
+        assert _doc(table).get("byteCapSettled")
+
+    @pytest.mark.asyncio
+    async def test_a_legacy_knowledge_base_is_untouched(self, owned, table):
+        """Legacy KBs are uncapped, so they hold no reservation to return. Touching
+        their counters here would invent accounting for a backend that has none."""
+        _seed(table, engine="s3vectors")
+
+        await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+
+        assert int(_kb(table)["reservedBytes"]) == SIZE
+        assert not _doc(table).get("byteCapSettled")
+
+    @pytest.mark.asyncio
+    async def test_a_completed_document_already_settled_is_not_double_credited(self, owned, table):
+        """The ordinary case: ingestion finished, so the reservation was already
+        committed to storedBytes. Deleting must not now ALSO release it — that would
+        drive the counters negative. The stamp from the earlier settlement is what
+        stops it."""
+        _seed(table, status="complete", reserved=0)
+        table.update_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"DOC#{DOCUMENT_ID}"},
+            UpdateExpression="SET byteCapSettled = :t",
+            ExpressionAttributeValues={":t": True},
+        )
+        table.update_item(
+            Key={"PK": f"AST#{ASSISTANT_ID}", "SK": f"KB#{ASSISTANT_ID}"},
+            UpdateExpression="SET storedBytes = :s, totalBytes = :s",
+            ExpressionAttributeValues={":s": SIZE},
+        )
+
+        await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+
+        kb = _kb(table)
+        assert int(kb["reservedBytes"]) == 0
+        assert int(kb["totalBytes"]) == SIZE
+        assert int(kb["storedBytes"]) == SIZE
+
+    @pytest.mark.asyncio
+    async def test_a_zero_size_row_is_a_no_op(self, owned, table):
+        """Imported documents are created with sizeBytes=0 — nothing was reserved at
+        request time, so there is nothing to give back."""
+        _seed(table, size=0, reserved=0)
+
+        await soft_delete_document(ASSISTANT_ID, DOCUMENT_ID, OWNER)
+
+        assert int(_kb(table)["reservedBytes"]) == 0
+        assert not _doc(table).get("byteCapSettled")
+
+    @pytest.mark.asyncio
+    async def test_a_missing_document_is_none_and_changes_nothing(self, owned, table):
+        _seed(table)
+
+        result = await soft_delete_document(ASSISTANT_ID, "DOC-does-not-exist", OWNER)
+
+        assert result is None
+        assert int(_kb(table)["reservedBytes"]) == SIZE

--- a/frontend/ai.client/src/app/assistants/services/document.service.ts
+++ b/frontend/ai.client/src/app/assistants/services/document.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject, computed } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../services/config.service';
+import { SUPPRESS_ERROR_TOAST } from '../../auth/error.interceptor';
 import {
   CreateDocumentRequest,
   UploadUrlResponse,
@@ -200,10 +201,24 @@ export class DocumentService {
    * @returns Promise resolving to document
    * @throws DocumentUploadError on API failure
    */
-  async getDocument(assistantId: string, documentId: string): Promise<Document> {
+  async getDocument(
+    assistantId: string,
+    documentId: string,
+    options?: { suppressErrorToast?: boolean },
+  ): Promise<Document> {
     try {
       return await firstValueFrom(
-        this.http.get<Document>(`${this.baseUrl()}/${assistantId}/documents/${documentId}`),
+        this.http.get<Document>(`${this.baseUrl()}/${assistantId}/documents/${documentId}`, {
+          // The global error interceptor pops a dialog for every failed request
+          // BEFORE any caller's catch runs, so a caller that handles its own
+          // failures has to say so here or the user sees both. The polling loop
+          // tolerates up to five consecutive 404s by design — a document deleted
+          // mid-upload produced five "Not found" dialogs, one per tolerated retry,
+          // even though the code was handling it correctly all along.
+          context: options?.suppressErrorToast
+            ? new HttpContext().set(SUPPRESS_ERROR_TOAST, true)
+            : undefined,
+        }),
       );
     } catch (err) {
       throw this.handleApiError(err, 'Failed to get document');
@@ -339,6 +354,15 @@ export class DocumentService {
     maxPollTime: number = 5 * 60 * 1000, // 5 minutes
     initialInterval: number = 500, // 500ms - start fast to catch quick status changes
     maxInterval: number = 10000, // 10 seconds
+    /**
+     * Asked before every request. Return true to abandon the poll immediately.
+     *
+     * Without this the loop keeps asking about a document the user has just
+     * deleted: it has no way to know, so it runs until its 404 tolerance is spent.
+     * The caller knows the moment the row goes away, which is why the decision
+     * belongs to it and not to a timeout in here.
+     */
+    isCancelled?: () => boolean,
   ): Promise<Document> {
     const startTime = Date.now();
     let currentInterval = initialInterval;
@@ -349,8 +373,17 @@ export class DocumentService {
     const STALE_THRESHOLD_MS = STALE_DOCUMENT_THRESHOLD_MS;
 
     while (Date.now() - startTime < maxPollTime) {
+      if (isCancelled?.()) {
+        throw new DocumentUploadError(
+          'Polling cancelled — the document is no longer being tracked',
+          'POLL_CANCELLED',
+          { documentId, assistantId },
+        );
+      }
       try {
-        const document = await this.getDocument(assistantId, documentId);
+        const document = await this.getDocument(assistantId, documentId, {
+          suppressErrorToast: true,
+        });
 
         // Reset 404 counter on successful response
         consecutive404Count = 0;
@@ -415,7 +448,9 @@ export class DocumentService {
     }
 
     // Timeout - get final status
-    const finalDocument = await this.getDocument(assistantId, documentId);
+    const finalDocument = await this.getDocument(assistantId, documentId, {
+      suppressErrorToast: true,
+    });
     if (onStatusUpdate) {
       onStatusUpdate(finalDocument);
     }

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.ts
@@ -1476,20 +1476,36 @@ export class KnowledgeBaseSectionComponent implements OnDestroy {
     this.pollingDocuments.update((set) => new Set(set).add(documentId));
 
     try {
-      await this.documentService.pollDocumentStatus(recordId, documentId, (document) => {
-        // Update the document in the list
-        this.uploadedDocuments.update((docs) =>
-          docs.map((doc) => (doc.documentId === documentId ? document : doc)),
-        );
-      });
+      await this.documentService.pollDocumentStatus(
+        recordId,
+        documentId,
+        (document) => {
+          // Update the document in the list
+          this.uploadedDocuments.update((docs) =>
+            docs.map((doc) => (doc.documentId === documentId ? document : doc)),
+          );
+        },
+        undefined,
+        undefined,
+        undefined,
+        // Deleting a row already drops it from this set, so this turns that into
+        // real cancellation instead of a display-only flag. Before it, deleting a
+        // document mid-upload left the loop asking about a row that no longer
+        // existed until its 404 tolerance ran out — five "Not found" dialogs.
+        () => !this.pollingDocuments().has(documentId),
+      );
 
       // Polling completed - reload full list to ensure consistency
       await this.loadDocuments();
     } catch (error) {
       // Handle document/record deletion gracefully
-      if (error instanceof DocumentUploadError && error.code === 'DOCUMENT_NOT_FOUND') {
-        console.warn('Document or record was deleted during polling:', documentId);
-        // Remove the document from the local list immediately
+      if (
+        error instanceof DocumentUploadError &&
+        (error.code === 'DOCUMENT_NOT_FOUND' || error.code === 'POLL_CANCELLED')
+      ) {
+        // Cancelled or gone. Both are ordinary outcomes, not faults: the row has
+        // already been removed from the list by whoever cancelled it, and a reload
+        // here would race the optimistic delete and flash the row back.
         this.uploadedDocuments.update((docs) =>
           docs.filter((doc) => doc.documentId !== documentId),
         );


### PR DESCRIPTION
Found by deleting an `uploading` document in dev. **Two** defects fixed; a **third**, more serious one is deliberately left out and described at the bottom.

## 1. Five "Not found" dialogs per delete

The polling loop already tolerated up to five consecutive 404s, and the component already handled the resulting `DOCUMENT_NOT_FOUND` cleanly. The noise came from somewhere else entirely: the global `errorInterceptor` pops a dialog for **every** failed request *before* any caller's `catch` runs. So the code was handling it correctly and invisibly, while the user got one dialog per tolerated retry.

The poll's reads now set `SUPPRESS_ERROR_TOAST` — the token that exists for precisely this case, per its own doc comment.

**And the poll is now actually stoppable.** `deleteDocument` already removed the id from `pollingDocuments`, but that was a display-only signal — the running loop never read it, so it kept asking about a deleted row until its 404 budget ran out. `pollDocumentStatus` takes an `isCancelled` callback and the component passes that same set membership, so the removal that was already there finally means something.

`POLL_CANCELLED` is handled alongside `DOCUMENT_NOT_FOUND`: both are ordinary outcomes rather than faults, and reloading the list on either would race the optimistic delete and flash the deleted row back into view.

## 2. A silent, cumulative byte-cap leak

This is the one worth caring about.

The request-time byte reservation is released on every abandon path **except deletion** — ingestion reaching a terminal state, a client-reported upload failure, and the stale sweep. A deleted document reaches none of them, so its reservation was stranded permanently.

`soft_delete_document` now releases it via `release_reservation_if_managed`, whose `settle_once` stamp keeps it exactly-once against the other three paths.

It had the worst shape a bug can have: **invisible, cumulative, and delayed.** Every cancelled upload permanently shaved bytes off that assistant's allowance, and it would surface months later as "uploads stopped working" with no failure anywhere near the deletes that caused it. `byte_cap.release`'s own docstring warns about exactly this.

## Deliberately NOT fixed here

**Neither ingestion pipeline checks whether a document is `deleting`.** I grepped both the managed consumer and the legacy handler; no such guard exists.

So if the S3 upload completes *after* the delete — entirely likely, since delete is instant and the PUT may still be in flight — the S3 event fires, the managed consumer ingests the document into Bedrock, and writes `complete` over `deleting`. Deleted content becomes answerable again and the row comes back to life.

That is a data-correctness bug on the live ingestion path. It deserves its own change with its own mutation guards rather than riding along with a toast fix, so it was scoped out by agreement.

## Tests

6 new in `backend/tests/routes/test_document_delete_releases_bytes.py`:

- release on delete of an uploading document
- exactly-once under a re-delete (a second settlement would let an owner exceed their cap by deleting repeatedly)
- legacy knowledge bases untouched (uncapped, so no reservation to return)
- an already-settled `complete` document not double-credited (would drive counters negative)
- a zero-size imported row is a no-op
- a missing document returns None and changes nothing

**Mutation guard verified:** removing the `release_reservation_if_managed` call fails two of them with `reservedBytes` still charged.

55 backend tests green across the document suites · `ruff` clean · `tsc --noEmit` clean.