### PR TITLE
fix(spa): stop unit specs opening real sockets, which flaked the coverage gate

### DIFF
--- a/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
+++ b/frontend/ai.client/src/app/admin/marketplace/pages/submission-review.page.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Dialog } from '@angular/cdk/dialog';
 import { signal } from '@angular/core';
 import { ActivatedRoute, Router, provideRouter } from '@angular/router';
@@ -70,6 +72,8 @@ describe('SubmissionReviewPage', () => {
     TestBed.configureTestingModule({
       providers: [
         provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: AdminMarketplaceService, useValue: mockService },
         { provide: Dialog, useValue: mockDialog },
         { provide: Router, useValue: { navigate } },
@@ -83,10 +87,32 @@ describe('SubmissionReviewPage', () => {
 
   afterEach(() => TestBed.resetTestingModule());
 
+  /**
+   * Answer the chat tree's own fetches, then wait for the page to settle.
+   *
+   * The test-drive panel mounts the real chat tree, and both `ModelService` and
+   * `FileUploadService` fetch from their constructors. Nothing here asserts on
+   * either, but neither can simply be left alone: a live backend opens a real
+   * socket (blocked in test-setup.ts) and the testing backend never answers on
+   * its own, so the request sits on Angular's `PendingTasks` queue and
+   * `whenStable()` never resolves. Flush them with an empty but well-formed
+   * payload so the tree reaches a stable state in silence.
+   */
+  async function settle(fixture: ComponentFixture<SubmissionReviewPage>): Promise<void> {
+    for (const req of TestBed.inject(HttpTestingController).match(() => true)) {
+      req.flush(
+        req.request.url.endsWith('/quota')
+          ? { usedBytes: 0, maxBytes: 1, fileCount: 0 }
+          : { models: [] },
+      );
+    }
+    await fixture.whenStable();
+  }
+
   async function render(): Promise<ComponentFixture<SubmissionReviewPage>> {
     const fixture = TestBed.createComponent(SubmissionReviewPage);
     fixture.detectChanges();
-    await fixture.whenStable();
+    await settle(fixture);
     fixture.detectChanges();
     return fixture;
   }
@@ -147,7 +173,7 @@ describe('SubmissionReviewPage', () => {
   it('declines through review with the reason and returns to the queue', async () => {
     const fixture = await render();
     button(fixture, 'Decline').click();
-    await fixture.whenStable();
+    await settle(fixture);
 
     expect(mockService.review).toHaveBeenCalledWith('ast-001', {
       decision: 'reject',
@@ -160,7 +186,7 @@ describe('SubmissionReviewPage', () => {
     mockDialog.open.mockReturnValue({ closed: of(undefined) });
     const fixture = await render();
     button(fixture, 'Decline').click();
-    await fixture.whenStable();
+    await settle(fixture);
 
     expect(mockService.review).not.toHaveBeenCalled();
   });
@@ -168,7 +194,7 @@ describe('SubmissionReviewPage', () => {
   it('approves without a dialog', async () => {
     const fixture = await render();
     button(fixture, 'Approve').click();
-    await fixture.whenStable();
+    await settle(fixture);
 
     expect(mockService.review).toHaveBeenCalledWith('ast-001', { decision: 'approve' });
   });
@@ -244,7 +270,7 @@ describe('SubmissionReviewPage', () => {
     mockService.review.mockRejectedValue({ error: { detail: 'Visibility is now Private.' } });
     const fixture = await render();
     button(fixture, 'Approve').click();
-    await fixture.whenStable();
+    await settle(fixture);
     fixture.detectChanges();
 
     const el = fixture.nativeElement as HTMLElement;
@@ -261,7 +287,7 @@ describe('SubmissionReviewPage', () => {
     mockService.review.mockRejectedValue({ error: { detail: 'Visibility is now Private.' } });
     const fixture = await render();
     button(fixture, 'Approve').click();
-    await fixture.whenStable();
+    await settle(fixture);
     fixture.detectChanges();
 
     expect(navigate).not.toHaveBeenCalled();

--- a/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
+++ b/frontend/ai.client/src/app/components/model-settings/tool-detail/tool-detail.component.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { ToolDetailComponent } from './tool-detail.component';
 import { Tool, ToolService } from '../../../services/tool/tool.service';
@@ -76,6 +78,10 @@ describe('ToolDetailComponent', () => {
     TestBed.configureTestingModule({
       imports: [ToolDetailComponent],
       providers: [
+        // ConnectorsService is reached through this component's tree and fetches
+        // in its constructor; without a testing backend that is a real socket.
+        provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ToolService, useValue: mockToolService },
         { provide: ToolCapabilityService, useValue: mockCapabilityService },
       ],

--- a/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/message-list/components/assistant-message.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { provideMarkdown, MarkdownService } from 'ngx-markdown';
 import { AssistantMessageComponent } from './assistant-message.component';
@@ -63,7 +65,10 @@ describe('AssistantMessageComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AssistantMessageComponent],
-      providers: [provideMarkdown()],
+      // The MCP App frame in this tree injects ToolService and ModelService, both
+      // of which fetch in their constructor. Without a testing backend Angular's
+      // root-provided HttpXhrBackend opens a real socket — see test-setup.ts.
+      providers: [provideMarkdown(), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     // Stub render before component creation to prevent unhandled

--- a/frontend/ai.client/src/test-setup.ts
+++ b/frontend/ai.client/src/test-setup.ts
@@ -40,3 +40,47 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
 });
+
+// Fail fast on a real network request.
+//
+// Angular 21 root-provides the entire HttpClient chain: `HttpClient`,
+// `HttpHandler` and `HttpBackend` are all `providedIn: 'root'`, and
+// `HttpBackend` resolves `useExisting: HttpXhrBackend`. A TestBed that omits
+// `provideHttpClientTesting()` therefore does NOT fail with a
+// NullInjectorError — it silently gets a live XHR backend and opens real
+// sockets to the dev API origin.
+//
+// That is how `EnvironmentTeardownError: [vitest-worker]: Closing rpc while
+// "onUserConsoleLog" was pending` reached CI. Services that load in their
+// constructor (`ToolService`, `ModelService`) fired those requests, the
+// connections were refused asynchronously, and the resulting `console.error`
+// landed after the test that created them had already finished. Vitest
+// forwards every console call to the reporter over RPC and rejects any call
+// still in flight when the worker tears down; the rejection is unhandled, so
+// the run exits non-zero with `Errors 4 errors` and every one of 2,750 tests
+// passing. Because worker assignment is timing-dependent (see `isolate: false`
+// above), whether a late log lost that race varied run to run — the same
+// commit went green on re-run, and the error named whichever spec happened to
+// be executing rather than the one that opened the socket.
+//
+// Unit tests never legitimately reach the network, so refuse the request where
+// it is issued rather than letting it fail on a socket some unknown number of
+// milliseconds later. A service that catches its own load error still logs, but
+// it logs synchronously, inside the test that caused it, and the message names
+// the URL — so the next offender is attributable instead of landing on whatever
+// spec the worker had moved on to. Specs that exercise a raw-XHR upload path
+// replace the global wholesale with `vi.stubGlobal`, which this file's
+// `unstubAllGlobals` restores back to the guard.
+if (typeof XMLHttpRequest !== 'undefined') {
+  const blockedOpen: typeof XMLHttpRequest.prototype.open = function (
+    method: string,
+    url: string | URL,
+  ): void {
+    throw new Error(
+      `Unit tests must not make real network requests (attempted ${method} ${String(url)}). ` +
+        'Add provideHttpClient() and provideHttpClientTesting() to this spec\'s TestBed, ' +
+        'or provide a stub for the service that issues the request.',
+    );
+  };
+  XMLHttpRequest.prototype.open = blockedOpen;
+}


### PR DESCRIPTION
## The flake

`Test frontend (coverage build)` failed on [#1065](https://github.com/Boise-State-Development/agentcore-public-stack/pull/1065) with **all 232 spec files and 2,750 tests passing** and `Errors 4 errors`:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
```

All four named `assistant-message.component.spec.ts` as the file that was running. Re-running the identical commit went green.

## Root cause

Reproduced locally by instrumenting vitest's `sendLog`, and confirmed exactly, not inferred.

**Angular 21 root-provides the entire HttpClient chain.** `HttpClient`, `HttpHandler` and `HttpBackend` are all `providedIn: 'root'`, and `HttpBackend` resolves `useExisting: HttpXhrBackend`. A TestBed that omits `provideHttpClientTesting()` therefore does **not** fail with a NullInjectorError — it silently gets a live XHR backend. The suite was opening **53 real connections to `http://localhost:8000`**.

`ToolService` and `ModelService` both call their loader from their *constructor*, so merely mounting a component tree that reaches them fires a request. The connection is refused asynchronously, and the resulting `console.error` lands **after the test that created it has finished**.

Vitest forwards every console call to the reporter over RPC (`onUserConsoleLog`) and, in `execute()`'s `finally`, rejects whatever is still pending when the worker tears down. `sendLog` does not catch, so the rejection is unhandled → counted as a run error → non-zero exit with every test passing.

The instrumentation counted **exactly four console logs emitted with no test running** — one for one with `Errors 4 errors`. They were `Tool load error:` and `Error loading models:`, each twice. Because worker assignment is timing-dependent (`isolate: false`), whether a late log loses that race varies run to run, and the reported file is whichever spec the worker had moved on to — not the one that opened the socket.

Upstream is aware of the class ([vitest-dev/vitest#8649](https://github.com/vitest-dev/vitest/issues/8649), [#9872](https://github.com/vitest-dev/vitest/issues/9872)); it is unfixed in every 4.1.x through 4.1.11, so an upgrade is not the answer.

## The fix

| File | Change |
|---|---|
| `src/test-setup.ts` | Refuse a real `XMLHttpRequest.open()` with a message naming the method and URL. Documents the class alongside the existing `isolate: false` backstop. |
| `assistant-message.component.spec.ts` | Add `provideHttpClient()` + `provideHttpClientTesting()` — the MCP App frame in its tree reaches `ToolService`/`ModelService`. |
| `tool-detail.component.spec.ts` | Same; its tree reaches `ConnectorsService`. |
| `submission-review.page.spec.ts` | The test-drive panel mounts the real chat tree, whose constructor fetches keep Angular's `PendingTasks` queue non-empty — a testing backend alone hangs `whenStable()` forever. A `settle()` helper flushes them with an empty but well-formed payload. |

The guard is the part that makes this stick: any future spec that reaches a fetch-on-construct service now fails where the request is issued, with the URL in the message, instead of as a stray log in an unrelated spec minutes later.

## Verification

Measured over full `bash scripts/frontend/test.sh` runs on this machine, with vitest's console path instrumented to count every `onUserConsoleLog`:

| | before | after |
|---|---|---|
| Real sockets opened | 53 | **0** |
| Console logs in the suite | 66 | **14** |
| Console logs emitted with **no test running** | **4** | **0** |
| Test files / tests | 232 / 2750 pass | 232 / 2750 pass |

Both gates run clean end to end: `bash scripts/frontend/test.sh` (exit 0) and `npm run test:ci` (exit 0). `tsc --noEmit -p tsconfig.spec.json` clean.

### Residual risk

The race needs console output emitted with no test running. There is none left in the suite, and the guard stops the mechanism that produced it. A different RPC method (`fetch`, `onUnhandledError`) could in principle hit the same upstream teardown bug; nothing in the suite currently does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)