### PR TITLE
feat(customize): add the Customize hub with Tools and Skills

### DIFF
--- a/docs/specs/customize-surface.md
+++ b/docs/specs/customize-surface.md
@@ -1,0 +1,208 @@
+# Customize — a browse surface for tools, skills and connectors
+
+**Status:** PR-1 (Customize shell: Tools + Skills) in flight. Steps 2–7 queued.
+**Supersedes:** the composer settings drawer (`components/model-settings/`) as the home for
+tool and skill enablement.
+**Related:** `docs/specs/skills-as-agent-primitive.md` (D6 opt-in), `docs/specs/agent-marketplace.md` (D1 one noun),
+`docs/specs/per-tool-mcp-enablement.md` equivalent in `tool-search-token-bloat-strategy.md`.
+
+## Problem
+
+Tool and skill enablement is **global, durable, per-user state**:
+
+- `services/skill/skill.service.ts:32` — "preferences persist globally per user"
+- `services/tool/tool.service.ts:414` — `savePreferences()` POSTs to the user preferences endpoint
+
+But it is presented in a drawer hanging off the composer, opened by a settings icon
+inside the chat input. That container reads as *settings for this conversation*. It is not.
+A user who enables a tool to get through one question has changed the `toolConfig` of every
+future turn, in every future session, permanently — and nothing in the UI said so.
+
+That is the defect. The secondary problem is capacity: the drawer is a ~320px column with
+collapsible sections, and the tool catalog has outgrown it. Per-tool MCP enablement means a
+single server (Student MyBoiseState, 17+ tools; canvas_faculty, 44) can exceed the entire
+drawer's comfortable length on its own. Browsing is not a thing the drawer can be made to do.
+
+## What Customize is
+
+A full page at `/customize` that owns the things a user *adds to* their assistant:
+
+| Tab | Contents | Today's home |
+|-----|----------|--------------|
+| **Tools** | The RBAC-granted tool catalog, per-tool and per-server enablement | Drawer § Tools |
+| **Skills** | Accessible skills (catalog-granted ∪ authored), opt-in toggles | Drawer § Skills |
+| **Connectors** | OAuth connection state for external MCP servers | `Settings → Connectors` |
+
+It is deliberately **capabilities only**. See §"What Customize is not".
+
+## Decision summary
+
+| Question | Decision |
+|----------|----------|
+| Does the composer settings drawer survive? | **No.** Deleted in step 5, once its contents have homes |
+| Does the settings icon survive? | **No.** `showSettingsControl` default flips to `false`, then the input is removed |
+| Where does model selection live? | Composer, where it already is (`chat-input.component.html:274`) |
+| Where do inference params live? | **Nowhere user-facing.** Effort subsumes them (step 3) |
+| What happens to Conversation Modes? | **Retired as a migration to Agents** (step 6), gated on prod usage |
+| Does the Agent Marketplace move into Customize? | **No.** See §"What Customize is not" |
+| Does Customize honour the Agent binding lock? | **No — deliberately.** See §"The agent-lock seam" |
+
+## Why the drawer can die entirely
+
+The drawer holds four things. Three of them are already redundant or dead:
+
+**Model selection — redundant.** `<app-model-dropdown />` is already in the composer at
+`session/components/chat-input/chat-input.component.html:274`. The drawer's model section is
+a second copy of a control the user can already see.
+
+**Advanced params — superseded by effort, and already lying.** Effort lives in the model
+dropdown's submenu with the active level in the trigger
+(`components/model-dropdown/model-dropdown.component.ts:41`). Meanwhile GPT-5.6
+**hard-rejects** `temperature` and `top_p` (measured; see `docs/specs/gpt-5-6-prompt-caching.md`
+and the inference-params findings), so a per-model numeric param form already misrepresents
+part of the catalog. Effort is the portable abstraction; the form is not.
+
+Removing the param form also retires the `max_tokens` ↔ extended-thinking coupling —
+Anthropic requires `thinking budget < max_tokens`, which is the entire reason
+`model-settings.ts:132-180` carries `unsatisfiable`, `clampNotices`, `disabledByConflict`
+and the post-edit re-check in `reconcileThinkingAfterMaxTokens`. That machinery, and its
+whole error-state vocabulary, goes with it.
+
+⚠️ `max_tokens` is a **truncation guard**, not a tuning knob. Before step 3 lands, confirm
+the admin-side default is generous enough that removing user control does not start clipping
+long outputs. Admin-locked params (`row.locked`, "locked by admin") are unaffected — this
+removes the *user-facing form*, not the governance behind it.
+
+**Conversation Mode — a strictly weaker Agent.** An admin-authored system prompt attached to
+a conversation, with no tools, no skills, no bindings, no icon and no `@`-mention. That is
+precisely the relationship Assistants had to Agents, which Marketplace D1 ("there is one noun,
+and it is Agent") resolved by migration. Untouched since the PR that introduced it (#411) apart
+from the delegated-admin-scope sweep and a theming pass.
+
+Retiring it is bigger than deleting a drawer section — it has admin CRUD pages and routes, an
+`admin.system_prompts` delegated scope, an admin nav entry, a user-facing `/system-prompts`
+app_api route, a DynamoDB entity, and `system_prompt_id` on the invocation payload
+(`apis/inference_api/chat/models.py:188`). ⚠️ **Gate on prod usage before writing any of it.**
+"Dormant in git" is not "dormant in prod"; if a department is using a Mode, it has users and
+the answer is a migration with redirects, not a deletion.
+
+**Skills and Tools — global state in a conversational container.** The actual problem. They
+move to Customize.
+
+Strip the first three and nothing conversation-scoped remains. The drawer is not slimmed; it
+is emptied, and then removed.
+
+## What Customize is not
+
+**Not the Agent Marketplace.** Customize is *capabilities you add to your assistant*. An Agent
+is not a capability you toggle — it is a thing you talk to. Putting Discover under Customize
+while My Agents stays in the sidenav splits one noun across two surfaces, which is the exact
+failure D1 exists to prevent and the reason the whole `/assistants` deprecation was written.
+
+The marketplace's real problem is narrower than placement: **Discover is already the first tab
+of `/agents`** (`agents/components/agents-tabs.component.ts:22`), but `/agents` resolves to
+*My Agents*, which is empty for nearly every user. The emptiest tab is the landing tab. The fix
+is a routing change — land `/agents` on Discover when the user has no agents — not a
+relocation. It is tracked here as step 7 and is independent of everything else in this spec.
+
+If a future decision does move the marketplace into Customize, it must move **all** of
+`/agents` and drop the sidenav entry. Splitting it is the one outcome to avoid.
+
+## The agent-lock seam
+
+⚠️ This is the sharp edge in PR-1, and it is a pre-existing defect the new surface exposes
+rather than one it creates.
+
+`ToolService` and `SkillService` are `providedIn: 'root'` singletons. When a conversation is
+bound to an Agent, `session.page.ts:806` calls `lockToAgentTools()` / `lockToAgentSkills()`,
+which makes `agentLocked()` true, rewrites what `visibleTools()` returns, and causes
+`toggleTool()` to **early-return without saving** (`tool.service.ts:272`).
+
+`ngOnDestroy` does **not** release these locks. They are cleared only when the session page
+later loads an unbound conversation (`session.page.ts:341,791`). So a user who navigates from
+an agent-bound chat straight to `/customize` arrives at a page where:
+
+1. the list shows the Agent's bound set instead of their own preferences, and
+2. every toggle silently does nothing.
+
+The lock is conversation-scoped state that leaked into a global singleton. Customize is a
+global surface and therefore **must not consult it**:
+
+- Read the user's true state (`tool.isEnabled` / `skill.isEnabled`), never the
+  display-shim (`isToolShownEnabled` / `isSkillShownEnabled`).
+- Write through a lock-agnostic path. `toggleTool` / `toggleSkill` take an optional
+  `{ respectAgentLock }`, defaulting to `true` so drawer behaviour is byte-identical.
+
+Deliberately **not** fixed by clearing locks in `ngOnDestroy`: the `/` ↔ `/s/:id` transition
+recreates the session component on a legitimate navigation (`session.page.ts:498`), so a
+destroy-time clear would drop and re-apply the lock mid-flow.
+
+The proper resolution is step 4 — the lock is a fact about the *conversation*, so it belongs
+on the assistant indicator pill
+(`session/components/assistant-indicator/assistant-indicator.component.ts`), which is already
+in the conversation and already has an actions menu, but says nothing about bindings today.
+Until then, a user toggling a skill in Customize has no way to know their agent-bound
+conversation will ignore it.
+
+## Cost consequence
+
+⚠️ **A surface designed to make enabling tools easy will raise enabled-tools-per-user, and
+every enabled tool grows `toolConfig` on every turn of every session** — the cacheable prefix
+the cost-effectiveness tenet exists to protect. This is the same pressure that made new
+injected tools ship `enabledByDefault=False` (default-on was a fleet-wide cache bypass), with
+a friendlier face.
+
+Two obligations, in the spec rather than discovered post-ship:
+
+1. **Ordering stays deterministic** regardless of the order the new UI writes preferences in.
+   Prompt-cache stability is exact-prefix-match; a set that reorders because the user toggled
+   from a grid instead of a list rewrites the whole prefix at the cache-write premium.
+2. **Browse should not be cost-blind.** Surfacing per-tool prompt weight (description +
+   schema token count) is the honest version of a store that encourages adding things. Not in
+   PR-1; named here so it is a decision rather than an omission.
+
+## Sequencing
+
+Each step is independently shippable. 3 and 6 do not depend on Customize at all.
+
+| # | Step | Depends on |
+|---|------|-----------|
+| 1 | **Customize shell** — `/customize`, Tools + Skills tabs, nav entry. Drawer stays; both live | — |
+| 2 | Fold `Settings → Connectors` in as the Connectors tab | 1 |
+| 3 | Drop model + Advanced params from the drawer (pure dedup + param removal) | — |
+| 4 | Agent-lock surfacing moves to the assistant indicator | — |
+| 5 | Delete the drawer and the settings icon | 1, 2, 3, 4 |
+| 6 | Conversation Modes retired as an Agent migration | prod-usage check |
+| 7 | `/agents` lands on Discover for users with no agents | — |
+
+Step 5 is last for a reason: pull the icon before Customize exists and you have removed the
+only path to skills and tools. The end-state composer already renders today —
+`showSettingsControl` is an existing input, set `false` in the agent preview
+(`agents/agent-form/components/agent-preview.component.ts:121`) and the marketplace review
+test-drive (`admin/marketplace/components/review-test-drive.component.ts:144`). Step 5 flips
+the default and deletes the input.
+
+## Open question
+
+**Does the composer keep a pointer to Customize?** Removing the icon outright is the clean
+version; a menu item under the `+` is the hedged one. Since enablement is global and durable,
+"I need a tool mid-conversation" is rarer than it feels — Claude itself has no in-composer
+skill toggle. But the path has to exist somewhere, and it should be decided rather than
+discovered. Resolve before step 5.
+
+## PR-1 scope
+
+**In:**
+
+- `/customize` → `/customize/tools`, `/customize/skills`, lazy-loaded, `authGuard`
+- Tabs strip mirroring `AgentsTabsComponent`
+- Browse idiom borrowed from `agents/discover`: search box + category chips + responsive grid
+- Cards read the existing root services — no new endpoints, no new state. Because both
+  surfaces share the same singletons, a toggle in Customize updates the drawer live and
+  vice versa
+- Sidenav entry (which also gives `/my-skills` a reachable home — see the standing
+  `sidenav.html:92` comment saying its navigation was undecided)
+- The lock-agnostic write path described in §"The agent-lock seam"
+
+**Out:** connectors tab (step 2), tool detail pane / per-sub-tool expansion, any drawer
+deletion, prompt-weight display, marketplace changes.

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -160,6 +160,30 @@ export const routes: Routes = [
         loadComponent: () => import('./my-skills/my-skills.page').then(m => m.MySkillsPage),
         canActivate: [authGuard],
     },
+    // ── Customize ───────────────────────────────────────────────────────────────
+    // The capabilities hub: what the user adds to their assistant. Tools and
+    // Skills in PR-1; Connectors folds in from `Settings → Connectors` in step 2.
+    // Deliberately NOT the Agent Marketplace — an Agent is something you talk to,
+    // not a capability you toggle, and splitting that noun across two surfaces is
+    // the failure Marketplace D1 exists to prevent.
+    // See `docs/specs/customize-surface.md`.
+    {
+        path: 'customize/tools',
+        loadComponent: () =>
+            import('./customize/tools/customize-tools.page').then(m => m.CustomizeToolsPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'customize/skills',
+        loadComponent: () =>
+            import('./customize/skills/customize-skills.page').then(m => m.CustomizeSkillsPage),
+        canActivate: [authGuard],
+    },
+    {
+        path: 'customize',
+        redirectTo: 'customize/tools',
+        pathMatch: 'full',
+    },
     {
         path: 'memories',
         loadComponent: () => import('./memory/memory-dashboard.page').then(m => m.MemoryDashboardPage),

--- a/frontend/ai.client/src/app/components/sidenav/sidenav.html
+++ b/frontend/ai.client/src/app/components/sidenav/sidenav.html
@@ -89,10 +89,29 @@
         </a>
 
         <!--
-            No "My Skills" nav entry: the /my-skills route, page, and service are
-            live, but how users reach them is still undecided, so the link stays
-            out of the sidenav until that navigation path is settled.
+            Customize — the capabilities hub: tools and skills now, connectors in
+            step 2. Ungated like Agents and Artifacts above; `/customize/*` carries
+            only `authGuard`, so there is no kill switch for the entry to ride.
+
+            This also answers the standing "how do users reach /my-skills" question
+            that kept that link out of this nav: the Skills tab links to it, so the
+            authoring surface is reachable without a fourth top-level entry
+            competing with the three that matter.
+
+            See `docs/specs/customize-surface.md`.
         -->
+        <a
+            routerLink="/customize"
+            routerLinkActive="bg-gray-200/80 dark:bg-white/10"
+            (click)="sidenavService.close()"
+            class="group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-gray-200/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary-500 dark:hover:bg-white/5">
+            <div class="flex size-7 shrink-0 items-center justify-center text-gray-500 dark:text-gray-400">
+                <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75" />
+                </svg>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Customize</span>
+        </a>
     </div>
 
     <nav class="flex-1 overflow-y-auto px-3 pb-4">

--- a/frontend/ai.client/src/app/customize/components/customize-card.component.ts
+++ b/frontend/ai.client/src/app/customize/components/customize-card.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+/** Connection chip shown beside a card's name, or null to draw none. */
+export type CustomizeCardBadge = 'connected' | 'connect' | null;
+
+/**
+ * One capability card in the Customize grid — a tool or a skill.
+ *
+ * Presentational only: it holds no service and decides nothing. The pages own
+ * "what is this" and "what happens when it flips"; this owns the shape. That
+ * split is what lets Tools and Skills share one visual language while their
+ * enable semantics stay opposite (tools default ON, skills default OFF —
+ * Skills v2 D6).
+ *
+ * The whole card is NOT a button. The switch is the only control, so the card
+ * carries no competing click target and the accessible name of the toggle is
+ * the thing being toggled. Detail views arrive in a later step; when they do,
+ * the body becomes a link and the switch stays a sibling, never a nested
+ * button-in-button (see the drawer's own note at `model-settings.html:667`).
+ */
+@Component({
+  selector: 'app-customize-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block h-full' },
+  template: `
+    <div
+      class="flex h-full items-start gap-3 rounded-2xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
+    >
+      <span
+        aria-hidden="true"
+        class="grid size-9 shrink-0 place-items-center rounded-xl border border-gray-200 bg-gray-50 font-mono text-xs font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+        >{{ monogram() }}</span
+      >
+
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 items-center gap-1.5">
+          <h3 class="min-w-0 truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
+            {{ name() }}
+          </h3>
+          @switch (badge()) {
+            @case ('connected') {
+              <span
+                class="shrink-0 rounded-sm bg-state-success-50 px-1.5 font-mono text-[10px]/5 font-medium text-state-success-700 dark:bg-state-success-900/30 dark:text-state-success-300"
+                >connected</span
+              >
+            }
+            @case ('connect') {
+              <span
+                class="shrink-0 rounded-sm bg-state-warning-50 px-1.5 font-mono text-[10px]/5 font-medium text-state-warning-700 dark:bg-state-warning-900/30 dark:text-state-warning-300"
+                >connect</span
+              >
+            }
+          }
+        </div>
+        <p class="mt-0.5 line-clamp-2 text-xs/5 text-gray-500 dark:text-gray-400">
+          {{ description() }}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        role="switch"
+        [attr.aria-checked]="enabled()"
+        [attr.aria-label]="(enabled() ? 'Disable ' : 'Enable ') + name()"
+        [disabled]="pending()"
+        (click)="toggled.emit()"
+        class="relative mt-0.5 inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+        [class]="enabled() ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'"
+      >
+        <span
+          aria-hidden="true"
+          class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+          [class.translate-x-5]="enabled()"
+          [class.translate-x-0]="!enabled()"
+        ></span>
+      </button>
+    </div>
+  `,
+})
+export class CustomizeCardComponent {
+  readonly name = input.required<string>();
+  readonly description = input<string>('');
+  readonly monogram = input<string>('?');
+  readonly enabled = input<boolean>(false);
+  /** In-flight save: the switch stays visually settled but refuses a second click. */
+  readonly pending = input<boolean>(false);
+  readonly badge = input<CustomizeCardBadge>(null);
+
+  readonly toggled = output<void>();
+}

--- a/frontend/ai.client/src/app/customize/components/customize-tabs.component.ts
+++ b/frontend/ai.client/src/app/customize/components/customize-tabs.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+
+/**
+ * The `/customize` hub tab strip.
+ *
+ * Two tabs in PR-1: **Tools** and **Skills**. **Connectors** joins them in step 2
+ * when `Settings → Connectors` folds in — connecting an external MCP server and
+ * enabling its tools are one user intent split across two pages today, and that
+ * split gets worse, not better, once Tools lives here.
+ *
+ * Mirrors `AgentsTabsComponent` deliberately: `/agents` and `/customize` are
+ * sibling hubs, and a second tab idiom would make them read as unrelated
+ * products.
+ */
+@Component({
+  selector: 'app-customize-tabs',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, RouterLinkActive],
+  template: `
+    <nav
+      class="inline-flex gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
+      aria-label="Customize views"
+    >
+      <a
+        routerLink="/customize/tools"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        Tools
+      </a>
+      <a
+        routerLink="/customize/skills"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        Skills
+      </a>
+    </nav>
+  `,
+})
+export class CustomizeTabsComponent {}

--- a/frontend/ai.client/src/app/customize/skills/customize-skills.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skills.page.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { CustomizeSkillsPage } from './customize-skills.page';
+import { SkillService, UserSkill } from '../../services/skill/skill.service';
+import { ConfigService } from '../../services/config.service';
+
+/**
+ * The rejection from a failed save travels catch → signal set, which lands a
+ * microtask after `whenStable()` has already resolved on the HTTP task. One
+ * macrotask tick is what makes the banner observable.
+ */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const skill = (
+  overrides: Partial<UserSkill> & Pick<UserSkill, 'skillId' | 'displayName'>,
+): UserSkill => ({
+  description: 'Knows a thing.',
+  category: 'writing',
+  userEnabled: null,
+  isEnabled: false,
+  ...overrides,
+});
+
+const CATALOG: UserSkill[] = [
+  skill({ skillId: 'sk_apa', displayName: 'APA Citations', isEnabled: true, userEnabled: true }),
+  skill({ skillId: 'sk_syllabus', displayName: 'Syllabus Builder', category: 'teaching' }),
+  skill({ skillId: 'sk_rubric', displayName: 'Rubric Writer', category: 'teaching' }),
+];
+
+describe('CustomizeSkillsPage', () => {
+  let http: HttpTestingController;
+  let skills: SkillService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    });
+    TestBed.inject(ConfigService).appApiUrl.set('/api');
+    http = TestBed.inject(HttpTestingController);
+    skills = TestBed.inject(SkillService);
+  });
+
+  afterEach(() => {
+    http.verify();
+    TestBed.resetTestingModule();
+  });
+
+  /** SkillService does NOT load in its constructor, so the page triggers it. */
+  async function create(catalog: UserSkill[] = CATALOG) {
+    const fixture = TestBed.createComponent(CustomizeSkillsPage);
+    fixture.detectChanges();
+    http.expectOne('/api/skills/').flush({ skills: catalog.map(s => ({ ...s })), totalCount: catalog.length });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = (fixture: { nativeElement: HTMLElement }) => fixture.nativeElement.textContent ?? '';
+
+  it('loads the catalog itself, since SkillService defers its own load', async () => {
+    const fixture = await create();
+    expect(skills.initialized()).toBe(true);
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(3);
+  });
+
+  it('counts what is on — skills default off, so most of the catalog is', async () => {
+    const fixture = await create();
+    expect(text(fixture)).toContain('1 of 3 skills on');
+  });
+
+  it('gives /my-skills the nav path it has never had', async () => {
+    const fixture = await create();
+    const link = fixture.nativeElement.querySelector('a[href="/my-skills"]');
+    expect(link).toBeTruthy();
+    expect(link.textContent).toContain('My skills');
+  });
+
+  it('searches across name, description and category', async () => {
+    const fixture = await create();
+    fixture.componentInstance['query'].set('rubric');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(1);
+    expect(text(fixture)).toContain('Rubric Writer');
+  });
+
+  it('filters by category chip', async () => {
+    const fixture = await create();
+    fixture.componentInstance['activeCategory'].set('teaching');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(2);
+  });
+
+  it('writes a toggle through to the preferences endpoint', async () => {
+    const fixture = await create();
+    const toggles = fixture.nativeElement.querySelectorAll('app-customize-card button[role="switch"]');
+    (toggles[1] as HTMLButtonElement).click();
+    await fixture.whenStable();
+
+    const req = http.expectOne('/api/skills/preferences');
+    expect(req.request.body.preferences).toEqual({ sk_syllabus: true });
+    req.flush({});
+  });
+
+  it('surfaces a failed save', async () => {
+    const fixture = await create();
+    const toggles = fixture.nativeElement.querySelectorAll('app-customize-card button[role="switch"]');
+    (toggles[1] as HTMLButtonElement).click();
+    await fixture.whenStable();
+
+    http.expectOne('/api/skills/preferences').flush('nope', { status: 500, statusText: 'Error' });
+    await settle();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain("Couldn't save the change to Syllabus Builder");
+    expect(skills.getSkill('sk_syllabus')?.isEnabled).toBe(false);
+  });
+
+  it('explains an empty catalog rather than showing a bare grid', async () => {
+    const fixture = await create([]);
+    expect(text(fixture)).toContain('No skills available');
+  });
+
+  describe('the agent-lock seam', () => {
+    // See docs/specs/customize-surface.md §"The agent-lock seam", and the
+    // matching block in customize-tools.page.spec.ts.
+
+    it('shows the user their own catalog, not the Agent’s bound subset', async () => {
+      skills.lockToAgentSkills(['sk_apa']);
+      const fixture = await create();
+
+      expect(skills.visibleSkills()).toHaveLength(1); // what the drawer would show
+      expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(3);
+    });
+
+    it('still saves a toggle while a lock is held', async () => {
+      skills.lockToAgentSkills(['sk_apa']);
+      const fixture = await create();
+
+      const toggles = fixture.nativeElement.querySelectorAll(
+        'app-customize-card button[role="switch"]',
+      );
+      (toggles[1] as HTMLButtonElement).click();
+      await fixture.whenStable();
+
+      const req = http.expectOne('/api/skills/preferences');
+      expect(req.request.body.preferences).toEqual({ sk_syllabus: true });
+      req.flush({});
+    });
+  });
+});

--- a/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
@@ -1,0 +1,257 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroMagnifyingGlass, heroArrowTopRightOnSquare } from '@ng-icons/heroicons/outline';
+import { SkillService, UserSkill } from '../../services/skill/skill.service';
+import { monogramFor } from '../../shared/utils/monogram';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+import { CustomizeTabsComponent } from '../components/customize-tabs.component';
+import { CustomizeCardComponent } from '../components/customize-card.component';
+
+/** A skill paired with everything the card needs, resolved once per render. */
+interface SkillCard {
+  skill: UserSkill;
+  name: string;
+  description: string;
+  monogram: string;
+  enabled: boolean;
+}
+
+/**
+ * Customize → Skills. The browsable home for skill enablement (spec step 1).
+ *
+ * ⚠️ Reads `skillService.skills()` and `skill.isEnabled`, NOT `visibleSkills()` /
+ * `isSkillShownEnabled()`, and writes with `respectAgentLock: false`. See
+ * `docs/specs/customize-surface.md` §"The agent-lock seam" and the matching note
+ * on `CustomizeToolsPage`.
+ *
+ * Skills default **off** (Skills v2 D6 opt-in — the reverse of tools), so the
+ * empty-ish state here is the expected one, not a fault. The copy says so rather
+ * than leaving a page of grey switches to imply something is broken.
+ */
+@Component({
+  selector: 'app-customize-skills',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgIcon,
+    RouterLink,
+    SpinnerComponent,
+    CustomizeTabsComponent,
+    CustomizeCardComponent,
+  ],
+  providers: [provideIcons({ heroMagnifyingGlass, heroArrowTopRightOnSquare })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <app-customize-tabs />
+
+        <div class="mt-6 mb-6 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Skills</h1>
+            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+              Instructions your assistant can pull in on demand. Skills are off until you
+              turn them on, and apply to every conversation.
+            </p>
+          </div>
+          <!-- The first nav path /my-skills has ever had. Its absence was a
+               standing open question in the sidenav (see sidenav.html). -->
+          <a
+            routerLink="/my-skills"
+            class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl border border-gray-200 bg-white px-3.5 py-1.5 text-sm/6 font-medium text-gray-700 transition-colors hover:border-gray-300 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
+          >
+            My skills
+            <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
+          </a>
+        </div>
+
+        <div class="relative max-w-md">
+          <ng-icon
+            name="heroMagnifyingGlass"
+            class="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <label for="customize-skill-search" class="sr-only">Search skills</label>
+          <input
+            type="search"
+            id="customize-skill-search"
+            [value]="query()"
+            (input)="onSearch($event)"
+            placeholder="Search skills…"
+            class="block w-full rounded-full border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+          />
+        </div>
+
+        @if (!query() && categoryChips().length > 1) {
+          <div class="mt-4 flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+            @for (chip of categoryChips(); track chip) {
+              <button
+                type="button"
+                (click)="onCategory(chip)"
+                [attr.aria-pressed]="activeCategory() === chip"
+                class="rounded-full border px-3.5 py-1 text-sm/6 font-medium capitalize transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                [class]="
+                  activeCategory() === chip
+                    ? 'border-gray-900 bg-gray-900 text-white dark:border-white dark:bg-white dark:text-gray-900'
+                    : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-white'
+                "
+              >
+                {{ chip === ALL ? 'All' : chip }}
+              </button>
+            }
+          </div>
+        }
+
+        @if (skillService.error(); as loadError) {
+          <div
+            role="alert"
+            class="mt-6 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+          >
+            {{ loadError }}
+          </div>
+        }
+
+        @if (saveError()) {
+          <div
+            role="alert"
+            class="mt-6 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+          >
+            {{ saveError() }}
+          </div>
+        }
+
+        @if (skillService.loading() && !skillService.initialized()) {
+          <div class="mt-8 flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
+            <app-spinner size="sm" label="Loading skills" />
+            Loading skills…
+          </div>
+        } @else if (cards().length === 0) {
+          <div
+            class="mt-8 rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700"
+          >
+            <p class="text-sm/6 font-medium text-gray-900 dark:text-white">
+              {{ query() ? 'No skills match your search' : 'No skills available' }}
+            </p>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              {{
+                query()
+                  ? 'Try a different word, or clear the search to browse everything.'
+                  : 'Your roles do not grant access to any skills yet, and you have not written one.'
+              }}
+            </p>
+          </div>
+        } @else {
+          <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400" aria-live="polite">
+            {{ enabledLabel() }}
+          </p>
+          <ul class="mt-3 grid gap-3 sm:grid-cols-2">
+            @for (card of cards(); track card.skill.skillId) {
+              <li>
+                <app-customize-card
+                  [name]="card.name"
+                  [description]="card.description"
+                  [monogram]="card.monogram"
+                  [enabled]="card.enabled"
+                  [pending]="pending().has(card.skill.skillId)"
+                  (toggled)="onToggle(card.skill)"
+                />
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class CustomizeSkillsPage {
+  protected readonly skillService = inject(SkillService);
+
+  /** The chip meaning "don't filter". Not a category id, so it can never collide. */
+  protected readonly ALL = '__all__';
+
+  protected readonly query = signal('');
+  protected readonly activeCategory = signal<string>(this.ALL);
+  protected readonly pending = signal<ReadonlySet<string>>(new Set());
+  protected readonly saveError = signal<string | null>(null);
+
+  constructor() {
+    // Unlike ToolService, SkillService does not load in its constructor — the
+    // load is deferred to whichever surface needs it first. This is now one of
+    // them.
+    if (!this.skillService.initialized() && !this.skillService.loading()) {
+      void this.skillService.loadSkills();
+    }
+  }
+
+  protected readonly categoryChips = computed(() => {
+    const categories = [
+      ...new Set(
+        this.skillService
+          .skills()
+          .map(s => s.category)
+          .filter((c): c is string => !!c),
+      ),
+    ].sort();
+    return [this.ALL, ...categories];
+  });
+
+  protected readonly cards = computed<SkillCard[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const category = this.activeCategory();
+
+    // `skills()`, never `visibleSkills()` — see the class comment.
+    let skills = this.skillService.skills();
+
+    if (q) {
+      skills = skills.filter(skill =>
+        [skill.displayName, skill.description, skill.category]
+          .filter((field): field is string => !!field)
+          .some(field => field.toLowerCase().includes(q)),
+      );
+    } else if (category !== this.ALL) {
+      skills = skills.filter(skill => skill.category === category);
+    }
+
+    return skills.map(skill => ({
+      skill,
+      name: skill.displayName,
+      description: skill.description || 'No description recorded.',
+      monogram: monogramFor(skill.displayName),
+      // `isEnabled`, never `isSkillShownEnabled()` — see the class comment.
+      enabled: skill.isEnabled,
+    }));
+  });
+
+  protected readonly enabledLabel = computed(() => {
+    const total = this.skillService.skills().length;
+    const on = this.skillService.skills().filter(s => s.isEnabled).length;
+    return `${on} of ${total} ${total === 1 ? 'skill' : 'skills'} on`;
+  });
+
+  protected onSearch(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onCategory(chip: string): void {
+    this.activeCategory.set(chip);
+  }
+
+  protected async onToggle(skill: UserSkill): Promise<void> {
+    const id = skill.skillId;
+    if (this.pending().has(id)) return;
+
+    this.saveError.set(null);
+    this.pending.update(set => new Set(set).add(id));
+    try {
+      // `respectAgentLock: false` — see the class comment.
+      await this.skillService.toggleSkill(id, { respectAgentLock: false });
+    } catch {
+      this.saveError.set(`Couldn't save the change to ${skill.displayName}. Please try again.`);
+    } finally {
+      this.pending.update(set => {
+        const next = new Set(set);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+}

--- a/frontend/ai.client/src/app/customize/tools/customize-tools.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tools.page.spec.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { CustomizeToolsPage } from './customize-tools.page';
+import { Tool, ToolService, ToolsResponse } from '../../services/tool/tool.service';
+import { ConfigService } from '../../services/config.service';
+import {
+  ConnectionState,
+  ConnectorStatusService,
+} from '../../settings/connectors/services/connector-status.service';
+
+/**
+ * Stands in for the real status service, which owns a BroadcastChannel and a
+ * window `message` subscription this page has no interest in. The page only
+ * ever asks it two things.
+ */
+class FakeConnectorStatus {
+  states: Record<string, ConnectionState> = {};
+  ensured: string[] = [];
+
+  stateFor(providerId: string | null | undefined): ConnectionState {
+    return providerId ? (this.states[providerId] ?? 'unknown') : 'unknown';
+  }
+
+  async ensure(providerIds: readonly (string | null | undefined)[]): Promise<void> {
+    this.ensured.push(...providerIds.filter((p): p is string => !!p));
+  }
+}
+
+/**
+ * The rejection from a failed save travels catch → signal set, which lands a
+ * microtask after `whenStable()` has already resolved on the HTTP task. One
+ * macrotask tick is what makes the banner observable.
+ */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const tool = (overrides: Partial<Tool> & Pick<Tool, 'toolId' | 'displayName'>): Tool => ({
+  description: 'Does a thing.',
+  category: 'utility',
+  icon: null,
+  protocol: 'local',
+  status: 'active',
+  grantedBy: [],
+  enabledByDefault: true,
+  userEnabled: null,
+  isEnabled: true,
+  ...overrides,
+});
+
+const CATALOG: Tool[] = [
+  tool({ toolId: 'web_search', displayName: 'Web Search', category: 'search' }),
+  tool({ toolId: 'calculator', displayName: 'Calculator', category: 'utility', isEnabled: false }),
+  tool({
+    toolId: 'canvas_faculty',
+    displayName: 'Canvas Faculty',
+    category: 'data',
+    protocol: 'mcp_external',
+    description: 'Canvas LMS access.\n\nArgs:\n  course_id: the course',
+    serverTools: [
+      { name: 'list_courses', enabled: true },
+      { name: 'list_assignments', enabled: false },
+    ],
+  }),
+];
+
+describe('CustomizeToolsPage', () => {
+  let http: HttpTestingController;
+  let tools: ToolService;
+  let connectors: FakeConnectorStatus;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    connectors = new FakeConnectorStatus();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: ConnectorStatusService, useValue: connectors },
+      ],
+    });
+    TestBed.inject(ConfigService).appApiUrl.set('/api');
+    http = TestBed.inject(HttpTestingController);
+
+    // ToolService loads in its own constructor; settle that before the page mounts
+    // so the component sees a resolved catalog.
+    tools = TestBed.inject(ToolService);
+    const response: ToolsResponse = {
+      tools: CATALOG.map(t => ({ ...t })),
+      categories: ['search', 'utility', 'data'],
+      appRolesApplied: [],
+    };
+    http.match(req => req.url.startsWith('/api/tools')).forEach(req => req.flush(response));
+  });
+
+  afterEach(() => {
+    http.verify();
+    TestBed.resetTestingModule();
+  });
+
+  async function create() {
+    const fixture = TestBed.createComponent(CustomizeToolsPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = (fixture: { nativeElement: HTMLElement }) => fixture.nativeElement.textContent ?? '';
+
+  it('lists every granted tool as a card', async () => {
+    const fixture = await create();
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(3);
+    expect(text(fixture)).toContain('Web Search');
+    expect(text(fixture)).toContain('Canvas Faculty');
+  });
+
+  it('counts what is on, not what exists', async () => {
+    const fixture = await create();
+    expect(text(fixture)).toContain('2 of 3 tools on');
+  });
+
+  it('searches across name, description and category', async () => {
+    const fixture = await create();
+    fixture.componentInstance['query'].set('canvas');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(1);
+    expect(text(fixture)).toContain('Canvas Faculty');
+  });
+
+  it('filters by category chip', async () => {
+    const fixture = await create();
+    fixture.componentInstance['activeCategory'].set('search');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(1);
+    expect(text(fixture)).toContain('Web Search');
+  });
+
+  it('leads an MCP server card with its partial-selection state', async () => {
+    const fixture = await create();
+    // The count is the fact a card can't bury while there is no per-tool pane.
+    expect(text(fixture)).toContain('1 of 2 tools on');
+    // And the docstring Args: block never reaches the card.
+    expect(text(fixture)).not.toContain('course_id');
+  });
+
+  it('counts a single-tool server in the singular', async () => {
+    // The dev catalog has several of these (Hello World, Search Boise State),
+    // and "1 tools" is the kind of thing a browse surface cannot ship with.
+    tools['_tools'].set([
+      tool({
+        toolId: 'hello_world',
+        displayName: 'Hello World',
+        protocol: 'mcp',
+        serverTools: [{ name: 'hello', enabled: true }],
+      }),
+    ]);
+    const fixture = await create();
+    expect(text(fixture)).toContain('1 tool ·');
+    expect(text(fixture)).not.toContain('1 tools');
+  });
+
+  it('writes a toggle through to the preferences endpoint', async () => {
+    const fixture = await create();
+    const toggle = fixture.nativeElement.querySelector(
+      'app-customize-card button[role="switch"]',
+    ) as HTMLButtonElement;
+    toggle.click();
+    await fixture.whenStable();
+
+    const req = http.expectOne('/api/tools/preferences');
+    expect(req.request.body.preferences).toEqual({ web_search: false });
+    req.flush({});
+  });
+
+  it('surfaces a failed save instead of letting the switch snap back silently', async () => {
+    const fixture = await create();
+    const toggle = fixture.nativeElement.querySelector(
+      'app-customize-card button[role="switch"]',
+    ) as HTMLButtonElement;
+    toggle.click();
+    await fixture.whenStable();
+
+    http.expectOne('/api/tools/preferences').flush('nope', { status: 500, statusText: 'Error' });
+    await settle();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain("Couldn't save the change to Web Search");
+    // The service reverted its optimistic update, so the switch is back ON.
+    expect(tools.getTool('web_search')?.isEnabled).toBe(true);
+  });
+
+  describe('the agent-lock seam', () => {
+    // ToolService is a root singleton and the session view never releases the
+    // Agent binding lock on teardown, so a user can arrive here carrying one.
+    // A global preference page must ignore it entirely.
+    // See docs/specs/customize-surface.md §"The agent-lock seam".
+
+    it('shows the user their own catalog, not the Agent’s bound subset', async () => {
+      tools.lockToAgentTools(['canvas_faculty']);
+      const fixture = await create();
+
+      expect(tools.agentLocked()).toBe(true);
+      expect(tools.visibleTools()).toHaveLength(1); // what the drawer would show
+      expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(3);
+    });
+
+    it('shows the user’s own enabled state, not membership of the bound set', async () => {
+      // `calculator` is OFF for the user and absent from the Agent's bindings.
+      // The drawer's shim would render it ON if it were bound, and the page
+      // must not inherit that.
+      tools.lockToAgentTools(['calculator']);
+      const fixture = await create();
+
+      expect(tools.isToolShownEnabled(CATALOG[1])).toBe(true); // drawer shim says ON
+      const cards = fixture.componentInstance['cards']();
+      expect(cards.find(c => c.tool.toolId === 'calculator')?.enabled).toBe(false);
+    });
+
+    it('still saves a toggle while a lock is held', async () => {
+      tools.lockToAgentTools(['canvas_faculty']);
+      const fixture = await create();
+
+      const toggle = fixture.nativeElement.querySelector(
+        'app-customize-card button[role="switch"]',
+      ) as HTMLButtonElement;
+      toggle.click();
+      await fixture.whenStable();
+
+      // Without `respectAgentLock: false` this request is never made and the
+      // user's click vanishes with no feedback.
+      const req = http.expectOne('/api/tools/preferences');
+      expect(req.request.body.preferences).toEqual({ web_search: false });
+      req.flush({});
+    });
+  });
+});

--- a/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
@@ -1,0 +1,298 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
+import { Tool, ToolService } from '../../services/tool/tool.service';
+import { ConnectorStatusService } from '../../settings/connectors/services/connector-status.service';
+import { splitToolDescription } from '../../shared/utils/tool-description';
+import { monogramFor } from '../../shared/utils/monogram';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+import { CustomizeTabsComponent } from '../components/customize-tabs.component';
+import {
+  CustomizeCardBadge,
+  CustomizeCardComponent,
+} from '../components/customize-card.component';
+
+/** A tool paired with everything the card needs, resolved once per render. */
+interface ToolCard {
+  tool: Tool;
+  name: string;
+  description: string;
+  monogram: string;
+  enabled: boolean;
+  badge: CustomizeCardBadge;
+}
+
+/**
+ * Customize → Tools. The browsable home for tool enablement (spec step 1).
+ *
+ * ⚠️ This page deliberately reads `toolService.tools()` and `tool.isEnabled`,
+ * NOT `visibleTools()` / `isToolShownEnabled()`, and writes with
+ * `respectAgentLock: false`. The Agent binding lock is conversation-scoped state
+ * held on a root singleton that the session view never releases on teardown, so
+ * a user arriving here from an agent-bound chat would otherwise see the Agent's
+ * toolset in place of their own preferences and find every switch inert. See
+ * `docs/specs/customize-surface.md` §"The agent-lock seam"; step 4 moves that
+ * fact onto the assistant indicator, where it belongs.
+ *
+ * The browse idiom — search box, category chips, responsive grid — is borrowed
+ * from `agents/discover` on purpose. Everything is already loaded, so filtering
+ * is instant and search and chips can never disagree.
+ */
+@Component({
+  selector: 'app-customize-tools',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, SpinnerComponent, CustomizeTabsComponent, CustomizeCardComponent],
+  providers: [provideIcons({ heroMagnifyingGlass })],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <app-customize-tabs />
+
+        <div class="mt-6 mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Tools</h1>
+          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+            What your assistant can do. Changes apply to every conversation, including
+            ones already open.
+          </p>
+        </div>
+
+        <div class="relative max-w-md">
+          <ng-icon
+            name="heroMagnifyingGlass"
+            class="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <label for="customize-tool-search" class="sr-only">Search tools</label>
+          <input
+            type="search"
+            id="customize-tool-search"
+            [value]="query()"
+            (input)="onSearch($event)"
+            placeholder="Search tools…"
+            class="block w-full rounded-full border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+          />
+        </div>
+
+        <!-- Category chips. Hidden while searching: search already crosses every
+             category, so a category filter beside it would offer two answers to
+             one question. -->
+        @if (!query() && categoryChips().length > 1) {
+          <div class="mt-4 flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+            @for (chip of categoryChips(); track chip) {
+              <button
+                type="button"
+                (click)="onCategory(chip)"
+                [attr.aria-pressed]="activeCategory() === chip"
+                class="rounded-full border px-3.5 py-1 text-sm/6 font-medium capitalize transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                [class]="
+                  activeCategory() === chip
+                    ? 'border-gray-900 bg-gray-900 text-white dark:border-white dark:bg-white dark:text-gray-900'
+                    : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:text-white'
+                "
+              >
+                {{ chip === ALL ? 'All' : chip }}
+              </button>
+            }
+          </div>
+        }
+
+        @if (toolService.error(); as loadError) {
+          <div
+            role="alert"
+            class="mt-6 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+          >
+            {{ loadError }}
+          </div>
+        }
+
+        <!-- A save that failed is a different event from a catalog that failed to
+             load, and a switch that silently snaps back is the worst outcome of
+             the three. -->
+        @if (saveError()) {
+          <div
+            role="alert"
+            class="mt-6 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+          >
+            {{ saveError() }}
+          </div>
+        }
+
+        @if (toolService.loading() && !toolService.initialized()) {
+          <div class="mt-8 flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
+            <app-spinner size="sm" label="Loading tools" />
+            Loading tools…
+          </div>
+        } @else if (cards().length === 0) {
+          <div
+            class="mt-8 rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700"
+          >
+            <p class="text-sm/6 font-medium text-gray-900 dark:text-white">
+              {{ query() ? 'No tools match your search' : 'No tools available' }}
+            </p>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              {{
+                query()
+                  ? 'Try a different word, or clear the search to browse everything.'
+                  : 'Your roles do not grant access to any tools yet.'
+              }}
+            </p>
+          </div>
+        } @else {
+          <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400" aria-live="polite">
+            {{ enabledLabel() }}
+          </p>
+          <ul class="mt-3 grid gap-3 sm:grid-cols-2">
+            @for (card of cards(); track card.tool.toolId) {
+              <li>
+                <app-customize-card
+                  [name]="card.name"
+                  [description]="card.description"
+                  [monogram]="card.monogram"
+                  [enabled]="card.enabled"
+                  [badge]="card.badge"
+                  [pending]="pending().has(card.tool.toolId)"
+                  (toggled)="onToggle(card.tool)"
+                />
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </div>
+  `,
+})
+export class CustomizeToolsPage {
+  protected readonly toolService = inject(ToolService);
+  private readonly connectorStatus = inject(ConnectorStatusService);
+
+  /** The chip meaning "don't filter". Not a category id, so it can never collide. */
+  protected readonly ALL = '__all__';
+
+  protected readonly query = signal('');
+  protected readonly activeCategory = signal<string>(this.ALL);
+  protected readonly pending = signal<ReadonlySet<string>>(new Set());
+  protected readonly saveError = signal<string | null>(null);
+
+  constructor() {
+    // ToolService loads in its own constructor, so the catalog is usually
+    // already in flight by the time this page mounts. Ask anyway when it isn't:
+    // a deep link to /customize/tools is a legitimate first paint.
+    if (!this.toolService.initialized() && !this.toolService.loading()) {
+      void this.toolService.loadTools();
+    }
+
+    // Resolve connection state for whichever providers the catalog actually
+    // references. `ensure` de-dupes and caches, so this settles once.
+    effect(() => {
+      const providers = this.toolService
+        .tools()
+        .map(t => t.requiresOauthProvider)
+        .filter(Boolean);
+      if (providers.length > 0) {
+        void this.connectorStatus.ensure(providers);
+      }
+    });
+  }
+
+  protected readonly categoryChips = computed(() => {
+    const categories = [...new Set(this.toolService.tools().map(t => t.category))].sort();
+    return [this.ALL, ...categories];
+  });
+
+  protected readonly cards = computed<ToolCard[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const category = this.activeCategory();
+
+    // `tools()`, never `visibleTools()` — see the class comment.
+    let tools = this.toolService.tools();
+
+    if (q) {
+      tools = tools.filter(tool =>
+        [tool.displayName, tool.description, tool.category]
+          .filter(Boolean)
+          .some(field => field.toLowerCase().includes(q)),
+      );
+    } else if (category !== this.ALL) {
+      tools = tools.filter(tool => tool.category === category);
+    }
+
+    return tools.map(tool => ({
+      tool,
+      name: tool.displayName,
+      description: this.describe(tool),
+      monogram: monogramFor(tool.displayName),
+      // `isEnabled`, never `isToolShownEnabled()` — see the class comment.
+      enabled: tool.isEnabled,
+      badge: this.badgeFor(tool),
+    }));
+  });
+
+  protected readonly enabledLabel = computed(() => {
+    const total = this.toolService.tools().length;
+    const on = this.toolService.tools().filter(t => t.isEnabled).length;
+    return `${on} of ${total} ${total === 1 ? 'tool' : 'tools'} on`;
+  });
+
+  protected onSearch(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onCategory(chip: string): void {
+    this.activeCategory.set(chip);
+  }
+
+  protected async onToggle(tool: Tool): Promise<void> {
+    const id = tool.toolId;
+    if (this.pending().has(id)) return;
+
+    this.saveError.set(null);
+    this.pending.update(set => new Set(set).add(id));
+    try {
+      // `respectAgentLock: false` — see the class comment.
+      await this.toolService.toggleTool(id, { respectAgentLock: false });
+    } catch {
+      // The service already reverted its optimistic update; say so, because a
+      // switch that snaps back on its own looks like a bug in the switch.
+      this.saveError.set(`Couldn't save the change to ${tool.displayName}. Please try again.`);
+    } finally {
+      this.pending.update(set => {
+        const next = new Set(set);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+
+  /**
+   * The card's one description line. Leads with the tool count for an MCP
+   * server, and with the partial-selection state when only some of its tools
+   * are on — PR-1 has no per-tool pane, so that is the fact a card must not
+   * bury.
+   */
+  private describe(tool: Tool): string {
+    const summary =
+      splitToolDescription(tool.description).summary || 'No description recorded.';
+    const subs = tool.serverTools ?? [];
+    if (subs.length === 0) return summary;
+
+    const on = subs.filter(s => s.enabled).length;
+    const noun = subs.length === 1 ? 'tool' : 'tools';
+    const prefix =
+      on > 0 && on < subs.length
+        ? `${on} of ${subs.length} ${noun} on`
+        : `${subs.length} ${noun}`;
+    return `${prefix} · ${summary}`;
+  }
+
+  /**
+   * `unknown` draws no chip: a probe that failed is not evidence the user is
+   * disconnected, and most tools need no connection at all.
+   */
+  private badgeFor(tool: Tool): CustomizeCardBadge {
+    if (!tool.requiresOauthProvider) return null;
+    const state = this.connectorStatus.stateFor(tool.requiresOauthProvider);
+    if (state === 'connected') return 'connected';
+    if (state === 'disconnected') return 'connect';
+    return null;
+  }
+}

--- a/frontend/ai.client/src/app/services/skill/skill.service.ts
+++ b/frontend/ai.client/src/app/services/skill/skill.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../config.service';
+import { ToggleOptions } from '../toggle-options';
 
 /**
  * One skill the user can reach (catalog-granted ∪ authored), as returned by
@@ -164,10 +165,17 @@ export class SkillService {
     }
   }
 
-  /** Toggle a skill's enabled state (optimistic, reverts on save failure). */
-  async toggleSkill(skillId: string): Promise<void> {
+  /**
+   * Toggle a skill's enabled state (optimistic, reverts on save failure).
+   *
+   * `respectAgentLock` defaults to true — the conversation-scoped behaviour the
+   * composer drawer depends on. Global surfaces (Customize) pass `false`; see
+   * `services/toggle-options.ts` and `docs/specs/customize-surface.md`
+   * §"The agent-lock seam" for why.
+   */
+  async toggleSkill(skillId: string, options?: ToggleOptions): Promise<void> {
     // Agent-locked: the skill set is dictated by the Agent; ignore toggles.
-    if (this._agentLockedSkillIds() !== null) return;
+    if ((options?.respectAgentLock ?? true) && this._agentLockedSkillIds() !== null) return;
     const skill = this._skills().find(s => s.skillId === skillId);
     if (!skill) return;
 

--- a/frontend/ai.client/src/app/services/toggle-options.ts
+++ b/frontend/ai.client/src/app/services/toggle-options.ts
@@ -1,0 +1,21 @@
+/**
+ * Options shared by the preference-writing toggles on `ToolService` and
+ * `SkillService`.
+ *
+ * `respectAgentLock` exists because both services are root singletons while the
+ * Agent binding lock is conversation-scoped state: the session view sets it via
+ * `lockToAgentTools` / `lockToAgentSkills` and does NOT release it on teardown
+ * (`session.page.ts` clears it only when it later loads an unbound
+ * conversation). A user who leaves an agent-bound chat therefore carries the
+ * lock with them.
+ *
+ * Conversation surfaces — the composer settings drawer — leave this `true`, so
+ * locked rows stay honestly inert. Global surfaces — Customize — pass `false`:
+ * a user's own preference page must not be silently read-only because of
+ * whichever conversation they happened to visit last.
+ *
+ * See `docs/specs/customize-surface.md` §"The agent-lock seam".
+ */
+export interface ToggleOptions {
+  respectAgentLock?: boolean;
+}

--- a/frontend/ai.client/src/app/services/tool/tool.service.ts
+++ b/frontend/ai.client/src/app/services/tool/tool.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '../config.service';
 import { makeScopedToolId } from '../../shared/utils/scoped-tool-id';
+import { ToggleOptions } from '../toggle-options';
+
 /**
  * Tool category enum
  */
@@ -76,6 +78,9 @@ export interface ToolsResponse {
   categories: string[];
   appRolesApplied: string[];
 }
+
+/** Re-exported so existing `tool.service` import sites keep working. */
+export type { ToggleOptions };
 
 /**
  * Request body for PUT /tools/preferences
@@ -267,10 +272,17 @@ export class ToolService {
    * Toggle a tool's enabled state. For an MCP server with per-tool entries this
    * toggles the whole server (every tool), authoritatively overriding any prior
    * per-tool selection.
+   *
+   * `respectAgentLock` defaults to true, which is the conversation-scoped
+   * behaviour the composer drawer depends on. Global surfaces (Customize) pass
+   * `false`: an Agent lock is a fact about one conversation, and this service is
+   * a root singleton whose lock outlives the session view that set it (see
+   * `docs/specs/customize-surface.md` §"The agent-lock seam"). Honouring it off
+   * the conversation would make the user's own preference page silently inert.
    */
-  async toggleTool(toolId: string): Promise<void> {
+  async toggleTool(toolId: string, options?: ToggleOptions): Promise<void> {
     // Agent-locked: the toolset is dictated by the Agent; ignore toggles.
-    if (this._agentLockedToolIds() !== null) return;
+    if ((options?.respectAgentLock ?? true) && this._agentLockedToolIds() !== null) return;
     const tool = this._tools().find(t => t.toolId === toolId);
     if (!tool) return;
 
@@ -333,9 +345,9 @@ export class ToolService {
    * Toggle a single tool of an MCP server (per-tool enablement). The server's
    * `isEnabled` becomes "any tool enabled".
    */
-  async toggleServerTool(toolId: string, name: string): Promise<void> {
+  async toggleServerTool(toolId: string, name: string, options?: ToggleOptions): Promise<void> {
     // Agent-locked: the toolset is dictated by the Agent; ignore toggles.
-    if (this._agentLockedToolIds() !== null) return;
+    if ((options?.respectAgentLock ?? true) && this._agentLockedToolIds() !== null) return;
     const tool = this._tools().find(t => t.toolId === toolId);
     const sub = tool?.serverTools?.find(s => s.name === name);
     if (!tool || !sub) return;

--- a/frontend/ai.client/src/app/shared/utils/monogram.ts
+++ b/frontend/ai.client/src/app/shared/utils/monogram.ts
@@ -1,0 +1,18 @@
+/**
+ * Initials for a display name, so a card or row reads as an object rather than
+ * a line of text.
+ *
+ * Strips anything that isn't a letter or a space first: catalog display names
+ * carry underscores, colons and version suffixes (`gmail_employee`,
+ * `canvas_faculty`), and a monogram built from punctuation is noise.
+ */
+export function monogramFor(displayName: string): string {
+  const initials = displayName
+    .replace(/[^A-Za-z ]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(word => word[0])
+    .join('');
+  return initials.toUpperCase() || '?';
+}


### PR DESCRIPTION
Step 1 of the Customize plan. Spec rides with it: [`docs/specs/customize-surface.md`](docs/specs/customize-surface.md).

## Why

Tool and skill enablement is **global, durable, per-user state** (`skill.service.ts:32`, `tool.service.ts:414`), but it lives in a drawer hanging off the composer — a container that reads as *settings for this conversation*. A user who enables a tool to get through one question has changed the `toolConfig` of every future turn, in every future session, and nothing in the UI said so. That's the defect; the ~320px column that can't hold a 48-tool MCP server is the secondary one.

## What's in it

- `/customize/tools` and `/customize/skills` — search, category chips, responsive grid. Browse idiom borrowed from `agents/discover` so the two hubs read as one product.
- Both pages read the **existing root services**. No new endpoints, no new state — and because the drawer shares those singletons, a toggle in either surface updates the other live.
- Sidenav entry. The Skills tab links to `/my-skills`, answering the standing "how do users reach it" question that kept that link out of the sidenav (see the comment it replaces).
- The drawer is **untouched**. Both surfaces are live; it comes out in step 5.

## ⚠️ The agent-lock seam

The sharp edge, and a pre-existing defect this surface exposes rather than creates.

`ToolService`/`SkillService` are root singletons. `session.page.ts` sets the Agent binding lock and **`ngOnDestroy` never releases it** — it's cleared only when the session page later loads an unbound conversation. So a user navigating from an agent-bound chat to a global page carries the lock with them, where it would have:

1. shown the Agent's bound subset in place of their own catalog, and
2. made every switch silently do nothing (`toggleTool` early-returns under a lock).

A global preference page must not consult conversation-scoped state. These pages read `tools()`/`skills()` and `isEnabled` — never the `visible*` / `isShownEnabled` display shims — and write with `respectAgentLock: false`. That option defaults to `true`, so drawer behaviour is byte-identical. Both specs cover the regression directly.

Deliberately *not* fixed by clearing locks on destroy: the `/` ↔ `/s/:id` transition recreates the session component on a legitimate navigation. Step 4 moves the fact onto the assistant indicator, where it belongs.

## Cost note

A surface that makes enabling tools easy raises enabled-tools-per-user, and every enabled tool grows `toolConfig` on every turn — the cacheable prefix. Same pressure that made injected tools ship `enabledByDefault=False`. Nothing here changes ordering or defaults, but the spec records two obligations before this gets more persuasive: keep preference ordering deterministic, and consider surfacing per-tool prompt weight.

## Verification

- `ng test` — **2801 passed**, full suite; 21 new across the two page specs.
- `tsc --noEmit` clean.
- Browser-verified against the real dev backend: 24 tools and 7 skills load, category chips filter, `connected`/`connect` badges resolve from live connector status, and a toggle round-trips `PUT /tools/preferences → 200`. Checked in dark and light. Test toggle reverted afterwards.

## Not in scope

Connectors tab (step 2), tool detail pane, any drawer deletion, marketplace changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)