### PR TITLE
feat(admin): refresh a tool's prompts and resources from the tool list

### DIFF
--- a/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.spec.ts
@@ -3,9 +3,12 @@ import {
   gatewayBadgeFor,
   gatewayFailureReasonsFor,
   isTransientGatewayStatus,
+  describeCount,
+  capabilityRefreshSummary,
   type GatewayHealth,
 } from './tool-list.page';
 import { GatewayTargetStatus } from '../models/admin-tool.model';
+import { ToolCapabilities } from '../../../services/tool-capability/tool-capability.service';
 
 /**
  * Gateway target health badge mapping (Tier-1 UX for issue #419): turn the live
@@ -95,3 +98,66 @@ describe('isTransientGatewayStatus', () => {
 // Type-only guard: GatewayHealth must accept both the response and UI states.
 const _h: GatewayHealth[] = ['loading', 'error'];
 void _h;
+
+
+/**
+ * Capability refresh summary. Nothing else writes a tool's capability snapshot
+ * and nothing re-runs on a schedule, so this button is the only way a server
+ * that gained a prompt since its last probe stops showing an empty Prompts tab.
+ * The summary is what tells the admin it actually worked.
+ */
+describe('describeCount', () => {
+  it('pluralises, and says "no" rather than 0', () => {
+    expect(describeCount(0, 'prompt')).toBe('no prompts');
+    expect(describeCount(1, 'prompt')).toBe('1 prompt');
+    expect(describeCount(8, 'prompt')).toBe('8 prompts');
+  });
+});
+
+describe('capabilityRefreshSummary', () => {
+  const snapshot = (over: Partial<ToolCapabilities>): ToolCapabilities => ({
+    toolId: 'canvas_faculty',
+    prompts: [],
+    resources: [],
+    supportsPrompts: true,
+    supportsResources: true,
+    truncated: false,
+    ...over,
+  });
+
+  const prompt = (name: string) => ({ name, arguments: [] });
+
+  it('reports what the probe found', () => {
+    const summary = capabilityRefreshSummary(
+      snapshot({ prompts: [prompt('a'), prompt('b')] }),
+      'Canvas Faculty'
+    );
+    expect(summary).toBe('2 prompts, no resources');
+  });
+
+  it('says so when a server genuinely offers nothing', () => {
+    expect(capabilityRefreshSummary(snapshot({}), 'Canvas Faculty')).toBe(
+      'no prompts, no resources'
+    );
+  });
+
+  it('flags a truncated listing rather than implying the count is complete', () => {
+    const summary = capabilityRefreshSummary(
+      snapshot({ prompts: [prompt('a')], truncated: true }),
+      'Canvas Faculty'
+    );
+    expect(summary).toContain('(truncated)');
+  });
+
+  // The distinction that matters: an unreachable server leaves the previous
+  // snapshot in place, so reporting "no prompts" would claim it offers none
+  // when we never got an answer at all.
+  it('reports an unreachable server as a failure, not as an empty result', () => {
+    const summary = capabilityRefreshSummary(
+      snapshot({ error: 'auth rejected', supportsPrompts: false }),
+      'Canvas Faculty'
+    );
+    expect(summary).toBe('Could not reach Canvas Faculty: auth rejected');
+    expect(summary).not.toContain('no prompts');
+  });
+});

--- a/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.ts
+++ b/frontend/ai.client/src/app/admin/tools/pages/tool-list.page.ts
@@ -19,6 +19,7 @@ import {
   heroPencilSquare,
   heroTrash,
   heroUserGroup,
+  heroArrowPath,
   heroGlobeAlt,
   heroExclamationTriangle,
 } from '@ng-icons/heroicons/outline';
@@ -98,9 +99,39 @@ export function isTransientGatewayStatus(status: string): boolean {
   return TRANSIENT_GATEWAY_STATUSES.includes(status.toUpperCase());
 }
 import { AppRolesService } from '../../roles/services/app-roles.service';
+import { ToolCapabilities } from '../../../services/tool-capability/tool-capability.service';
 import { ToolRoleDialogComponent, ToolRoleDialogData, ToolRoleDialogResult } from '../components/tool-role-dialog.component';
 import { DeleteToolDialogComponent, DeleteToolDialogData, DeleteToolDialogResult } from '../components/delete-tool-dialog.component';
 import { SpinnerComponent } from '../../../components/spinner/spinner.component';
+
+/** "1 prompt" / "8 prompts" / "no prompts". */
+export function describeCount(count: number, noun: string): string {
+  if (count === 0) {
+    return `no ${noun}s`;
+  }
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * What a finished capability refresh should say.
+ *
+ * A probe that could not reach the server records `error` and leaves the
+ * previous snapshot in place, so that case must read as a failure — reporting
+ * "no prompts" there would claim the server offers none when we never asked it
+ * successfully. The two are genuinely different facts.
+ */
+export function capabilityRefreshSummary(
+  snapshot: ToolCapabilities,
+  displayName: string
+): string {
+  if (snapshot.error) {
+    return `Could not reach ${displayName}: ${snapshot.error}`;
+  }
+  const counts =
+    `${describeCount(snapshot.prompts.length, 'prompt')}, ` +
+    `${describeCount(snapshot.resources.length, 'resource')}`;
+  return snapshot.truncated ? `${counts} (truncated)` : counts;
+}
 
 @Component({
   selector: 'app-tool-list',
@@ -114,6 +145,7 @@ import { SpinnerComponent } from '../../../components/spinner/spinner.component'
       heroPencilSquare,
       heroTrash,
       heroUserGroup,
+      heroArrowPath,
       heroGlobeAlt,
       heroExclamationTriangle,
       heroStarSolid,
@@ -321,6 +353,23 @@ import { SpinnerComponent } from '../../../components/spinner/spinner.component'
 
                     <!-- Actions -->
                     <div class="flex shrink-0 items-center gap-1">
+                      @if (tool.protocol === 'mcp_external') {
+                        <button
+                          type="button"
+                          (click)="refreshCapabilities(tool)"
+                          [disabled]="isRefreshingCapabilities(tool.toolId)"
+                          [attr.aria-label]="'Refresh prompts and resources for ' + tool.displayName"
+                          [title]="capabilityRefreshTitle(tool)"
+                          class="flex size-8 items-center justify-center rounded-2xl text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                        >
+                          <ng-icon
+                            name="heroArrowPath"
+                            class="size-4"
+                            [class.animate-spin]="isRefreshingCapabilities(tool.toolId)"
+                            aria-hidden="true"
+                          />
+                        </button>
+                      }
                       <button
                         type="button"
                         (click)="openRoleDialog(tool)"
@@ -672,6 +721,84 @@ export class ToolListPage {
   /** The joined failure reasons for an unhealthy gateway tool, else null. */
   gatewayFailureReasons(toolId: string): string | null {
     return gatewayFailureReasonsFor(this.gatewayStatuses().get(toolId));
+  }
+
+  /**
+   * Tools whose capability probe is in flight, and the outcome of the last one
+   * per tool. Kept per row because refreshing is a live MCP session against
+   * that one server, and a slow server should not freeze the others.
+   */
+  private readonly refreshingCapabilities = signal<ReadonlySet<string>>(new Set());
+  private readonly capabilityRefreshOutcome = signal<ReadonlyMap<string, string>>(new Map());
+
+  isRefreshingCapabilities(toolId: string): boolean {
+    return this.refreshingCapabilities().has(toolId);
+  }
+
+  /** Tooltip: what the button does, or what the last refresh in this session found. */
+  capabilityRefreshTitle(tool: AdminTool): string {
+    if (this.isRefreshingCapabilities(tool.toolId)) {
+      return `Asking ${tool.displayName} what it offers...`;
+    }
+    return (
+      this.capabilityRefreshOutcome().get(tool.toolId) ??
+      `Refresh the prompts and resources listed for ${tool.displayName}`
+    );
+  }
+
+  /**
+   * Re-probe one external MCP server and store what it reports.
+   *
+   * Nothing else writes a capability snapshot and nothing re-runs on a
+   * schedule, so a server that gained a prompt since its last probe shows the
+   * old answer — an empty Prompts tab — until this runs. Deploying a server
+   * does not refresh it.
+   */
+  async refreshCapabilities(tool: AdminTool): Promise<void> {
+    const toolId = tool.toolId;
+    if (this.isRefreshingCapabilities(toolId)) {
+      return;
+    }
+    this.setRefreshingCapabilities(toolId, true);
+    try {
+      const snapshot = await this.adminToolService.refreshToolCapabilities(toolId);
+      if (this.destroyed) {
+        return;
+      }
+      this.setCapabilityOutcome(
+        toolId,
+        capabilityRefreshSummary(snapshot, tool.displayName)
+      );
+    } catch (error: unknown) {
+      console.error('Error refreshing tool capabilities:', error);
+      const message =
+        error instanceof Error ? error.message : 'Failed to refresh capabilities.';
+      alert(message);
+    } finally {
+      if (!this.destroyed) {
+        this.setRefreshingCapabilities(toolId, false);
+      }
+    }
+  }
+
+  private setRefreshingCapabilities(toolId: string, value: boolean): void {
+    this.refreshingCapabilities.update(prev => {
+      const next = new Set(prev);
+      if (value) {
+        next.add(toolId);
+      } else {
+        next.delete(toolId);
+      }
+      return next;
+    });
+  }
+
+  private setCapabilityOutcome(toolId: string, summary: string): void {
+    this.capabilityRefreshOutcome.update(prev => {
+      const next = new Map(prev);
+      next.set(toolId, summary);
+      return next;
+    });
   }
 
   async openRoleDialog(tool: AdminTool): Promise<void> {

--- a/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
+++ b/frontend/ai.client/src/app/admin/tools/services/admin-tool.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, resource, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
+import { ToolCapabilities } from '../../../services/tool-capability/tool-capability.service';
 import {
   AdminTool,
   AdminToolListResponse,
@@ -244,6 +245,26 @@ export class AdminToolService {
     return firstValueFrom(
       this.http.get<GatewayTargetStatus>(
         `${this.baseUrl()}/${toolId}/gateway-status`
+      )
+    );
+  }
+
+  /**
+   * Ask a protocol='mcp_external' server what prompts and resources it exposes,
+   * and store the answer as that tool's capability snapshot.
+   *
+   * The snapshot is what the tool detail drawer reads; nothing else writes it
+   * and nothing re-runs on its own, so a server that gains a prompt after its
+   * last probe keeps showing the old, empty answer until someone calls this.
+   *
+   * Probing opens a live MCP session against the server, which is why it is an
+   * admin action rather than something the drawer does per view.
+   */
+  async refreshToolCapabilities(toolId: string): Promise<ToolCapabilities> {
+    return firstValueFrom(
+      this.http.post<ToolCapabilities>(
+        `${this.baseUrl()}/${encodeURIComponent(toolId)}/capabilities/refresh`,
+        {}
       )
     );
   }


### PR DESCRIPTION
Adds a refresh button to each `mcp_external` row in the admin tool list, so an admin can re-probe a server's prompts and resources.

## The gap

The Prompts and Resources tabs in the tool detail drawer read a stored `ToolCapabilitySnapshot`. That snapshot is written by exactly one endpoint — `POST /admin/tools/{tool_id}/capabilities/refresh` — and **nothing in the frontend called it.** There's no cron or sync job either, so a snapshot was only ever written by hitting the admin API by hand, and never rewritten afterwards.

The failure mode is quiet, and it's live in dev right now:

| tool | last probed (UTC) | supportsPrompts | prompts |
|---|---|---|---|
| `canvas_faculty` | 2026-09-11 **05:02:57** | true | **0** |
| `student_myboisestate` | 2026-09-11 05:03:34 | true | **0** |
| `gmail_employee` | — | — | never probed |

Those first two servers gained their first prompts at **16:01 UTC the same day** — eleven hours after they were probed. `supportsPrompts: true` with zero prompts was the correct answer at 05:02 (FastMCP serves `prompts/list` whether or not anything is registered), so the tabs now render their *supported-but-empty* state, which a viewer cannot distinguish from a server that genuinely offers nothing.

Deploying a server doesn't refresh its snapshot. Without a way to re-probe, the tabs get quietly less accurate with every deploy that changes a server's surface.

## The change

- `AdminToolService.refreshToolCapabilities(toolId)` wrapping the existing endpoint
- A refresh button on `mcp_external` rows only, beside role access and edit
- Per-row in-flight state and a tooltip carrying the outcome

**Gateway (`mcp`) tools deliberately get no button.** `discovery.py` refuses them — the AgentCore Gateway enumerates a target's tools at registration and exposes no prompt surface to ask about — so a button there would always error.

**Per-row state rather than a page-level flag**, mirroring `gatewayStatuses`: a probe opens a live MCP session against that one server, and a slow server shouldn't freeze the other rows.

**`capabilityRefreshSummary` is exported and separate** so it can be tested the way this file's other logic is. It keeps apart the two outcomes that genuinely differ — a server that answered and offers nothing, versus one we could not reach. The unreachable case leaves the previous snapshot in place, so reporting "no prompts" there would claim something we never learned.

Errors use `alert()`, matching `deleteTool` in the same file. Introducing a notification system here would be scope creep.

## Verification

- `tsc --noEmit` clean
- `ng build` clean — templates compile, not only types
- `tool-list.page.spec.ts`: **13 passing**, the 8 that existed plus 5 new covering pluralisation, the empty case, truncation, and the unreachable-vs-empty distinction

## Not included

`prompts/get` is still unimplemented, so the drawer stays read-only by design — this makes the listing correct, not the prompts invokable from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)