### PR TITLE
perf: remove two per-load multipliers on the first-load path

### DIFF
--- a/backend/src/apis/shared/auth/dependencies.py
+++ b/backend/src/apis/shared/auth/dependencies.py
@@ -4,6 +4,7 @@ import asyncio
 import jwt
 import logging
 import os
+import time
 from typing import Optional
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -62,6 +63,84 @@ def invalidate_user_profile_cache(user_id: str) -> None:
     """
     _user_profile_cache.pop(user_id, None)
 
+
+# ─── Background User-Sync Throttle ─────────────────────────────────────
+# `sync_user_from_jwt` is an upsert: a GetItem followed by a PutItem that
+# rewrites the whole profile row and its GSI projections. Firing it on every
+# authenticated request meant one SPA first load — 12 API calls — issued 24
+# DynamoDB operations against a single item, writing identical values except
+# `last_login_at`. A classroom signing in together multiplied that by the
+# class size, against one hot partition per student.
+#
+# Throttling is safe because this is not the authoritative write. The BFF
+# callback's `_sync_user_from_id_token` syncs on every login off the ID token
+# (which is the only place the full claim set exists), and `POST /users/me/sync`
+# writes through the repository directly. What remains here is a periodic
+# refresh, so it only needs to run periodically. The cost is that
+# `last_login_at` is accurate to within the window rather than to the request.
+#
+# A brand-new user is unaffected: with no entry recorded, the first request
+# always claims the sync, so row creation still happens immediately.
+
+_USER_SYNC_THROTTLE_SECONDS = int(os.environ.get("USER_SYNC_THROTTLE_SECONDS", "300"))
+_USER_SYNC_TRACKER_MAX = 10_000
+
+_user_sync_last_run: dict[str, float] = {}
+
+# Strong references to in-flight sync tasks. The event loop only holds a weak
+# reference to a bare `asyncio.create_task(...)`, so without keeping one here
+# the GC can collect the task mid-await — the same hazard
+# `SessionRefreshMiddleware` guards its slide writes against.
+_user_sync_tasks: set[asyncio.Task] = set()
+
+
+def _claim_user_sync(user_id: str) -> bool:
+    """Return True if this request should run the background user sync.
+
+    The claim is recorded BEFORE the sync runs, not after it completes. The
+    12 requests of a single page load overlap, so a marker written on
+    completion would let most of them through before the first one landed —
+    which is the exact pileup this exists to prevent.
+    """
+    now = time.monotonic()
+    last = _user_sync_last_run.get(user_id)
+    if last is not None and now - last < _USER_SYNC_THROTTLE_SECONDS:
+        return False
+
+    _user_sync_last_run[user_id] = now
+    if len(_user_sync_last_run) > _USER_SYNC_TRACKER_MAX:
+        _prune_user_sync_tracker(now)
+    return True
+
+
+def _prune_user_sync_tracker(now: float) -> None:
+    """Drop entries older than the throttle window.
+
+    Bounds the dict on a long-lived container that has served many distinct
+    users. An entry past the window is already a no-op for `_claim_user_sync`,
+    so dropping it changes no behaviour.
+    """
+    stale = [
+        uid
+        for uid, ts in _user_sync_last_run.items()
+        if now - ts >= _USER_SYNC_THROTTLE_SECONDS
+    ]
+    for uid in stale:
+        _user_sync_last_run.pop(uid, None)
+
+
+def reset_user_sync_throttle(user_id: Optional[str] = None) -> None:
+    """Let the next request re-sync `user_id` (or every user when None).
+
+    Exposed for tests and for any caller that has just invalidated profile
+    state and wants the refresh to happen now rather than at the next window.
+    """
+    if user_id is None:
+        _user_sync_last_run.clear()
+    else:
+        _user_sync_last_run.pop(user_id, None)
+
+
 _user_repository = None
 
 
@@ -95,8 +174,6 @@ async def _enrich_user_from_store(user: User) -> None:
 
     Results are cached in-memory to avoid per-request DynamoDB lookups.
     """
-    import time
-
     from apis.shared.rbac.version import get_roles_version
 
     current_version = get_roles_version()
@@ -144,6 +221,24 @@ async def _sync_user_background(sync_service, user: User) -> None:
     except Exception as e:
         # Log but don't fail - sync should never break authentication
         logger.warning(f"Failed to sync user {user.user_id}: {e}")
+
+
+def _schedule_user_sync(user: User) -> None:
+    """Dispatch the throttled background profile sync for `user`.
+
+    No-op when sync is unconfigured or the user was already synced inside the
+    throttle window. Never raises: a sync problem must not break auth.
+    """
+    sync_service = _get_user_sync_service()
+    if not (sync_service and sync_service.enabled):
+        return
+    if not _claim_user_sync(user.user_id):
+        return
+
+    task = asyncio.create_task(_sync_user_background(sync_service, user))
+    _user_sync_tasks.add(task)
+    task.add_done_callback(_user_sync_tasks.discard)
+
 
 # Cognito JWT validator for tokens minted by the BFF confidential client.
 # The SPA-public PKCE client was decommissioned in Phase 7; all browser-facing
@@ -277,9 +372,7 @@ async def get_current_user_from_session(request: Request) -> User:
     user.raw_token = record.cognito_access_token
     await _enrich_user_from_store(user)
 
-    sync_service = _get_user_sync_service()
-    if sync_service and sync_service.enabled:
-        asyncio.create_task(_sync_user_background(sync_service, user))
+    _schedule_user_sync(user)
 
     return user
 
@@ -380,9 +473,7 @@ async def get_current_user_trusted(
         await _enrich_user_from_store(user)
 
         # Fire-and-forget sync to Users table
-        sync_service = _get_user_sync_service()
-        if sync_service and sync_service.enabled:
-            asyncio.create_task(_sync_user_background(sync_service, user))
+        _schedule_user_sync(user)
 
         return user
 

--- a/backend/tests/auth/test_dependencies.py
+++ b/backend/tests/auth/test_dependencies.py
@@ -7,11 +7,13 @@ Covers:
 Requirements: 10.5, 10.6
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
+from apis.shared.auth import dependencies as deps
 from apis.shared.auth.dependencies import (
     get_current_user_id,
     get_current_user_trusted,
@@ -163,3 +165,131 @@ class TestGetCurrentUserId:
 
         assert user_id == "uid-42"
         assert isinstance(user_id, str)
+
+
+# ---------------------------------------------------------------------------
+# Background user-sync throttle tests
+# ---------------------------------------------------------------------------
+
+
+class TestUserSyncThrottle:
+    """The per-request profile upsert must collapse to one write per window.
+
+    Regression cover for the first-load fan-out: 12 concurrent SPA calls each
+    fired `sync_user_from_jwt`, and that upsert is a GetItem + PutItem, so a
+    single page load issued 24 DynamoDB operations against one item.
+    """
+
+    def setup_method(self):
+        deps.reset_user_sync_throttle()
+
+    def teardown_method(self):
+        deps.reset_user_sync_throttle()
+
+    def test_first_claim_wins_rest_are_throttled(self):
+        """Only the first of a burst claims the sync."""
+        claims = [deps._claim_user_sync("uid-1") for _ in range(12)]
+
+        assert claims[0] is True
+        assert not any(claims[1:])
+
+    def test_throttle_is_per_user(self):
+        """One user's claim must not suppress another's — a classroom of
+        students signing in together each need their own row created."""
+        assert deps._claim_user_sync("uid-a") is True
+        assert deps._claim_user_sync("uid-b") is True
+
+    def test_claim_allowed_again_after_window(self, monkeypatch):
+        """Past the window the sync resumes, so the refresh still happens."""
+        monkeypatch.setattr(deps, "_USER_SYNC_THROTTLE_SECONDS", 300)
+
+        clock = {"now": 1_000.0}
+        monkeypatch.setattr(deps.time, "monotonic", lambda: clock["now"])
+
+        assert deps._claim_user_sync("uid-1") is True
+        clock["now"] += 299
+        assert deps._claim_user_sync("uid-1") is False
+        clock["now"] += 2  # now 301s past the first claim
+        assert deps._claim_user_sync("uid-1") is True
+
+    def test_reset_forces_immediate_resync(self):
+        """An explicit reset lets the next request through without waiting."""
+        assert deps._claim_user_sync("uid-1") is True
+        assert deps._claim_user_sync("uid-1") is False
+
+        deps.reset_user_sync_throttle("uid-1")
+
+        assert deps._claim_user_sync("uid-1") is True
+
+    def test_tracker_is_pruned_when_it_grows(self, monkeypatch):
+        """A long-lived container that has served many users stays bounded."""
+        monkeypatch.setattr(deps, "_USER_SYNC_THROTTLE_SECONDS", 300)
+        monkeypatch.setattr(deps, "_USER_SYNC_TRACKER_MAX", 10)
+
+        clock = {"now": 1_000.0}
+        monkeypatch.setattr(deps.time, "monotonic", lambda: clock["now"])
+
+        for i in range(10):
+            deps._claim_user_sync(f"old-{i}")
+
+        # Move past the window so every recorded entry is now stale, then add
+        # one more to trip the prune.
+        clock["now"] += 301
+        deps._claim_user_sync("fresh")
+
+        assert list(deps._user_sync_last_run) == ["fresh"]
+
+    def test_schedule_is_noop_when_sync_disabled(self, make_user, monkeypatch):
+        """No sync service configured means no task and no claim consumed."""
+        monkeypatch.setattr(deps, "_get_user_sync_service", lambda: None)
+
+        deps._schedule_user_sync(make_user(user_id="uid-1"))
+
+        assert deps._user_sync_last_run == {}
+        assert deps._user_sync_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_schedule_dispatches_once_per_window(self, make_user):
+        """End to end: a 12-call page load produces exactly one sync."""
+        service = MagicMock()
+        service.enabled = True
+        calls = []
+
+        async def _record(user):
+            calls.append(user.user_id)
+
+        service.sync_user_from_jwt = _record
+        user = make_user(user_id="uid-1")
+
+        with patch.object(deps, "_get_user_sync_service", return_value=service):
+            for _ in range(12):
+                deps._schedule_user_sync(user)
+            # Let the dispatched task run to completion.
+            await asyncio.gather(*list(deps._user_sync_tasks))
+
+        assert calls == ["uid-1"]
+
+    @pytest.mark.asyncio
+    async def test_task_reference_is_held_then_released(self, make_user):
+        """The task is strongly referenced while in flight (so the GC cannot
+        collect it mid-await) and discarded once it finishes."""
+        service = MagicMock()
+        service.enabled = True
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _block(user):
+            started.set()
+            await release.wait()
+
+        service.sync_user_from_jwt = _block
+
+        with patch.object(deps, "_get_user_sync_service", return_value=service):
+            deps._schedule_user_sync(make_user(user_id="uid-1"))
+            await started.wait()
+            assert len(deps._user_sync_tasks) == 1
+
+            release.set()
+            await asyncio.gather(*list(deps._user_sync_tasks))
+
+        assert deps._user_sync_tasks == set()

--- a/frontend/ai.client/src/app/services/user-settings.service.spec.ts
+++ b/frontend/ai.client/src/app/services/user-settings.service.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { UserSettingsService, UserSettings } from './user-settings.service';
+import { ConfigService } from './config.service';
+
+const API = 'http://localhost:8000';
+const URL = `${API}/users/me/settings`;
+
+describe('UserSettingsService', () => {
+  let service: UserSettingsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        UserSettingsService,
+        { provide: ConfigService, useValue: { appApiUrl: signal(API) } },
+      ],
+    });
+    service = TestBed.inject(UserSettingsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.match(() => true); // discard pending requests
+    TestBed.resetTestingModule();
+  });
+
+  /** Flush every outstanding GET for the settings URL, returning the count. */
+  const flushSettings = (body: UserSettings): number => {
+    const reqs = httpMock.match(r => r.url === URL && r.method === 'GET');
+    reqs.forEach(r => r.flush(body));
+    return reqs.length;
+  };
+
+  // ── First-load de-duplication ─────────────────────────────────────────
+  // Regression cover for the duplicate `/users/me/settings` on first load:
+  // `settingsResource` fetched eagerly and `ModelService` fetched again once
+  // `/models` landed, so the SPA read the same row twice per page load.
+
+  it('issues one GET when several callers read on first load', async () => {
+    const a = service.getSettings();
+    const b = service.getSettings();
+    const c = service.getSettings();
+
+    expect(flushSettings({ defaultModelId: 'm-1' })).toBe(1);
+
+    expect(await a).toEqual({ defaultModelId: 'm-1' });
+    expect(await b).toEqual({ defaultModelId: 'm-1' });
+    expect(await c).toEqual({ defaultModelId: 'm-1' });
+  });
+
+  it('reuses the settled read for a caller that arrives later', async () => {
+    // The real shape of the bug: the two callers were ~280ms apart, so the
+    // second one arrived after the first had already resolved. A single-flight
+    // guard would not have caught it — only a memo does.
+    const first = service.getSettings();
+    expect(flushSettings({ defaultModelId: 'm-1' })).toBe(1);
+    await first;
+
+    const second = await service.getSettings();
+
+    httpMock.expectNone(r => r.url === URL && r.method === 'GET');
+    expect(second).toEqual({ defaultModelId: 'm-1' });
+  });
+
+  // ── Correctness guards on the memo ────────────────────────────────────
+
+  it('retries after a failed read rather than caching the rejection', async () => {
+    const failed = service.getSettings();
+    const reqs = httpMock.match(r => r.url === URL && r.method === 'GET');
+    expect(reqs.length).toBe(1);
+    reqs[0].flush('boom', { status: 500, statusText: 'Server Error' });
+    await expect(failed).rejects.toBeTruthy();
+
+    // A cached rejection would strand every later caller on a failure they
+    // had no way to see or clear.
+    const retried = service.getSettings();
+    expect(flushSettings({ defaultModelId: 'm-2' })).toBe(1);
+    expect(await retried).toEqual({ defaultModelId: 'm-2' });
+  });
+
+  it('drops the memo after a write so the next read sees the new value', async () => {
+    const initial = service.getSettings();
+    expect(flushSettings({ defaultModelId: 'old' })).toBe(1);
+    await initial;
+
+    const update = service.updateSettings({ defaultModelId: 'new' });
+    httpMock.expectOne(r => r.url === URL && r.method === 'PUT')
+      .flush({ defaultModelId: 'new' });
+    await update;
+
+    // `updateSettings` also reloads `settingsResource`, which reads through
+    // `getSettings` — so absorb whatever it issued alongside our own read.
+    const next = service.getSettings();
+    expect(flushSettings({ defaultModelId: 'new' })).toBeGreaterThan(0);
+    expect(await next).toEqual({ defaultModelId: 'new' });
+  });
+});

--- a/frontend/ai.client/src/app/services/user-settings.service.ts
+++ b/frontend/ai.client/src/app/services/user-settings.service.ts
@@ -17,11 +17,38 @@ export class UserSettingsService {
 
   private readonly baseUrl = () => `${this.config.appApiUrl()}/users/me/settings`;
 
+  /**
+   * In-flight/settled read shared by every caller. See `getSettings`.
+   * Null means "nothing fetched yet" — the next read issues the request.
+   */
+  private settingsPromise: Promise<UserSettings> | null = null;
+
   readonly settingsResource = resource({
-    loader: async () => this.fetchSettings(),
+    loader: async () => this.getSettings(),
   });
 
-  async fetchSettings(): Promise<UserSettings> {
+  /**
+   * Read the user's settings, reusing the first fetch.
+   *
+   * WHY: two independent callers want this on first load — `settingsResource`
+   * eagerly, the moment this service is injected, and `ModelService` later,
+   * once `/models` has landed and it can resolve `defaultModelId` against the
+   * catalog. Those land ~280ms apart, so they are sequential rather than
+   * concurrent and a single-flight guard would not have caught the second one.
+   * Memoizing the promise does, and it collapses any future caller too.
+   *
+   * A rejected read is not cached: the promise is cleared in the catch so the
+   * next caller retries rather than inheriting a failure it cannot see.
+   */
+  getSettings(): Promise<UserSettings> {
+    this.settingsPromise ??= this.fetchSettings().catch((err) => {
+      this.settingsPromise = null;
+      throw err;
+    });
+    return this.settingsPromise;
+  }
+
+  private async fetchSettings(): Promise<UserSettings> {
     return firstValueFrom(
       this.http.get<UserSettings>(this.baseUrl())
     );
@@ -43,6 +70,9 @@ export class UserSettingsService {
     const result = await firstValueFrom(
       this.http.put<UserSettings>(this.baseUrl(), settings, { context })
     );
+    // Drop the memo BEFORE reloading, or the resource's loader would be
+    // handed back the pre-write value it is reloading to get rid of.
+    this.settingsPromise = null;
     this.settingsResource.reload();
     return result;
   }

--- a/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.spec.ts
@@ -11,7 +11,7 @@ import { signal } from '@angular/core';
 describe('ModelService', () => {
   let service: ModelService;
   let httpMock: HttpTestingController;
-  let mockUserSettings: { fetchSettings: ReturnType<typeof vi.fn> };
+  let mockUserSettings: { getSettings: ReturnType<typeof vi.fn> };
 
   const mockModels: ManagedModel[] = [
     { id: 'm1', modelId: 'claude-haiku', modelName: 'Claude Haiku', provider: 'bedrock', providerName: 'Anthropic', inputModalities: ['TEXT'], outputModalities: ['TEXT'], maxInputTokens: 200000, maxOutputTokens: 4096, allowedAppRoles: [], availableToRoles: [], enabled: true, inputPricePerMillionTokens: 0.25, outputPricePerMillionTokens: 1.25, knowledgeCutoffDate: null, supportsCaching: true, isDefault: false },
@@ -31,7 +31,7 @@ describe('ModelService', () => {
     });
 
     mockUserSettings = {
-      fetchSettings: vi.fn().mockResolvedValue({ defaultModelId: null }),
+      getSettings: vi.fn().mockResolvedValue({ defaultModelId: null }),
     };
 
     TestBed.configureTestingModule({
@@ -115,7 +115,7 @@ describe('ModelService', () => {
         removeItem: vi.fn((k: string) => { delete sessionStore[k]; }),
       });
 
-      mockUserSettings = { fetchSettings: vi.fn().mockResolvedValue({ defaultModelId: null }) };
+      mockUserSettings = { getSettings: vi.fn().mockResolvedValue({ defaultModelId: null }) };
 
       TestBed.configureTestingModule({
         providers: [
@@ -217,7 +217,7 @@ describe('ModelService', () => {
       service['_selectedModel'].set(null);
       service['usingDefaultModel'].set(true);
       delete sessionStore['selectedModelId'];
-      mockUserSettings.fetchSettings.mockResolvedValueOnce({ defaultModelId: 'claude-haiku' });
+      mockUserSettings.getSettings.mockResolvedValueOnce({ defaultModelId: 'claude-haiku' });
 
       const promise = service.loadModels();
       await vi.waitFor(() => {
@@ -228,14 +228,14 @@ describe('ModelService', () => {
       // claude-haiku wins even though claude-sonnet has isDefault=true,
       // because the user's persisted preference is consulted first.
       expect(service.selectedModel().modelId).toBe('claude-haiku');
-      expect(mockUserSettings.fetchSettings).toHaveBeenCalled();
+      expect(mockUserSettings.getSettings).toHaveBeenCalled();
     });
 
     it('should fall back to admin default when user setting is null', async () => {
       service['_selectedModel'].set(null);
       service['usingDefaultModel'].set(true);
       delete sessionStore['selectedModelId'];
-      mockUserSettings.fetchSettings.mockResolvedValueOnce({ defaultModelId: null });
+      mockUserSettings.getSettings.mockResolvedValueOnce({ defaultModelId: null });
 
       const promise = service.loadModels();
       await vi.waitFor(() => {
@@ -250,7 +250,7 @@ describe('ModelService', () => {
       service['_selectedModel'].set(null);
       service['usingDefaultModel'].set(true);
       delete sessionStore['selectedModelId'];
-      mockUserSettings.fetchSettings.mockResolvedValueOnce({ defaultModelId: 'no-longer-here' });
+      mockUserSettings.getSettings.mockResolvedValueOnce({ defaultModelId: 'no-longer-here' });
 
       const promise = service.loadModels();
       await vi.waitFor(() => {

--- a/frontend/ai.client/src/app/session/services/model/model.service.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.ts
@@ -329,7 +329,7 @@ export class ModelService {
    */
   private async findUserDefaultModel(enabledModels: ManagedModel[]): Promise<ManagedModel | null> {
     try {
-      const settings = await this.userSettings.fetchSettings();
+      const settings = await this.userSettings.getSettings();
       const id = settings?.defaultModelId;
       if (!id) return null;
       return enabledModels.find(m => m.modelId === id) ?? null;


### PR DESCRIPTION
## Why

Scrum raised that first load fires a lot of individual calls, and asked whether a
classroom logging in at once would be taxing. I measured an authenticated first
load against dev and traced each call to its handler.

**Headline: the fan-out itself is not worth consolidating.** 12 API calls, ~1.28s
to last response, and the Sept 10–11 load test shows app-api peaked at 38.2% CPU
with 3 tasks while holding 300 concurrent streams. The measured pain is TTFT tail
latency (p95 32s, p99 37s), which is entirely downstream of first load. A
`/api/bootstrap` aggregate endpoint would couple 12 independent concerns, break
per-resource caching, and collapse ~700ms nobody is complaining about.

Two things behind that fan-out *were* worth deleting, because they are
per-request multipliers rather than one-time cost. This PR removes both.

## What changed

**1. The per-request user-profile upsert is now throttled** (`perf(auth)`)

`get_current_user_from_session` fired `sync_user_from_jwt` on *every*
authenticated request. `upsert_user` reads the row and then calls `update_user`,
which is a `put_item` — a full-item replace, not a targeted update. The only
value that actually differs between calls is `lastLoginAt`.

`lastLoginAt` is also the sort key of two GSIs (`GSI2SK` on EmailDomainIndex,
`GSI3SK` on StatusLoginIndex). A GSI whose key moves cannot be updated in place,
so each sync forces a delete + insert on both — and since the value is `now`,
that churn is guaranteed, never skippable. One sync is therefore ~7 write units,
not 2:

| Operation | Units |
|---|---|
| `get_item` existence check | 1 read |
| `put_item` on the base table | 1 write |
| UserIdIndex / EmailIndex (ALL projection, keys stable) | 2 writes |
| EmailDomainIndex (sort key moved -> delete + insert) | 2 writes |
| StatusLoginIndex (sort key moved -> delete + insert) | 2 writes |

That is **~84 write units per page load**, ~25,000 for a 300-student class.

In dollars that is negligible (~3 cents). The reason it matters at classroom
scale is that these are **synchronous boto3 calls inside `async def` with no
`to_thread`**, so each round trip blocks the event loop rather than merely adding
latency — twelve of them per page load, on 3 tasks serving 300 students. The
index churn is waste worth deleting; the blocked loop is why it compounds.

Safe to throttle because it was never the authoritative write: the BFF callback's
`_sync_user_from_id_token` syncs on every login off the ID token, and
`POST /users/me/sync` writes through the repository directly. Default window 5
minutes, tunable via `USER_SYNC_THROTTLE_SECONDS`. New users are unaffected —
with no entry recorded the first request always claims the sync.

Note the field is named `lastLoginAt` but was being written on every *request*,
so it recorded last activity rather than last login — and the admin user lists
sort on exactly that index. Throttling arguably makes the field more honest; it
is now accurate to within the window, which is fine for a "recently active" sort.

Also fixes a latent bug at the same site: the dispatched task held no strong
reference, so the GC could collect it mid-await. `SessionRefreshMiddleware`
already guards its slide writes against exactly this.

**2. `/users/me/settings` is fetched once, not twice** (`fix(spa)`)

`settingsResource` fetched eagerly on injection; `ModelService` fetched again
once `/models` landed. Measured ~280ms apart (t=863ms, t=1146ms) — sequential,
so a single-flight guard would not have caught it. `getSettings()` memoizes the
promise instead.

## Testing

- `pytest tests/auth/ tests/architecture/` — 149 passed, including 8 new throttle
  tests (burst collapses to one claim, per-user isolation, window expiry, prune
  bound, reset, disabled no-op, end-to-end single dispatch, task ref held/released).
- `ng test` — 2,750 passed (232 files), including 4 new `UserSettingsService`
  specs asserting one GET for concurrent callers, reuse for a later caller, no
  cached rejection, and memo invalidation on write.
- `tsc --noEmit` clean.

Browser verification of the SPA change was not possible: the local app-api returns
503 unconfigured, and standing up a full local stack with SSO was a bigger detour
than the change warrants. The new specs assert the behavioural claim directly and
are permanent regression cover, which is stronger evidence than a screenshot.

## Deliberately not in scope

- **Four uncached full table scans per load** (`/models`, `/tools/`,
  `/system-prompts/`, `/connectors/`) — all `async def` + blocking boto3 `.scan()`
  with no `to_thread` and no cache, so they also block the event loop.
  `apis/shared/rbac/cache.py` is the in-house pattern to copy. Worth doing, but a
  separate change.
- **Payload sizes**: `/sessions` is 129 KB and `/tools/` 87 KB on first load.
  `/sessions` in particular grows with a heavy user's history — worth checking
  whether it is paginated.
- **A measurement gap worth naming**: the load tests never exercised this path.
  `AuthenticatedUser.on_start` does the login chain only, the classroom scenario
  goes straight to chat turns, and the read-only scenario polls 6 endpoints
  one-at-a-time with `wait_time = between(1, 5)`. So "300 users was fine" is
  evidence about the streaming path, not about first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

