### PR TITLE
fix(seed): stamp EntityTypeIndex keys, and gate releases on backfill notes

### DIFF
--- a/.claude/skills/cutting-a-release/SKILL.md
+++ b/.claude/skills/cutting-a-release/SKILL.md
@@ -181,6 +181,67 @@ flag, or skip path**. So a failed two-index deploy costs two patch releases
 
 ---
 
+## 1b. Pre-merge prerequisite — data backfills
+
+A backfill script is not code that runs itself. Someone has to run it, against
+each environment, in a window that matters. **If this release adds one, the
+release notes must name it** — that is the only place an operator looks.
+
+### Why this is its own gate
+
+The failure is silent, and in the same shape as §1. Backfills populate a sparse
+index or a new attribute, and the read path does not error when the data is
+missing — a sparse index returns **fewer rows**, not an exception. An unrun
+backfill therefore looks like a short list, not an outage: the tool catalog
+missing half its tools, the artifact library missing the older entries. Nothing
+goes red, and no alarm fires.
+
+`develop` cannot surface it either. Whoever wrote the script ran it against dev
+by hand the day they wrote it, so dev is always fine. **Prod is the environment
+with nobody assigned**, and the release is the last moment the instruction can
+still reach someone.
+
+### How to check
+
+CI enforces this on every PR into `main`
+(`.github/workflows/pending-backfills.yml`). Locally:
+
+```bash
+node scripts/release/check-pending-backfills.mjs
+```
+
+It diffs `backend/scripts/backfill_*.py` between `origin/main` and your branch
+and fails when a script added in the range is not named in `RELEASE_NOTES.md`.
+
+It cannot verify the backfill was actually **run** — no CI job can know that.
+It guarantees the instruction reaches the person who can.
+
+### What to write
+
+Name the script, the command, and the environments. Not "a backfill is
+required" — that is the note that sends someone digging through `git log`:
+
+> **Manual step — run before/with this deploy.** Populates `EntityTypeIndex`
+> for tool rows written before it existed. Idempotent; dry-run by default.
+>
+> ```bash
+> AWS_PROFILE=<env> python backend/scripts/backfill_tool_catalog_index.py \
+>     --table <prefix>-app-roles --region us-west-2 --apply
+> ```
+>
+> Verify `skipped=0 failed=0` and that the index item count matches the tool
+> count before considering the deploy complete.
+
+### Ordering, when the release also switches a read onto the backfilled data
+
+Deploy → backfill → *then* the read. If the release carries both the backfill
+and the code that depends on it, the backfill runs **inside the release
+window**, not afterwards. A fresh deployment is exempt only if its seed path
+already writes the new keys — check, do not assume: `seed_bootstrap_data.py`
+hand-builds its items rather than going through the model.
+
+---
+
 ## 2. Branch workflow
 
 ```bash

--- a/.github/workflows/pending-backfills.yml
+++ b/.github/workflows/pending-backfills.yml
@@ -1,0 +1,106 @@
+name: "Pending Backfills"
+
+# Release gate: a release that ships a data backfill must say so in RELEASE_NOTES.md.
+#
+# A backfill script is not code that runs itself. Someone has to run it, against
+# each environment, in a window that matters — and the release notes are the only
+# place an operator looks for that. A backfill that ships unannounced is a
+# migration nobody performs.
+#
+# This only triggers on PRs into `main`, for the same reason the GSI gate does:
+# whoever writes a backfill runs it against dev by hand the day they write it, so
+# `develop` is always fine. Prod is the environment with nobody assigned, and a
+# release is the only moment the instruction can still reach someone.
+#
+# The failure mode is silent. Backfills populate a sparse index or a new
+# attribute, and the code that reads them does not error when the data is
+# missing — a sparse index returns FEWER ROWS, not an exception. An unrun
+# backfill therefore looks like a short list (half the tool catalog, the older
+# artifacts missing), not an outage. Nothing goes red.
+#
+# See .claude/skills/cutting-a-release/SKILL.md §1b.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# Safe to cancel superseded runs: this reads a git diff and a markdown file and
+# does no AWS work, so there is no deploy hazard in interrupting it.
+concurrency:
+  group: pending-backfills-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pending-backfills:
+    name: Pending Backfills
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: |
+          git fetch origin main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      # Diffs backend/scripts/backfill_*.py between origin/main and this PR and
+      # requires each ADDED script to be named in RELEASE_NOTES.md. No install
+      # needed — both sides are already in git.
+      #
+      # This gate cannot verify the backfill was RUN; no CI job can know that. It
+      # guarantees the instruction reaches the person who can.
+      - name: Check pending backfills
+        id: backfill-check
+        continue-on-error: true
+        run: |
+          node scripts/release/check-pending-backfills.mjs --base origin/main \
+            2>&1 | tee /tmp/backfill-check-output.txt
+
+          # tee masks the script's exit status, so read it back from PIPESTATUS.
+          exit "${PIPESTATUS[0]}"
+
+      - name: Generate summary
+        if: always()
+        run: |
+          source scripts/common/summary.sh
+
+          if [ "${{ steps.backfill-check.outcome }}" = "success" ]; then
+            STATUS="success"
+          else
+            STATUS="failure"
+          fi
+
+          write_workflow_header "Pending Backfills" "${STATUS}"
+
+          {
+            echo '```'
+            cat /tmp/backfill-check-output.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+            echo ""
+            if [ "${STATUS}" != "success" ]; then
+              echo "This release adds a backfill script that the release notes do not name."
+              echo "Add it, with the exact command and the environments it must run against,"
+              echo "so whoever deploys knows there is a step to perform. An unrun backfill"
+              echo "fails **silently** — as a short list, not an error."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Evaluate result
+        run: |
+          if [ "${{ steps.backfill-check.outcome }}" != "success" ]; then
+            echo "::error::This release adds a backfill script that RELEASE_NOTES.md does not name. Add it with the command to run and the environments it applies to — see .claude/skills/cutting-a-release/SKILL.md §1b."
+            exit 1
+          fi
+          echo "Pending-backfill check passed."

--- a/backend/scripts/seed_bootstrap_data.py
+++ b/backend/scripts/seed_bootstrap_data.py
@@ -806,6 +806,14 @@ def seed_default_tools(
             "SK": sk,
             "GSI1PK": f"CATEGORY#{tool_def['category']}",
             "GSI1SK": pk,
+            # EntityTypeIndex (GSI5) — mirrors ToolDefinition.to_dynamo_item.
+            # This seeder hand-builds the item rather than going through the
+            # model, so a new index key has to be added in BOTH places. Miss it
+            # here and a freshly bootstrapped deployment lists zero tools once
+            # the catalog read moves to the index — with no error, because a
+            # sparse index answers "nothing matched", not "something is wrong".
+            "GSI5PK": "ENTITY#TOOL",
+            "GSI5SK": pk,
             "toolId": tool_id,
             "displayName": tool_def["displayName"],
             "description": tool_def["description"],

--- a/backend/tests/test_seed_tool_index_keys.py
+++ b/backend/tests/test_seed_tool_index_keys.py
@@ -1,0 +1,70 @@
+"""The bootstrap seeder's tool rows must carry the same index keys the model writes.
+
+`seed_bootstrap_data.py` hand-builds its tool item instead of going through
+`ToolDefinition.to_dynamo_item`, so every index key exists in TWO places and a
+new one can be added to the model while the seeder is forgotten.
+
+That omission is invisible in the worst way. A freshly bootstrapped deployment —
+a fork, a new environment, a rebuilt dev — would seed tools with no index keys,
+and once the catalog read moves to `EntityTypeIndex` it would list ZERO tools. No
+error: a sparse index answers "nothing matched", not "something is wrong". And a
+backfill would not be the fix, because nothing about that install is legacy.
+
+This test is the thing that fails instead.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from apis.shared.tools.models import ENTITY_TYPE_TOOL, ToolDefinition  # noqa: E402
+
+SEED_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "seed_bootstrap_data.py"
+)
+
+
+def _model_index_keys() -> set[str]:
+    """Every GSI key attribute `to_dynamo_item` writes on a tool row."""
+    item = ToolDefinition(
+        tool_id="probe",
+        display_name="Probe",
+        description="d",
+        category="utility",
+        protocol="local",
+    ).to_dynamo_item()
+    return {k for k in item if re.fullmatch(r"GSI\d+(PK|SK)", k)}
+
+
+def _seeded_tool_block() -> str:
+    """The seeder's hand-built tool item literal."""
+    source = open(SEED_SCRIPT, encoding="utf-8").read()
+    start = source.index('"GSI1PK": f"CATEGORY#')
+    return source[start : start + 1200]
+
+
+class TestSeederMirrorsTheModel:
+    def test_seeder_writes_every_index_key_the_model_does(self):
+        block = _seeded_tool_block()
+        missing = sorted(k for k in _model_index_keys() if f'"{k}"' not in block)
+
+        assert not missing, (
+            f"seed_bootstrap_data.py does not write {missing} on its tool rows. "
+            "It hand-builds the item rather than calling "
+            "ToolDefinition.to_dynamo_item, so a new index key must be added in "
+            "both places — otherwise a freshly bootstrapped deployment is absent "
+            "from that index, silently."
+        )
+
+    def test_seeder_uses_the_shared_entity_type_constant(self):
+        """A literal that drifts from ENTITY_TYPE_TOOL puts seeded tools in a
+        partition the reader never queries — the same silent-empty failure."""
+        assert f'"{ENTITY_TYPE_TOOL}"' in _seeded_tool_block()
+
+    def test_model_is_the_source_of_truth_for_this_test(self):
+        """Guards the test itself: if the probe stops producing index keys the
+        assertions above would pass vacuously."""
+        keys = _model_index_keys()
+        assert {"GSI1PK", "GSI1SK", "GSI5PK", "GSI5SK"} <= keys

--- a/infrastructure/test/pending-backfills.test.ts
+++ b/infrastructure/test/pending-backfills.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Exit-code contract for `scripts/release/check-pending-backfills.mjs`.
+ *
+ * The gate itself runs on PRs into `main` (`.github/workflows/pending-backfills.yml`)
+ * and requires every backfill script ADDED in a release to be named in
+ * RELEASE_NOTES.md — because a backfill is not code that runs itself, and an
+ * unrun one fails silently as a short list rather than an error.
+ *
+ * Lives here, next to `gsi-update-limit.test.ts`, because this is the other half
+ * of the same idea: a release-only hazard that no amount of dev soak time can
+ * surface, guarded by a script whose exit codes CI depends on.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CHECKER = resolve(REPO_ROOT, 'scripts/release/check-pending-backfills.mjs');
+
+describe('check-pending-backfills.mjs', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'backfill-check-'));
+  });
+
+  /** Run the real CLI the way CI does; returns its exit code and output. */
+  function run(added: string[], notes: string) {
+    const notesPath = join(dir, `notes-${Math.random().toString(36).slice(2)}.md`);
+    writeFileSync(notesPath, notes);
+
+    try {
+      const stdout = execFileSync(
+        process.execPath,
+        [CHECKER, '--added', added.join(','), '--notes-file', notesPath],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      return { code: 0, output: stdout };
+    } catch (err) {
+      const e = err as { status: number; stdout: string; stderr: string };
+      return { code: e.status, output: `${e.stdout}${e.stderr}` };
+    }
+  }
+
+  it('passes when the release adds no backfill', () => {
+    const { code } = run([], '# 1.2.3\n\nNothing to see.\n');
+    expect(code).toBe(0);
+  });
+
+  it('fails when a backfill ships unannounced — the case this exists for', () => {
+    const { code, output } = run(
+      ['backend/scripts/backfill_tool_catalog_index.py'],
+      '# 1.2.3\n\nAdded a nice feature.\n',
+    );
+    expect(code).toBe(1);
+    expect(output).toContain('backfill_tool_catalog_index.py');
+  });
+
+  it('passes when the notes name the script', () => {
+    const { code } = run(
+      ['backend/scripts/backfill_tool_catalog_index.py'],
+      '# 1.2.3\n\nRun `backfill_tool_catalog_index.py` against each environment.\n',
+    );
+    expect(code).toBe(0);
+  });
+
+  it('accepts the full path spelling too', () => {
+    const { code } = run(
+      ['backend/scripts/backfill_tool_catalog_index.py'],
+      '# 1.2.3\n\nRun backend/scripts/backfill_tool_catalog_index.py --apply\n',
+    );
+    expect(code).toBe(0);
+  });
+
+  it('fails the release when only SOME of several are named', () => {
+    // The dangerous near-miss: the notes mention a backfill, so a human skims
+    // past, but a second one is missing.
+    const { code, output } = run(
+      [
+        'backend/scripts/backfill_tool_catalog_index.py',
+        'backend/scripts/backfill_widget_owner_keys.py',
+      ],
+      '# 1.2.3\n\nRun `backfill_tool_catalog_index.py`.\n',
+    );
+    expect(code).toBe(1);
+    expect(output).toContain('backfill_widget_owner_keys.py');
+    expect(output).not.toMatch(/✗ .*backfill_tool_catalog_index/);
+  });
+
+  it('ignores non-backfill scripts in the same directory', () => {
+    const { code } = run(
+      ['backend/scripts/seed_bootstrap_data.py'],
+      '# 1.2.3\n\nNo mention.\n',
+    );
+    expect(code).toBe(0);
+  });
+});

--- a/scripts/release/check-pending-backfills.mjs
+++ b/scripts/release/check-pending-backfills.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Pre-merge guard: a release that ships a data backfill must say so.
+ *
+ * A backfill script is not code that runs itself. Someone has to run it, against
+ * each environment, in a window that matters — and the release notes are the only
+ * place an operator looks for that. A backfill that ships unannounced is a
+ * migration nobody performs.
+ *
+ * WHY THIS NEEDS A DEDICATED CHECK: the failure is silent in exactly the same
+ * shape as the GSI limit this file sits next to. Backfills exist to populate a
+ * sparse index or a new attribute, and the code that reads it does not error when
+ * the data is missing — a sparse index returns *fewer rows*, not an exception. So
+ * an unrun backfill looks like a short list, not an outage: the tool catalog is
+ * missing half its tools, the library is missing the older artifacts. Nothing goes
+ * red. And `develop` cannot surface it either, because whoever wrote the script
+ * ran it against dev by hand the day they wrote it; prod is the environment with
+ * nobody assigned.
+ *
+ * WHAT IT CHECKS: every `backend/scripts/backfill_*.py` ADDED between the baseline
+ * and this branch must be named in `RELEASE_NOTES.md`. Naming the file is the bar
+ * because that is what an operator needs to type — a prose mention of "a backfill
+ * is required" that omits the script name is exactly the release note that sends
+ * someone digging through git log.
+ *
+ * WHAT IT DOES NOT CHECK: that the backfill was actually *run*. No CI job can know
+ * that. This guarantees the instruction reaches the person who can.
+ *
+ * Usage:
+ *   node scripts/release/check-pending-backfills.mjs
+ *   node scripts/release/check-pending-backfills.mjs --base origin/develop
+ *   node scripts/release/check-pending-backfills.mjs --added a.py,b.py --notes-file n.md
+ *
+ * Exit codes: 0 = nothing to announce, or all announced; 1 = unannounced backfill;
+ * 2 = bad usage.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const NOTES_PATH = 'RELEASE_NOTES.md';
+const BACKFILL_DIR = 'backend/scripts';
+const BACKFILL_RE = /^backend\/scripts\/backfill_[^/]+\.py$/;
+
+function parseArgs(argv) {
+  const opts = { base: 'origin/main', added: null, notesFile: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const v = argv[i + 1];
+      if (v === undefined) {
+        console.error(`error: ${arg} needs a value`);
+        process.exit(2);
+      }
+      i += 1;
+      return v;
+    };
+    if (arg === '--base') opts.base = next();
+    else if (arg === '--added') opts.added = next();
+    else if (arg === '--notes-file') opts.notesFile = next();
+    else if (arg === '--help' || arg === '-h') {
+      console.log(readFileSync(fileURLToPath(import.meta.url), 'utf8').split('*/')[0]);
+      process.exit(0);
+    } else {
+      console.error(`error: unknown argument ${arg}`);
+      process.exit(2);
+    }
+  }
+  return opts;
+}
+
+/** Backfill scripts added on this branch relative to `base`. */
+function addedBackfills(base) {
+  let out;
+  try {
+    out = execFileSync(
+      'git',
+      ['diff', '--name-only', '--diff-filter=A', `${base}...HEAD`, '--', BACKFILL_DIR],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+  } catch {
+    // No baseline to diff against (a fresh clone, or `main` predates this check).
+    // Reporting SKIPPED beats failing every release until the first one lands.
+    return null;
+  }
+  return out.split('\n').map((l) => l.trim()).filter((l) => BACKFILL_RE.test(l));
+}
+
+function readNotes(notesFile) {
+  const path = notesFile ? resolve(notesFile) : resolve(REPO_ROOT, NOTES_PATH);
+  if (!existsSync(path)) return null;
+  return readFileSync(path, 'utf8');
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  // Both paths apply the same filename filter, so `--added` (tests, local runs)
+  // cannot classify a file differently from the git path CI uses.
+  const added =
+    opts.added !== null
+      ? opts.added
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => BACKFILL_RE.test(s))
+      : addedBackfills(opts.base);
+
+  if (added === null) {
+    console.log(`SKIPPED — no baseline at ${opts.base} to diff against.`);
+    console.log('Check by hand: does this release add a backfill script?');
+    process.exit(0);
+  }
+
+  if (added.length === 0) {
+    console.log('No backfill scripts added in this range — nothing to announce.');
+    process.exit(0);
+  }
+
+  const notes = readNotes(opts.notesFile);
+  if (notes === null) {
+    console.error(`error: ${NOTES_PATH} not found`);
+    process.exit(2);
+  }
+
+  // Match on the bare filename rather than the full path: release notes reasonably
+  // write `backfill_tool_catalog_index.py` or the full `backend/scripts/...` form,
+  // and both name the thing an operator has to run.
+  const missing = added.filter((p) => !notes.includes(basename(p)));
+
+  console.log(`Backfill scripts added since ${opts.base}: ${added.length}`);
+  for (const p of added) {
+    console.log(`  ${missing.includes(p) ? '✗' : '✓'} ${p}`);
+  }
+
+  if (missing.length === 0) {
+    console.log(`\nAll named in ${NOTES_PATH}.`);
+    process.exit(0);
+  }
+
+  console.error(
+    `\n${missing.length} backfill script(s) are not named in ${NOTES_PATH}:`,
+  );
+  for (const p of missing) console.error(`  ${p}`);
+  console.error(
+    '\nAdd each one to the release notes with the command to run it and the ' +
+      'environments it must run against. An unannounced backfill is a migration ' +
+      'nobody performs — and it fails silently, as a short list rather than an error.',
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Two problems, both the same shape: a data migration that fails **silently**, because
the read path returns fewer rows rather than an error.

The first was found by asking a good question about #1069 — *would a fork with
existing data need to run the backfill?* Checking properly turned up that a fork
**without** existing data was the broken case.

## 1. A fresh deployment would have listed zero tools

`seed_bootstrap_data.py` hand-builds its tool item instead of calling
`ToolDefinition.to_dynamo_item`. It writes `GSI1PK`/`GSI1SK` by hand — and had no
`GSI5PK`.

So a freshly bootstrapped deployment — a fork, a new environment, a rebuilt dev —
would seed every default tool with **no EntityTypeIndex keys**, and once the catalog
read moves to that index (part 2) it would list **nothing**. A sparse index answers
"nothing matched", not "something is wrong", so there is no error to notice. And a
backfill would not even be the obvious remedy, because nothing about that install is
legacy — it would simply look broken out of the box.

To be explicit about who is affected:

| Deployment | Backfill needed? |
|---|---|
| Fresh install | **No** — index created with the table, and seeded rows now stamped |
| Existing (any fork, and ours) | **Yes**, before the read switches |

`test_seed_tool_index_keys.py` derives the expected key set from the model and asserts
the seeder writes all of it, so the next index added to tools cannot be forgotten in
the one place that mirrors the model by hand. Verified non-vacuous — with the keys
removed it fails and names them. There are exactly two writers of tool rows (the model
and this seeder), so that is the whole surface.

## 2. A release could ship a backfill nobody runs

There are now six `backfill_*.py` scripts and no step that surfaces "this release needs
one run" — they reach the changelog only when whoever writes it remembers.

Same silent shape: an unrun backfill looks like a short list (half the tool catalog,
the older artifacts missing), not an outage. Nothing goes red. And `develop` never
exposes it, because whoever writes the script runs it against dev by hand that day —
**prod is the environment with nobody assigned**, and the release is the last moment
the instruction can still reach someone.

Adds `scripts/release/check-pending-backfills.mjs` plus a PR-into-`main` workflow
requiring every newly added backfill script to be **named** in `RELEASE_NOTES.md`,
mirroring the one-GSI-per-`UpdateTable` gate it sits next to. Naming the file is the
bar: "a backfill is required" without the script name is exactly the note that sends
someone digging through `git log`. Plus `SKILL.md` §1b with a worked example and the
deploy → backfill → read ordering.

It deliberately **cannot** verify a backfill was *run* — no CI job can know that. It
guarantees the instruction reaches the person who can.

**Run against `origin/main` today it fails on `backfill_tool_catalog_index.py` from
#1069.** That is the intended behaviour, not a bug in the gate: the next release is
blocked until that step is written down.

## Testing

- Backend `pytest tests/` — **8,269 passed, 3 skipped**.
- Infra `npx jest` — **822 passed** (44 suites, up from 43).
- Six exit-code contract tests for the checker, alongside the GSI one. One of them
  caught a real inconsistency while I wrote it: `--added` skipped the filename filter
  the git path applies, so the CLI could classify a file differently from CI. I fixed
  the script, not the test. Another covers the dangerous near-miss where the notes
  mention *one* backfill and a human skims past a second.

## Dev status for #1069

Both deploys green, `EntityTypeIndex` **ACTIVE**, backfill applied — 24/24 stamped,
`skipped=0 failed=0`, idempotent on re-run. A real query against the index returns
**24 items reading 24**, against the base-table scan's **24 returned reading 95**.

Part 2 (switching `list_tools` to the index) follows once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
