### PR TITLE
perf(api): cache the tenant-global config catalogs read on first load

### DIFF
--- a/backend/Dockerfile.kb-sync
+++ b/backend/Dockerfile.kb-sync
@@ -34,6 +34,12 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY backend/src/apis/shared/__init__.py ${LAMBDA_TASK_ROOT}/apis/shared/__init__.py
 COPY backend/src/apis/shared/timestamps.py ${LAMBDA_TASK_ROOT}/apis/shared/timestamps.py
 COPY backend/src/apis/shared/dynamo_errors.py ${LAMBDA_TASK_ROOT}/apis/shared/dynamo_errors.py
+# feature_flags.py + caching/ — oauth/provider_repository.py memoizes its
+# provider list in the process-wide config cache, which reads the
+# CONFIG_CACHE_ENABLED kill switch. Both are module-level imports, so a miss
+# here is a cold-start ModuleNotFoundError, not a degraded path.
+COPY backend/src/apis/shared/feature_flags.py ${LAMBDA_TASK_ROOT}/apis/shared/feature_flags.py
+COPY backend/src/apis/shared/caching/ ${LAMBDA_TASK_ROOT}/apis/shared/caching/
 COPY backend/src/apis/shared/sync_policies/ ${LAMBDA_TASK_ROOT}/apis/shared/sync_policies/
 COPY backend/src/apis/shared/oauth/ ${LAMBDA_TASK_ROOT}/apis/shared/oauth/
 COPY backend/src/apis/shared/embeddings/ ${LAMBDA_TASK_ROOT}/apis/shared/embeddings/

--- a/backend/src/apis/shared/caching/__init__.py
+++ b/backend/src/apis/shared/caching/__init__.py
@@ -1,0 +1,27 @@
+"""Shared caching primitives."""
+
+from .config_cache import (
+    MANAGED_MODELS,
+    OAUTH_PROVIDERS_ALL,
+    OAUTH_PROVIDERS_ENABLED,
+    SYSTEM_PROMPTS,
+    TOOL_CATALOG,
+    ConfigListCache,
+    get_config_cache,
+    get_or_load,
+    invalidate,
+    invalidate_oauth_providers,
+)
+
+__all__ = [
+    "MANAGED_MODELS",
+    "OAUTH_PROVIDERS_ALL",
+    "OAUTH_PROVIDERS_ENABLED",
+    "SYSTEM_PROMPTS",
+    "TOOL_CATALOG",
+    "ConfigListCache",
+    "get_config_cache",
+    "get_or_load",
+    "invalidate",
+    "invalidate_oauth_providers",
+]

--- a/backend/src/apis/shared/caching/config_cache.py
+++ b/backend/src/apis/shared/caching/config_cache.py
@@ -1,0 +1,215 @@
+"""TTL + single-flight cache for tenant-global config item lists.
+
+The SPA's first load reads several catalogs that are the *same for everyone*
+on the deployment — the model catalog, the tool catalog, the system-prompt
+list, the connector list. Each read was an uncached DynamoDB scan (or, for
+connectors, a GSI query) that also re-parsed every row. A classroom signing in
+together ran one of each per student.
+
+Two properties matter here, and the second is the one that actually shows up
+under a burst:
+
+**TTL.** A catalog changes when an admin edits it, which is rare, so a short
+window collapses ~all of the reads.
+
+**Single flight.** A cold cache with 300 simultaneous requests would otherwise
+produce 300 concurrent scans — the stampede lands at exactly the moment the
+burst does, which is the case this exists to prevent. One loader runs per key;
+everyone else awaits it.
+
+## What is cached: raw items, not parsed objects
+
+Entries hold the **raw DynamoDB items**, and callers re-parse on every read.
+
+That is deliberate, and it is not a missed optimization. Callers mutate the
+objects these lists produce: ``hydrate_model_roles`` documents itself as
+"models to hydrate (mutated in place and returned)" and writes
+``allowed_app_roles`` onto each model, and ``list_tools_with_roles`` does the
+same to ``ToolDefinition``. Caching parsed objects would hand every caller a
+reference to one shared instance, so an admin opening the models page would
+write derived, display-only role fields onto the objects subsequently served
+to every user — and per CLAUDE.md ``allowedAppRoles`` is precisely the field
+that must never be mistaken for a grant.
+
+Re-parsing costs microseconds of CPU against a network round trip of ~50-100ms
+(measured medians: ``/models`` 46ms, ``/tools/`` 91ms), so the saving that
+matters is kept while the shared-mutable-state class of bug is designed out
+entirely — including for callers added later, who cannot be audited in advance.
+
+The list itself is shallow-copied on read so a caller cannot append to or sort
+the cached list. The item dicts are shared; parsers treat them as read-only.
+
+## Scope: per process, like the rest of our caches
+
+This is an in-process cache, matching ``AppRoleCache`` and the roles-version
+watermark. A write invalidates only the task that served it, so a second ECS
+task can serve a stale catalog until its entry expires. That is why the default
+TTL is short (60s) rather than the 5-10 minutes ``AppRoleCache`` uses for
+authorization data: an admin edit should not appear to "not take" for minutes.
+Bounding it to a minute keeps the burst win (a classroom arrives inside a few
+seconds) while keeping admin feedback close to immediate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 60
+
+# Cache keys. Named here rather than passed as bare strings at each call site
+# so a typo cannot silently create a second, never-invalidated entry.
+MANAGED_MODELS = "managed_models"
+TOOL_CATALOG = "tool_catalog"
+SYSTEM_PROMPTS = "system_prompts"
+
+# Providers are read two ways — the enabled-only GSI query that `/connectors/`
+# uses on first load, and the full scan the admin console uses. They are
+# separate entries because they return different rows, and BOTH are dropped on
+# any provider write: `enabled` is part of the GSI partition key, so flipping it
+# moves a provider between the two result sets.
+OAUTH_PROVIDERS_ENABLED = "oauth_providers:enabled"
+OAUTH_PROVIDERS_ALL = "oauth_providers:all"
+
+Items = List[dict]
+Loader = Callable[[], Awaitable[Items]]
+
+
+def _ttl_seconds() -> int:
+    """Cache lifetime, from ``CONFIG_CACHE_TTL_SECONDS``.
+
+    A non-numeric or negative value falls back to the default rather than
+    raising: a malformed env var should degrade to sane caching, not break
+    every catalog read on the deployment.
+    """
+    raw = os.environ.get("CONFIG_CACHE_TTL_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "CONFIG_CACHE_TTL_SECONDS=%r is not an integer; using %ds",
+            raw,
+            DEFAULT_TTL_SECONDS,
+        )
+        return DEFAULT_TTL_SECONDS
+    if value < 0:
+        logger.warning(
+            "CONFIG_CACHE_TTL_SECONDS=%d is negative; using %ds",
+            value,
+            DEFAULT_TTL_SECONDS,
+        )
+        return DEFAULT_TTL_SECONDS
+    return value
+
+
+class ConfigListCache:
+    """TTL cache with single-flight loading, holding raw DynamoDB items."""
+
+    def __init__(self) -> None:
+        # key -> (expires_at_monotonic, items)
+        self._entries: Dict[str, tuple[float, Items]] = {}
+        # key -> lock serialising loads for that key. Created lazily; an
+        # asyncio.Lock built at import time would be fine on 3.10+ but the
+        # per-key dict has to be lazy regardless.
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    def _lock_for(self, key: str) -> asyncio.Lock:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        return lock
+
+    def _live_entry(self, key: str) -> Optional[Items]:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        expires_at, items = entry
+        if time.monotonic() >= expires_at:
+            return None
+        return items
+
+    async def get_or_load(self, key: str, loader: Loader) -> Items:
+        """Return cached items for ``key``, loading via ``loader`` on a miss.
+
+        Concurrent callers that miss together run ``loader`` exactly once; the
+        rest wait on the same load and read the result.
+
+        A loader that raises propagates to every waiter and caches nothing, so
+        the next request retries rather than inheriting a failure. An expired
+        entry is not served as a fallback: these catalogs drive authorization
+        surfaces, and serving one the store may have since changed is worse
+        than surfacing the error the caller already knows how to handle.
+        """
+        from apis.shared.feature_flags import config_cache_enabled
+
+        if not config_cache_enabled():
+            return await loader()
+
+        cached = self._live_entry(key)
+        if cached is not None:
+            return list(cached)
+
+        async with self._lock_for(key):
+            # Re-check: another coroutine may have loaded while we queued.
+            cached = self._live_entry(key)
+            if cached is not None:
+                return list(cached)
+
+            items = await loader()
+            self._entries[key] = (time.monotonic() + _ttl_seconds(), items)
+            logger.debug("Config cache filled %s (%d items)", key, len(items))
+            return list(items)
+
+    def invalidate(self, key: str) -> None:
+        """Drop ``key`` so the next read reloads from DynamoDB.
+
+        Called from the write paths themselves rather than from admin routes,
+        so a new mutation cannot forget to invalidate.
+        """
+        if self._entries.pop(key, None) is not None:
+            logger.debug("Config cache invalidated %s", key)
+
+    def clear(self) -> None:
+        """Drop every entry. For tests and process-wide invalidation."""
+        self._entries.clear()
+
+
+_cache: Optional[ConfigListCache] = None
+
+
+def get_config_cache() -> ConfigListCache:
+    """Return the process-wide cache instance."""
+    global _cache
+    if _cache is None:
+        _cache = ConfigListCache()
+    return _cache
+
+
+async def get_or_load(key: str, loader: Loader) -> Items:
+    """Module-level convenience wrapper over the process-wide cache."""
+    return await get_config_cache().get_or_load(key, loader)
+
+
+def invalidate(key: str) -> None:
+    """Module-level convenience wrapper over the process-wide cache."""
+    get_config_cache().invalidate(key)
+
+
+def invalidate_oauth_providers() -> None:
+    """Drop both provider entries.
+
+    Always both: ``enabled`` is part of the GSI partition key backing the
+    enabled-only read, so a write that flips it changes what BOTH the query and
+    the scan return.
+    """
+    cache = get_config_cache()
+    cache.invalidate(OAUTH_PROVIDERS_ENABLED)
+    cache.invalidate(OAUTH_PROVIDERS_ALL)

--- a/backend/src/apis/shared/feature_flags.py
+++ b/backend/src/apis/shared/feature_flags.py
@@ -282,3 +282,24 @@ def tool_summaries_enabled() -> bool:
     before they are sent), which is why it is affordable to leave on.
     """
     return os.environ.get("TOOL_SUMMARIES_ENABLED", "").strip().lower() != "false"
+
+
+def config_cache_enabled() -> bool:
+    """Whether tenant-global config catalogs are served from the in-process cache.
+
+    Covers the model catalog, tool catalog, system-prompt list and connector
+    list — the lists every user's first load reads and that only an admin edit
+    changes. **Default ON with a kill switch** (house style, mirroring
+    ``scheduled_runs_enabled``): unset or empty resolves to enabled; only the
+    literal ``"false"`` (case-insensitive) disables.
+
+    While off, every read goes straight to DynamoDB exactly as before — the
+    loaders are unchanged and still correct, they simply stop being memoized.
+    Turning this off costs latency and read units, never correctness, which is
+    what makes it a safe switch to flip if a stale catalog is ever suspected.
+
+    Note the cache is per process (see ``apis.shared.caching.config_cache``), so
+    a write invalidates only the task that served it; other tasks catch up
+    within ``CONFIG_CACHE_TTL_SECONDS`` (default 60).
+    """
+    return os.environ.get("CONFIG_CACHE_ENABLED", "").strip().lower() != "false"

--- a/backend/src/apis/shared/models/managed_models.py
+++ b/backend/src/apis/shared/models/managed_models.py
@@ -4,6 +4,7 @@ This service handles CRUD operations for managed models.
 Requires DynamoDB storage via DYNAMODB_MANAGED_MODELS_TABLE_NAME.
 """
 
+import asyncio
 import logging
 import os
 import uuid
@@ -14,6 +15,7 @@ from decimal import Decimal
 import boto3
 from botocore.exceptions import ClientError
 
+from apis.shared.caching import config_cache
 from .models import ManagedModel, ManagedModelCreate, ManagedModelUpdate
 
 logger = logging.getLogger(__name__)
@@ -224,7 +226,11 @@ async def create_managed_model(model_data: ManagedModelCreate) -> ManagedModel:
     managed_models_table = os.environ.get('DYNAMODB_MANAGED_MODELS_TABLE_NAME')
     if not managed_models_table:
         raise RuntimeError("DYNAMODB_MANAGED_MODELS_TABLE_NAME environment variable is required")
-    return await _create_managed_model_cloud(model_data, managed_models_table)
+    created = await _create_managed_model_cloud(model_data, managed_models_table)
+    # Invalidate here rather than in the admin route: every write to this table
+    # funnels through these three functions, so a future caller cannot forget.
+    config_cache.invalidate(config_cache.MANAGED_MODELS)
+    return created
 
 
 async def _create_managed_model_cloud(model_data: ManagedModelCreate, table_name: str) -> ManagedModel:
@@ -470,9 +476,41 @@ async def list_all_managed_models() -> List[ManagedModel]:
     return await _list_managed_models_cloud(managed_models_table)
 
 
+def _scan_managed_model_items(table_name: str) -> List[dict]:
+    """Scan the raw MODEL# items. Blocking; call via ``asyncio.to_thread``."""
+    table = dynamodb.Table(table_name)
+
+    response = table.scan(
+        FilterExpression='begins_with(PK, :pk_prefix)',
+        ExpressionAttributeValues={
+            ':pk_prefix': 'MODEL#'
+        }
+    )
+
+    items = response.get('Items', [])
+
+    # Handle pagination
+    while 'LastEvaluatedKey' in response:
+        response = table.scan(
+            FilterExpression='begins_with(PK, :pk_prefix)',
+            ExpressionAttributeValues={
+                ':pk_prefix': 'MODEL#'
+            },
+            ExclusiveStartKey=response['LastEvaluatedKey']
+        )
+        items.extend(response.get('Items', []))
+
+    return items
+
+
 async def _list_managed_models_cloud(table_name: str) -> List[ManagedModel]:
     """
     List all managed models from DynamoDB
+
+    The scan is cached per process (see ``apis.shared.caching.config_cache``);
+    parsing is not. Callers mutate the models they receive — the admin list
+    route hands them straight to ``hydrate_model_roles``, which writes
+    ``allowed_app_roles`` in place — so each caller must get objects it owns.
 
     Args:
         table_name: DynamoDB table name
@@ -480,30 +518,13 @@ async def _list_managed_models_cloud(table_name: str) -> List[ManagedModel]:
     Returns:
         List of ManagedModel objects
     """
-    table = dynamodb.Table(table_name)
     models = []
 
     try:
-        # Scan table for all models (PK starts with MODEL#)
-        response = table.scan(
-            FilterExpression='begins_with(PK, :pk_prefix)',
-            ExpressionAttributeValues={
-                ':pk_prefix': 'MODEL#'
-            }
+        items = await config_cache.get_or_load(
+            config_cache.MANAGED_MODELS,
+            lambda: asyncio.to_thread(_scan_managed_model_items, table_name),
         )
-
-        items = response.get('Items', [])
-
-        # Handle pagination
-        while 'LastEvaluatedKey' in response:
-            response = table.scan(
-                FilterExpression='begins_with(PK, :pk_prefix)',
-                ExpressionAttributeValues={
-                    ':pk_prefix': 'MODEL#'
-                },
-                ExclusiveStartKey=response['LastEvaluatedKey']
-            )
-            items.extend(response.get('Items', []))
 
         # Convert items to ManagedModel objects
         for item in items:
@@ -562,7 +583,9 @@ async def update_managed_model(model_id: str, updates: ManagedModelUpdate) -> Op
     managed_models_table = os.environ.get('DYNAMODB_MANAGED_MODELS_TABLE_NAME')
     if not managed_models_table:
         raise RuntimeError("DYNAMODB_MANAGED_MODELS_TABLE_NAME environment variable is required")
-    return await _update_managed_model_cloud(model_id, updates, managed_models_table)
+    updated = await _update_managed_model_cloud(model_id, updates, managed_models_table)
+    config_cache.invalidate(config_cache.MANAGED_MODELS)
+    return updated
 
 
 async def _update_managed_model_cloud(model_id: str, updates: ManagedModelUpdate, table_name: str) -> Optional[ManagedModel]:
@@ -707,7 +730,9 @@ async def delete_managed_model(model_id: str) -> bool:
     managed_models_table = os.environ.get('DYNAMODB_MANAGED_MODELS_TABLE_NAME')
     if not managed_models_table:
         raise RuntimeError("DYNAMODB_MANAGED_MODELS_TABLE_NAME environment variable is required")
-    return await _delete_managed_model_cloud(model_id, managed_models_table)
+    deleted = await _delete_managed_model_cloud(model_id, managed_models_table)
+    config_cache.invalidate(config_cache.MANAGED_MODELS)
+    return deleted
 
 
 async def _delete_managed_model_cloud(model_id: str, table_name: str) -> bool:

--- a/backend/src/apis/shared/oauth/provider_repository.py
+++ b/backend/src/apis/shared/oauth/provider_repository.py
@@ -5,6 +5,7 @@ provider ARN and callback URL) live here. `clientId` / `clientSecret` are
 registered directly with AgentCore Identity by the admin route.
 """
 
+import asyncio
 import logging
 import os
 from typing import List, Optional
@@ -12,6 +13,7 @@ from typing import List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
+from apis.shared.caching import config_cache
 from .models import OAuthProvider, OAuthProviderUpdate
 from apis.shared.timestamps import utc_now_iso
 
@@ -67,34 +69,19 @@ class OAuthProviderRepository:
             return []
 
         try:
+            # Two entries, because the branches return different rows. Both are
+            # dropped on any write — see `invalidate_oauth_providers`. Parsing
+            # stays per-call so each caller owns its OAuthProvider objects.
             if enabled_only:
-                response = self._table.query(
-                    IndexName="EnabledProvidersIndex",
-                    KeyConditionExpression="GSI1PK = :pk",
-                    ExpressionAttributeValues={":pk": "ENABLED#true"},
+                items = await config_cache.get_or_load(
+                    config_cache.OAUTH_PROVIDERS_ENABLED,
+                    lambda: asyncio.to_thread(self._query_enabled_provider_items),
                 )
-                items = response.get("Items", [])
-                while "LastEvaluatedKey" in response:
-                    response = self._table.query(
-                        IndexName="EnabledProvidersIndex",
-                        KeyConditionExpression="GSI1PK = :pk",
-                        ExpressionAttributeValues={":pk": "ENABLED#true"},
-                        ExclusiveStartKey=response["LastEvaluatedKey"],
-                    )
-                    items.extend(response.get("Items", []))
             else:
-                response = self._table.scan(
-                    FilterExpression="SK = :sk",
-                    ExpressionAttributeValues={":sk": "CONFIG"},
+                items = await config_cache.get_or_load(
+                    config_cache.OAUTH_PROVIDERS_ALL,
+                    lambda: asyncio.to_thread(self._scan_provider_items),
                 )
-                items = response.get("Items", [])
-                while "LastEvaluatedKey" in response:
-                    response = self._table.scan(
-                        FilterExpression="SK = :sk",
-                        ExpressionAttributeValues={":sk": "CONFIG"},
-                        ExclusiveStartKey=response["LastEvaluatedKey"],
-                    )
-                    items.extend(response.get("Items", []))
 
             providers = [OAuthProvider.from_dynamo_item(item) for item in items]
             providers.sort(key=lambda p: p.display_name.lower())
@@ -102,6 +89,40 @@ class OAuthProviderRepository:
         except ClientError as e:
             logger.error("Error listing providers: %s", e)
             raise
+
+    def _query_enabled_provider_items(self) -> List[dict]:
+        """Query raw enabled-provider items. Blocking; call via ``to_thread``."""
+        response = self._table.query(
+            IndexName="EnabledProvidersIndex",
+            KeyConditionExpression="GSI1PK = :pk",
+            ExpressionAttributeValues={":pk": "ENABLED#true"},
+        )
+        items = response.get("Items", [])
+        while "LastEvaluatedKey" in response:
+            response = self._table.query(
+                IndexName="EnabledProvidersIndex",
+                KeyConditionExpression="GSI1PK = :pk",
+                ExpressionAttributeValues={":pk": "ENABLED#true"},
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            items.extend(response.get("Items", []))
+        return items
+
+    def _scan_provider_items(self) -> List[dict]:
+        """Scan all raw provider items. Blocking; call via ``to_thread``."""
+        response = self._table.scan(
+            FilterExpression="SK = :sk",
+            ExpressionAttributeValues={":sk": "CONFIG"},
+        )
+        items = response.get("Items", [])
+        while "LastEvaluatedKey" in response:
+            response = self._table.scan(
+                FilterExpression="SK = :sk",
+                ExpressionAttributeValues={":sk": "CONFIG"},
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            items.extend(response.get("Items", []))
+        return items
 
     # ------------------------------------------------------------------ writes
     async def put_provider(self, provider: OAuthProvider) -> OAuthProvider:
@@ -114,6 +135,7 @@ class OAuthProviderRepository:
             raise RuntimeError("OAuth provider repository is not enabled")
 
         self._table.put_item(Item=provider.to_dynamo_item())
+        config_cache.invalidate_oauth_providers()
         logger.info("Upserted OAuth provider: %s", provider.provider_id)
         return provider
 
@@ -165,6 +187,7 @@ class OAuthProviderRepository:
 
         existing.updated_at = utc_now_iso()
         self._table.put_item(Item=existing.to_dynamo_item())
+        config_cache.invalidate_oauth_providers()
         logger.info("Updated OAuth provider metadata: %s", provider_id)
         return existing
 
@@ -180,6 +203,7 @@ class OAuthProviderRepository:
             self._table.delete_item(
                 Key={"PK": f"PROVIDER#{provider_id}", "SK": "CONFIG"}
             )
+            config_cache.invalidate_oauth_providers()
             logger.info("Deleted OAuth provider: %s", provider_id)
             return True
         except ClientError as e:

--- a/backend/src/apis/shared/system_prompts/repository.py
+++ b/backend/src/apis/shared/system_prompts/repository.py
@@ -1,5 +1,6 @@
 """DynamoDB repository for admin-managed system prompts."""
 
+import asyncio
 import logging
 import os
 import uuid
@@ -8,6 +9,7 @@ from typing import List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
+from apis.shared.caching import config_cache
 from .models import SystemPrompt, SystemPromptCreate, SystemPromptUpdate
 from apis.shared.timestamps import utc_now_iso
 
@@ -53,18 +55,12 @@ class SystemPromptsRepository:
             return []
 
         try:
-            response = self._table.scan(
-                FilterExpression="SK = :sk",
-                ExpressionAttributeValues={":sk": "METADATA"},
+            # Cached per process; parsing stays per-call so each caller owns
+            # the SystemPrompt objects it gets back.
+            items = await config_cache.get_or_load(
+                config_cache.SYSTEM_PROMPTS,
+                lambda: asyncio.to_thread(self._scan_prompt_items),
             )
-            items = response.get("Items", [])
-            while "LastEvaluatedKey" in response:
-                response = self._table.scan(
-                    FilterExpression="SK = :sk",
-                    ExpressionAttributeValues={":sk": "METADATA"},
-                    ExclusiveStartKey=response["LastEvaluatedKey"],
-                )
-                items.extend(response.get("Items", []))
         except ClientError:
             logger.error("Error listing system prompts", exc_info=True)
             raise
@@ -74,6 +70,22 @@ class SystemPromptsRepository:
             prompts = [p for p in prompts if p.status == "enabled"]
         prompts.sort(key=lambda p: p.name.lower())
         return prompts
+
+    def _scan_prompt_items(self) -> List[dict]:
+        """Scan the raw PROMPT# items. Blocking; call via ``asyncio.to_thread``."""
+        response = self._table.scan(
+            FilterExpression="SK = :sk",
+            ExpressionAttributeValues={":sk": "METADATA"},
+        )
+        items = response.get("Items", [])
+        while "LastEvaluatedKey" in response:
+            response = self._table.scan(
+                FilterExpression="SK = :sk",
+                ExpressionAttributeValues={":sk": "METADATA"},
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            items.extend(response.get("Items", []))
+        return items
 
     async def get_prompt(self, prompt_id: str) -> Optional[SystemPrompt]:
         """Return a single prompt by ID, or None if not found."""
@@ -119,6 +131,7 @@ class SystemPromptsRepository:
             logger.error("Error creating system prompt", exc_info=True)
             raise
 
+        config_cache.invalidate(config_cache.SYSTEM_PROMPTS)
         logger.info(f"Created system prompt: {prompt.prompt_id} name={prompt.name!r}")
         return prompt
 
@@ -156,6 +169,7 @@ class SystemPromptsRepository:
             logger.error("Error updating system prompt", exc_info=True)
             raise
 
+        config_cache.invalidate(config_cache.SYSTEM_PROMPTS)
         logger.info(f"Updated system prompt: {prompt_id}")
         return existing
 
@@ -173,6 +187,7 @@ class SystemPromptsRepository:
         except ClientError:
             logger.error("Error deleting system prompt", exc_info=True)
             raise
+        config_cache.invalidate(config_cache.SYSTEM_PROMPTS)
         logger.info(f"Deleted system prompt: {prompt_id}")
         return True
 

--- a/backend/src/apis/shared/tools/repository.py
+++ b/backend/src/apis/shared/tools/repository.py
@@ -5,6 +5,7 @@ DynamoDB operations for tool catalog and user preferences.
 Uses the same table as AppRoles with different PK patterns.
 """
 
+import asyncio
 import os
 import logging
 from datetime import datetime, timezone
@@ -13,6 +14,7 @@ from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
 
+from apis.shared.caching import config_cache
 from .models import (
     ToolCapabilitySnapshot,
     ToolDefinition,
@@ -131,42 +133,17 @@ class ToolCatalogRepository:
         """
         try:
             if category:
-                # Use GSI1 for category queries
-                response = self._table.query(
-                    IndexName="JwtRoleMappingIndex",
-                    KeyConditionExpression="GSI1PK = :pk",
-                    ExpressionAttributeValues={":pk": f"CATEGORY#{category}"},
-                )
-                items = response.get("Items", [])
-
-                # Handle pagination
-                while "LastEvaluatedKey" in response:
-                    response = self._table.query(
-                        IndexName="JwtRoleMappingIndex",
-                        KeyConditionExpression="GSI1PK = :pk",
-                        ExpressionAttributeValues={":pk": f"CATEGORY#{category}"},
-                        ExclusiveStartKey=response["LastEvaluatedKey"],
-                    )
-                    items.extend(response.get("Items", []))
+                items = await asyncio.to_thread(self._query_tool_items_by_category, category)
             else:
-                # Scan for all tools
-                filter_expr = "begins_with(PK, :pk_prefix) AND SK = :sk"
-                expr_values = {":pk_prefix": "TOOL#", ":sk": "METADATA"}
-
-                response = self._table.scan(
-                    FilterExpression=filter_expr,
-                    ExpressionAttributeValues=expr_values,
+                # The whole-catalog read is the one on the SPA's first-load path
+                # (GET /tools/), so it is cached per process; parsing below is
+                # not, because callers mutate what they get back — see
+                # `list_tools_with_roles`, which writes `allowed_app_roles` onto
+                # each ToolDefinition in place.
+                items = await config_cache.get_or_load(
+                    config_cache.TOOL_CATALOG,
+                    lambda: asyncio.to_thread(self._scan_tool_items),
                 )
-                items = response.get("Items", [])
-
-                # Handle pagination
-                while "LastEvaluatedKey" in response:
-                    response = self._table.scan(
-                        FilterExpression=filter_expr,
-                        ExpressionAttributeValues=expr_values,
-                        ExclusiveStartKey=response["LastEvaluatedKey"],
-                    )
-                    items.extend(response.get("Items", []))
 
             tools = [ToolDefinition.from_dynamo_item(item) for item in items]
 
@@ -182,6 +159,52 @@ class ToolCatalogRepository:
         except ClientError as e:
             logger.error(f"Error listing tools: {e}")
             raise
+
+    def _scan_tool_items(self) -> List[dict]:
+        """Scan the raw TOOL#/METADATA items. Blocking; call via ``to_thread``."""
+        filter_expr = "begins_with(PK, :pk_prefix) AND SK = :sk"
+        expr_values = {":pk_prefix": "TOOL#", ":sk": "METADATA"}
+
+        response = self._table.scan(
+            FilterExpression=filter_expr,
+            ExpressionAttributeValues=expr_values,
+        )
+        items = response.get("Items", [])
+
+        while "LastEvaluatedKey" in response:
+            response = self._table.scan(
+                FilterExpression=filter_expr,
+                ExpressionAttributeValues=expr_values,
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            items.extend(response.get("Items", []))
+
+        return items
+
+    def _query_tool_items_by_category(self, category: str) -> List[dict]:
+        """Query raw items for one category. Blocking; call via ``to_thread``.
+
+        Not cached: it is a bounded GSI query off the first-load path, and
+        caching per category would multiply the invalidation surface for no
+        measured gain.
+        """
+        response = self._table.query(
+            IndexName="JwtRoleMappingIndex",
+            KeyConditionExpression="GSI1PK = :pk",
+            ExpressionAttributeValues={":pk": f"CATEGORY#{category}"},
+        )
+        items = response.get("Items", [])
+
+        while "LastEvaluatedKey" in response:
+            response = self._table.query(
+                IndexName="JwtRoleMappingIndex",
+                KeyConditionExpression="GSI1PK = :pk",
+                ExpressionAttributeValues={":pk": f"CATEGORY#{category}"},
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            items.extend(response.get("Items", []))
+
+        return items
 
     async def create_tool(self, tool: ToolDefinition) -> ToolDefinition:
         """
@@ -214,6 +237,9 @@ class ToolCatalogRepository:
                 ConditionExpression="attribute_not_exists(PK)",
             )
 
+            # Invalidate in the repository, not the admin route: every write
+            # to the catalog lands here, so a new caller cannot forget to.
+            config_cache.invalidate(config_cache.TOOL_CATALOG)
             logger.info(f"Created tool: {tool.tool_id}")
             return tool
 
@@ -256,6 +282,7 @@ class ToolCatalogRepository:
             item = existing.to_dynamo_item()
             self._table.put_item(Item=item)
 
+            config_cache.invalidate(config_cache.TOOL_CATALOG)
             logger.info(f"Updated tool: {tool_id}")
             return existing
 
@@ -282,6 +309,7 @@ class ToolCatalogRepository:
                 Key={"PK": f"TOOL#{tool_id}", "SK": "METADATA"}
             )
 
+            config_cache.invalidate(config_cache.TOOL_CATALOG)
             logger.info(f"Deleted tool: {tool_id}")
             return True
 
@@ -496,6 +524,7 @@ class ToolCatalogRepository:
                     item = tool.to_dynamo_item()
                     batch.put_item(Item=item)
 
+            config_cache.invalidate(config_cache.TOOL_CATALOG)
             logger.info(f"Batch created {len(tools)} tools")
             return tools
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -106,6 +106,30 @@ _ENV_CONFIG_BLEED_PREFIXES = (
 
 
 @pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """Drop the process-wide config-catalog cache between tests.
+
+    ``apis.shared.caching.config_cache`` memoizes the model / tool /
+    system-prompt / provider catalogs for the life of the process. In
+    production that is invalidated by the write paths themselves, but tests
+    swap the whole table out underneath it — fixtures already reset the
+    module-level repo and service singletons for the same reason, and this is
+    the same class of state. Without it, a test that seeds a catalog leaves the
+    next test reading the previous one's rows.
+
+    A backstop, not the primary contract: production correctness comes from the
+    invalidation in the repositories, not from here.
+    """
+    from apis.shared.caching import config_cache
+
+    config_cache.get_config_cache().clear()
+    try:
+        yield
+    finally:
+        config_cache.get_config_cache().clear()
+
+
+@pytest.fixture(autouse=True)
 def _clear_env_config_bleed():
     saved = {
         k: os.environ.pop(k)

--- a/backend/tests/shared/test_config_cache.py
+++ b/backend/tests/shared/test_config_cache.py
@@ -1,0 +1,240 @@
+"""Tests for the tenant-global config catalog cache.
+
+The behaviours worth pinning here are the ones that would silently regress:
+single-flight under a burst (the case the cache exists for), invalidation on
+write, and the raw-items contract that keeps a mutating caller from poisoning
+what every other user sees.
+"""
+
+import asyncio
+
+import pytest
+
+from apis.shared.caching import config_cache
+from apis.shared.caching.config_cache import ConfigListCache
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    """Every test starts on an empty, enabled, default-TTL cache."""
+    monkeypatch.delenv("CONFIG_CACHE_ENABLED", raising=False)
+    monkeypatch.delenv("CONFIG_CACHE_TTL_SECONDS", raising=False)
+    config_cache.get_config_cache().clear()
+    yield
+    config_cache.get_config_cache().clear()
+
+
+def _counting_loader(items, calls):
+    async def loader():
+        calls.append(1)
+        return list(items)
+    return loader
+
+
+class TestCaching:
+    @pytest.mark.asyncio
+    async def test_second_read_does_not_hit_the_loader(self):
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        first = await cache.get_or_load("k", loader)
+        second = await cache.get_or_load("k", loader)
+
+        assert len(calls) == 1
+        assert first == second == [{"id": "a"}]
+
+    @pytest.mark.asyncio
+    async def test_keys_are_independent(self):
+        cache = ConfigListCache()
+        calls_a, calls_b = [], []
+
+        await cache.get_or_load("a", _counting_loader([{"id": "a"}], calls_a))
+        await cache.get_or_load("b", _counting_loader([{"id": "b"}], calls_b))
+
+        assert len(calls_a) == 1
+        assert len(calls_b) == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_entry_reloads(self, monkeypatch):
+        monkeypatch.setenv("CONFIG_CACHE_TTL_SECONDS", "0")
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        await cache.get_or_load("k", loader)
+        await cache.get_or_load("k", loader)
+
+        # TTL 0 means every entry is already expired on read.
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_malformed_ttl_falls_back_to_default(self, monkeypatch):
+        """A bad env var should degrade to sane caching, not break every read."""
+        monkeypatch.setenv("CONFIG_CACHE_TTL_SECONDS", "not-a-number")
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        await cache.get_or_load("k", loader)
+        await cache.get_or_load("k", loader)
+
+        assert len(calls) == 1
+
+
+class TestSingleFlight:
+    @pytest.mark.asyncio
+    async def test_concurrent_miss_loads_once(self):
+        """The stampede case: a cold cache and a classroom arriving together.
+
+        Without single flight this is one scan per request, and the pileup
+        lands at exactly the moment the burst does.
+        """
+        cache = ConfigListCache()
+        calls = []
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_loader():
+            calls.append(1)
+            started.set()
+            await release.wait()
+            return [{"id": "a"}]
+
+        waiters = [asyncio.create_task(cache.get_or_load("k", slow_loader)) for _ in range(50)]
+        await started.wait()
+        release.set()
+        results = await asyncio.gather(*waiters)
+
+        assert len(calls) == 1
+        assert all(r == [{"id": "a"}] for r in results)
+
+    @pytest.mark.asyncio
+    async def test_loader_failure_is_not_cached(self):
+        """A failed load must not strand later callers on a cached error."""
+        cache = ConfigListCache()
+        calls = []
+
+        async def failing_loader():
+            calls.append(1)
+            raise RuntimeError("dynamo down")
+
+        with pytest.raises(RuntimeError):
+            await cache.get_or_load("k", failing_loader)
+
+        # Next caller retries rather than inheriting the failure.
+        items = await cache.get_or_load("k", _counting_loader([{"id": "a"}], calls))
+        assert items == [{"id": "a"}]
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_failure_propagates_to_every_concurrent_waiter(self):
+        cache = ConfigListCache()
+        release = asyncio.Event()
+
+        async def failing_loader():
+            await release.wait()
+            raise RuntimeError("dynamo down")
+
+        waiters = [
+            asyncio.create_task(cache.get_or_load("k", failing_loader))
+            for _ in range(5)
+        ]
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.gather(*waiters, return_exceptions=True)
+
+        # The leader raises; the queued waiters re-check, miss, and retry the
+        # loader themselves — every one of them ends in an error rather than a
+        # silently empty catalog, which is the property that matters.
+        assert all(isinstance(r, RuntimeError) for r in results)
+
+
+class TestInvalidation:
+    @pytest.mark.asyncio
+    async def test_invalidate_forces_reload(self):
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        await cache.get_or_load("k", loader)
+        cache.invalidate("k")
+        await cache.get_or_load("k", loader)
+
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_invalidate_oauth_drops_both_entries(self):
+        """`enabled` is part of the GSI key, so a write moves providers between
+        the enabled-only and full result sets — both must be dropped."""
+        calls_enabled, calls_all = [], []
+        await config_cache.get_or_load(
+            config_cache.OAUTH_PROVIDERS_ENABLED,
+            _counting_loader([{"id": "p"}], calls_enabled),
+        )
+        await config_cache.get_or_load(
+            config_cache.OAUTH_PROVIDERS_ALL,
+            _counting_loader([{"id": "p"}], calls_all),
+        )
+
+        config_cache.invalidate_oauth_providers()
+
+        await config_cache.get_or_load(
+            config_cache.OAUTH_PROVIDERS_ENABLED,
+            _counting_loader([{"id": "p"}], calls_enabled),
+        )
+        await config_cache.get_or_load(
+            config_cache.OAUTH_PROVIDERS_ALL,
+            _counting_loader([{"id": "p"}], calls_all),
+        )
+
+        assert len(calls_enabled) == 2
+        assert len(calls_all) == 2
+
+
+class TestIsolationContract:
+    @pytest.mark.asyncio
+    async def test_caller_cannot_mutate_the_cached_list(self):
+        """A caller that appends or sorts its result must not corrupt the entry.
+
+        This is the guard that lets us cache at all: `hydrate_model_roles` and
+        `list_tools_with_roles` mutate what they are handed.
+        """
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        first = await cache.get_or_load("k", loader)
+        first.append({"id": "injected"})
+        first.clear()
+
+        second = await cache.get_or_load("k", loader)
+        assert second == [{"id": "a"}]
+        assert len(calls) == 1
+
+
+class TestKillSwitch:
+    @pytest.mark.asyncio
+    async def test_disabled_bypasses_the_cache_entirely(self, monkeypatch):
+        monkeypatch.setenv("CONFIG_CACHE_ENABLED", "false")
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        await cache.get_or_load("k", loader)
+        await cache.get_or_load("k", loader)
+
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_value_is_still_enabled(self, monkeypatch):
+        """House style: unset or empty resolves to ON; only literal 'false' disables."""
+        monkeypatch.setenv("CONFIG_CACHE_ENABLED", "")
+        cache = ConfigListCache()
+        calls = []
+        loader = _counting_loader([{"id": "a"}], calls)
+
+        await cache.get_or_load("k", loader)
+        await cache.get_or_load("k", loader)
+
+        assert len(calls) == 1

--- a/scripts/build/build-one.sh
+++ b/scripts/build/build-one.sh
@@ -134,6 +134,9 @@ case "$SERVICE" in
             "backend/src/apis/shared/oauth"
             "backend/src/apis/shared/embeddings"
             "backend/src/apis/shared/assistants"
+            # caching/ — oauth/provider_repository.py memoizes its provider
+            # list in the process-wide config cache.
+            "backend/src/apis/shared/caching"
         )
         # Single-file COPYs hashed as manifests (same as rag-ingestion);
         # kb_sync/requirements.txt lives inside the first source dir.
@@ -141,6 +144,7 @@ case "$SERVICE" in
             "backend/src/apis/shared/__init__.py"
             "backend/src/apis/shared/timestamps.py"
             "backend/src/apis/shared/dynamo_errors.py"
+            "backend/src/apis/shared/feature_flags.py"
         )
         # Both kb-sync Lambdas are arm64 (see the kb-sync CDK construct).
         PLATFORM="linux/arm64"


### PR DESCRIPTION
Follow-up to #1065, which named this as the remaining item on the first-load path.

## Why

Every SPA first load reads four catalogs that are identical for every user on the
deployment — models, tools, system prompts and connectors. None was cached, so a
classroom signing in together ran one DynamoDB read per catalog per student, and
three of the four are full table scans.

Worth restating the framing from #1065: **the 12-call fan-out itself is still not
worth consolidating.** This is about deleting per-request work behind it, not about
merging endpoints.

## What changed

New `apis.shared.caching.config_cache` — a TTL + single-flight cache — with the four
read paths wired through it and invalidation placed next to each write.

**Single flight is the half that matters here.** With a cold cache, 300 simultaneous
requests would otherwise issue 300 concurrent scans, and that stampede lands at
exactly the moment the burst does. One loader runs per key; everyone else awaits it.

The scans also move onto `asyncio.to_thread`. They were blocking boto3 calls made
from `async def`, so each stalled the whole event loop rather than just its own
request — with a cache the frequency drops, but a cold-start scan under load is
precisely when blocking the loop hurts most.

### Raw items, not parsed objects

Entries hold raw DynamoDB items and callers re-parse on every read. This is
deliberate, not a missed optimization. Callers **mutate** what these lists produce:
`hydrate_model_roles` documents itself as "models to hydrate (mutated in place and
returned)" and writes `allowed_app_roles` onto each model; `list_tools_with_roles`
does the same to `ToolDefinition`. Caching parsed objects would hand every caller one
shared instance, so an admin opening the models page would write derived,
display-only role fields onto the objects then served to every user — and per
CLAUDE.md `allowedAppRoles` is precisely the field that must never be mistaken for a
grant. Re-parsing is microseconds of CPU against a 50-100ms round trip, so the saving
that matters is kept and that whole class of bug is designed out, including for
callers added later who cannot be audited in advance.

### Invalidation and scope

Invalidation lives in the repositories, next to the writes, rather than in the admin
routes — every write to these tables funnels through them, so a future caller cannot
forget. Both provider entries are dropped on any provider write: `enabled` is part of
the GSI partition key, so flipping it moves a provider between the enabled-only and
full result sets.

The cache is per process, matching `AppRoleCache` and the roles-version watermark, so
a write invalidates only the task that served it. That is why the TTL defaults to 60s
rather than the 5-10 minutes `AppRoleCache` uses for authorization data: an admin edit
must not appear to "not take" for minutes. `CONFIG_CACHE_ENABLED=false` disables the
memoization; loaders are unchanged, so turning it off costs latency, never correctness.

## Please look at this one thing

`asyncio.to_thread` means a boto3 `Table` resource is now touched from a worker thread
while the event loop may use the same object. boto3 documents *clients* as thread-safe
but not *resources*. The operations involved are passthroughs to the underlying client,
and this repo already does exactly this — `query_due_work` uses a shared module-level
`_table()` from `to_thread` — so I followed the established precedent rather than
minting a per-thread resource. Flagging it explicitly because it is a judgment call,
not a certainty.

## Testing

- `pytest tests/` — **8,254 passed, 3 skipped, 0 failed** (full suite, post-rebase).
- 12 new tests in `tests/shared/test_config_cache.py`: single-flight under a
  50-caller burst, per-key isolation, TTL expiry, malformed-TTL fallback, failure not
  cached, failure propagating to every waiter, invalidation, the both-entries OAuth
  rule, the no-mutation contract, and both kill-switch states.

Two real problems surfaced while testing, both fixed here:

1. **A production break.** `test_lambda_image_imports` caught that the kb-sync Lambda
   imports `provider_repository`, which now pulls in `caching` + `feature_flags` —
   neither COPYed into its image. That would have been a cold-start
   `ModuleNotFoundError`. Fixed in `Dockerfile.kb-sync` and the build manifest.
2. **Cross-test cache bleed** — a seeded catalog leaked into the next test. Fixed with
   an autouse reset in `tests/conftest.py`, alongside the existing ones; the fixtures
   there already reset the module-level repo/service singletons for the same reason.

Unrelated but worth knowing: the worktree venv had strands-agents 1.51.0 against a
1.55.0 pin, failing an agent-factory test. `uv sync` fixed it; no code change.

## Follow-up this does NOT fix

`/api/tools/` reads the shared `app-roles` table, which also holds RBAC rows and one
`USER#…/TOOL_PREFERENCES` row **per user**. Measured on dev: 95 items scanned to
return 24 tools, of which 17 are per-user rows. Scan cost is proportional to table
size, not result size, so that read's cost tracks enrollment, not the tool count — in
prod it reads thousands of preference rows to return ~24 tools. The same applies to
RBAC `list_roles` and the skills catalog.

The cache hides this at read time, but a cold cache or TTL expiry still pays it and the
bill grows. The real fix is a discriminator GSI (`TYPE#TOOL`) so "list all tools"
becomes a query — the pattern the OAuth providers table already uses with
`EnabledProvidersIndex`. Separate change: it is a schema addition and needs its own
deploy per the GSI ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
