### PR TITLE
feat(ui): restructure the side nav and stop gating its entries

### DIFF
--- a/frontend/ai.client/src/app/components/sidenav/sidenav.branding.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.branding.spec.ts
@@ -7,7 +7,7 @@
 // `chat-container.component.branding.spec.ts`.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { Component, input, output, signal } from '@angular/core';
 import fc from 'fast-check';
 
@@ -15,9 +15,6 @@ import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
-import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
-import { AgentService } from '../../agents/services/agent.service';
-import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 import { BrandingService } from '../../../branding/branding.service';
 
 /**
@@ -76,7 +73,10 @@ describe('Sidenav — Property 9: Logo alt text equals normalized app name', () 
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: Router, useValue: { navigate: vi.fn() } },
+        // A real (empty-config) router, not a `navigate` stub: the nav's
+        // `routerLink` entries instantiate `RouterLink`, which resolves
+        // `ActivatedRoute` and builds hrefs through the router itself.
+        provideRouter([]),
         {
           provide: SessionService,
           useValue: {
@@ -109,15 +109,6 @@ describe('Sidenav — Property 9: Logo alt text equals normalized app name', () 
             canAccessAdmin: signal(false),
           },
         },
-        {
-          provide: MemorySpaceService,
-          useValue: { accessible$: signal<boolean | null>(false), loadSpaces: vi.fn().mockResolvedValue(undefined) },
-        },
-        {
-          provide: AgentService,
-          useValue: { accessible$: signal<boolean | null>(false), loadAgents: vi.fn().mockResolvedValue(undefined) },
-        },
-        { provide: LEGACY_MIGRATION_HOST, useValue: false },
         { provide: BrandingService, useValue: mockBranding },
       ],
     });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.error-handling.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.error-handling.spec.ts
@@ -7,9 +7,6 @@ import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
-import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
-import { AgentService } from '../../agents/services/agent.service';
-import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 
 /**
  * Feature: branding-customization
@@ -76,15 +73,6 @@ describe('Sidenav — branding logo theme swap and error handling', () => {
             canAccessAdmin: signal(false),
           },
         },
-        {
-          provide: MemorySpaceService,
-          useValue: { accessible$: signal<boolean | null>(false), loadSpaces: vi.fn().mockResolvedValue(undefined) },
-        },
-        {
-          provide: AgentService,
-          useValue: { accessible$: signal<boolean | null>(false), loadAgents: vi.fn().mockResolvedValue(undefined) },
-        },
-        { provide: LEGACY_MIGRATION_HOST, useFactory: () => false },
       ],
     });
   });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -43,100 +43,50 @@
         <!--
             Agents (Agent Designer + Marketplace) — the ONE noun (Marketplace D1).
 
-            Gated on the API surface alone (D14): `showAgents()` is "the /agents list call did
-            not 404", i.e. the AGENTS_API_ENABLED / AGENT_MARKETPLACE_ENABLED kill switches.
-            The former `&& isAdmin()` came off when the marketplace went GA — it hid the nav
-            entry while `/agents/discover`, `/agents/:id`, the composer `@`-menu and
-            role-seeded pins were all reachable by any authenticated user, so the one entry
-            point we controlled was the only one that was closed. There is deliberately no
-            RBAC capability behind this: a capability id cannot be granted from the admin
-            roles UI (see `AppRoleService.resolve_user_permissions`), which is what made the
-            `skills` and `scheduled-runs` gates inoperable.
+            Ungated, and deliberately so. This used to hang on `showAgents()` — "the
+            /agents list call did not 404", i.e. the AGENTS_API_ENABLED /
+            AGENT_MARKETPLACE_ENABLED kill switches — which meant the entry could only
+            appear after a network round-trip, popping into a nav the user was already
+            reading. A kill switch that is off in no environment we run bought a visible
+            layout shift on every single page load, and the probe it rode was the sidenav's
+            only reason to fetch the agent list at boot (every real consumer — the agents
+            page, the composer `@`-menu, the schedule form — loads it itself).
 
-            ⚠️ This is now the only authoring entry point, so `AGENTS_API_ENABLED=false` no
-            longer degrades to an older surface — it removes agent authoring outright. The
-            flag's semantics changed from "fall back to Assistants" to "there is nothing
-            here"; see `agents_enabled()` in the backend for the same note.
+            With the switch off the entry now leads to an empty agents page rather than
+            being absent. That is the trade: the page degrades on its own (`load()` swallows
+            the error), and the nav stays still.
         -->
-        @if (showAgents()) {
-            <!--
-                Assistants — a **signpost, not a feature**. The entry was removed in
-                Designer Phase 5 on the grounds that there is one noun; it comes back
-                because removing the word from the nav is exactly what makes someone who
-                built an assistant think theirs is gone. It does not lead to an Assistants
-                page (there is none): `/assistants` renders the migration explainer, whose
-                every route out lands on `/agents`.
+        <a
+            routerLink="/agents"
+            routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+            (click)="sidenavService.close()"
+            class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+            <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z" />
+                </svg>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
+        </a>
 
-                Deliberately inside the `showAgents()` block. With the agent surface off,
-                every call to action on that page is dead, and a nav entry leading to a
-                page of dead links is worse than no entry.
-
-                Sits **above** Agents and wears the ordinary link treatment — no muting, no
-                "Moved" tag. Someone still thinking in the old noun scans for the word they
-                know, and a greyed-out entry with a past-tense badge reads as deactivated
-                rather than as a door. Retire it, and the "New" badge below, once the
-                rename has landed with users.
-
-                ⚠️ TEMPORARY host gate (`showAssistantsSignpost`): production apex only, the
-                same gate the `/assistants` route carries, because the page now also answers
-                "where did my assistants from the *previous site* go?" — a question only
-                people arriving off legacy.boisestate.ai have. See
-                `shared/utils/legacy-migration-host.ts`.
-            -->
-            @if (showAssistantsSignpost) {
-            <a
-                routerLink="/assistants"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Assistants</span>
-            </a>
-            }
-
-            <a
-                routerLink="/agents"
-                routerLinkActive="bg-gray-200/80 dark:bg-white/10"
-                (click)="sidenavService.close()"
-                class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
-                <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
-                    <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z" />
-                    </svg>
-                </div>
-                <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Agents</span>
-                <!--
-                    "New" rather than the amber "Preview" badge the preview surfaces wore:
-                    this is not unstable, it is unfamiliar.
-
-                    Ember (`secondary`), not primary blue. Blue is the nav's structural
-                    colour — the active-row wash, the links, the icons — so a blue badge
-                    sits *inside* the furniture and reads as one more piece of chrome. The
-                    one job of this badge is to be the thing your eye lands on first, and
-                    ember is the only accent here that is not already load-bearing.
-
-                    Filled `secondary-500` — the brand ember itself (#d64309), the same
-                    value the New Session `+` above is drawn in. Only the 500 step: it is
-                    the one literal hex in the scale, and every other step is derived by
-                    moving lightness alone while holding chroma, which walks the colour out
-                    of gamut in both directions. 50 clipped to a pale yellow and read as
-                    amber; 600 clipped toward pure red. Neither is the brand colour.
-
-                    ⚠️ White on 500 measures exactly 4.50:1 — it clears the AA floor for
-                    10px text with nothing to spare. Any change that darkens the text,
-                    lightens the fill, or puts this treatment on smaller type needs the
-                    contrast re-measured, not assumed.
-
-                    Remove this once the rename has stopped being news, together with the
-                    Assistants signpost above.
-                -->
-                <span class="ml-auto rounded-full bg-secondary-500 px-1.5 py-px text-[10px] font-semibold uppercase leading-4 tracking-wide text-white">New</span>
-            </a>
-        }
+        <!--
+            Artifacts — the library of everything the assistant has made, across
+            every conversation. Ungated like Agents above, and more simply so:
+            `/artifacts` carries only `authGuard`, so there is no kill switch for
+            the entry to ride in the first place.
+        -->
+        <a
+            routerLink="/artifacts"
+            routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+            (click)="sidenavService.close()"
+            class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+            <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                </svg>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Artifacts</span>
+        </a>
 
         <!--
             No "My Skills" nav entry: the /my-skills route, page, and service are

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.spec.ts
@@ -7,9 +7,7 @@ import { SessionService } from '../../session/services/session/session.service';
 import { UserService } from '../../auth/user.service';
 import { SessionService as BffSessionService } from '../../auth/session.service';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
-import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
 import { AgentService } from '../../agents/services/agent.service';
-import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 
 describe('Sidenav', () => {
   let mockRouter: any;
@@ -17,8 +15,6 @@ describe('Sidenav', () => {
   let mockBffSession: any;
   let mockSidenavService: any;
   let mockUserService: any;
-  let mockMemorySpaceService: any;
-  let mockAgentService: any;
 
   beforeEach(() => {
     TestBed.resetTestingModule();
@@ -40,15 +36,6 @@ describe('Sidenav', () => {
       isAdmin: signal(false),
       canAccessAdmin: signal(false),
     };
-    mockMemorySpaceService = {
-      accessible$: signal<boolean | null>(null),
-      loadSpaces: vi.fn().mockResolvedValue(undefined),
-    };
-    mockAgentService = {
-      accessible$: signal<boolean | null>(null),
-      loadAgents: vi.fn().mockResolvedValue(undefined),
-    };
-
     TestBed.configureTestingModule({
       providers: [
         { provide: Router, useValue: mockRouter },
@@ -56,8 +43,6 @@ describe('Sidenav', () => {
         { provide: BffSessionService, useValue: mockBffSession },
         { provide: SidenavService, useValue: mockSidenavService },
         { provide: UserService, useValue: mockUserService },
-        { provide: MemorySpaceService, useValue: mockMemorySpaceService },
-        { provide: AgentService, useValue: mockAgentService },
       ],
     });
   });
@@ -69,7 +54,6 @@ describe('Sidenav', () => {
   async function createComponent() {
     const { Sidenav } = await import('./sidenav');
     const component = TestBed.runInInjectionContext(() => new Sidenav());
-    TestBed.tick(); // flush the constructor effect that probes feature accessibility
     return component;
   }
 
@@ -101,69 +85,24 @@ describe('Sidenav', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/auth/login']);
   });
 
-  it('probes memory-space accessibility once a user is authenticated', async () => {
-    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
-    await createComponent();
-    expect(mockMemorySpaceService.loadSpaces).toHaveBeenCalled();
-  });
-
-  it('does not probe memory-space accessibility while unauthenticated', async () => {
-    mockUserService.currentUser.set(null);
-    await createComponent();
-    expect(mockMemorySpaceService.loadSpaces).not.toHaveBeenCalled();
-  });
-
-  it('hides the Memory Spaces nav entry until accessibility resolves true', async () => {
-    const component = await createComponent();
-
-    mockMemorySpaceService.accessible$.set(null);
-    expect(component.showMemorySpaces()).toBe(false);
-
-    mockMemorySpaceService.accessible$.set(false);
-    expect(component.showMemorySpaces()).toBe(false);
-
-    mockMemorySpaceService.accessible$.set(true);
-    expect(component.showMemorySpaces()).toBe(true);
-  });
-
-  it('probes agent accessibility once a user is authenticated', async () => {
-    mockUserService.currentUser.set({ user_id: 'u1', email: 'u1@example.com' });
-    await createComponent();
-    expect(mockAgentService.loadAgents).toHaveBeenCalled();
-  });
-
-  it('does not probe agent accessibility while unauthenticated', async () => {
-    mockUserService.currentUser.set(null);
-    await createComponent();
-    expect(mockAgentService.loadAgents).not.toHaveBeenCalled();
-  });
-
-  it('hides the Agents nav entry until accessibility resolves true', async () => {
-    const component = await createComponent();
-
-    mockAgentService.accessible$.set(null);
-    expect(component.showAgents()).toBe(false);
-
-    mockAgentService.accessible$.set(false);
-    expect(component.showAgents()).toBe(false);
-
-    mockAgentService.accessible$.set(true);
-    expect(component.showAgents()).toBe(true);
-  });
 });
 
 /**
- * Template-level gating (marketplace D14).
+ * The nav entries, rendered from the real template.
  *
- * These render the real template rather than reading the computed, because the bug they
- * guard against lives *only* in the template: `showAgents()` was already true for every
- * user while `@if (showAgents() && isAdmin())` hid the entry anyway. A spec that asserts
- * the computed passes against both the gated and the GA'd code, so it proves nothing.
+ * Both Agents and Artifacts are **unconditional**: nothing about them waits on a feature
+ * probe, a role, or a network round-trip. That is what these assert, and it is a
+ * regression guard in two directions — an entry that reappears behind an `@if`, and the
+ * boot-time list fetch that `@if` used to ride.
  *
- * The child components are stubbed — this is a spec about one `@if`, and pulling
- * `SessionList` / `UserDropdownComponent` in would drag their dependency graphs with them.
+ * They render the real template rather than reading a computed, because the bugs they
+ * guard against live *only* there: `showAgents()` was already true for every user while
+ * `@if (showAgents() && isAdmin())` hid the entry anyway.
+ *
+ * The child components are stubbed — pulling `SessionList` / `UserDropdownComponent` in
+ * would drag their dependency graphs with them.
  */
-describe('Sidenav — Agents nav entry gating (D14)', () => {
+describe('Sidenav — nav entries', () => {
   @Component({ selector: 'app-session-list', template: '' })
   class SessionListStub {}
 
@@ -176,17 +115,8 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
 
   let mockUserService: any;
   let mockAgentService: any;
-  /**
-   * ⚠️ TEMPORARY, with the Assistants signpost it gates. Defaults to `true` — the interesting
-   * assertions below are about the signpost's *content* and its coupling to `showAgents()`,
-   * and every one of them would pass vacuously on a host where the entry is absent outright.
-   * The host gate itself gets its own test rather than silently suppressing the others.
-   */
-  let onLegacyMigrationHost: boolean;
-
   beforeEach(() => {
     TestBed.resetTestingModule();
-    onLegacyMigrationHost = true;
     mockUserService = {
       hasAnyRole: vi.fn().mockReturnValue(false),
       currentUser: signal({ user_id: 'u1', email: 'u1@example.com' }),
@@ -217,14 +147,9 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
           useValue: { isCollapsed: signal(false), close: vi.fn(), toggleCollapsed: vi.fn() },
         },
         { provide: UserService, useValue: mockUserService },
-        {
-          provide: MemorySpaceService,
-          useValue: { accessible$: signal<boolean | null>(false), loadSpaces: vi.fn().mockResolvedValue(undefined) },
-        },
+        // Still provided, though the component no longer injects it: that is what
+        // makes the "fetches nothing at boot" assertion below a real guard.
         { provide: AgentService, useValue: mockAgentService },
-        // `useFactory`, not `useValue`: resolution happens at render time, so a test can
-        // flip the flag after `configureTestingModule` and before `renderSidenav()`.
-        { provide: LEGACY_MIGRATION_HOST, useFactory: () => onLegacyMigrationHost },
       ],
     });
   });
@@ -253,7 +178,7 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
     return anchors.length ? (anchors[0] as HTMLAnchorElement) : undefined;
   }
 
-  it('renders the Agents nav entry for a NON-admin once the surface is reachable', async () => {
+  it('renders the Agents nav entry for a NON-admin', async () => {
     mockUserService.isAdmin.set(false);
     mockUserService.canAccessAdmin.set(false);
     const fixture = await renderSidenav();
@@ -270,62 +195,72 @@ describe('Sidenav — Agents nav entry gating (D14)', () => {
     expect(agentsNavLink(fixture)).toBeDefined();
   });
 
-  it('still hides the Agents nav entry when the surface 404s, regardless of role', async () => {
-    mockAgentService.accessible$.set(false);
+  it('renders Agents on first paint, without waiting on the agent list', async () => {
+    // The entry used to hang on `showAgents()` — "the /agents list call did not 404" —
+    // so it could only appear a round-trip after the nav around it, popping into a
+    // sidebar the user was already reading. `accessible$` unresolved is exactly that
+    // pre-response state, and the entry must already be there.
+    mockAgentService.accessible$.set(null);
     const fixture = await renderSidenav();
-    expect(agentsNavLink(fixture)).toBeUndefined();
-  });
-
-  // ── Assistant deprecation (Designer Phase 5, #746) ────────────────────────────────
-  //
-  // The Assistants entry is back, but as a **signpost onto the migration explainer**, not
-  // as a second authoring surface. The distinction is the whole point, so it is what these
-  // assert: the link exists, and it does NOT go anywhere an assistant can be built.
-  function assistantsNavLink(fixture: ComponentFixture<unknown>): HTMLAnchorElement | null {
-    return fixture.nativeElement.querySelector('a[href="/assistants"]');
-  }
-
-  it('keeps an Assistants signpost so the old name is still findable', async () => {
-    const fixture = await renderSidenav();
-
-    expect(assistantsNavLink(fixture)).not.toBeNull();
-    expect(assistantsNavLink(fixture)!.textContent).toContain('Assistants');
-  });
-
-  it('still ships one authoring noun — no /assistants/new or editor entry', async () => {
-    const fixture = await renderSidenav();
-    const html = fixture.nativeElement as HTMLElement;
-
-    expect(html.querySelector('a[href="/assistants/new"]')).toBeNull();
-    expect(html.querySelector('a[href^="/assistants/"]')).toBeNull();
-  });
-
-  it('hides the Assistants signpost when the agent surface 404s', async () => {
-    // Every route out of the explainer lands on /agents. With the surface off, the
-    // signpost points at a page of dead links, so it must go with it.
-    mockAgentService.accessible$.set(false);
-    const fixture = await renderSidenav();
-    expect(assistantsNavLink(fixture)).toBeNull();
-  });
-
-  it('hides the Assistants signpost off the production apex', async () => {
-    // ⚠️ TEMPORARY, with the signpost. The explainer now also answers "where did the
-    // assistants I built on the *previous site* go?", which is a question only production
-    // has — on dev or beta the entry would point at an explanation of a site that reader is
-    // not on. (`localhost` is allowed, but as a bench, not an audience.) Paired with
-    // `legacyMigrationHostGuard` on the route, so the URL cannot be reached by hand where
-    // the nav entry is hidden.
-    onLegacyMigrationHost = false;
-    const fixture = await renderSidenav();
-
-    expect(assistantsNavLink(fixture)).toBeNull();
-    // The Agents entry is untouched by the host gate — it is a different feature.
     expect(agentsNavLink(fixture)).toBeDefined();
   });
 
-  it('badges Agents as New, not as Preview — unfamiliar is not unstable', async () => {
+  it('renders Agents even when the agent surface 404s', async () => {
+    // The trade made when the gate came off: with `AGENTS_API_ENABLED` off the entry
+    // leads to an empty agents page (which swallows the error itself) rather than
+    // being absent. Asserted so the layout shift is not quietly reintroduced.
+    mockAgentService.accessible$.set(false);
     const fixture = await renderSidenav();
-    expect(agentsNavLink(fixture)!.textContent).toContain('New');
+    expect(agentsNavLink(fixture)).toBeDefined();
+  });
+
+  it('fetches nothing at boot — the nav no longer probes feature accessibility', async () => {
+    // Every real consumer of the agent list (the agents page, the composer `@`-menu,
+    // the schedule form) loads it itself. The sidenav's copy existed only to feed the
+    // gate above, so rendering the nav must cost no HTTP at all.
+    await renderSidenav();
+    expect(mockAgentService.loadAgents).not.toHaveBeenCalled();
+  });
+
+  // ── Assistant deprecation, finished ───────────────────────────────────────────────
+  //
+  // The Assistants signpost is gone: the rename has landed with users, so the old noun no
+  // longer needs a door in the nav. `/assistants` still resolves to the migration
+  // explainer for anyone holding a link — this only asserts the nav does not offer it,
+  // and in particular that nothing here leads to a second authoring surface.
+  it('no longer signposts Assistants anywhere in the nav', async () => {
+    const fixture = await renderSidenav();
+    const html = fixture.nativeElement as HTMLElement;
+
+    expect(html.querySelector('a[href="/assistants"]')).toBeNull();
+    expect(html.querySelector('a[href^="/assistants/"]')).toBeNull();
+    expect(html.textContent).not.toContain('Assistants');
+  });
+
+  it('drops the "New" badge on Agents — the rename has stopped being news', async () => {
+    const fixture = await renderSidenav();
+    expect(agentsNavLink(fixture)!.textContent).not.toContain('New');
     expect(agentsNavLink(fixture)!.textContent).not.toContain('Preview');
+  });
+
+  // ── Artifacts ─────────────────────────────────────────────────────────────────────
+  //
+  // `/artifacts` carries only `authGuard`, so there is no kill switch for the entry to
+  // ride even in principle: it is there for every signed-in user.
+  function artifactsNavLink(fixture: ComponentFixture<unknown>): HTMLAnchorElement | null {
+    return fixture.nativeElement.querySelector('a[href="/artifacts"]');
+  }
+
+  it('offers the Artifacts library', async () => {
+    const fixture = await renderSidenav();
+
+    expect(artifactsNavLink(fixture)).not.toBeNull();
+    expect(artifactsNavLink(fixture)!.textContent).toContain('Artifacts');
+  });
+
+  it('renders Artifacts on first paint too', async () => {
+    mockAgentService.accessible$.set(null);
+    const fixture = await renderSidenav();
+    expect(artifactsNavLink(fixture)).not.toBeNull();
   });
 });

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.ts
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, computed, signal } from '@angular/core';
+import { Component, inject, computed, signal } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SessionList } from './components/session-list/session-list';
 import { SessionService } from '../../session/services/session/session.service';
@@ -7,9 +7,6 @@ import { SessionService as BffSessionService } from '../../auth/session.service'
 import { UserDropdownComponent } from '../topnav/components/user-dropdown.component';
 import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { TooltipDirective } from '../tooltip/tooltip.directive';
-import { MemorySpaceService } from '../../memory-spaces/services/memory-space.service';
-import { AgentService } from '../../agents/services/agent.service';
-import { LEGACY_MIGRATION_HOST } from '../../shared/utils/legacy-migration-host';
 import { BrandingService } from '../../../branding/branding.service';
 
 @Component({
@@ -22,8 +19,6 @@ export class Sidenav {
   private router = inject(Router);
   private sessionService = inject(SessionService);
   private bffSession = inject(BffSessionService);
-  private memorySpaceService = inject(MemorySpaceService);
-  private agentService = inject(AgentService);
   protected sidenavService = inject(SidenavService);
   protected userService = inject(UserService);
   protected branding = inject(BrandingService);
@@ -52,45 +47,6 @@ export class Sidenav {
    * link would leave them typing `/admin` by hand.
    */
   protected isAdmin = this.userService.canAccessAdmin;
-
-  /**
-   * Whether to show the "Memory Spaces" nav entry. Rides the spaces list
-   * call: a successful (even empty) list means the `MEMORY_SPACES_ENABLED`
-   * kill switch is on; a 404 flips `accessible$` false and the entry stays
-   * hidden. `null` (unresolved) also hides it so it doesn't flash in before
-   * disappearing.
-   */
-  readonly showMemorySpaces = computed(() => this.memorySpaceService.accessible$() === true);
-
-  /**
-   * Whether to show the "Agents" (Agent Designer) nav entry. Rides the agents
-   * list call the same way `showMemorySpaces` rides spaces: a successful (even
-   * empty) list means the `AGENTS_API_ENABLED` kill switch is on; a 404 flips
-   * `accessible$` false and the entry stays hidden. `null` (unresolved) also
-   * hides it so it doesn't flash in before disappearing.
-   */
-  readonly showAgents = computed(() => this.agentService.accessible$() === true);
-
-  /**
-   * Whether to show the "Assistants" signpost. ⚠️ TEMPORARY, and deliberately *not* a
-   * signal: the host cannot change without a full page load, so this is a constant for the
-   * lifetime of the app instance. Scoped to the production apex because that is the only
-   * place the question it answers ("where did the assistants I built on the old site go?")
-   * gets asked — see `shared/utils/legacy-migration-host.ts`. The `/assistants` route is
-   * gated on the same host, so the two never disagree.
-   */
-  protected readonly showAssistantsSignpost = inject(LEGACY_MIGRATION_HOST);
-
-  constructor() {
-    // Kick off the accessibility probes once the user is authenticated —
-    // mirrors UserService's own permissions-fetch gating.
-    effect(() => {
-      if (this.userService.currentUser()) {
-        void this.memorySpaceService.loadSpaces();
-        void this.agentService.loadAgents();
-      }
-    });
-  }
 
   newSession() {
     this.sidenavService.close();


### PR DESCRIPTION
The side nav is now **New Session → Agents → Artifacts**, and all of it paints at once.

## What changed

**Assistants comes out.** It was a signpost onto the migration explainer, kept so the old noun stayed findable through the rename. The rename has landed, so the word no longer needs a door in the nav. The `/assistants` route and the explainer are untouched — anyone holding a link still lands on it.

**The "New" badge comes off Agents**, for the same reason it existed: it marked the entry as unfamiliar, and it no longer is.

**Artifacts takes the freed slot** — the library of everything the assistant has made, across every conversation. Previously it was reachable only from profile settings.

**Agents loses its `@if (showAgents())` gate**, which is what made it pop in. `showAgents()` meant "the `GET /agents` list call came back and didn't 404" — the `AGENTS_API_ENABLED` kill switch, probed over the network — so the entry could only appear a round-trip after the nav around it, shifting the layout on every page load.

**Two fewer HTTP calls per page load.** Removing the gate left the sidenav's boot probes with no consumer: `showMemorySpaces` was already dead (computed, never used in the template), and every real consumer of those lists — the agents page, the composer `@`-menu, the schedule form, the memory-spaces page — loads its own. So the constructor `effect` that fired `loadAgents()` + `loadSpaces()` goes too.

## Trade worth knowing

With `AGENTS_API_ENABLED=false`, Agents now leads to an *empty agents page* instead of being absent. The page degrades on its own (`load()` catches and logs), so it's an empty list rather than a break — and that switch is off in no environment we run. Noted in the template comment where the gate used to be.

## Verification

- Reloaded on a local stack (SPA `:4300` → app-api `:8010`, dev data): all three entries paint together while the session list is still skeletons; the load's network log shows **no `GET /agents` and no `/memory/spaces`** at all. Checked in both light and dark.
- Artifacts navigates to the library and takes the active-row wash.
- Full SPA suite green — 2741 tests, 231 files. `tsc --noEmit` clean.
- Specs: the gating tests are replaced by their inverses (both entries present with `accessible$` unresolved *and* false), plus a guard that `loadAgents` is never called at boot. The `AgentService` mock is still provided even though the component no longer injects it — that's what keeps the assertion honest.
- `sidenav.branding.spec.ts` needed a real `provideRouter([])` in place of its `{navigate}` Router stub: with the entries ungated, `RouterLink` now instantiates even when the agent probe is false, and it resolves `ActivatedRoute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)