### PR TITLE
perf(tools): list the catalog by Query instead of scanning a shared table

### DIFF
--- a/backend/src/apis/shared/tools/repository.py
+++ b/backend/src/apis/shared/tools/repository.py
@@ -15,7 +15,9 @@ import boto3
 from botocore.exceptions import ClientError
 
 from apis.shared.caching import config_cache
+from apis.shared.dynamo_errors import is_missing_index_error
 from .models import (
+    ENTITY_TYPE_TOOL,
     ToolCapabilitySnapshot,
     ToolDefinition,
     UserToolPreference,
@@ -23,6 +25,10 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The GSI that makes "list every tool" a Query instead of a Scan of a table
+# shared with roles, skills and a preferences row per user.
+ENTITY_TYPE_INDEX = "EntityTypeIndex"
 
 
 class ToolCatalogRepository:
@@ -142,7 +148,7 @@ class ToolCatalogRepository:
                 # each ToolDefinition in place.
                 items = await config_cache.get_or_load(
                     config_cache.TOOL_CATALOG,
-                    lambda: asyncio.to_thread(self._scan_tool_items),
+                    self._load_all_tool_items,
                 )
 
             tools = [ToolDefinition.from_dynamo_item(item) for item in items]
@@ -159,6 +165,85 @@ class ToolCatalogRepository:
         except ClientError as e:
             logger.error(f"Error listing tools: {e}")
             raise
+
+    async def _load_all_tool_items(self) -> List[dict]:
+        """Every tool row, by Query on EntityTypeIndex, with Scan as the safety net.
+
+        The Query is the point of the index: this table is shared with roles,
+        skills, role grants and one tool-preferences row PER USER, so the Scan
+        reads the whole table to return the tool rows and its cost grows with
+        enrollment rather than with the catalog. Measured on dev, 95 items read
+        to return 24.
+
+        Two ways the index can fail to answer, and neither may take the catalog
+        down with it — an empty tool list is not a degraded experience here, it
+        is a broken one:
+
+        **The index is not there.** `platform.yml` and `backend.yml` are ordered
+        by nothing, a GSI is still CREATING after CloudFormation reports success,
+        and a rolled-back stack ships its images anyway. Unlike the surfaces
+        `dynamo_errors` was written for, we have a *correct* answer available, so
+        we fall back to it rather than degrading to empty.
+
+        **The index is there but unpopulated.** The keys are sparse, so a catalog
+        whose backfill has not run indexes nothing and the Query succeeds with
+        zero rows — no error to catch. A zero result is therefore treated as
+        suspect and re-read via Scan: if the table really is empty (a fresh
+        install before seeding) both agree and it costs one extra read per cache
+        fill; if it is not, we serve the truth and say loudly why.
+
+        A partial backfill is NOT covered — detecting it would mean scanning
+        every time, which is the cost being removed. That is what the release
+        gate and the backfill's own `skipped=0 failed=0` report are for.
+        """
+        try:
+            items = await asyncio.to_thread(self._query_tool_items)
+        except ClientError as exc:
+            if not is_missing_index_error(exc):
+                raise
+            logger.warning(
+                "⚠️ DynamoDB index '%s' does not exist — falling back to Scan for "
+                "the tool catalog. Expected transiently while the GSI is CREATING "
+                "or a deploy is incomplete; if it persists, every catalog read is "
+                "paying a full table scan.",
+                ENTITY_TYPE_INDEX,
+            )
+            return await asyncio.to_thread(self._scan_tool_items)
+
+        if items:
+            return items
+
+        # Zero rows from a sparse index is indistinguishable from "no tools", so
+        # confirm against the base table before believing it.
+        scanned = await asyncio.to_thread(self._scan_tool_items)
+        if scanned:
+            logger.error(
+                "⚠️ DynamoDB index '%s' returned 0 tools but the table holds %d — "
+                "the %s backfill has not been run in this environment. Serving the "
+                "Scan result so the catalog is correct; run the backfill.",
+                ENTITY_TYPE_INDEX,
+                len(scanned),
+                "backfill_tool_catalog_index.py",
+            )
+        return scanned
+
+    def _query_tool_items(self) -> List[dict]:
+        """Query the raw tool rows off EntityTypeIndex. Blocking; via ``to_thread``."""
+        kwargs = {
+            "IndexName": ENTITY_TYPE_INDEX,
+            "KeyConditionExpression": "GSI5PK = :pk",
+            "ExpressionAttributeValues": {":pk": ENTITY_TYPE_TOOL},
+        }
+        response = self._table.query(**kwargs)
+        items = response.get("Items", [])
+
+        while "LastEvaluatedKey" in response:
+            response = self._table.query(
+                **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+            )
+            items.extend(response.get("Items", []))
+
+        return items
 
     def _scan_tool_items(self) -> List[dict]:
         """Scan the raw TOOL#/METADATA items. Blocking; call via ``to_thread``."""

--- a/backend/tests/test_tool_catalog_index_read.py
+++ b/backend/tests/test_tool_catalog_index_read.py
@@ -1,0 +1,240 @@
+"""`list_tools` reads EntityTypeIndex, and must never answer "no tools" wrongly.
+
+The Query is the optimization; the fallbacks are the reason it is safe to ship.
+An empty tool catalog is not a degraded experience — every user loses every
+tool — and both ways this index can fail to answer produce exactly that unless
+something catches them:
+
+* the index is absent (deploy race), which raises; and
+* the index is present but unpopulated (backfill not run), which does NOT raise —
+  a sparse index simply matches nothing.
+
+These tests exist for the fallbacks more than for the happy path.
+"""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from apis.shared.caching import config_cache
+from apis.shared.tools.models import ENTITY_TYPE_TOOL, ToolDefinition
+from apis.shared.tools.repository import ENTITY_TYPE_INDEX, ToolCatalogRepository
+
+REGION = "us-east-1"
+TABLE = "test-app-roles-index-read"
+
+KEY_SCHEMA = [
+    {"AttributeName": "PK", "KeyType": "HASH"},
+    {"AttributeName": "SK", "KeyType": "RANGE"},
+]
+ATTRS = [
+    {"AttributeName": "PK", "AttributeType": "S"},
+    {"AttributeName": "SK", "AttributeType": "S"},
+    {"AttributeName": "GSI5PK", "AttributeType": "S"},
+    {"AttributeName": "GSI5SK", "AttributeType": "S"},
+    {"AttributeName": "GSI1PK", "AttributeType": "S"},
+    {"AttributeName": "GSI1SK", "AttributeType": "S"},
+]
+
+# The category path queries this one; it exists on the real table and is
+# deliberately untouched by this change.
+CATEGORY_INDEX = {
+    "IndexName": "JwtRoleMappingIndex",
+    "KeySchema": [
+        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+    ],
+    "Projection": {"ProjectionType": "ALL"},
+}
+INDEX = {
+    "IndexName": ENTITY_TYPE_INDEX,
+    "KeySchema": [
+        {"AttributeName": "GSI5PK", "KeyType": "HASH"},
+        {"AttributeName": "GSI5SK", "KeyType": "RANGE"},
+    ],
+    "Projection": {"ProjectionType": "ALL"},
+}
+
+
+@pytest.fixture()
+def aws(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    with mock_aws():
+        yield
+
+
+def _make_table(with_index: bool):
+    # Without EntityTypeIndex the table still has the category index, matching
+    # the real pre-deploy shape rather than a table with no indexes at all.
+    attrs = ATTRS if with_index else [a for a in ATTRS if not a["AttributeName"].startswith("GSI5")]
+    kwargs = {
+        "TableName": TABLE,
+        "KeySchema": KEY_SCHEMA,
+        "AttributeDefinitions": attrs,
+        "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [CATEGORY_INDEX] + ([INDEX] if with_index else []),
+    }
+    boto3.client("dynamodb", region_name=REGION).create_table(**kwargs)
+    return boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+
+def _tool(tool_id: str, stamped: bool = True) -> dict:
+    item = ToolDefinition(
+        tool_id=tool_id,
+        display_name=tool_id.title(),
+        description="d",
+        category="utility",
+        protocol="local",
+    ).to_dynamo_item()
+    if not stamped:
+        # A row written before the keys existed — the pre-backfill state.
+        item.pop("GSI5PK", None)
+        item.pop("GSI5SK", None)
+    return item
+
+
+def _seed_noise(table):
+    """The other tenants of this shared table. None may reach the catalog."""
+    table.put_item(Item={"PK": "SKILL#research", "SK": "METADATA"})
+    table.put_item(Item={"PK": "ROLE#student", "SK": "DEFINITION"})
+    table.put_item(Item={"PK": "USER#u1", "SK": "TOOL_PREFERENCES"})
+    table.put_item(Item={"PK": "TOOL#calculator", "SK": "CAPABILITIES"})
+
+
+def _repo(monkeypatch):
+    monkeypatch.setenv("DYNAMODB_APP_ROLES_TABLE_NAME", TABLE)
+    config_cache.get_config_cache().clear()
+    return ToolCatalogRepository(table_name=TABLE)
+
+
+class TestQueryPath:
+    @pytest.mark.asyncio
+    async def test_reads_the_catalog_off_the_index(self, aws, monkeypatch):
+        table = _make_table(with_index=True)
+        _seed_noise(table)
+        for t in ("calculator", "web_search"):
+            table.put_item(Item=_tool(t))
+
+        tools = await _repo(monkeypatch).list_tools()
+
+        assert sorted(t.tool_id for t in tools) == ["calculator", "web_search"]
+
+    @pytest.mark.asyncio
+    async def test_index_excludes_the_shared_table_noise(self, aws, monkeypatch):
+        """The whole point: skills, roles and per-user rows never come back."""
+        table = _make_table(with_index=True)
+        _seed_noise(table)
+        table.put_item(Item=_tool("calculator"))
+
+        tools = await _repo(monkeypatch).list_tools()
+
+        assert [t.tool_id for t in tools] == ["calculator"]
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_catalog_is_empty(self, aws, monkeypatch):
+        table = _make_table(with_index=True)
+        _seed_noise(table)
+
+        assert await _repo(monkeypatch).list_tools() == []
+
+
+class TestMissingIndexFallback:
+    @pytest.mark.asyncio
+    async def test_serves_the_catalog_when_the_index_does_not_exist(
+        self, aws, monkeypatch
+    ):
+        """The deploy race: backend ships before platform. Must NOT go empty —
+        we have a correct answer available, so serve it."""
+        table = _make_table(with_index=False)
+        _seed_noise(table)
+        for t in ("calculator", "web_search"):
+            table.put_item(Item=_tool(t))
+
+        tools = await _repo(monkeypatch).list_tools()
+
+        assert sorted(t.tool_id for t in tools) == ["calculator", "web_search"]
+
+    @pytest.mark.asyncio
+    async def test_a_real_query_error_still_propagates(self, aws, monkeypatch):
+        """Only 'index missing' is absorbed. Throttling must not read as
+        'there are no tools' — that is a lie about the data."""
+        _make_table(with_index=True)
+        repo = _repo(monkeypatch)
+
+        def boom(**_kwargs):
+            raise ClientError(
+                {"Error": {"Code": "ProvisionedThroughputExceededException",
+                           "Message": "slow down"}},
+                "Query",
+            )
+
+        monkeypatch.setattr(repo._table, "query", boom)
+
+        with pytest.raises(ClientError):
+            await repo.list_tools()
+
+
+class TestUnbackfilledIndexFallback:
+    @pytest.mark.asyncio
+    async def test_serves_the_catalog_when_the_index_is_unpopulated(
+        self, aws, monkeypatch
+    ):
+        """The silent case: index exists, backfill never ran, Query succeeds with
+        zero rows and raises nothing. Without the guard every user loses every
+        tool and no error is logged anywhere."""
+        table = _make_table(with_index=True)
+        _seed_noise(table)
+        for t in ("calculator", "web_search"):
+            table.put_item(Item=_tool(t, stamped=False))
+
+        tools = await _repo(monkeypatch).list_tools()
+
+        assert sorted(t.tool_id for t in tools) == ["calculator", "web_search"]
+
+    @pytest.mark.asyncio
+    async def test_says_loudly_that_the_backfill_has_not_run(
+        self, aws, monkeypatch, caplog
+    ):
+        table = _make_table(with_index=True)
+        table.put_item(Item=_tool("calculator", stamped=False))
+
+        with caplog.at_level("ERROR"):
+            await _repo(monkeypatch).list_tools()
+
+        assert "backfill_tool_catalog_index.py" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_empty_table_logs_nothing_alarming(self, aws, monkeypatch, caplog):
+        """A fresh install before seeding is not a broken backfill."""
+        _make_table(with_index=True)
+
+        with caplog.at_level("ERROR"):
+            assert await _repo(monkeypatch).list_tools() == []
+
+        assert "backfill" not in caplog.text
+
+
+class TestCategoryPathUnchanged:
+    @pytest.mark.asyncio
+    async def test_category_filter_still_uses_its_own_index(self, aws, monkeypatch):
+        """The category read is a separate bounded GSI query and is deliberately
+        untouched — it must not start returning the whole catalog."""
+        table = _make_table(with_index=True)
+        table.put_item(Item=_tool("calculator"))
+
+        repo = _repo(monkeypatch)
+        called = {"n": 0}
+        original = repo._query_tool_items_by_category
+
+        def spy(category):
+            called["n"] += 1
+            return original(category)
+
+        monkeypatch.setattr(repo, "_query_tool_items_by_category", spy)
+        await repo.list_tools(category="utility")
+
+        assert called["n"] == 1


### PR DESCRIPTION
**Part 2 of 2.** #1069 added `EntityTypeIndex` and stamped the tool rows; this switches
the read onto it. Closes out the follow-up named in #1068.

## Why

The `app-roles` table is shared — tools, skills, roles, role grants, JWT mappings and one
tool-preferences row **per user**. The Scan read the whole table and filtered, and Scan
cost tracks table size rather than result size, so the catalog read's cost grew with
**enrollment** rather than with the number of tools.

Measured on dev, before and after:

| | Items read | Returned |
|---|---:|---:|
| Base-table Scan | **95** | 24 |
| `EntityTypeIndex` Query | **24** | 24 |

The 95 grows with every user who ever saves a tool preference. The 24 does not.

## The fallbacks are why this is safe to ship

An empty tool catalog is not a degraded experience — every user loses every tool — and
**both** ways this index can fail to answer produce exactly that.

**The index is absent.** `platform.yml` and `backend.yml` are ordered by nothing, a GSI
is still `CREATING` after CloudFormation reports success, and a rolled-back stack ships
its images anyway. Falls back to the Scan.

This deliberately does *not* use `dynamo_errors.log_missing_index`. That helper is written
for surfaces that degrade to empty and its message says so — which would be a lie here,
because we have a correct answer available. We serve it and log accurately instead.

**The index is present but unpopulated.** This one raises *nothing*: the keys are sparse,
so a catalog whose backfill has not run indexes nothing and the Query succeeds with zero
rows. There is no error to catch. A zero result is therefore treated as suspect and
re-read via Scan — if the table really holds tools we serve them and log an ERROR naming
the backfill script; if it is genuinely empty (a fresh install before seeding) both agree,
it costs one extra read per cache fill, and nothing alarming is logged.

**A partial backfill is NOT covered.** Detecting it would mean scanning every time, which
is the cost being removed. That is what #1070's release gate and the backfill's own
`skipped=0 failed=0` report are for. Stated rather than papered over.

Only "index missing" is absorbed — throttling still propagates, because reporting "there
are no tools" would be a lie about the data rather than a degradation.

The category-filtered read is untouched (a bounded GSI query, off the first-load path),
with a test pinning that it still uses its own index.

## Testing

- Backend `pytest tests/` — **8,278 passed, 3 skipped**.
- 9 new tests, weighted toward the fallbacks rather than the happy path: catalog served
  when the index is absent; catalog served *and* an actionable ERROR logged when it is
  unpopulated; a genuinely empty table stays quiet; throttling propagates; shared-table
  noise (skills, roles, per-user rows, capability snapshots) never reaches the catalog;
  category path unchanged.
- One of them caught my own fixture modelling a table with **no** category index, which
  is not the real pre-deploy shape — fixed the fixture.

## Deploy state

dev already has the index `ACTIVE` and 24/24 rows stamped (verified by a live query), so
this can merge and deploy straight onto it.

**Prod needs `backfill_tool_catalog_index.py` run in the release window that carries this
commit** — before this code is live there. #1070's gate forces that into the release
notes; running it is still a human step. Worth noting the fallback means getting the
order wrong degrades to a Scan and a loud log rather than an empty catalog, but that is
a safety net, not the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
