### PR TITLE
Model selector refactor: descriptions, effort selection, and a More models submenu

### DIFF
--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -275,6 +275,7 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         id=model_id,
         model_id=model_data.model_id,
         model_name=model_data.model_name,
+        short_description=model_data.short_description,
         provider=model_data.provider,
         provider_name=model_data.provider_name,
         input_modalities=model_data.input_modalities,
@@ -293,6 +294,7 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         knowledge_cutoff_date=model_data.knowledge_cutoff_date,
         supports_caching=_resolve_supports_caching(model_data.supports_caching, model_data.provider),
         is_default=model_data.is_default,
+        is_featured=model_data.is_featured,
         mantle_api_mode=_resolve_mantle_api_mode(model_data.mantle_api_mode, model_data.provider),
         mantle_region=_resolve_mantle_region(model_data.mantle_region, model_data.provider),
         supported_params=model_data.supported_params,
@@ -320,6 +322,7 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         'outputPricePerMillionTokens': model_data.output_price_per_million_tokens,
         'supportsCaching': _resolve_supports_caching(model_data.supports_caching, model_data.provider),
         'isDefault': model_data.is_default,
+        'isFeatured': model_data.is_featured,
         'createdAt': now.isoformat(),
         'updatedAt': now.isoformat(),
     }
@@ -333,6 +336,8 @@ async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name
         item['cacheReadPricePerMillionTokens'] = model_data.cache_read_price_per_million_tokens
     if model_data.knowledge_cutoff_date is not None:
         item['knowledgeCutoffDate'] = model_data.knowledge_cutoff_date
+    if model_data.short_description:
+        item['shortDescription'] = model_data.short_description
     resolved_api_mode = _resolve_mantle_api_mode(model_data.mantle_api_mode, model_data.provider)
     if resolved_api_mode is not None:
         item['apiMode'] = resolved_api_mode

--- a/backend/src/apis/shared/models/models.py
+++ b/backend/src/apis/shared/models/models.py
@@ -151,6 +151,13 @@ class ManagedModelCreate(BaseModel):
 
     model_id: str = Field(..., alias="modelId", min_length=1)
     model_name: str = Field(..., alias="modelName", min_length=1)
+    short_description: Optional[str] = Field(
+        None,
+        alias="shortDescription",
+        max_length=80,
+        description="One-line reason a user would pick this model, shown under its name "
+                    "in the chat model picker. Keep it short — the picker truncates.",
+    )
     provider: str = Field(..., min_length=1)
     provider_name: str = Field(..., alias="providerName", min_length=1)
     input_modalities: List[str] = Field(..., alias="inputModalities", min_length=1)
@@ -201,6 +208,14 @@ class ManagedModelCreate(BaseModel):
         alias="isDefault",
         description="Whether this is the default model for new sessions. Only one model can be default."
     )
+    is_featured: bool = Field(
+        True,
+        alias="isFeatured",
+        description="Whether the model appears at the top level of the chat model "
+                    "picker. False collapses it into the picker's 'More models' "
+                    "submenu. Defaults to True so an uncurated catalog keeps showing "
+                    "every model where it always has."
+    )
     mantle_api_mode: Optional[str] = Field(
         None,
         alias="apiMode",
@@ -247,6 +262,13 @@ class ManagedModelUpdate(BaseModel):
 
     model_id: Optional[str] = Field(None, alias="modelId", min_length=1)
     model_name: Optional[str] = Field(None, alias="modelName")
+    short_description: Optional[str] = Field(
+        None,
+        alias="shortDescription",
+        max_length=80,
+        description="One-line reason a user would pick this model, shown under its name "
+                    "in the chat model picker. Keep it short — the picker truncates.",
+    )
     provider: Optional[str] = None
     provider_name: Optional[str] = Field(None, alias="providerName")
     input_modalities: Optional[List[str]] = Field(None, alias="inputModalities")
@@ -293,6 +315,14 @@ class ManagedModelUpdate(BaseModel):
         alias="isDefault",
         description="Whether this is the default model for new sessions."
     )
+    is_featured: Optional[bool] = Field(
+        None,
+        alias="isFeatured",
+        description="Whether the model appears at the top level of the chat model "
+                    "picker. False collapses it into the picker's 'More models' "
+                    "submenu. Defaults to True so an uncurated catalog keeps showing "
+                    "every model where it always has."
+    )
     mantle_api_mode: Optional[str] = Field(
         None,
         alias="apiMode",
@@ -332,6 +362,18 @@ class ManagedModel(BaseModel):
     id: str
     model_id: str = Field(..., alias="modelId")
     model_name: str = Field(..., alias="modelName")
+    short_description: Optional[str] = Field(
+        None,
+        alias="shortDescription",
+        # Deliberately NOT length-capped here, unlike the create/update models.
+        # This is the READ model: a stored value longer than the write-path cap
+        # (hand-edited record, or a future cap that shrinks) would fail
+        # validation and take the whole /models listing down with it. Bound the
+        # input, be permissive about what is already persisted; the picker
+        # truncates visually anyway.
+        description="One-line reason a user would pick this model, shown under its name "
+                    "in the chat model picker.",
+    )
     provider: str
     provider_name: str = Field(..., alias="providerName")
     input_modalities: List[str] = Field(..., alias="inputModalities")
@@ -384,6 +426,14 @@ class ManagedModel(BaseModel):
         False,
         alias="isDefault",
         description="Whether this is the default model for new sessions. Only one model can be default."
+    )
+    is_featured: bool = Field(
+        True,
+        alias="isFeatured",
+        description="Whether the model appears at the top level of the chat model "
+                    "picker. False collapses it into the picker's 'More models' "
+                    "submenu. Defaults to True so an uncurated catalog keeps showing "
+                    "every model where it always has."
     )
     mantle_api_mode: Optional[str] = Field(
         None,

--- a/frontend/ai.client/src/app/admin/manage-models/manage-models.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/manage-models.page.html
@@ -138,7 +138,10 @@
               <!-- Name + model id -->
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-1.5">
-                  <span class="truncate text-sm/6 font-medium text-gray-900 dark:text-white">
+                  <span
+                    class="truncate text-sm/6 font-medium text-gray-900 dark:text-white"
+                    [title]="model.modelName"
+                  >
                     {{ model.modelName }}
                   </span>
                   @if (model.isDefault) {
@@ -149,7 +152,10 @@
                     />
                   }
                 </div>
-                <p class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400">
+                <p
+                  class="truncate font-mono text-xs/5 text-gray-500 dark:text-gray-400"
+                  [title]="model.modelId"
+                >
                   {{ model.modelId }}
                 </p>
               </div>

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
@@ -377,4 +377,65 @@ describe('ModelCatalogPage', () => {
     expect(gpt54?.template.cacheReadPricePerMillionTokens).toBeCloseTo(0.275, 6);
     expect(gpt54?.template.cacheWritePricePerMillionTokens).toBe(0);
   });
+
+  describe('curated picker placement', () => {
+    const ALL = [
+      ...CURATED_BEDROCK_MODELS,
+      ...CURATED_MANTLE_MODELS,
+      ...CURATED_BEDROCK_RESPONSES_MODELS,
+    ];
+
+    // Demoted = superseded by a newer sibling ON THE SAME PROVIDER SURFACE, or
+    // specialist enough that it isn't a general chat default. Everything else
+    // stays at the picker's top level. This list is a change-detector: adding a
+    // model or re-ranking one should be a deliberate edit here, not a drift.
+    //
+    // "Same surface" is load-bearing. GPT-5.4 (mantle) looks superseded by the
+    // GPT-5.6 family until you notice those are bedrock-responses — a different
+    // provider an install may not use at all. Demoting it left Mantle with no
+    // featured model but a specialist coding one, which the family check below
+    // now catches. A template default cannot assume what else gets added.
+    const DEMOTED = ['claude-sonnet-4-6', 'qwen3-coder-30b', 'gpt-5-6-luna'];
+
+    it('demotes exactly the superseded and specialist models', () => {
+      const demoted = ALL.filter(m => m.template.isFeatured === false)
+        .map(m => m.key)
+        .sort();
+      expect(demoted).toEqual([...DEMOTED].sort());
+    });
+
+    it('leaves featured models undeclared so they inherit the backend default', () => {
+      // `isFeatured` defaults true server-side. Featured rows say nothing
+      // rather than `true`, so the default stays in exactly one place.
+      for (const model of ALL) {
+        if (DEMOTED.includes(model.key)) continue;
+        expect(
+          model.template.isFeatured,
+          `${model.key} should not declare isFeatured`,
+        ).toBeUndefined();
+      }
+    });
+
+    it('keeps a featured model in every provider family', () => {
+      // A catalog tab whose every entry is demoted would put an entire
+      // provider behind the submenu, which is never the intent.
+      for (const [label, group] of [
+        ['bedrock', CURATED_BEDROCK_MODELS],
+        ['mantle', CURATED_MANTLE_MODELS],
+        ['bedrock-responses', CURATED_BEDROCK_RESPONSES_MODELS],
+      ] as const) {
+        const featured = group.filter(m => m.template.isFeatured !== false);
+        expect(featured.length, `${label} must keep a featured model`).toBeGreaterThan(0);
+      }
+    });
+
+    it('does not let two featured models both claim to be the most capable', () => {
+      // GPT-6 Astra outranks (and out-prices) GPT-5.6 Sol in the same catalog,
+      // so Sol's copy must not say "most capable".
+      const featuredCopy = ALL.filter(m => m.template.isFeatured !== false)
+        .map(m => m.template.shortDescription ?? '');
+      const superlatives = featuredCopy.filter(d => /most capable/i.test(d));
+      expect(superlatives).toEqual([]);
+    });
+  });
 });

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
@@ -302,12 +302,38 @@ describe('ModelCatalogPage', () => {
       }
     });
 
-    it('declares no supportedParams rather than an invented one', () => {
-      // AWS publishes no parameter table for GPT-5.6. A declared spec flips the
-      // #915 guard from permissive to restrictive, so a guessed one would
-      // silently block params the model actually accepts.
+    it('declares only the MEASURED supportedParams, never a guessed one', () => {
+      // Supersedes an earlier invariant that required NO spec at all. The bar
+      // was never "no spec" — it was "no invented spec": a declared spec flips
+      // the #915 guard from permissive to restrictive, so a guess silently
+      // blocks params the model really accepts. AWS still publishes no
+      // parameter table, so this spec comes from probing all four ids in
+      // us-west-2 on 2026-09-12 (see the block comment on the array).
+      //
+      // If a future sibling is added without re-probing, this fails — which is
+      // the point.
       for (const model of CURATED_BEDROCK_RESPONSES_MODELS) {
-        expect(model.template.supportedParams ?? null).toBeNull();
+        const params = model.template.supportedParams?.params;
+        expect(params, `${model.key} must declare a measured spec`).toBeTruthy();
+
+        // The endpoint's own 400 enumerates exactly these, identically on all four.
+        expect(`${model.key}:${params!['reasoning_effort'].allowed?.join(',')}`).toBe(
+          `${model.key}:none,low,medium,high,xhigh,max`,
+        );
+
+        // Measured 400: "Unsupported parameter: 'temperature' is not supported
+        // with this model." Declared false so the request never carries them.
+        expect(`${model.key}:${params!['temperature'].supported}`).toBe(`${model.key}:false`);
+        expect(`${model.key}:${params!['top_p'].supported}`).toBe(`${model.key}:false`);
+
+        expect(`${model.key}:${params!['max_tokens'].supported}`).toBe(`${model.key}:true`);
+
+        // No published default, and inventing one would silently change how
+        // every turn on these models reasons and bills.
+        expect(
+          params!['reasoning_effort'].default ?? null,
+          `${model.key} must not invent a default effort`,
+        ).toBeNull();
       }
     });
 

--- a/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-catalog.page.spec.ts
@@ -328,12 +328,16 @@ describe('ModelCatalogPage', () => {
 
         expect(`${model.key}:${params!['max_tokens'].supported}`).toBe(`${model.key}:true`);
 
-        // No published default, and inventing one would silently change how
-        // every turn on these models reasons and bills.
-        expect(
-          params!['reasoning_effort'].default ?? null,
-          `${model.key} must not invent a default effort`,
-        ).toBeNull();
+        // `medium` pins what the provider was already doing implicitly —
+        // measured at ~376 reasoning tokens unset vs ~308 for medium, so this
+        // is cost-neutral-to-cheaper rather than an increase. A default must
+        // stay a member of `allowed` or the backend drops it.
+        expect(`${model.key}:${params!['reasoning_effort'].default}`).toBe(
+          `${model.key}:medium`,
+        );
+        expect(params!['reasoning_effort'].allowed).toContain(
+          params!['reasoning_effort'].default,
+        );
       }
     });
 

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.html
@@ -82,6 +82,33 @@
             }
           </div>
 
+          <!-- Short Description -->
+          <div>
+            <label for="shortDescription" class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+              Short Description
+            </label>
+            <input
+              type="text"
+              id="shortDescription"
+              formControlName="shortDescription"
+              maxlength="80"
+              placeholder="e.g., For your toughest challenges"
+              aria-describedby="shortDescription-help"
+              class="mt-1 block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+              [class.border-state-danger-500]="modelForm.controls.shortDescription.invalid && modelForm.controls.shortDescription.touched"
+            />
+            <p id="shortDescription-help" class="mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+              Shown under the model name in the chat model picker. Keep it to a
+              fragment, not a sentence — the picker truncates. Leave blank to
+              show the provider name instead.
+            </p>
+            @if (modelForm.controls.shortDescription.invalid && modelForm.controls.shortDescription.touched) {
+              <p class="mt-1 text-sm/6 text-state-danger-600 dark:text-state-danger-400">
+                Keep the short description to 80 characters or fewer
+              </p>
+            }
+          </div>
+
           <!-- Provider + Provider Name Row -->
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
@@ -394,6 +421,24 @@
             </label>
             <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
               Only one model can be the default. Setting this will unset any previous default.
+            </p>
+          </div>
+
+          <!-- Featured in the model picker -->
+          <div>
+            <label class="flex items-center gap-3">
+              <input
+                type="checkbox"
+                formControlName="isFeatured"
+                class="size-4 rounded border-gray-300 text-primary-600 focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+              />
+              <span class="text-sm/6 font-medium text-gray-700 dark:text-gray-300">
+                Featured (shown at the top level of the model picker)
+              </span>
+            </label>
+            <p class="ml-7 mt-1 text-xs/5 text-gray-500 dark:text-gray-400">
+              Unfeatured models move into the picker's "More models" submenu. They
+              stay fully available — this only changes where users find them.
             </p>
           </div>
         </section>

--- a/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/model-form.page.ts
@@ -223,6 +223,7 @@ function knownParamKeyControl(fb: FormBuilder, key: string): FormControl<string>
 interface ModelFormGroup {
   modelId: FormControl<string>;
   modelName: FormControl<string>;
+  shortDescription: FormControl<string>;
   provider: FormControl<ModelProvider>;
   providerName: FormControl<string>;
   inputModalities: FormControl<string[]>;
@@ -233,6 +234,7 @@ interface ModelFormGroup {
   availableToRoles: FormControl<string[]>;
   enabled: FormControl<boolean>;
   isDefault: FormControl<boolean>;
+  isFeatured: FormControl<boolean>;
   inputPricePerMillionTokens: FormControl<number>;
   outputPricePerMillionTokens: FormControl<number>;
   cacheWritePricePerMillionTokens: FormControl<number | null>;
@@ -341,6 +343,10 @@ export class ModelFormPage implements OnInit {
   readonly modelForm: FormGroup<ModelFormGroup> = this.fb.group({
     modelId: this.fb.control('', { nonNullable: true, validators: [Validators.required] }),
     modelName: this.fb.control('', { nonNullable: true, validators: [Validators.required] }),
+    shortDescription: this.fb.control('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(80)],
+    }),
     provider: this.fb.control<ModelProvider>('bedrock', { nonNullable: true, validators: [Validators.required] }),
     providerName: this.fb.control('', { nonNullable: true, validators: [Validators.required] }),
     inputModalities: this.fb.control<string[]>([], { nonNullable: true, validators: [Validators.required] }),
@@ -354,6 +360,7 @@ export class ModelFormPage implements OnInit {
     availableToRoles: this.fb.control<string[]>([], { nonNullable: true }),
     enabled: this.fb.control(true, { nonNullable: true }),
     isDefault: this.fb.control(false, { nonNullable: true }),
+    isFeatured: this.fb.control(true, { nonNullable: true }),
     inputPricePerMillionTokens: this.fb.control(0, { nonNullable: true, validators: [Validators.required, Validators.min(0)] }),
     outputPricePerMillionTokens: this.fb.control(0, { nonNullable: true, validators: [Validators.required, Validators.min(0)] }),
     cacheWritePricePerMillionTokens: this.fb.control<number | null>(null, { validators: [Validators.min(0)] }),
@@ -875,6 +882,7 @@ export class ModelFormPage implements OnInit {
       this.modelForm.patchValue({
         modelId: model.modelId,
         modelName: model.modelName,
+        shortDescription: model.shortDescription ?? '',
         provider: model.provider as ModelProvider,
         providerName: model.providerName,
         inputModalities: model.inputModalities.map(m => m.toUpperCase()),
@@ -885,6 +893,9 @@ export class ModelFormPage implements OnInit {
         availableToRoles: model.availableToRoles ?? [],
         enabled: model.enabled,
         isDefault: model.isDefault ?? false,
+        // Absent on records written before the field existed, and those
+        // models are featured today — mirror the backend default.
+        isFeatured: model.isFeatured ?? true,
         inputPricePerMillionTokens: model.inputPricePerMillionTokens,
         outputPricePerMillionTokens: model.outputPricePerMillionTokens,
         cacheWritePricePerMillionTokens: model.cacheWritePricePerMillionTokens ?? null,
@@ -918,6 +929,7 @@ export class ModelFormPage implements OnInit {
     this.modelForm.patchValue({
       modelId: template.modelId,
       modelName: template.modelName,
+      shortDescription: template.shortDescription ?? '',
       provider: template.provider,
       providerName: template.providerName,
       inputModalities: template.inputModalities.map(m => m.toUpperCase()),
@@ -928,6 +940,7 @@ export class ModelFormPage implements OnInit {
       availableToRoles: template.availableToRoles ?? [],
       enabled: template.enabled,
       isDefault: template.isDefault,
+      isFeatured: template.isFeatured ?? true,
       inputPricePerMillionTokens: template.inputPricePerMillionTokens,
       outputPricePerMillionTokens: template.outputPricePerMillionTokens,
       cacheWritePricePerMillionTokens: template.cacheWritePricePerMillionTokens ?? null,
@@ -949,6 +962,7 @@ export class ModelFormPage implements OnInit {
       this.modelForm.patchValue({
         modelId: params['modelId'] || '',
         modelName: params['modelName'] || '',
+        shortDescription: params['shortDescription'] || '',
         provider: params['provider'] || 'bedrock',
         providerName: params['providerName'] || '',
         inputModalities: params['inputModalities'] ? params['inputModalities'].split(',') : [],
@@ -1018,6 +1032,9 @@ export class ModelFormPage implements OnInit {
       const formData: ManagedModelFormData = {
         modelId: v.modelId,
         modelName: v.modelName,
+        // Empty string rather than null: the update path drops null fields
+        // (`exclude_none`), so null could never clear a description once set.
+        shortDescription: v.shortDescription.trim(),
         provider: v.provider,
         providerName: v.providerName,
         inputModalities: v.inputModalities,
@@ -1029,6 +1046,7 @@ export class ModelFormPage implements OnInit {
         availableToRoles: v.availableToRoles,
         enabled: v.enabled,
         isDefault: v.isDefault,
+        isFeatured: v.isFeatured,
         inputPricePerMillionTokens: v.inputPricePerMillionTokens,
         outputPricePerMillionTokens: v.outputPricePerMillionTokens,
         cacheWritePricePerMillionTokens: v.cacheWritePricePerMillionTokens,

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -458,10 +458,34 @@ const bedrockResponsesDefaults = (): Pick<
  * instead — the same failure class the guard inversion was written to close on
  * Claude Opus 4.7.
  *
- * No `default` is declared for `reasoning_effort`: neither the cards nor the
- * blog publish one, and inventing a default would silently change how every
- * turn on these models is priced. Absent a default the param is simply not
- * sent and the provider's own default applies.
+ * `reasoning_effort` defaults to `medium`, which was also measured rather than
+ * assumed. Neither the cards nor the blog publish a default, so the question
+ * was what the provider does when the param is ABSENT — which is not the same
+ * as sending `none`. Sending nothing still reasons; `none` is an explicit
+ * "off". Three samples per level on Luna, in reasoning tokens:
+ *
+ *     unset  285 / 516 / 327   (mean 376)
+ *     none     0 /   0 /   0
+ *     low    221 / 222 / 230   (mean 224)
+ *     medium 274 / 346 / 303   (mean 308)
+ *     high   516 / 363 / 497   (mean 459)
+ *
+ * So the implicit default already sits around medium, and declaring `medium`
+ * is cost-neutral-to-slightly-cheaper (-18% reasoning tokens), NOT an increase.
+ * It is declared anyway because otherwise the provider can move its own
+ * default and our spend follows with no code change and no signal — and
+ * because a declared default is what lets the picker show the level in force
+ * instead of a blank row. Counts are noisy (unset spanned 285-516 across three
+ * identical calls), so treat the middle levels as roughly interchangeable.
+ *
+ * The level that actually moves the bill is `max`: ~2.3x the output tokens of
+ * unset on Terra, and reasoning bills as output. It stays in `allowed`
+ * deliberately — dropping a level from that list is the lever if the exposure
+ * is ever unwanted, since the picker and the backend both read it.
+ *
+ * GPT-6 Astra inherits this default by sharing the helper. Its effort ENUM was
+ * probed directly, but its token counts were not — medium there is an
+ * extrapolation from its GPT-5.6 siblings, not a measurement.
  *
  * The standing rule is unchanged — a declared spec flips the guard from
  * permissive to restrictive, so a wrong entry silently blocks a parameter the
@@ -483,6 +507,9 @@ const openaiResponsesParams = (maxOutputTokens: number | null = null): Supported
     reasoning_effort: {
       supported: true,
       allowed: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+      // Pins what the provider was already doing implicitly — see the block
+      // comment above for the measurement. NOT an increase in reasoning.
+      default: 'medium',
     },
     max_tokens: {
       supported: true,

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -1,4 +1,4 @@
-import { ManagedModelFormData, ModelProvider } from './managed-model.model';
+import { ManagedModelFormData, ModelProvider, SupportedParams } from './managed-model.model';
 
 /**
  * A curated entry shown in the model catalog. Carries everything needed to
@@ -432,13 +432,64 @@ const bedrockResponsesDefaults = (): Pick<
  * because a request that crosses 272K bills input at 2x, output at 1.5x and
  * both cache buckets at 2x. Raising it silently UNDER-charges every long turn.
  *
- * `supportedParams` is deliberately absent. AWS publishes no parameter table
- * for these models (`model-parameters-openai.html` documents only the
- * open-weight gpt-oss family), and an invented spec would be worse than none:
- * a declared spec flips the #915 guard from permissive to restrictive, so a
- * wrong entry silently blocks a parameter the model actually accepts. Add one
- * only from published or measured evidence.
+ * `supportedParams` was deliberately absent here until 2026-09-12, when it was
+ * MEASURED — the bar this comment has always set. AWS still publishes no
+ * parameter table for these models (`model-parameters-openai.html` documents
+ * only the open-weight gpt-oss family), so the evidence is the endpoint's own
+ * responses, probed against all four ids in us-west-2:
+ *
+ *   - `reasoning.effort` — sending a deliberately invalid value returns a 400
+ *     that ENUMERATES the enum: "Supported values are: 'none', 'low',
+ *     'medium', 'high', 'xhigh', and 'max'." Identical on Sol, Terra, Luna and
+ *     Astra, and it matches the launch blog ("They also support none, low,
+ *     medium, high, xhigh, and max reasoning effort"). Two independent sources.
+ *   - `temperature` and `top_p` — hard 400 on all four: "Unsupported
+ *     parameter: 'temperature' is not supported with this model."
+ *   - `max_output_tokens` — accepted.
+ *
+ * That last pair is why declaring a spec here is a FIX, not just an enabler.
+ * With no spec the #915 guard stays permissive, so a `temperature` reaching
+ * this family from any caller that can set one kills the turn with a 400
+ * mid-stream. Declaring them `supported: false` drops them before the request
+ * instead — the same failure class the guard inversion was written to close on
+ * Claude Opus 4.7.
+ *
+ * No `default` is declared for `reasoning_effort`: neither the cards nor the
+ * blog publish one, and inventing a default would silently change how every
+ * turn on these models is priced. Absent a default the param is simply not
+ * sent and the provider's own default applies.
+ *
+ * The standing rule is unchanged — a declared spec flips the guard from
+ * permissive to restrictive, so a wrong entry silently blocks a parameter the
+ * model really accepts. Add or widen one only from published or measured
+ * evidence, and re-probe rather than assume when a new sibling ships.
  */
+/**
+ * Measured Responses-API parameter profile for the OpenAI family on
+ * `bedrock-runtime`. See the block comment on
+ * {@link CURATED_BEDROCK_RESPONSES_MODELS} for the probe and its evidence.
+ *
+ * `temperature` / `top_p` are declared `supported: false` rather than omitted:
+ * omission drops them too (an authoritative spec treats silence as
+ * unsupported), but an explicit false records the measured fact and logs the
+ * clearer "unsupported inference param" line when one is dropped.
+ */
+const openaiResponsesParams = (maxOutputTokens: number | null = null): SupportedParams => ({
+  params: {
+    reasoning_effort: {
+      supported: true,
+      allowed: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+    },
+    max_tokens: {
+      supported: true,
+      min: 1,
+      ...(maxOutputTokens === null ? {} : { max: maxOutputTokens }),
+    },
+    temperature: { supported: false },
+    top_p: { supported: false },
+  },
+});
+
 export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
   {
     key: 'gpt-6-astra',
@@ -472,6 +523,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       // Published on the card as April 30, 2026 — again unlike the GPT-5.6
       // cards, which state none.
       knowledgeCutoffDate: '2026-04-30',
+      supportedParams: openaiResponsesParams(128_000),
     },
   },
   {
@@ -487,6 +539,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       // Geo CRIS: $4.40 / $22.00. Global CRIS is $4.00 / $20.00.
       ...ratesWithDerivedCache(4.4, 22.0),
       knowledgeCutoffDate: null,
+      supportedParams: openaiResponsesParams(),
     },
   },
   {
@@ -502,6 +555,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       // Geo CRIS: $2.20 / $13.20. Global CRIS is $2.00 / $12.00.
       ...ratesWithDerivedCache(2.2, 13.2),
       knowledgeCutoffDate: null,
+      supportedParams: openaiResponsesParams(),
     },
   },
   {
@@ -517,6 +571,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       // Geo CRIS: $0.22 / $1.32. Global CRIS is $0.20 / $1.20.
       ...ratesWithDerivedCache(0.22, 1.32),
       knowledgeCutoffDate: null,
+      supportedParams: openaiResponsesParams(),
     },
   },
 ];

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -150,6 +150,7 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
       ...claude4xDefaults(),
       modelId: 'us.anthropic.claude-opus-4-7',
       modelName: 'Claude Opus 4.7',
+      shortDescription: 'For your toughest challenges',
       maxOutputTokens: 64_000,
       // Regional (CRIS): $5.50 / $27.50. Global is $5.00 / $25.00.
       ...ratesWithDerivedCache(5.5, 27.5),
@@ -175,6 +176,7 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
       ...claude4xDefaults(),
       modelId: 'global.anthropic.claude-sonnet-5',
       modelName: 'Claude Sonnet 5',
+      shortDescription: 'Strong reasoning over very long context',
       maxInputTokens: 1_000_000,
       maxOutputTokens: 128_000,
       // Global: $2.00 / $10.00 — correct as declared, this id really is
@@ -202,6 +204,7 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
       ...claude4xDefaults(),
       modelId: 'us.anthropic.claude-sonnet-4-6',
       modelName: 'Claude Sonnet 4.6',
+      shortDescription: 'Balanced reasoning for everyday work',
       maxOutputTokens: 64_000,
       // Regional (CRIS): $3.30 / $16.50. Global is $3.00 / $15.00.
       ...ratesWithDerivedCache(3.3, 16.5),
@@ -226,6 +229,7 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
       ...claude4xDefaults(),
       modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
       modelName: 'Claude Haiku 4.5',
+      shortDescription: 'Fastest for quick answers',
       maxOutputTokens: 64_000,
       // Regional (CRIS): $1.10 / $5.50. Global is $1.00 / $5.00. This is the
       // platform default model, so this is the row every cost number rides on.
@@ -291,6 +295,7 @@ export const CURATED_MANTLE_MODELS: CuratedModel[] = [
       ...mantleDefaults(),
       modelId: 'openai.gpt-5.4',
       modelName: 'GPT-5.4',
+      shortDescription: 'Multimodal reasoning',
       providerName: 'OpenAI',
       inputModalities: ['TEXT', 'IMAGE'],
       maxInputTokens: 272_000,
@@ -320,6 +325,7 @@ export const CURATED_MANTLE_MODELS: CuratedModel[] = [
       ...mantleDefaults(),
       modelId: 'qwen.qwen3-coder-30b-a3b-instruct',
       modelName: 'Qwen3 Coder 30B',
+      shortDescription: 'Long-context coding',
       providerName: 'Qwen',
       inputModalities: ['TEXT'],
       maxInputTokens: 256_000,
@@ -453,6 +459,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       // chip, not a mispriced bill.
       modelId: 'us.openai.gpt-6-astra',
       modelName: 'GPT-6 Astra',
+      shortDescription: 'Frontier reasoning, coding and research',
       // Geo CRIS Short Context: $11.00 / $55.00. Global CRIS is $10.00 /
       // $50.00. Long Context (1.05M) would be $22.00 / $82.50 — unreachable
       // while maxInputTokens stays pinned at the 272K boundary.
@@ -476,6 +483,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       ...bedrockResponsesDefaults(),
       modelId: 'us.openai.gpt-5.6-sol',
       modelName: 'GPT-5.6 Sol',
+      shortDescription: "OpenAI's most capable model",
       // Geo CRIS: $4.40 / $22.00. Global CRIS is $4.00 / $20.00.
       ...ratesWithDerivedCache(4.4, 22.0),
       knowledgeCutoffDate: null,
@@ -490,6 +498,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       ...bedrockResponsesDefaults(),
       modelId: 'us.openai.gpt-5.6-terra',
       modelName: 'GPT-5.6 Terra',
+      shortDescription: 'Balanced performance per dollar',
       // Geo CRIS: $2.20 / $13.20. Global CRIS is $2.00 / $12.00.
       ...ratesWithDerivedCache(2.2, 13.2),
       knowledgeCutoffDate: null,
@@ -504,6 +513,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       ...bedrockResponsesDefaults(),
       modelId: 'us.openai.gpt-5.6-luna',
       modelName: 'GPT-5.6 Luna',
+      shortDescription: 'Fast and affordable, for high volume',
       // Geo CRIS: $0.22 / $1.32. Global CRIS is $0.20 / $1.20.
       ...ratesWithDerivedCache(0.22, 1.32),
       knowledgeCutoffDate: null,

--- a/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/curated-models.ts
@@ -205,6 +205,8 @@ export const CURATED_BEDROCK_MODELS: CuratedModel[] = [
       modelId: 'us.anthropic.claude-sonnet-4-6',
       modelName: 'Claude Sonnet 4.6',
       shortDescription: 'Balanced reasoning for everyday work',
+      // Superseded by Claude Sonnet 5 in this same catalog.
+      isFeatured: false,
       maxOutputTokens: 64_000,
       // Regional (CRIS): $3.30 / $16.50. Global is $3.00 / $15.00.
       ...ratesWithDerivedCache(3.3, 16.5),
@@ -326,6 +328,8 @@ export const CURATED_MANTLE_MODELS: CuratedModel[] = [
       modelId: 'qwen.qwen3-coder-30b-a3b-instruct',
       modelName: 'Qwen3 Coder 30B',
       shortDescription: 'Long-context coding',
+      // Specialist coding model, not a general chat default.
+      isFeatured: false,
       providerName: 'Qwen',
       inputModalities: ['TEXT'],
       maxInputTokens: 256_000,
@@ -535,7 +539,7 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       ...bedrockResponsesDefaults(),
       modelId: 'us.openai.gpt-5.6-sol',
       modelName: 'GPT-5.6 Sol',
-      shortDescription: "OpenAI's most capable model",
+      shortDescription: 'Strong reasoning and agentic work',
       // Geo CRIS: $4.40 / $22.00. Global CRIS is $4.00 / $20.00.
       ...ratesWithDerivedCache(4.4, 22.0),
       knowledgeCutoffDate: null,
@@ -568,6 +572,9 @@ export const CURATED_BEDROCK_RESPONSES_MODELS: CuratedModel[] = [
       modelId: 'us.openai.gpt-5.6-luna',
       modelName: 'GPT-5.6 Luna',
       shortDescription: 'Fast and affordable, for high volume',
+      // Its own card pitches it for classification, routing and high
+      // volume — a batch workhorse rather than a chat default.
+      isFeatured: false,
       // Geo CRIS: $0.22 / $1.32. Global CRIS is $0.20 / $1.20.
       ...ratesWithDerivedCache(0.22, 1.32),
       knowledgeCutoffDate: null,

--- a/frontend/ai.client/src/app/admin/manage-models/models/effort-control.spec.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/effort-control.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ManagedModel,
+  effortLevelLabel,
+  resolveEffortControl,
+} from './managed-model.model';
+
+/**
+ * `resolveEffortControl` decides whether the chat model picker offers an
+ * Effort submenu at all. Its contract is "only offer what the backend will
+ * actually honor" — `_merge_inference_params` keeps an enum override ONLY
+ * when it's a member of the admin-declared `allowed` set, and pins `locked`
+ * params to the admin default regardless of what the client sends. Every
+ * case below is one of those backend behaviours, read back from the UI side.
+ */
+function model(params: Record<string, unknown> | null): ManagedModel {
+  return {
+    id: 'm1',
+    modelId: 'test-model',
+    modelName: 'Test Model',
+    provider: 'bedrock',
+    providerName: 'Anthropic',
+    inputModalities: ['TEXT'],
+    outputModalities: ['TEXT'],
+    maxInputTokens: 200000,
+    maxOutputTokens: 4096,
+    allowedAppRoles: [],
+    availableToRoles: [],
+    enabled: true,
+    inputPricePerMillionTokens: 1,
+    outputPricePerMillionTokens: 1,
+    knowledgeCutoffDate: null,
+    supportsCaching: true,
+    isDefault: false,
+    supportedParams: params === null ? null : { params: params as never },
+  };
+}
+
+describe('resolveEffortControl', () => {
+  it('returns null when the model declares no params at all', () => {
+    expect(resolveEffortControl(model(null))).toBeNull();
+  });
+
+  it('returns null for a null/undefined model', () => {
+    expect(resolveEffortControl(null)).toBeNull();
+    expect(resolveEffortControl(undefined)).toBeNull();
+  });
+
+  it('returns null when the model declares no effort param', () => {
+    expect(resolveEffortControl(model({ temperature: { supported: true } }))).toBeNull();
+  });
+
+  it('returns null when effort is declared but unsupported', () => {
+    const control = resolveEffortControl(
+      model({ effort: { supported: false, allowed: ['low', 'high'] } }),
+    );
+    expect(control).toBeNull();
+  });
+
+  it('returns null when effort is supported but enumerates no levels', () => {
+    // The backend's enum branch needs `allowed` to keep an override; without
+    // it there is nothing safe to render.
+    expect(resolveEffortControl(model({ effort: { supported: true } }))).toBeNull();
+    expect(resolveEffortControl(model({ effort: { supported: true, allowed: [] } }))).toBeNull();
+  });
+
+  it('returns null when the admin locked the param', () => {
+    // Locked params are pinned to the admin default server-side and user
+    // overrides are dropped, so offering the choice would be a lie.
+    const control = resolveEffortControl(
+      model({ effort: { supported: true, locked: true, allowed: ['low', 'high'], default: 'low' } }),
+    );
+    expect(control).toBeNull();
+  });
+
+  it('resolves levels and default for a configured Bedrock effort param', () => {
+    const control = resolveEffortControl(
+      model({
+        effort: { supported: true, allowed: ['low', 'medium', 'high'], default: 'medium' },
+      }),
+    );
+    expect(control).toEqual({ key: 'effort', levels: ['low', 'medium', 'high'], defaultLevel: 'medium' });
+  });
+
+  it('reports no default when the admin declared none', () => {
+    const control = resolveEffortControl(
+      model({ effort: { supported: true, allowed: ['low', 'high'] } }),
+    );
+    expect(control?.defaultLevel).toBeNull();
+  });
+
+  it('ignores a default that is not one of the allowed levels', () => {
+    // Mirrors the backend, which would fall through to the provider default
+    // rather than send a value outside the declared set.
+    const control = resolveEffortControl(
+      model({ effort: { supported: true, allowed: ['low', 'high'], default: 'max' } }),
+    );
+    expect(control?.defaultLevel).toBeNull();
+  });
+
+  it('falls back to reasoning_effort on the OpenAI-compatible surfaces', () => {
+    const control = resolveEffortControl(
+      model({ reasoning_effort: { supported: true, allowed: ['low', 'high'], default: 'high' } }),
+    );
+    expect(control).toEqual({ key: 'reasoning_effort', levels: ['low', 'high'], defaultLevel: 'high' });
+  });
+
+  it('prefers effort over reasoning_effort when a model somehow declares both', () => {
+    const control = resolveEffortControl(
+      model({
+        effort: { supported: true, allowed: ['low'] },
+        reasoning_effort: { supported: true, allowed: ['high'] },
+      }),
+    );
+    expect(control?.key).toBe('effort');
+  });
+
+  it('coerces non-string levels to strings', () => {
+    const control = resolveEffortControl(
+      model({ effort: { supported: true, allowed: [1, 2], default: 2 } }),
+    );
+    expect(control).toEqual({ key: 'effort', levels: ['1', '2'], defaultLevel: '2' });
+  });
+});
+
+describe('effortLevelLabel', () => {
+  it('title-cases a plain level', () => {
+    expect(effortLevelLabel('low')).toBe('Low');
+    expect(effortLevelLabel('medium')).toBe('Medium');
+  });
+
+  it('spells out the xhigh shorthand', () => {
+    expect(effortLevelLabel('xhigh')).toBe('Extra high');
+  });
+});

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -464,8 +464,19 @@ export const KNOWN_PARAMS: KnownParamMeta[] = [
     label: 'Reasoning Effort',
     description:
       'Reasoning depth (OpenAI o-series and reasoning models on the ' +
-      'OpenAI-compatible Bedrock surfaces).',
-    kind: 'number',
+      'OpenAI-compatible Bedrock surfaces). Check the levels this model ' +
+      'supports; pick a default.',
+    // A string enum, not a number — `kind: 'number'` here was simply wrong,
+    // and it was load-bearing: the admin form renders the `allowed` checklist
+    // only for `kind: 'select'`, so there was no way to declare the levels a
+    // model accepts, and anything that reads `allowed` (the chat picker's
+    // Effort submenu, the backend's enum branch) could never see one.
+    kind: 'select',
+    // The union across the OpenAI-compatible surfaces. Per-model subsets are
+    // declared in each model's `allowed`, which is what actually gates a
+    // request — `none` and `max` are real GPT-5.6 levels but absent from the
+    // older o-series, so this list is a superset by design.
+    options: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
     providers: ['openai', 'mantle', 'bedrock-responses'],
   },
 ];

--- a/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
+++ b/frontend/ai.client/src/app/admin/manage-models/models/managed-model.model.ts
@@ -162,6 +162,13 @@ export interface ManagedModel {
   modelId: string;
   /** Human-readable name of the model */
   modelName: string;
+  /**
+   * One-line reason a user would pick this model, shown under its name in the
+   * chat model picker. Deliberately shorter than the catalog card's `tagline`
+   * — the picker is a narrow menu, not a card, so this reads as a fragment
+   * ("For your toughest challenges"), not a sentence.
+   */
+  shortDescription?: string | null;
   /** Model provider (AWS, OpenAI, Google) */
   provider: ModelProvider;
   /** Provider name (e.g., 'Anthropic', 'Amazon', 'Meta') */
@@ -212,6 +219,18 @@ export interface ManagedModel {
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
   /**
+   * Whether the model sits at the top level of the chat model picker. `false`
+   * collapses it into the picker's "More models" submenu — the model stays
+   * fully available, it just stops competing for the first glance.
+   *
+   * Defaults to `true` on the backend so a catalog nobody has curated keeps
+   * showing every model exactly where it always has.
+   *
+   * Optional because a record stored before this field existed genuinely has
+   * no value for it. Read it as `isFeatured !== false`, never `=== true`.
+   */
+  isFeatured?: boolean;
+  /**
    * OpenAI-compatible API surface: `chat` (OpenAI Chat Completions, the
    * default) or `responses` (OpenAI Responses API — required by models that
    * don't serve Chat Completions, e.g. openai.gpt-5.x).
@@ -246,6 +265,13 @@ export interface ManagedModelFormData {
   modelId: string;
   /** Human-readable name of the model */
   modelName: string;
+  /**
+   * One-line reason a user would pick this model, shown under its name in the
+   * chat model picker. Deliberately shorter than the catalog card's `tagline`
+   * — the picker is a narrow menu, not a card, so this reads as a fragment
+   * ("For your toughest challenges"), not a sentence.
+   */
+  shortDescription?: string | null;
   /** Model provider (AWS, OpenAI, Google) */
   provider: ModelProvider;
   /** Provider name (e.g., 'Anthropic', 'Amazon', 'Meta') */
@@ -286,6 +312,15 @@ export interface ManagedModelFormData {
   supportsCaching?: boolean;
   /** Whether this is the default model for new sessions */
   isDefault: boolean;
+  /**
+   * Whether the model sits at the top level of the chat model picker. `false`
+   * collapses it into the picker's "More models" submenu — the model stays
+   * fully available, it just stops competing for the first glance.
+   *
+   * Defaults to `true` on the backend so a catalog nobody has curated keeps
+   * showing every model exactly where it always has.
+   */
+  isFeatured?: boolean;
   /**
    * OpenAI-compatible API surface: `chat` or `responses`. Selectable for
    * `mantle`; forced to `responses` for `bedrock-responses`. Inert for other
@@ -446,3 +481,63 @@ export const AVAILABLE_ROLES = [
   'User',
   'Guest',
 ] as const;
+
+/**
+ * Canonical param keys that express reasoning/output effort, in the order the
+ * picker prefers them. Anthropic calls it `effort` (output_config.effort);
+ * the OpenAI-compatible surfaces call it `reasoning_effort`. A model declares
+ * at most one.
+ */
+export const EFFORT_PARAM_KEYS = ['effort', 'reasoning_effort'] as const;
+
+/** An effort control the chat model picker can render for a model. */
+export interface EffortControl {
+  /** Canonical param key to send in `inference_params`. */
+  key: string;
+  /** Selectable levels, admin-declared, ordered low -> high. */
+  levels: string[];
+  /** The admin's default level, or null when they didn't pick one. */
+  defaultLevel: string | null;
+}
+
+/**
+ * Resolve the effort control for a model, or null when it has none.
+ *
+ * Deliberately strict: an effort param is only offered when the admin declared
+ * it `supported`, left it unlocked, AND enumerated the `allowed` levels. That
+ * mirrors `_merge_inference_params` on the backend, whose enum branch keeps a
+ * user override *only* if it's a member of `allowed` and otherwise silently
+ * falls back to the default. Rendering a level the backend would discard would
+ * show the user a choice that does nothing.
+ *
+ * `locked` is excluded for the same reason — the backend pins those to the
+ * admin default and drops overrides without erroring.
+ */
+export function resolveEffortControl(model: ManagedModel | null | undefined): EffortControl | null {
+  const spec = model?.supportedParams?.params;
+  if (!spec) return null;
+
+  for (const key of EFFORT_PARAM_KEYS) {
+    const paramSpec = spec[key];
+    if (!paramSpec?.supported || paramSpec.locked) continue;
+    const levels = (paramSpec.allowed ?? []).map(level => String(level));
+    if (levels.length === 0) continue;
+    const declaredDefault =
+      paramSpec.default === null || paramSpec.default === undefined
+        ? null
+        : String(paramSpec.default);
+    return {
+      key,
+      levels,
+      defaultLevel: declaredDefault !== null && levels.includes(declaredDefault) ? declaredDefault : null,
+    };
+  }
+
+  return null;
+}
+
+/** Title-case an effort level for display ('xhigh' -> 'Extra high'). */
+export function effortLevelLabel(level: string): string {
+  if (level === 'xhigh') return 'Extra high';
+  return level.charAt(0).toUpperCase() + level.slice(1);
+}

--- a/frontend/ai.client/src/app/components/model-dropdown/components/model-option.component.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/components/model-option.component.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheck } from '@ng-icons/heroicons/outline';
+import { ManagedModel } from '../../../admin/manage-models/models/managed-model.model';
+
+/**
+ * One model row in the chat model picker.
+ *
+ * Exists as a component rather than an `<ng-template>` + `ngTemplateOutlet`
+ * because the same row renders in two menus — the picker's top level and its
+ * "More models" submenu — and CDK's `CdkMenu` finds its items with a CONTENT
+ * query. A template declared outside the menu and rendered into it with
+ * `ngTemplateOutlet` belongs to the declaring view, so the query never matches
+ * it: the rows would render but register as no menu items at all, taking
+ * keyboard navigation and typeahead with them.
+ *
+ * `cdkMenuItem` goes on this component's host in the parent template, which is
+ * why the row renders spans and no interactive element of its own — a `<button>`
+ * inside a `role="menuitem"` host nests two controls and breaks the a11y tree.
+ */
+@Component({
+  selector: 'app-model-option',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon],
+  providers: [provideIcons({ heroCheck })],
+  host: {
+    class:
+      'flex w-full cursor-pointer items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700',
+  },
+  template: `
+    <span class="min-w-0 text-left">
+      <span class="block truncate font-medium">{{ model().modelName }}</span>
+      <span class="block truncate text-xs/4 text-gray-500 dark:text-gray-400">
+        {{ model().shortDescription || model().providerName }}
+      </span>
+    </span>
+
+    @if (selected()) {
+      <ng-icon
+        name="heroCheck"
+        class="size-4 shrink-0 text-primary-500 dark:text-slate-400"
+        aria-hidden="true"
+      />
+    } @else if (showNewChatHint()) {
+      <span
+        class="shrink-0 rounded-sm bg-gray-100 px-1.5 py-0.5 text-[10px]/3 font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+        >New chat</span
+      >
+    }
+  `,
+})
+export class ModelOptionComponent {
+  readonly model = input.required<ManagedModel>();
+  readonly selected = input<boolean>(false);
+  /** Show the "New chat" hint — picking a different model starts a new session. */
+  readonly showNewChatHint = input<boolean>(false);
+}

--- a/frontend/ai.client/src/app/components/model-dropdown/components/model-option.component.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/components/model-option.component.ts
@@ -17,6 +17,16 @@ import { ManagedModel } from '../../../admin/manage-models/models/managed-model.
  * `cdkMenuItem` goes on this component's host in the parent template, which is
  * why the row renders spans and no interactive element of its own — a `<button>`
  * inside a `role="menuitem"` host nests two controls and breaks the a11y tree.
+ *
+ * Layout: name and provider share the first line separated by a bullet, with
+ * the description (when there is one) on a second. The bullet is
+ * `aria-hidden` so the row reads as "Claude Sonnet 5 Anthropic" rather than
+ * "Claude Sonnet 5 bullet Anthropic".
+ *
+ * Spacing around the bullet is margin (`ml-1.5` / `mr-1`), NOT template
+ * whitespace: Angular strips whitespace-only text nodes by default
+ * (`preserveWhitespaces: false`), so a space written between the two spans
+ * silently disappears and the row renders "Claude Sonnet 5• Anthropic".
  */
 @Component({
   selector: 'app-model-option',
@@ -25,14 +35,24 @@ import { ManagedModel } from '../../../admin/manage-models/models/managed-model.
   providers: [provideIcons({ heroCheck })],
   host: {
     class:
-      'flex w-full cursor-pointer items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700',
+      'flex w-full cursor-pointer items-center justify-between gap-2 rounded-xs px-3 py-2 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700',
   },
   template: `
     <span class="min-w-0 text-left">
-      <span class="block truncate font-medium">{{ model().modelName }}</span>
-      <span class="block truncate text-xs/4 text-gray-500 dark:text-gray-400">
-        {{ model().shortDescription || model().providerName }}
+      <span class="block truncate">
+        <span class="font-medium">{{ model().modelName }}</span>
+        <span class="ml-1.5 text-xs/4 text-gray-500 dark:text-gray-400"
+          ><span aria-hidden="true" class="mr-1">&bull;</span>{{ model().providerName }}</span
+        >
       </span>
+      <!-- Second line only when there's something to say. A model with no
+           description collapses to a single line rather than leaving a blank
+           one, which is most of what makes the menu shorter. -->
+      @if (model().shortDescription) {
+        <span class="mt-0.5 block truncate text-xs/4 text-gray-500 dark:text-gray-400">{{
+          model().shortDescription
+        }}</span>
+      }
     </span>
 
     @if (selected()) {

--- a/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.spec.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { signal, computed } from '@angular/core';
+import { Router } from '@angular/router';
+import { ModelDropdownComponent } from './model-dropdown.component';
+import { ModelService } from '../../session/services/model/model.service';
+import { SessionService } from '../../session/services/session/session.service';
+import {
+  EffortControl,
+  ManagedModel,
+} from '../../admin/manage-models/models/managed-model.model';
+
+function makeModel(overrides: Partial<ManagedModel> = {}): ManagedModel {
+  return {
+    id: 'm1',
+    modelId: 'model-1',
+    modelName: 'Model One',
+    provider: 'bedrock',
+    providerName: 'Anthropic',
+    inputModalities: ['TEXT'],
+    outputModalities: ['TEXT'],
+    maxInputTokens: 200000,
+    maxOutputTokens: 4096,
+    allowedAppRoles: [],
+    availableToRoles: [],
+    enabled: true,
+    inputPricePerMillionTokens: 1,
+    outputPricePerMillionTokens: 1,
+    knowledgeCutoffDate: null,
+    supportsCaching: true,
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Stand-in for ModelService exposing exactly the signals the picker reads.
+ * DI-token override rather than vi.mock, per house convention.
+ */
+function setup(options: {
+  featured?: ManagedModel[];
+  more?: ManagedModel[];
+  selected?: ManagedModel;
+  effortControl?: EffortControl | null;
+  selectedEffort?: string | null;
+  hasSession?: boolean;
+} = {}) {
+  const featured = signal(options.featured ?? [makeModel()]);
+  const more = signal(options.more ?? []);
+  const selected = signal(options.selected ?? featured()[0]);
+  const effortControl = signal<EffortControl | null>(options.effortControl ?? null);
+  const selectedEffort = signal<string | null>(options.selectedEffort ?? null);
+  const setSelectedModel = vi.fn();
+  const setEffort = vi.fn();
+
+  const modelService = {
+    featuredModels: featured,
+    moreModels: more,
+    selectedModel: selected,
+    availableModels: computed(() => [...featured(), ...more()]),
+    modelsLoading: signal(false),
+    modelsError: signal(null),
+    agentModelLocked: signal(false),
+    effortControl,
+    selectedEffort,
+    setSelectedModel,
+    setEffort,
+  };
+
+  const sessionService = {
+    hasCurrentSession: () => options.hasSession ?? false,
+  };
+
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: ModelService, useValue: modelService },
+      { provide: SessionService, useValue: sessionService },
+      { provide: Router, useValue: { navigate: vi.fn() } },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(ModelDropdownComponent);
+  fixture.detectChanges();
+  return { fixture, modelService, setSelectedModel, setEffort };
+}
+
+/** Open the picker by clicking its trigger, then flush the overlay render. */
+function openMenu(fixture: ReturnType<typeof setup>['fixture']) {
+  const trigger = fixture.nativeElement.querySelector('button[aria-label="Select model"]');
+  expect(trigger, 'trigger button should render').toBeTruthy();
+  trigger.click();
+  fixture.detectChanges();
+}
+
+/** CDK renders menus into an overlay container outside the fixture element. */
+function menuItems(): HTMLElement[] {
+  return Array.from(document.querySelectorAll('[role="menuitem"]'));
+}
+
+function itemLabelled(text: string): HTMLElement | undefined {
+  return menuItems().find(el => el.textContent?.includes(text));
+}
+
+describe('ModelDropdownComponent', () => {
+  beforeEach(() => {
+    document.querySelectorAll('.cdk-overlay-container').forEach(el => el.remove());
+  });
+
+  it('renders one menu item per featured model', () => {
+    const { fixture } = setup({
+      featured: [
+        makeModel({ id: 'a', modelId: 'a', modelName: 'Alpha' }),
+        makeModel({ id: 'b', modelId: 'b', modelName: 'Beta' }),
+      ],
+    });
+    openMenu(fixture);
+
+    // The rows are a child component carrying `cdkMenuItem` on its host. If
+    // that ever regresses to an ngTemplateOutlet, CDK's CONTENT query stops
+    // matching them and this count drops to zero while the rows still render
+    // — which is the whole reason the row is a component.
+    expect(itemLabelled('Alpha')).toBeTruthy();
+    expect(itemLabelled('Beta')).toBeTruthy();
+  });
+
+  it('shows the short description under the model name', () => {
+    const { fixture } = setup({
+      featured: [makeModel({ modelName: 'Alpha', shortDescription: 'For hard problems' })],
+    });
+    openMenu(fixture);
+    expect(itemLabelled('Alpha')?.textContent).toContain('For hard problems');
+  });
+
+  it('falls back to the provider name when a model has no description', () => {
+    const { fixture } = setup({
+      featured: [makeModel({ modelName: 'Alpha', providerName: 'Anthropic' })],
+    });
+    openMenu(fixture);
+    expect(itemLabelled('Alpha')?.textContent).toContain('Anthropic');
+  });
+
+  it('omits the "More models" entry when nothing is demoted', () => {
+    const { fixture } = setup({ featured: [makeModel()], more: [] });
+    openMenu(fixture);
+    expect(itemLabelled('More models')).toBeUndefined();
+  });
+
+  it('offers a "More models" entry when models are demoted', () => {
+    const { fixture } = setup({
+      featured: [makeModel({ id: 'a', modelId: 'a', modelName: 'Alpha' })],
+      more: [makeModel({ id: 'z', modelId: 'z', modelName: 'Zeta', isFeatured: false })],
+    });
+    openMenu(fixture);
+
+    // Demoted models stay out of the top level until the submenu is opened.
+    expect(itemLabelled('Zeta')).toBeUndefined();
+    expect(itemLabelled('More models')).toBeTruthy();
+  });
+
+  it('reveals demoted models when the submenu is opened', () => {
+    const { fixture } = setup({
+      featured: [makeModel({ id: 'a', modelId: 'a', modelName: 'Alpha' })],
+      more: [makeModel({ id: 'z', modelId: 'z', modelName: 'Zeta', isFeatured: false })],
+    });
+    openMenu(fixture);
+    itemLabelled('More models')!.click();
+    fixture.detectChanges();
+
+    expect(itemLabelled('Zeta')).toBeTruthy();
+  });
+
+  it('omits the Effort entry for a model with no effort control', () => {
+    const { fixture } = setup({ effortControl: null });
+    openMenu(fixture);
+    expect(itemLabelled('Effort')).toBeUndefined();
+  });
+
+  it('offers an Effort entry showing the active level', () => {
+    const { fixture } = setup({
+      effortControl: { key: 'effort', levels: ['low', 'medium', 'high'], defaultLevel: 'medium' },
+      selectedEffort: 'medium',
+    });
+    openMenu(fixture);
+
+    const effortItem = itemLabelled('Effort');
+    expect(effortItem).toBeTruthy();
+    expect(effortItem?.textContent).toContain('Medium');
+  });
+
+  it('surfaces the active effort in the trigger without opening the menu', () => {
+    const { fixture } = setup({
+      effortControl: { key: 'effort', levels: ['low', 'high'], defaultLevel: 'low' },
+      selectedEffort: 'high',
+    });
+    const trigger = fixture.nativeElement.querySelector('button[aria-label="Select model"]');
+    expect(trigger.textContent).toContain('High');
+  });
+
+  it('lists the model-declared effort levels and marks the admin default', () => {
+    const { fixture } = setup({
+      effortControl: { key: 'effort', levels: ['low', 'medium', 'high'], defaultLevel: 'medium' },
+      selectedEffort: 'high',
+    });
+    openMenu(fixture);
+    itemLabelled('Effort')!.click();
+    fixture.detectChanges();
+
+    for (const label of ['Low', 'Medium', 'High']) {
+      expect(itemLabelled(label), `${label} should be offered`).toBeTruthy();
+    }
+    expect(itemLabelled('Medium')?.textContent).toContain('Default');
+  });
+
+  it('writes the chosen effort level back to the service', () => {
+    const { fixture, setEffort } = setup({
+      effortControl: { key: 'effort', levels: ['low', 'high'], defaultLevel: 'low' },
+      selectedEffort: 'low',
+    });
+    openMenu(fixture);
+    itemLabelled('Effort')!.click();
+    fixture.detectChanges();
+    itemLabelled('High')!.click();
+
+    expect(setEffort).toHaveBeenCalledWith('high');
+  });
+
+  it('locks the picker to a plain label when an agent pins the model', () => {
+    const { fixture, modelService } = setup();
+    modelService.agentModelLocked.set(true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('button[aria-label="Select model"]')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Model One');
+  });
+});

--- a/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.spec.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.spec.ts
@@ -124,20 +124,48 @@ describe('ModelDropdownComponent', () => {
     expect(itemLabelled('Beta')).toBeTruthy();
   });
 
-  it('shows the short description under the model name', () => {
+  it('puts the provider on the name line and the description below it', () => {
     const { fixture } = setup({
-      featured: [makeModel({ modelName: 'Alpha', shortDescription: 'For hard problems' })],
+      featured: [
+        makeModel({
+          modelName: 'Alpha',
+          providerName: 'Anthropic',
+          shortDescription: 'For hard problems',
+        }),
+      ],
     });
     openMenu(fixture);
-    expect(itemLabelled('Alpha')?.textContent).toContain('For hard problems');
+    const row = itemLabelled('Alpha')!;
+    expect(row.textContent).toContain('Anthropic');
+    expect(row.textContent).toContain('For hard problems');
+
+    // Name + provider share one line; the description is its own.
+    const lines = row.querySelectorAll('.block');
+    expect(lines.length).toBe(2);
+    expect(lines[0].textContent).toContain('Alpha');
+    expect(lines[0].textContent).toContain('Anthropic');
+    expect(lines[1].textContent).toContain('For hard problems');
   });
 
-  it('falls back to the provider name when a model has no description', () => {
+  it('collapses to a single line when a model has no description', () => {
+    // This is most of what makes the menu shorter — an undescribed model must
+    // not leave an empty second line behind.
     const { fixture } = setup({
       featured: [makeModel({ modelName: 'Alpha', providerName: 'Anthropic' })],
     });
     openMenu(fixture);
-    expect(itemLabelled('Alpha')?.textContent).toContain('Anthropic');
+    const row = itemLabelled('Alpha')!;
+    expect(row.textContent).toContain('Anthropic');
+    expect(row.querySelectorAll('.block').length).toBe(1);
+  });
+
+  it('hides the bullet separator from assistive tech', () => {
+    const { fixture } = setup({
+      featured: [makeModel({ modelName: 'Alpha', providerName: 'Anthropic' })],
+    });
+    openMenu(fixture);
+    const bullet = itemLabelled('Alpha')!.querySelector('[aria-hidden="true"]');
+    expect(bullet?.textContent?.trim()).toBe('\u2022');
   });
 
   it('omits the "More models" entry when nothing is demoted', () => {

--- a/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
@@ -1,24 +1,28 @@
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { CdkMenuTrigger, CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroCheck, heroLockClosed } from '@ng-icons/heroicons/outline';
+import { heroCheck, heroChevronRight, heroLockClosed } from '@ng-icons/heroicons/outline';
 import { ModelService } from '../../session/services/model/model.service';
 import { SessionService } from '../../session/services/session/session.service';
-import { ManagedModel } from '../../admin/manage-models/models/managed-model.model';
+import {
+  ManagedModel,
+  effortLevelLabel,
+} from '../../admin/manage-models/models/managed-model.model';
+import { ModelOptionComponent } from './components/model-option.component';
 
 @Component({
   selector: 'app-model-dropdown',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CdkMenuTrigger, CdkMenu, CdkMenuItem, NgIcon],
-  providers: [provideIcons({ heroCheck, heroLockClosed })],
+  imports: [CdkMenuTrigger, CdkMenu, CdkMenuItem, NgIcon, ModelOptionComponent],
+  providers: [provideIcons({ heroCheck, heroChevronRight, heroLockClosed })],
   template: `
     <div class="relative">
       @if (modelService.agentModelLocked()) {
         <!-- Agent-dictated: the active agent pins this model; the picker is locked. -->
         <div
-          class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1 text-sm/5 text-gray-500 dark:text-gray-400"
           title="This agent runs on a fixed model"
         >
           <ng-icon name="heroLockClosed" class="size-3.5 shrink-0" aria-hidden="true" />
@@ -26,28 +30,33 @@ import { ManagedModel } from '../../admin/manage-models/models/managed-model.mod
           <span class="sr-only">(set by this agent)</span>
         </div>
       } @else {
-      <button
-        type="button"
-        [cdkMenuTriggerFor]="modelMenu"
-        [cdkMenuPosition]="menuPositions"
-        class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/5 dark:hover:text-gray-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]"
-        aria-label="Select model"
-      >
-        <span>{{ modelService.selectedModel().modelName || 'Loading...' }}</span>
-        <svg
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
-          class="size-4 transition-transform"
-          [class.rotate-180]="isMenuOpen()"
+        <button
+          type="button"
+          [cdkMenuTriggerFor]="modelMenu"
+          [cdkMenuPosition]="menuPositions"
+          class="flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm/5 text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
+          aria-label="Select model"
         >
-          <path
-            fill-rule="evenodd"
-            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
-            clip-rule="evenodd"
-          />
-        </svg>
-      </button>
+          <span>{{ modelService.selectedModel().modelName || 'Loading...' }}</span>
+          @if (activeEffortLabel(); as effort) {
+            <!-- The active effort rides in the trigger so it's visible without
+                 opening the menu — it changes cost and latency, not just output. -->
+            <span class="text-gray-400 dark:text-gray-500">{{ effort }}</span>
+          }
+          <svg
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+            class="size-4 transition-transform"
+            [class.rotate-180]="isMenuOpen()"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
       }
 
       <ng-template #modelMenu>
@@ -55,59 +64,156 @@ import { ManagedModel } from '../../admin/manage-models/models/managed-model.mod
           cdkMenu
           (closed)="onMenuClosed()"
           (opened)="onMenuOpened()"
-          class="w-64 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10 animate-in fade-in slide-in-from-top-1 duration-200"
+          class="w-72 rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10 animate-in fade-in slide-in-from-top-1 duration-200"
           role="menu"
           aria-orientation="vertical"
         >
-          <div class="p-1">
-            @if (modelService.modelsLoading()) {
-              <div class="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
-                Loading models...
+          @if (modelService.modelsLoading()) {
+            <div class="px-2.5 py-1.5 text-sm/5 text-gray-500 dark:text-gray-400">
+              Loading models...
+            </div>
+          } @else if (modelService.modelsError()) {
+            <div class="px-2.5 py-1.5 text-sm/5 text-state-danger-600 dark:text-state-danger-400">
+              {{ modelService.modelsError() }}
+            </div>
+          } @else if (modelService.availableModels().length === 0) {
+            <!-- Show default model option when no models are available -->
+            <button
+              cdkMenuItem
+              type="button"
+              class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              role="menuitem"
+              disabled
+            >
+              <div class="min-w-0 text-left">
+                <div class="truncate font-medium">
+                  {{ modelService.selectedModel().modelName || 'System Default' }}
+                </div>
+                <div class="truncate text-xs/4 text-gray-500 dark:text-gray-400">
+                  Using backend default
+                </div>
               </div>
-            } @else if (modelService.modelsError()) {
-              <div class="px-3 py-2 text-sm text-state-danger-600 dark:text-state-danger-400">
-                {{ modelService.modelsError() }}
-              </div>
-            } @else if (modelService.availableModels().length === 0) {
-              <!-- Show default model option when no models are available -->
+              <ng-icon
+                name="heroCheck"
+                class="size-4 shrink-0 text-primary-500 dark:text-slate-400"
+                aria-hidden="true"
+              />
+            </button>
+          } @else {
+            @for (model of modelService.featuredModels(); track model.modelId) {
+              <app-model-option
+                cdkMenuItem
+                [model]="model"
+                [selected]="isSelected(model)"
+                [showNewChatHint]="sessionService.hasCurrentSession()"
+                (cdkMenuItemTriggered)="selectModel(model)"
+              />
+            }
+
+            @if (effortControl(); as effort) {
+              <div class="my-1 border-t border-gray-200 dark:border-gray-700"></div>
               <button
                 cdkMenuItem
                 type="button"
-                class="flex w-full items-center justify-between px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700 rounded-xs outline-hidden"
+                [cdkMenuTriggerFor]="effortMenu"
+                [cdkMenuPosition]="submenuPositions"
+                class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
                 role="menuitem"
-                disabled
               >
-                <div class="flex flex-col items-start">
-                  <span class="font-medium">{{ modelService.selectedModel().modelName || 'System Default' }}</span>
-                  <span class="text-xs text-gray-500 dark:text-gray-400">Using backend default</span>
-                </div>
-                <ng-icon name="heroCheck" class="size-5 text-primary-500 dark:text-slate-400" aria-hidden="true" />
-              </button>
-            } @else {
-              @for (model of modelService.availableModels(); track model.modelId) {
-                <button
-                  cdkMenuItem
-                  type="button"
-                  (click)="selectModel(model)"
-                  class="flex w-full items-center justify-between px-3 py-2 text-sm/6 text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700 rounded-xs outline-hidden"
-                  role="menuitem"
-                >
-                  <div class="min-w-0 text-left">
-                    <div class="truncate font-medium">{{ model.modelName }}</div>
-                    <div class="truncate text-xs text-gray-500 dark:text-gray-400">{{ model.providerName }}</div>
-                  </div>
-
-                  @if (isSelected(model)) {
-                    <ng-icon name="heroCheck" class="size-5 shrink-0 text-primary-500 dark:text-slate-400" aria-hidden="true" />
-                  } @else if (sessionService.hasCurrentSession()) {
-                    <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">New chat</span>
+                <span>Effort</span>
+                <span class="flex items-center gap-1">
+                  @if (activeEffortLabel(); as label) {
+                    <span class="text-xs/4 text-gray-500 dark:text-gray-400">{{ label }}</span>
                   }
-                </button>
-              }
+                  <ng-icon
+                    name="heroChevronRight"
+                    class="size-4 shrink-0 text-gray-400 dark:text-gray-500"
+                    aria-hidden="true"
+                  />
+                </span>
+              </button>
+
+              <ng-template #effortMenu>
+                <div
+                  cdkMenu
+                  class="w-56 rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
+                  role="menu"
+                  aria-orientation="vertical"
+                >
+                  <p class="px-2.5 py-1.5 text-xs/4 text-gray-500 dark:text-gray-400">
+                    Higher effort means more thorough responses, but takes longer and costs more.
+                  </p>
+                  @for (level of effort.levels; track level) {
+                    <button
+                      cdkMenuItem
+                      type="button"
+                      (click)="selectEffort(level)"
+                      class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                      role="menuitem"
+                    >
+                      <span class="flex items-center gap-1.5">
+                        <span>{{ levelLabel(level) }}</span>
+                        @if (level === effort.defaultLevel) {
+                          <span
+                            class="rounded-sm bg-gray-100 px-1 py-0.5 text-[10px]/3 font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+                            >Default</span
+                          >
+                        }
+                      </span>
+                      @if (level === modelService.selectedEffort()) {
+                        <ng-icon
+                          name="heroCheck"
+                          class="size-4 shrink-0 text-primary-500 dark:text-slate-400"
+                          aria-hidden="true"
+                        />
+                      }
+                    </button>
+                  }
+                </div>
+              </ng-template>
             }
-          </div>
+
+            @if (modelService.moreModels().length > 0) {
+              <div class="my-1 border-t border-gray-200 dark:border-gray-700"></div>
+              <button
+                cdkMenuItem
+                type="button"
+                [cdkMenuTriggerFor]="moreModelsMenu"
+                [cdkMenuPosition]="submenuPositions"
+                class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                role="menuitem"
+              >
+                <span>More models</span>
+                <ng-icon
+                  name="heroChevronRight"
+                  class="size-4 shrink-0 text-gray-400 dark:text-gray-500"
+                  aria-hidden="true"
+                />
+              </button>
+
+              <ng-template #moreModelsMenu>
+                <div
+                  cdkMenu
+                  class="max-h-96 w-72 overflow-y-auto rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
+                  role="menu"
+                  aria-orientation="vertical"
+                >
+                  @for (model of modelService.moreModels(); track model.modelId) {
+                    <app-model-option
+                      cdkMenuItem
+                      [model]="model"
+                      [selected]="isSelected(model)"
+                      [showNewChatHint]="sessionService.hasCurrentSession()"
+                      (cdkMenuItemTriggered)="selectModel(model)"
+                    />
+                  }
+                </div>
+              </ng-template>
+            }
+          }
         </div>
       </ng-template>
+
     </div>
   `,
   styles: `
@@ -150,6 +256,15 @@ export class ModelDropdownComponent {
   // Internal state
   protected menuOpen = false;
 
+  /** The effort control for the selected model, or null when it offers none. */
+  protected readonly effortControl = this.modelService.effortControl;
+
+  /** Effort level to show in the trigger and the submenu row, already labelled. */
+  protected readonly activeEffortLabel = computed<string | null>(() => {
+    const level = this.modelService.selectedEffort();
+    return level ? effortLevelLabel(level) : null;
+  });
+
   // Menu positioning - align to bottom-left of trigger
   protected menuPositions: ConnectedPosition[] = [
     {
@@ -168,6 +283,40 @@ export class ModelDropdownComponent {
     }
   ];
 
+  // Submenus fly out to the right of their parent row, flipping to the left
+  // when there isn't room — the picker sits in the composer, which can be
+  // close to either edge depending on the sidebar state.
+  protected submenuPositions: ConnectedPosition[] = [
+    {
+      originX: 'end',
+      originY: 'top',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetX: 4
+    },
+    {
+      originX: 'start',
+      originY: 'top',
+      overlayX: 'end',
+      overlayY: 'top',
+      offsetX: -4
+    },
+    {
+      originX: 'end',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'bottom',
+      offsetX: 4
+    },
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'end',
+      overlayY: 'bottom',
+      offsetX: -4
+    }
+  ];
+
   protected isMenuOpen(): boolean {
     return this.menuOpen;
   }
@@ -178,6 +327,14 @@ export class ModelDropdownComponent {
 
   protected onMenuClosed(): void {
     this.menuOpen = false;
+  }
+
+  protected levelLabel(level: string): string {
+    return effortLevelLabel(level);
+  }
+
+  protected selectEffort(level: string): void {
+    this.modelService.setEffort(level);
   }
 
   protected selectModel(model: ManagedModel): void {

--- a/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
+++ b/frontend/ai.client/src/app/components/model-dropdown/model-dropdown.component.ts
@@ -22,7 +22,7 @@ import { ModelOptionComponent } from './components/model-option.component';
       @if (modelService.agentModelLocked()) {
         <!-- Agent-dictated: the active agent pins this model; the picker is locked. -->
         <div
-          class="flex items-center gap-2 rounded-lg px-2.5 py-1 text-sm/5 text-gray-500 dark:text-gray-400"
+          class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm/5 text-gray-500 dark:text-gray-400"
           title="This agent runs on a fixed model"
         >
           <ng-icon name="heroLockClosed" class="size-3.5 shrink-0" aria-hidden="true" />
@@ -34,7 +34,7 @@ import { ModelOptionComponent } from './components/model-option.component';
           type="button"
           [cdkMenuTriggerFor]="modelMenu"
           [cdkMenuPosition]="menuPositions"
-          class="flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm/5 text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
+          class="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm/5 text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
           aria-label="Select model"
         >
           <span>{{ modelService.selectedModel().modelName || 'Loading...' }}</span>
@@ -64,16 +64,16 @@ import { ModelOptionComponent } from './components/model-option.component';
           cdkMenu
           (closed)="onMenuClosed()"
           (opened)="onMenuOpened()"
-          class="w-72 rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10 animate-in fade-in slide-in-from-top-1 duration-200"
+          class="w-72 rounded-md bg-white p-1.5 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10 animate-in fade-in slide-in-from-top-1 duration-200"
           role="menu"
           aria-orientation="vertical"
         >
           @if (modelService.modelsLoading()) {
-            <div class="px-2.5 py-1.5 text-sm/5 text-gray-500 dark:text-gray-400">
+            <div class="px-3 py-2 text-sm/5 text-gray-500 dark:text-gray-400">
               Loading models...
             </div>
           } @else if (modelService.modelsError()) {
-            <div class="px-2.5 py-1.5 text-sm/5 text-state-danger-600 dark:text-state-danger-400">
+            <div class="px-3 py-2 text-sm/5 text-state-danger-600 dark:text-state-danger-400">
               {{ modelService.modelsError() }}
             </div>
           } @else if (modelService.availableModels().length === 0) {
@@ -81,7 +81,7 @@ import { ModelOptionComponent } from './components/model-option.component';
             <button
               cdkMenuItem
               type="button"
-              class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              class="flex w-full items-center justify-between gap-2 rounded-xs px-3 py-2 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
               role="menuitem"
               disabled
             >
@@ -111,13 +111,13 @@ import { ModelOptionComponent } from './components/model-option.component';
             }
 
             @if (effortControl(); as effort) {
-              <div class="my-1 border-t border-gray-200 dark:border-gray-700"></div>
+              <div class="my-1.5 border-t border-gray-200 dark:border-gray-700"></div>
               <button
                 cdkMenuItem
                 type="button"
                 [cdkMenuTriggerFor]="effortMenu"
                 [cdkMenuPosition]="submenuPositions"
-                class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                class="flex w-full items-center justify-between gap-2 rounded-xs px-3 py-2 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
                 role="menuitem"
               >
                 <span>Effort</span>
@@ -136,11 +136,11 @@ import { ModelOptionComponent } from './components/model-option.component';
               <ng-template #effortMenu>
                 <div
                   cdkMenu
-                  class="w-56 rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
+                  class="w-56 rounded-md bg-white p-1.5 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
                   role="menu"
                   aria-orientation="vertical"
                 >
-                  <p class="px-2.5 py-1.5 text-xs/4 text-gray-500 dark:text-gray-400">
+                  <p class="px-3 py-2 text-xs/4 text-gray-500 dark:text-gray-400">
                     Higher effort means more thorough responses, but takes longer and costs more.
                   </p>
                   @for (level of effort.levels; track level) {
@@ -148,7 +148,7 @@ import { ModelOptionComponent } from './components/model-option.component';
                       cdkMenuItem
                       type="button"
                       (click)="selectEffort(level)"
-                      class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                      class="flex w-full items-center justify-between gap-2 rounded-xs px-3 py-2 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
                       role="menuitem"
                     >
                       <span class="flex items-center gap-1.5">
@@ -174,13 +174,13 @@ import { ModelOptionComponent } from './components/model-option.component';
             }
 
             @if (modelService.moreModels().length > 0) {
-              <div class="my-1 border-t border-gray-200 dark:border-gray-700"></div>
+              <div class="my-1.5 border-t border-gray-200 dark:border-gray-700"></div>
               <button
                 cdkMenuItem
                 type="button"
                 [cdkMenuTriggerFor]="moreModelsMenu"
                 [cdkMenuPosition]="submenuPositions"
-                class="flex w-full items-center justify-between gap-2 rounded-xs px-2.5 py-1.5 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+                class="flex w-full items-center justify-between gap-2 rounded-xs px-3 py-2 text-sm/5 text-gray-700 outline-hidden hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
                 role="menuitem"
               >
                 <span>More models</span>
@@ -194,7 +194,7 @@ import { ModelOptionComponent } from './components/model-option.component';
               <ng-template #moreModelsMenu>
                 <div
                   cdkMenu
-                  class="max-h-96 w-72 overflow-y-auto rounded-md bg-white p-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
+                  class="max-h-96 w-72 overflow-y-auto rounded-md bg-white p-1.5 shadow-lg ring-1 ring-black/5 focus:outline-hidden dark:bg-gray-800 dark:ring-white/10"
                   role="menu"
                   aria-orientation="vertical"
                 >

--- a/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
+++ b/frontend/ai.client/src/app/session/services/chat/chat-request.service.ts
@@ -338,9 +338,11 @@ export class ChatRequestService implements OnDestroy {
       requestObject['enabled_skills'] = enabledSkillIds;
     }
 
-    // Per-model inference param overrides set in the Settings → Advanced
-    // panel. Backend layers these on top of admin defaults and clamps to the
-    // model's bounds; locked params drop the override silently.
+    // Per-model inference param overrides, set either in the Settings →
+    // Advanced panel or from the model picker's Effort submenu (which writes
+    // the `effort` / `reasoning_effort` param through the same store).
+    // Backend layers these on top of admin defaults and clamps to the model's
+    // bounds; locked params drop the override silently.
     if (!isDefaultModel) {
       const overrides = this.modelService.getInferenceParamOverrides();
       if (Object.keys(overrides).length > 0) {

--- a/frontend/ai.client/src/app/session/services/model/model.service.ts
+++ b/frontend/ai.client/src/app/session/services/model/model.service.ts
@@ -2,7 +2,11 @@ import { Injectable, signal, computed, effect, inject, untracked } from '@angula
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../../../services/config.service';
-import { ManagedModel } from '../../../admin/manage-models/models/managed-model.model';
+import {
+  EffortControl,
+  ManagedModel,
+  resolveEffortControl,
+} from '../../../admin/manage-models/models/managed-model.model';
 import { UserSettingsService } from '../../../services/user-settings.service';
 
 interface ManagedModelsListResponse {
@@ -93,6 +97,54 @@ export class ModelService {
     const model = this.selectedModel();
     if (!model) return {};
     return this._inferenceOverrides()[model.modelId] ?? {};
+  });
+
+  /**
+   * Models shown at the top level of the chat model picker.
+   *
+   * `isFeatured !== false` rather than `=== true` on purpose: a record written
+   * before the field existed has it absent, and those models must keep showing
+   * where they always have. Only an explicit `false` demotes one.
+   *
+   * The selected model is always included even when demoted — a picker whose
+   * trigger names a model you can't find in the open menu (and that shows no
+   * check mark) reads as broken.
+   */
+  readonly featuredModels = computed<ManagedModel[]>(() => {
+    const selectedId = this.selectedModel()?.modelId;
+    return this.models().filter(m => m.isFeatured !== false || m.modelId === selectedId);
+  });
+
+  /** Models collapsed behind the picker's "More models" submenu. */
+  readonly moreModels = computed<ManagedModel[]>(() => {
+    const selectedId = this.selectedModel()?.modelId;
+    return this.models().filter(m => m.isFeatured === false && m.modelId !== selectedId);
+  });
+
+  /**
+   * The effort control the selected model offers, or null when it offers none.
+   * Null is the common case — only models whose admin enumerated the `allowed`
+   * effort levels get a control (see `resolveEffortControl`).
+   */
+  readonly effortControl = computed<EffortControl | null>(() =>
+    resolveEffortControl(this.selectedModel()),
+  );
+
+  /**
+   * The effort level in force for the selected model: the user's override when
+   * they've set one, otherwise the admin's default. Null when the model has no
+   * effort control, or has one with no admin default and no user choice yet —
+   * in which case the provider's own default applies and we don't claim to
+   * know what it is.
+   */
+  readonly selectedEffort = computed<string | null>(() => {
+    const control = this.effortControl();
+    if (!control) return null;
+    const override = this.selectedModelOverrides()[control.key];
+    if (typeof override === 'string' && control.levels.includes(override)) {
+      return override;
+    }
+    return control.defaultLevel;
   });
 
   constructor() {
@@ -361,6 +413,21 @@ export class ModelService {
     }
     this._inferenceOverrides.set(next);
     this.persistOverrides(next);
+  }
+
+  /**
+   * Set the effort level for the selected model. Writes through the same
+   * per-model override store as every other inference param, so it rides the
+   * existing `inference_params` request path with no special casing.
+   *
+   * A level the model doesn't declare is ignored rather than stored — the
+   * backend would drop it anyway, and a stored value that never takes effect
+   * would keep showing as the active level in the picker.
+   */
+  setEffort(level: string): void {
+    const control = this.effortControl();
+    if (!control || !control.levels.includes(level)) return;
+    this.setInferenceParamOverride(control.key, level);
   }
 
   /** Clear all inference param overrides for the currently selected model. */


### PR DESCRIPTION
Refactors the chat model picker into a compact, curatable surface, and adds the two model fields it needs.

## What changed

**Short descriptions.** New `shortDescription` on the managed model, surfaced in the admin form and rendered in the picker. The row now reads `Claude Sonnet 5 • Anthropic` on one line with the description below; a model without one collapses to a single line rather than leaving a blank one.

**Effort selection.** An Effort submenu on the picker. This is *not* a new mechanism — it surfaces the existing per-model `supportedParams` system, and appears only when a model declares an effort param that is `supported`, unlocked, and has an enumerated `allowed` list. That mirrors `_merge_inference_params`, whose enum branch keeps an override only if it is a member of that set; offering a level the backend would discard would be a lie. Selections write through the same per-model override store as every other inference param, so they ride the existing `inference_params` request path and stay in sync with Settings → Advanced.

**"More models" submenu.** New `isFeatured` flag, admin-editable, defaulting to `true` so nothing moves until someone curates. The curated templates demote Claude Sonnet 4.6, Qwen3 Coder 30B and GPT-5.6 Luna.

**A measured param spec for the OpenAI family** (see below).

## The bug this turned up

The OpenAI family on `bedrock-runtime` carried no `supportedParams` at all, which left the #915 guard **permissive**. Probing the live endpoint showed `temperature` and `top_p` are hard-rejected by every model in that family:

```
Unsupported parameter: 'temperature' is not supported with this model.
```

So a `temperature` reaching those models from any caller that can set one killed the turn with a mid-stream 400. Declaring the spec drops it before the request instead — the same failure class the guard inversion was written to close on Claude Opus 4.7.

## On the measurements

`curated-models.ts` has a standing rule against declaring a `supportedParams` spec for this family without published or measured evidence, because a declared spec flips that guard from permissive to restrictive and a wrong entry silently *blocks* a parameter the model accepts. AWS publishes no parameter table for these models, so everything here was measured against all four ids in us-west-2 on 2026-09-12:

- **Effort enum** — sending an invalid value returns a 400 that enumerates the set: `Supported values are: 'none', 'low', 'medium', 'high', 'xhigh', and 'max'.` Identical on Sol, Terra, Luna and Astra, matching the AWS launch blog. Two independent sources.
- **`temperature` / `top_p`** — hard 400 on all four.
- **Default effort** — none is published, so the question was what happens when the param is *absent*, which is **not** the same as sending `none` (absent still reasons; `none` is an explicit off). Three samples per level on Luna, reasoning tokens: unset 285/516/327 (mean 376), none 0/0/0, low ~224, medium ~308, high ~459. The implicit default already sits around medium, so declaring `medium` is cost-neutral to ~18% cheaper, **not** an increase. It is declared anyway so the provider cannot move our spend by moving their default, and so the picker can show the level in force.

`max` stays in `allowed`. It is the only level that meaningfully moves the bill (~2.3x the output tokens of unset on Terra, where reasoning bills as output); trimming the list is the lever if that exposure is ever unwanted.

## Implementation note worth knowing

The model row is a child component rather than an `<ng-template>` + `ngTemplateOutlet`. The same row renders in two menus, and `CdkMenu` finds its items with a **content** query — a template declared outside the menu belongs to the declaring view, so the rows would render but register as *zero* menu items, taking keyboard navigation and typeahead with them, silently. `model-dropdown.component.spec.ts` pins that.

Also: spacing around the `•` is margin, not template whitespace. Angular strips whitespace-only text nodes by default, so a written space silently vanishes.

## Compatibility

- `isFeatured` defaults `true` server-side and is read as `!== false`, so records written before the field existed stay exactly where they are.
- `shortDescription` falls back to nothing; the provider is always shown.
- `max_length=80` is on the create/update models but deliberately **not** on the read model — a longer stored value would otherwise fail validation and take the whole `/models` listing down.
- No migration. Existing rows are untouched until an admin edits them.

## Testing

- SPA: **2777 passing** (233 files), including 40 new tests across the picker, the effort resolver and the catalog invariants.
- Backend: **8275 passing, 3 skipped** (full suite, run against the only commit that touches backend source).
- Browser-verified end to end against real dev data: effort selection persists and reaches the provider as `{'reasoning': {'effort': ...}}`, featured/demoted split renders, descriptions render, single-line collapse works.

The catalog invariant test that previously required *no* spec was replaced rather than dropped — its bar was never "no spec" but "no invented spec", so it now asserts the measured contents and fails for a future sibling added without re-probing.

## Note for the reviewer

The three live **dev** records (Sol, Terra, Luna) were updated out-of-band to carry this spec and the featured/description curation, since curated templates only seed *new* models. Prod is untouched and will need the same treatment if this behaviour is wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

