### PR TITLE
feat(ui): trail the live agent state with an ellipsis

### DIFF
--- a/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.spec.ts
@@ -48,14 +48,14 @@ describe('PulsatingLoaderComponent', () => {
 
   describe('what it says', () => {
     it('shows the live state from agent_status', () => {
-      expect(stateOf(render({ status: 'Thinking' }))).toBe('Thinking');
+      expect(stateOf(render({ status: 'Thinking' }))).toBe('Thinking\u2026');
     });
 
     it('shows the running tool by its real name', () => {
       // The identifier is the most accurate label available while a tool runs,
       // and is the same one the tool rail and admin catalog use.
       const fixture = render({ status: 'Running', statusTool: 'list_assignments' });
-      expect(stateOf(fixture)).toBe('Running list_assignments');
+      expect(stateOf(fixture)).toBe('Running list_assignments\u2026');
     });
 
     it('renders the tool name as an identifier, not prose', () => {
@@ -72,7 +72,7 @@ describe('PulsatingLoaderComponent', () => {
       // The fallback is "Thinking", not a vaguer hedge: on a cold start the
       // gap before the first agent_status can run several seconds, and that
       // gap is the only thing the user sees.
-      expect(stateOf(render())).toBe('Thinking');
+      expect(stateOf(render())).toBe('Thinking\u2026');
     });
 
     it('lets a notice outrank the state', () => {
@@ -84,6 +84,14 @@ describe('PulsatingLoaderComponent', () => {
       const text = textOf(fixture);
       expect(text).toContain('The model is busy. Retrying');
       expect(text).not.toContain('Thinking');
+    });
+
+    it('does not double the punctuation a notice already carries', () => {
+      // Every notice string ends in its own punctuation.
+      expect(stateOf(render({ notice: 'Still working\u2026' }))).toBe('Still working\u2026');
+      expect(stateOf(render({ notice: 'The model is busy. Retrying \u2014 attempt 2.' }))).toBe(
+        'The model is busy. Retrying \u2014 attempt 2.',
+      );
     });
   });
 

--- a/frontend/ai.client/src/app/components/pulsating-loader.component.ts
+++ b/frontend/ai.client/src/app/components/pulsating-loader.component.ts
@@ -72,9 +72,10 @@ import { isPlatformBrowser } from '@angular/common';
           [class.is-notice]="!!notice()"
           [class.shimmer]="!notice()"
         >
-          {{ label() }}
           @if (statusTool(); as tool) {
-            <span class="font-mono text-[13px]">{{ tool }}</span>
+            {{ label() }} <span class="font-mono text-[13px]">{{ tool }}</span>{{ trailer() }}
+          } @else {
+            {{ label() }}{{ trailer() }}
           }
         </span>
       }
@@ -255,6 +256,16 @@ export class PulsatingLoaderComponent implements OnInit, OnDestroy {
   protected readonly label = computed(
     () => this.notice() ?? this.status() ?? 'Thinking',
   );
+
+  /**
+   * The trailing ellipsis on the live state — "Thinking…", "Running
+   * list_assignments…" — which reads as the ongoing action it is.
+   *
+   * A notice gets none: every notice string already ends in its own
+   * punctuation ("Still working…", "…attempt 2."), so appending here would
+   * double it.
+   */
+  protected readonly trailer = computed(() => (this.notice() ? '' : '…'));
 
   protected readonly elapsedLabel = computed(() => {
     const started = this.startedAt();


### PR DESCRIPTION
## What

The loading indicator's live state now ends in an ellipsis — `Thinking…`, `Running list_courses…` — so it reads as the ongoing action it is.

## Notes

- **Notices are deliberately excluded.** Every notice string already ends in its own punctuation (`"Still working…"`, `"The model is busy. Retrying — attempt 2."`), so appending there would double it. A `trailer()` computed returns `''` whenever a notice is present.
- The tool and no-tool branches are split in the template so the ellipsis sits **flush** against the mono tool name rather than picking up a space from Angular's whitespace handling — `Running <span class="font-mono">list_courses</span>…`.
- `ariaLabel()` is unchanged: the ellipsis is visual punctuation, and some screen readers announce it.

## Verification

Browser-verified at `localhost:4200` against a live local stack, both states:

- `• 1s • Thinking…`
- `• 16s • Running list_courses…` — DOM confirmed no space before the ellipsis.

Unit tests: 22/22 pass in `pulsating-loader.component.spec.ts`. The two exact-text assertions were updated, and a new guard asserts a notice keeps its own punctuation undoubled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)