### PR TITLE
feat(tools): add EntityTypeIndex and stamp the tool catalog for it

### DIFF
--- a/backend/scripts/backfill_tool_catalog_index.py
+++ b/backend/scripts/backfill_tool_catalog_index.py
@@ -1,0 +1,217 @@
+"""Backfill: stamp GSI5PK/GSI5SK on tool-catalog rows written before they existed.
+
+``ToolDefinition.to_dynamo_item`` began stamping EntityTypeIndex keys in
+``perf(tools): index the tool catalog so listing it stops scanning`` — every
+tool row written before that carries neither attribute:
+
+    tool row : PK=TOOL#{tool_id}  SK=METADATA
+             + GSI5PK=ENTITY#TOOL
+             + GSI5SK=TOOL#{tool_id}
+
+``EntityTypeIndex`` is **sparse**: DynamoDB indexes a row only if it carries
+the index's key attributes. A row missing them is not "stale" in the index, it
+is *absent from it forever* — and the omission is silent, no error anywhere.
+Switching ``list_tools`` to that index without this backfill would serve an
+empty (or partial) tool catalog to every user on the deployment, which reads
+as "all my tools disappeared", not as an outage anyone gets paged for.
+
+WHY THIS EXISTS AT ALL
+----------------------
+The app-roles table is shared. Tools, skills, roles, role grants, JWT mappings
+and one tool-preferences row PER USER live in it, so listing tools by Scan
+reads the whole table and filters. Scan cost tracks table size, not result
+size — measured on dev, 95 items read to return 24 tools, 17 of them per-user
+rows. That read's cost therefore grows with enrollment rather than with the
+number of tools. The index turns it into a Query on one partition.
+
+RUN THIS BEFORE THE INDEX IS CREATED, IF YOU CAN
+------------------------------------------------
+DynamoDB backfills a new GSI at creation time from rows that already carry its
+keys, so stamping first means the index is complete the moment it reports
+ACTIVE, with no partially-populated window. The attributes are inert until an
+index consumes them, so running early costs nothing.
+
+Running *after* creation is also fine and is the expected order here, because
+the CDK change and this script ship in the same PR: the index simply picks up
+each row as this script stamps it. Either way the rule that matters is the
+same — **do not switch the read to the index until this reports
+``skipped=0 failed=0`` and the index item count matches the tool count.**
+
+SAFETY
+------
+* **Dry-run by default.** Pass ``--apply`` to write.
+* **Idempotent.** Guarded by ``attribute_not_exists(GSI5PK)``, so a second run
+  finds nothing and a row the writer has since stamped is left alone.
+* **Never resurrects a deleted row.** ``attribute_exists(SK)`` on every update.
+* **Touches only tool metadata rows.** ``TOOL#``/``CAPABILITIES`` snapshots,
+  skills, roles and user preferences are left alone — they are not tools, and
+  the tool partition of the index must contain exactly the tool catalog.
+* **Invents nothing.** Both key values derive from the row's own PK, so a
+  stamped row is byte-identical to what the writer would have written.
+
+Run against dev first, then prod::
+
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_tool_catalog_index.py \\
+        --table dev-boisestateai-v2-app-roles --region us-west-2
+    AWS_PROFILE=dev-ai python backend/scripts/backfill_tool_catalog_index.py \\
+        --table dev-boisestateai-v2-app-roles --region us-west-2 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Any, Dict, Iterator, List
+
+import boto3
+from botocore.exceptions import ClientError
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+)
+logger = logging.getLogger("backfill_tool_catalog_index")
+
+# Kept as a literal rather than imported from apis.shared.tools.models so the
+# script runs standalone against a deployed table without importing the app.
+# The value is asserted against the model in
+# tests/test_backfill_tool_catalog_index.py, so the two cannot drift.
+ENTITY_TYPE_TOOL = "ENTITY#TOOL"
+
+
+def iter_tool_rows(table: Any) -> Iterator[Dict[str, Any]]:
+    """Every tool METADATA row in the table.
+
+    A Scan, not a Query — this migration exists precisely because there is no
+    index to query yet. ``FilterExpression`` runs server-side to cut payload;
+    DynamoDB still reads every item either way, so it saves bandwidth, not
+    capacity.
+    """
+    kwargs: Dict[str, Any] = {
+        "FilterExpression": "begins_with(PK, :p) AND SK = :sk",
+        "ExpressionAttributeValues": {":p": "TOOL#", ":sk": "METADATA"},
+    }
+    while True:
+        resp = table.scan(**kwargs)
+        for item in resp.get("Items", []):
+            yield item
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            return
+        kwargs["ExclusiveStartKey"] = last
+
+
+def plan_row(item: Dict[str, Any]) -> Dict[str, Any] | None:
+    """What this row needs, or None if it needs nothing.
+
+    Returns the computed keys, or ``{"skip": reason}`` for a row that cannot
+    be stamped safely.
+    """
+    if "GSI5PK" in item:
+        return None  # already stamped — writer or a previous run
+
+    pk = str(item.get("PK", ""))
+    if not pk.startswith("TOOL#"):
+        return {"skip": f"unexpected PK {pk!r}"}
+    if pk == "TOOL#":
+        return {"skip": "empty tool id in PK"}
+
+    # GSI5SK is the row's own PK. Deriving both keys from the PK rather than
+    # from the `toolId` attribute means a row with a missing or disagreeing
+    # `toolId` still lands in the index under the identity the base table
+    # already uses — there is no way for this to invent a different one.
+    return {"gsi5pk": ENTITY_TYPE_TOOL, "gsi5sk": pk}
+
+
+def backfill(table: Any, apply: bool) -> Dict[str, int]:
+    stats = {"tool_rows": 0, "already": 0, "stamped": 0, "skipped": 0, "failed": 0}
+    skipped: List[str] = []
+
+    for item in iter_tool_rows(table):
+        stats["tool_rows"] += 1
+        plan = plan_row(item)
+
+        if plan is None:
+            stats["already"] += 1
+            continue
+
+        pk = str(item.get("PK", ""))
+        if "skip" in plan:
+            stats["skipped"] += 1
+            skipped.append(f"{pk}: {plan['skip']}")
+            continue
+
+        logger.info("stamp %s -> GSI5PK=%s GSI5SK=%s", pk, plan["gsi5pk"], plan["gsi5sk"])
+        if not apply:
+            stats["stamped"] += 1
+            continue
+
+        try:
+            table.update_item(
+                Key={"PK": item["PK"], "SK": item["SK"]},
+                UpdateExpression="SET GSI5PK = :pk, GSI5SK = :sk",
+                ExpressionAttributeValues={
+                    ":pk": plan["gsi5pk"],
+                    ":sk": plan["gsi5sk"],
+                },
+                # attribute_exists(SK): never resurrect a row the delete path
+                # removed between the scan and this write.
+                # attribute_not_exists(GSI5PK): idempotent, and yields to the
+                # writer if it stamped the row in the meantime.
+                ConditionExpression=(
+                    "attribute_exists(SK) AND attribute_not_exists(GSI5PK)"
+                ),
+            )
+            stats["stamped"] += 1
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code == "ConditionalCheckFailedException":
+                # Deleted, or stamped by the writer, while we scanned.
+                stats["already"] += 1
+                continue
+            stats["failed"] += 1
+            logger.error("failed to stamp %s: %s", pk, code, exc_info=True)
+
+    if skipped:
+        logger.warning("%s row(s) could not be stamped:", len(skipped))
+        for line in skipped:
+            logger.warning("  %s", line)
+
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", required=True, help="app-roles table name")
+    parser.add_argument("--region", default="us-west-2")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually write (default is a dry run)",
+    )
+    args = parser.parse_args()
+
+    table = boto3.resource("dynamodb", region_name=args.region).Table(args.table)
+
+    if not args.apply:
+        logger.info("DRY RUN — no writes. Pass --apply to commit.")
+
+    stats = backfill(table, args.apply)
+
+    logger.info(
+        "tool rows=%s already-stamped=%s stamped=%s skipped=%s failed=%s",
+        stats["tool_rows"],
+        stats["already"],
+        stats["stamped"],
+        stats["skipped"],
+        stats["failed"],
+    )
+    if stats["skipped"] or stats["failed"]:
+        logger.warning(
+            "Index will be INCOMPLETE for the rows above. Resolve them before "
+            "switching list_tools to EntityTypeIndex — a sparse index drops "
+            "them silently, and the catalog just looks short."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/apis/shared/tools/models.py
+++ b/backend/src/apis/shared/tools/models.py
@@ -12,6 +12,15 @@ from typing import Any, Dict, List, Literal, Optional, Set
 from pydantic import BaseModel, Field, field_validator, model_validator
 from apis.shared.timestamps import from_iso, to_iso
 
+# EntityTypeIndex (GSI5) partition value for tool-catalog rows.
+#
+# The index is generic — "list every item of type X" on a table that mixes
+# tools, skills, roles, role grants and one preferences row per user. Only the
+# tool partition is written and read today; a second entity type can be added
+# without another GSI, which matters because DynamoDB allows only one GSI
+# creation per UpdateTable.
+ENTITY_TYPE_TOOL = "ENTITY#TOOL"
+
 
 class ToolCategory(str, Enum):
     """Categories for organizing tools in the UI."""
@@ -743,6 +752,13 @@ class ToolDefinition(BaseModel):
             "SK": "METADATA",
             "GSI1PK": f"CATEGORY#{self.category}",
             "GSI1SK": f"TOOL#{self.tool_id}",
+            # EntityTypeIndex — lets "list every tool" be a Query on one
+            # partition instead of a Scan of a table shared with roles, skills
+            # and a preferences row per user. Sparse: a row without these two
+            # attributes simply is not in the index, which is why existing rows
+            # need backfill_tool_catalog_index.py.
+            "GSI5PK": ENTITY_TYPE_TOOL,
+            "GSI5SK": f"TOOL#{self.tool_id}",
             "toolId": self.tool_id,
             "displayName": self.display_name,
             "description": self.description,

--- a/backend/tests/test_backfill_tool_catalog_index.py
+++ b/backend/tests/test_backfill_tool_catalog_index.py
@@ -1,0 +1,202 @@
+"""Tests for the tool-catalog EntityTypeIndex backfill.
+
+The stakes are asymmetric: a row this script misses is not stale in the index,
+it is absent from a sparse index forever — and once `list_tools` queries that
+index, an absent row is a tool that silently vanished from every user's
+catalog. So the tests care most about *which rows get stamped* and *which are
+left alone*, not just the happy path.
+"""
+
+import os
+import sys
+
+import boto3
+import pytest
+from moto import mock_aws
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from backfill_tool_catalog_index import (  # noqa: E402
+    ENTITY_TYPE_TOOL,
+    backfill,
+    plan_row,
+)
+
+REGION = "us-east-1"
+TABLE = "test-app-roles"
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def table(aws):
+    ddb = boto3.client("dynamodb", region_name=REGION)
+    ddb.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    return boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+def _seed_shared_table(table):
+    """The app-roles table as it really is — tools mixed with everything else."""
+    rows = [
+        {"PK": "TOOL#calculator", "SK": "METADATA", "toolId": "calculator"},
+        {"PK": "TOOL#web_search", "SK": "METADATA", "toolId": "web_search"},
+        # Not tools, and must not be stamped:
+        {"PK": "TOOL#calculator", "SK": "CAPABILITIES", "prompts": []},
+        {"PK": "SKILL#research", "SK": "METADATA", "skillId": "research"},
+        {"PK": "ROLE#student", "SK": "DEFINITION", "roleId": "student"},
+        {"PK": "ROLE#student", "SK": "TOOL_GRANT#calculator"},
+        {"PK": "USER#u1", "SK": "TOOL_PREFERENCES", "userId": "u1"},
+    ]
+    for r in rows:
+        table.put_item(Item=r)
+
+
+class TestPlanRow:
+    def test_derives_both_keys_from_the_pk(self):
+        plan = plan_row({"PK": "TOOL#calculator", "SK": "METADATA"})
+        assert plan == {"gsi5pk": ENTITY_TYPE_TOOL, "gsi5sk": "TOOL#calculator"}
+
+    def test_already_stamped_row_needs_nothing(self):
+        assert plan_row(
+            {"PK": "TOOL#calculator", "SK": "METADATA", "GSI5PK": ENTITY_TYPE_TOOL}
+        ) is None
+
+    def test_unexpected_pk_is_skipped_not_guessed(self):
+        assert "skip" in plan_row({"PK": "SKILL#research", "SK": "METADATA"})
+
+    def test_empty_tool_id_is_skipped(self):
+        assert "skip" in plan_row({"PK": "TOOL#", "SK": "METADATA"})
+
+    def test_key_ignores_a_disagreeing_toolid_attribute(self):
+        """Identity comes from the PK, so the index cannot diverge from the
+        base table even if `toolId` is wrong or missing."""
+        plan = plan_row({"PK": "TOOL#real", "SK": "METADATA", "toolId": "WRONG"})
+        assert plan["gsi5sk"] == "TOOL#real"
+
+
+class TestBackfill:
+    def test_dry_run_writes_nothing(self, table):
+        _seed_shared_table(table)
+
+        stats = backfill(table, apply=False)
+
+        assert stats["stamped"] == 2
+        for tool_id in ("calculator", "web_search"):
+            item = table.get_item(
+                Key={"PK": f"TOOL#{tool_id}", "SK": "METADATA"}
+            )["Item"]
+            assert "GSI5PK" not in item
+
+    def test_stamps_only_tool_metadata_rows(self, table):
+        _seed_shared_table(table)
+
+        stats = backfill(table, apply=True)
+
+        assert stats["tool_rows"] == 2
+        assert stats["stamped"] == 2
+        assert stats["skipped"] == 0
+        assert stats["failed"] == 0
+
+        for tool_id in ("calculator", "web_search"):
+            item = table.get_item(
+                Key={"PK": f"TOOL#{tool_id}", "SK": "METADATA"}
+            )["Item"]
+            assert item["GSI5PK"] == ENTITY_TYPE_TOOL
+            assert item["GSI5SK"] == f"TOOL#{tool_id}"
+
+        # Everything that is not a tool stays untouched — the tool partition of
+        # the index must contain exactly the tool catalog.
+        for key in (
+            {"PK": "TOOL#calculator", "SK": "CAPABILITIES"},
+            {"PK": "SKILL#research", "SK": "METADATA"},
+            {"PK": "ROLE#student", "SK": "DEFINITION"},
+            {"PK": "ROLE#student", "SK": "TOOL_GRANT#calculator"},
+            {"PK": "USER#u1", "SK": "TOOL_PREFERENCES"},
+        ):
+            assert "GSI5PK" not in table.get_item(Key=key)["Item"]
+
+    def test_is_idempotent(self, table):
+        _seed_shared_table(table)
+        backfill(table, apply=True)
+
+        second = backfill(table, apply=True)
+
+        assert second["stamped"] == 0
+        assert second["already"] == 2
+        assert second["failed"] == 0
+
+    def test_leaves_a_row_the_writer_already_stamped(self, table):
+        _seed_shared_table(table)
+        table.put_item(
+            Item={
+                "PK": "TOOL#fresh",
+                "SK": "METADATA",
+                "toolId": "fresh",
+                "GSI5PK": ENTITY_TYPE_TOOL,
+                "GSI5SK": "TOOL#fresh",
+            }
+        )
+
+        stats = backfill(table, apply=True)
+
+        assert stats["already"] == 1
+        assert stats["stamped"] == 2
+
+    def test_paginates_past_one_scan_page(self, table):
+        """A short table would hide a missing ExclusiveStartKey, and the rows
+        beyond page one would be the ones silently dropped from the index."""
+        for i in range(120):
+            table.put_item(
+                Item={"PK": f"TOOL#t{i:03d}", "SK": "METADATA", "toolId": f"t{i:03d}"}
+            )
+
+        stats = backfill(table, apply=True)
+
+        assert stats["tool_rows"] == 120
+        assert stats["stamped"] == 120
+
+
+class TestContractWithTheWriter:
+    def test_partition_value_matches_the_model(self):
+        """The script hardcodes the constant so it can run standalone; this is
+        what stops the two drifting."""
+        from apis.shared.tools.models import ENTITY_TYPE_TOOL as MODEL_CONSTANT
+
+        assert ENTITY_TYPE_TOOL == MODEL_CONSTANT
+
+    def test_backfilled_keys_match_what_the_writer_would_write(self):
+        """A stamped row must be byte-identical to a freshly written one, or
+        the index would sort or resolve differently for old vs new tools."""
+        from apis.shared.tools.models import ToolDefinition
+
+        written = ToolDefinition(
+            tool_id="calculator",
+            display_name="Calculator",
+            description="d",
+            category="utility",
+            protocol="local",
+        ).to_dynamo_item()
+
+        planned = plan_row({"PK": "TOOL#calculator", "SK": "METADATA"})
+
+        assert planned["gsi5pk"] == written["GSI5PK"]
+        assert planned["gsi5sk"] == written["GSI5SK"]

--- a/infrastructure/gsi-inventory.json
+++ b/infrastructure/gsi-inventory.json
@@ -5,6 +5,7 @@
       "KeyHashIndex"
     ],
     "app-roles": [
+      "EntityTypeIndex",
       "JwtRoleMappingIndex",
       "ModelRoleMappingIndex",
       "SkillOwnerIndex",

--- a/infrastructure/lib/constructs/data/auth-tables-construct.ts
+++ b/infrastructure/lib/constructs/data/auth-tables-construct.ts
@@ -154,6 +154,35 @@ export class AuthTablesConstruct extends Construct {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // EntityTypeIndex — "list every X" without scanning the table
+    // (GSI5PK=ENTITY#{type}, GSI5SK=the item's own PK).
+    //
+    // WHY: this table is shared. Tools, skills, roles, role grants, JWT
+    // mappings AND one tool-preferences row PER USER all live in it, so
+    // `list_tools`'s Scan reads the whole table and filters down to the tool
+    // rows. Scan cost tracks table size, not result size, so that read's cost
+    // grows with ENROLLMENT, not with the number of tools: measured on dev,
+    // 95 items read to return 24 tools, of which 17 were per-user rows.
+    //
+    // Deliberately generic rather than a TOOL-only index. `list_roles` and the
+    // skills catalog scan this same table for the same reason, and DynamoDB
+    // permits only ONE GSI creation per UpdateTable — so a second entity type
+    // wanting its own index later would need its own release, and two
+    // accumulating into one release rolls the whole stack back (see
+    // docs/kaizen and PR #814). One partition per entity type costs nothing
+    // extra now and leaves that door open.
+    //
+    // Sparse by construction: only items that carry GSI5PK are indexed, so
+    // adding it changes nothing until rows are stamped. Populated for tools by
+    // `ToolDefinition.to_dynamo_item` plus
+    // `backend/scripts/backfill_tool_catalog_index.py`.
+    this.appRolesTable.addGlobalSecondaryIndex({
+      indexName: 'EntityTypeIndex',
+      partitionKey: { name: 'GSI5PK', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'GSI5SK', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     new ssm.StringParameter(this, 'AppRolesTableNameParameter', {
       parameterName: `/${config.projectPrefix}/rbac/app-roles-table-name`,
       stringValue: this.appRolesTable.tableName,

--- a/infrastructure/test/tables-detailed.test.ts
+++ b/infrastructure/test/tables-detailed.test.ts
@@ -86,7 +86,7 @@ describe('AuthTablesConstruct — detailed', () => {
     });
   });
 
-  it('AppRoles table has 4 GSIs incl. SkillOwnerIndex', () => {
+  it('AppRoles table has 5 GSIs incl. SkillOwnerIndex and EntityTypeIndex', () => {
     t.hasResourceProperties('AWS::DynamoDB::Table', {
       TableName: 'test-project-app-roles',
       GlobalSecondaryIndexes: Match.arrayWith([
@@ -94,6 +94,26 @@ describe('AuthTablesConstruct — detailed', () => {
         Match.objectLike({ IndexName: 'ToolRoleMappingIndex' }),
         Match.objectLike({ IndexName: 'ModelRoleMappingIndex' }),
         Match.objectLike({ IndexName: 'SkillOwnerIndex' }),
+        Match.objectLike({ IndexName: 'EntityTypeIndex' }),
+      ]),
+    });
+  });
+
+  it('EntityTypeIndex is keyed on GSI5PK/GSI5SK with full projection', () => {
+    // Full projection because the tool catalog is rebuilt from these rows —
+    // an INCLUDE projection would force a base-table read per tool and give
+    // back the amplification the index exists to remove.
+    t.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: 'test-project-app-roles',
+      GlobalSecondaryIndexes: Match.arrayWith([
+        Match.objectLike({
+          IndexName: 'EntityTypeIndex',
+          KeySchema: [
+            { AttributeName: 'GSI5PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI5SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+        }),
       ]),
     });
   });


### PR DESCRIPTION
Follow-up to #1068, which named this as the remaining item. **Part 1 of 2 — this
PR deliberately does not switch the read.**

## Why

The `app-roles` table is shared. Tools, skills, roles, role grants, JWT mappings
and one tool-preferences row **per user** all live in it. `list_tools` Scans it and
filters, and Scan cost is proportional to **table size, not result size** — so that
read's cost grows with **enrollment**, not with the number of tools.

Measured on dev:

```
total items scanned: 95   →  to return 24 tools
  24  TOOL#  / METADATA        ← what /api/tools/ actually wants
  12  USER#  / TOOL_PREFERENCES   ← one row per user, forever
  12  SKILL# / METADATA
   5  USER#  / SKILL_PREFERENCES  ← ditto
   4  ROLE#  / DEFINITION
  38  ROLE#  / *_GRANT#… , JWT_MAPPING#…
```

In prod that is thousands of preference rows read to return ~24 tools. #1068's cache
hides this at read time but does not fix it — a cold cache or TTL expiry still pays
it, and the bill grows.

## What changed

- **`EntityTypeIndex`** on `app-roles`: `GSI5PK=ENTITY#{type}`, `GSI5SK=` the item's
  own PK, full projection.
- **`ToolDefinition.to_dynamo_item`** stamps `ENTITY#TOOL`, so every tool written or
  edited from now on is indexed.
- **`backfill_tool_catalog_index.py`** for rows written before the keys existed.

**Generic index, not a TOOL-only one.** `list_roles` and the skills catalog scan this
same table for the same reason. DynamoDB permits only **one GSI creation per
UpdateTable**, so giving a second entity type its own index later would need its own
release — and two accumulating into a single release rolls the whole stack back, which
is what took production down on 2026-08-01 (release 1.12.0). One partition per entity
type costs nothing now and leaves that door open.

**Full projection** because the catalog is rebuilt from these rows; an INCLUDE
projection would force a base-table read per tool and hand back the amplification the
index exists to remove.

`gsi-inventory.json` is regenerated and shows **exactly one index added to one existing
table** — which is precisely what `check-gsi-update-limit.mjs` gates on for release PRs.

## Why the read is not switched here

A sparse index contains only rows that carry its key attributes, so it is **empty until
the backfill runs** — and an empty index is not an error, it is a successful query
returning nothing. Switching `list_tools` in this PR would serve an **empty tool
catalog to every user** the moment it deployed, silently, with no error anywhere and
nothing to page on.

So this ships first. The read switch follows once, in each environment:
1. `EntityTypeIndex` reports `IndexStatus: ACTIVE` (CloudFormation returning green is
   not that signal — the index builds asynchronously afterwards), and
2. the backfill reports `skipped=0 failed=0` and the index item count matches the tool
   count.

**Safe to merge alone, in any deploy order.** GSI key attributes are ordinary
attributes when no index consumes them, so if `backend.yml` wins the race against
`platform.yml` the writes are simply inert — which matters, because that ordering
cannot be guaranteed by merging (the two workflows share a concurrency group, and the
queued platform run can even be evicted outright).

## Testing

- Backend `pytest tests/` — **8,266 passed, 3 skipped**, including 12 new tests.
- Infra `npx jest` — **816 passed** (43 suites), including the regenerated inventory
  guard and a new assertion on the index's keys and projection. `tsc --noEmit` clean.

The backfill tests weight toward *which rows get stamped and which are left alone*,
since a missed row is not stale in a sparse index — it is absent from it forever, and
once the read switches that is a tool that silently vanished from every user's catalog:
dry-run writes nothing; only `TOOL#`/`METADATA` rows are stamped (capabilities
snapshots, skills, roles, grants and user preferences explicitly left alone);
idempotent on re-run; yields to a row the writer already stamped; paginates past one
Scan page; and two contract tests pin the script's hardcoded constant and its computed
keys to what `to_dynamo_item` actually writes, so the two cannot drift.

## Follow-up (part 2)

Switch `_scan_tool_items` to a Query on `EntityTypeIndex`, after the deploy +
backfill above. I'll run the backfill against dev and verify the index before opening
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
