### PR TITLE
fix(api): keep app-generated redirects on the public HTTPS URL

### DIFF
--- a/backend/src/apis/app_api/main.py
+++ b/backend/src/apis/app_api/main.py
@@ -171,6 +171,17 @@ app.add_middleware(CSRFMiddleware)
 app.add_middleware(SessionRefreshMiddleware)
 logger.info("Added BFF session-refresh + CSRF middlewares (dormant until cookie present)")
 
+# Outermost middleware: repair `Location` headers on redirects this app
+# generates for itself (Starlette's `redirect_slashes`, chiefly). Behind
+# CloudFront those come out as `http://api.<domain>/<path>` — the internal
+# ALB host, over plain HTTP, without the stripped `/api` prefix — which a
+# browser blocks as mixed content. Added last so it wraps every other
+# middleware and sees the final response headers.
+from apis.shared.middleware.proxied_redirect import ProxiedRedirectMiddleware
+
+app.add_middleware(ProxiedRedirectMiddleware)
+logger.info("Added proxied-redirect middleware")
+
 
 # Import routers
 from apis.app_api.health import router as health_router

--- a/backend/src/apis/shared/middleware/proxied_redirect.py
+++ b/backend/src/apis/shared/middleware/proxied_redirect.py
@@ -1,0 +1,135 @@
+"""ProxiedRedirectMiddleware — keep app-generated redirects on the public URL.
+
+app-api never sees the URL the browser actually asked for. CloudFront's
+`/api/*` behaviour strips the `/api` prefix, sends the request to the ALB
+under the origin's own hostname (`ALL_VIEWER_EXCEPT_HOST_HEADER`), and the
+ALB terminates TLS — so a request the user made as
+
+    GET https://dev.boisestate.ai/api/agents/
+
+arrives at Starlette as path `/agents/`, `Host: api.dev.boisestate.ai`,
+scheme `http`. Starlette's `redirect_slashes` then answers it with an
+*absolute* `Location` built from what it can see:
+
+    Location: http://api.dev.boisestate.ai/agents
+
+which is wrong three times over. The browser refuses it outright as mixed
+content ("was loaded over HTTPS, but requested an insecure resource"), so
+the caller silently gets nothing; the internal ALB hostname leaks into a
+page the user can read; and even if a client did follow it, the host is a
+different origin, so the `__Host-` BFF session cookies would not be sent
+and the redirected request would 401.
+
+This middleware rewrites exactly those self-referential redirects into a
+root-relative `Location`, restoring the proxy's stripped prefix from
+`X-Forwarded-Prefix` (stamped by the CloudFront path-strip Function):
+
+    Location: /api/agents
+
+A root-relative `Location` inherits the browser's own scheme and host, so it
+is correct under CloudFront, behind a bare ALB, and on localhost without the
+app having to be told which one it is under.
+
+**Only self-referential redirects are touched.** A `Location` pointing at
+another host is left exactly as-is — that is the BFF's OAuth flow bouncing
+to Cognito/Entra and back to the SPA origin, and rewriting those would break
+sign-in.
+
+Implemented as raw ASGI rather than `BaseHTTPMiddleware` on purpose: it needs
+nothing but the response headers, and `BaseHTTPMiddleware` would wrap every
+response body in an extra stream — including the SSE chat streams, which are
+the one thing in this service least worth putting another layer around.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlsplit
+
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+#: Set by the CloudFront path-strip Function to the prefix it removed.
+FORWARDED_PREFIX_HEADER = "x-forwarded-prefix"
+
+
+def _sanitize_prefix(raw: str | None) -> str:
+    """Normalise `X-Forwarded-Prefix` to `''` or `/segment[/segment...]`.
+
+    The header reaches us through CloudFront, which overwrites it on every
+    request to this origin, so a viewer cannot choose its value. It is still
+    normalised here rather than trusted: this middleware writes the result
+    into a `Location`, and a value like `//evil.example` would turn a
+    same-origin redirect into a scheme-relative jump off-site.
+    """
+    if not raw:
+        return ""
+    prefix = raw.strip().rstrip("/")
+    if not prefix.startswith("/") or prefix.startswith("//"):
+        return ""
+    return prefix
+
+
+def rewrite_location(location: str, request_headers: Headers) -> str | None:
+    """Return the rewritten `Location`, or `None` to leave it alone.
+
+    `None` covers everything that is already correct or none of our business:
+    an already-relative `Location`, and any absolute one aimed at a different
+    host than the one this request arrived on.
+    """
+    if not location:
+        return None
+
+    parts = urlsplit(location)
+    if not parts.netloc:
+        # Already relative — the browser resolves it against the public URL.
+        return None
+
+    request_host = request_headers.get("host", "")
+    if parts.netloc.lower() != request_host.lower():
+        # Some other origin (Cognito, Entra, the SPA). Not ours to touch.
+        return None
+
+    prefix = _sanitize_prefix(request_headers.get(FORWARDED_PREFIX_HEADER))
+    rewritten = f"{prefix}{parts.path}"
+    if parts.query:
+        rewritten = f"{rewritten}?{parts.query}"
+    if parts.fragment:
+        rewritten = f"{rewritten}#{parts.fragment}"
+
+    # A redirect to the host root with no prefix leaves nothing to anchor on.
+    if not rewritten.startswith("/"):
+        rewritten = f"/{rewritten}"
+    return rewritten
+
+
+class ProxiedRedirectMiddleware:
+    """Rewrite self-referential absolute redirects to root-relative ones."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_headers = Headers(scope=scope)
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                status = message["status"]
+                if 300 <= status < 400:
+                    headers = MutableHeaders(scope=message)
+                    location = headers.get("location")
+                    rewritten = rewrite_location(location or "", request_headers)
+                    if rewritten is not None:
+                        logger.debug(
+                            "Rewrote proxied redirect %s -> %s", location, rewritten
+                        )
+                        headers["location"] = rewritten
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/backend/tests/apis/shared/middleware/test_proxied_redirect_middleware.py
+++ b/backend/tests/apis/shared/middleware/test_proxied_redirect_middleware.py
@@ -1,0 +1,149 @@
+"""Tests for ProxiedRedirectMiddleware.
+
+The regression these lock down: loading a conversation page on dev logged
+
+    Mixed Content: ... requested an insecure resource
+    'http://api.dev.boisestate.ai/agents'. This request has been blocked.
+
+That URL is not built anywhere in the SPA — it is Starlette's own
+`redirect_slashes` answer to `GET /api/agents/`, rendered from what app-api
+can see behind CloudFront: the ALB's hostname, plain HTTP, and a path with
+the `/api` prefix already stripped off.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.responses import RedirectResponse
+
+from apis.shared.middleware.proxied_redirect import (
+    FORWARDED_PREFIX_HEADER,
+    ProxiedRedirectMiddleware,
+)
+
+PROXY_HOST = "api.dev.boisestate.ai"
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(ProxiedRedirectMiddleware)
+
+    # Declared without a trailing slash, exactly like the real `/agents`
+    # router — so `GET /agents/` is answered by `redirect_slashes`.
+    @app.get("/agents")
+    def list_agents() -> dict:
+        return {"agents": []}
+
+    @app.get("/agents/pins")
+    def list_pins() -> dict:
+        return {"pins": []}
+
+    @app.get("/auth/login")
+    def login() -> RedirectResponse:
+        return RedirectResponse(
+            url="https://login.microsoftonline.com/oauth2/authorize?client_id=x",
+            status_code=302,
+        )
+
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, follow_redirects=False)
+
+
+def _proxied(path: str) -> dict:
+    """Headers as CloudFront's `/api/*` behaviour delivers them to the ALB."""
+    return {"host": PROXY_HOST, FORWARDED_PREFIX_HEADER: "/api"}
+
+
+class TestTrailingSlashRedirects:
+    def test_agents_redirect_is_relative_and_keeps_the_api_prefix(
+        self, client: TestClient
+    ) -> None:
+        response = client.get("/agents/", headers=_proxied("/agents/"))
+
+        assert response.status_code == 307
+        assert response.headers["location"] == "/api/agents"
+
+    def test_location_never_names_the_origin_host_or_plain_http(
+        self, client: TestClient
+    ) -> None:
+        response = client.get("/agents/", headers=_proxied("/agents/"))
+
+        location = response.headers["location"]
+        assert "http://" not in location
+        assert PROXY_HOST not in location
+
+    def test_nested_path_keeps_its_full_path(self, client: TestClient) -> None:
+        response = client.get("/agents/pins/", headers=_proxied("/agents/pins/"))
+
+        assert response.headers["location"] == "/api/agents/pins"
+
+    def test_query_string_survives_the_rewrite(self, client: TestClient) -> None:
+        response = client.get(
+            "/agents/?include_drafts=false", headers=_proxied("/agents/")
+        )
+
+        assert response.headers["location"] == "/api/agents?include_drafts=false"
+
+
+class TestWithoutTheProxy:
+    """Local dev and direct-to-ALB calls: no prefix was stripped, so none is added."""
+
+    def test_redirect_is_root_relative_when_no_prefix_header_is_present(
+        self, client: TestClient
+    ) -> None:
+        response = client.get("/agents/", headers={"host": "localhost:8000"})
+
+        assert response.headers["location"] == "/agents"
+
+
+class TestRedirectsWeMustNotTouch:
+    def test_cross_host_redirect_is_left_alone(self, client: TestClient) -> None:
+        """The BFF's OAuth bounce to Entra/Cognito must stay absolute."""
+        response = client.get("/auth/login", headers=_proxied("/auth/login"))
+
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://login.microsoftonline.com/oauth2/authorize?client_id=x"
+        )
+
+    def test_non_redirect_responses_are_untouched(self, client: TestClient) -> None:
+        response = client.get("/agents", headers=_proxied("/agents"))
+
+        assert response.status_code == 200
+        assert "location" not in response.headers
+
+
+class TestPrefixSanitization:
+    """The header is overwritten by CloudFront, but a `Location` is worth guarding."""
+
+    @pytest.mark.parametrize(
+        "spoofed",
+        ["//evil.example", "evil.example", "https://evil.example", ""],
+    )
+    def test_a_prefix_that_could_escape_the_origin_is_dropped(
+        self, client: TestClient, spoofed: str
+    ) -> None:
+        response = client.get(
+            "/agents/",
+            headers={"host": PROXY_HOST, FORWARDED_PREFIX_HEADER: spoofed},
+        )
+
+        location = response.headers["location"]
+        assert location == "/agents"
+        assert not location.startswith("//")
+
+    def test_trailing_slash_on_the_prefix_does_not_double_up(
+        self, client: TestClient
+    ) -> None:
+        response = client.get(
+            "/agents/", headers={"host": PROXY_HOST, FORWARDED_PREFIX_HEADER: "/api/"}
+        )
+
+        assert response.headers["location"] == "/api/agents"

--- a/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
+++ b/infrastructure/lib/constructs/spa/spa-distribution-construct.ts
@@ -156,9 +156,21 @@ export class SpaDistributionConstruct extends Construct {
         runtime: cloudfront.FunctionRuntime.JS_2_0,
         comment:
           'Strip /api prefix before forwarding requests to the app-api ALB origin',
+        // `x-forwarded-prefix` tells app-api what this function removed, so a
+        // redirect it generates for itself (Starlette's trailing-slash
+        // `redirect_slashes`, chiefly) can be put back on the public URL by
+        // `ProxiedRedirectMiddleware`. Without it those redirects come out as
+        // `http://api.<domain>/<path>` — the origin's own hostname, over plain
+        // HTTP, missing the `/api` prefix — and the browser blocks them as
+        // mixed content, so the caller silently gets nothing.
+        //
+        // Set unconditionally (not only on the stripping branches) so a
+        // viewer-supplied `X-Forwarded-Prefix` is always overwritten rather
+        // than passed through to the origin.
         code: cloudfront.FunctionCode.fromInline(`
 function handler(event) {
   var req = event.request;
+  req.headers['x-forwarded-prefix'] = { value: '/api' };
   if (req.uri === '/api') {
     req.uri = '/';
   } else if (req.uri.indexOf('/api/') === 0) {

--- a/infrastructure/test/platform-stack.test.ts
+++ b/infrastructure/test/platform-stack.test.ts
@@ -191,6 +191,20 @@ describe('PlatformStack', () => {
       // MCP sandbox: csp-function
       template.resourceCountIs('AWS::CloudFront::Function', 3);
     });
+
+    it('tells app-api which prefix the path-strip function removed', () => {
+      // app-api cannot see the public URL: CloudFront strips `/api`, swaps in
+      // the origin's own hostname, and the ALB terminates TLS. Without this
+      // header a redirect Starlette generates for itself comes back as
+      // `http://api.<domain>/<path>`, which the browser blocks as mixed
+      // content. `ProxiedRedirectMiddleware` reads it to put the redirect
+      // back on the public URL.
+      template.hasResourceProperties('AWS::CloudFront::Function', {
+        FunctionCode: Match.stringLikeRegexp(
+          "x-forwarded-prefix'\\] = \\{ value: '/api' \\}",
+        ),
+      });
+    });
   });
 
   describe('SSM parameters', () => {


### PR DESCRIPTION
## The error

Loading a conversation page on dev logged, twice:

```
Mixed Content: The page at 'https://dev.boisestate.ai/s/<id>' was loaded over HTTPS,
but requested an insecure resource 'http://api.dev.boisestate.ai/agents'.
This request has been blocked; the content must be served over HTTPS.
```

## It is not a stale base URL in the SPA

I went looking for a second way of building the API base and there isn't one. Every agents
call goes through `ConfigService.appApiUrl()` (`/api` in production builds) like the rest of
the app; no `http://` or `api.<domain>` literal exists anywhere under
`frontend/ai.client/src`, and none ever has in git history. The deployed bundle on dev
contains no such string either, and a clean load of `/s/<id>` issues
`GET /api/agents?include_drafts=false` and `GET /api/agents/pins`, both 200.

That URL is generated **by app-api**. It is Starlette's `redirect_slashes` answer to
`GET /api/agents/`, rendered from the only things app-api can see behind CloudFront:

| what the browser sent | what app-api sees | why |
|---|---|---|
| `https://dev.boisestate.ai/api/agents/` | path `/agents/` | the `/api/*` path-strip Function |
| host `dev.boisestate.ai` | `Host: api.dev.boisestate.ai` | `ALL_VIEWER_EXCEPT_HOST_HEADER` |
| scheme `https` | scheme `http` | the ALB terminates TLS |

…so it answers `Location: http://api.dev.boisestate.ai/agents`. Confirmed in the dev app-api
access log — `"GET /agents/ HTTP/1.1" 307 Temporary Redirect` — and reproduced live from the
page with `fetch('/api/agents/')`, which reproduces the console error verbatim.

Every part of that Location is wrong. The browser blocks it, so the caller silently gets
nothing; the internal ALB hostname leaks into a page the user can read; and a client that
*did* follow it would land on a different origin, where the `__Host-` BFF session cookies are
not sent and the request 401s. Nothing about it is specific to `/agents` — `/models/`,
`/files/` and `/auth/login/` all produced 307s in the last 7 days of dev logs.

## The fix

`ProxiedRedirectMiddleware` rewrites redirects app-api generates *for itself* into a
root-relative Location, restoring the stripped prefix from `X-Forwarded-Prefix`, which the
CloudFront path-strip Function now stamps:

```
http://api.dev.boisestate.ai/agents  ->  /api/agents
```

A root-relative Location inherits the browser's own scheme and host, so it is correct under
CloudFront, behind a bare ALB, and on localhost without the app having to be told which one
it is under.

- **Redirects to another host are left untouched.** That is the BFF's OAuth bounce to
  Cognito/Entra and back to the SPA origin; rewriting those would break sign-in. Covered by a
  test.
- **Raw ASGI, not `BaseHTTPMiddleware`.** It needs nothing but the response headers, and
  `BaseHTTPMiddleware` would wrap every response body in another stream — including the SSE
  chat streams.
- **`X-Forwarded-Prefix` is normalised, not trusted.** CloudFront overwrites it on every
  request to this origin, but the value ends up inside a `Location`, so `//evil.example` and
  friends are dropped.

## Deploy order

The two halves are independent and safe in either order. Backend-first, a trailing-slash
request redirects to the SPA shell instead of being blocked; platform-first, behaviour is
unchanged from today.

## Testing

- `backend/tests/apis/shared/middleware/test_proxied_redirect_middleware.py` — 12 new tests
  covering the rewrite, the no-proxy fallback, the cross-host exemption, and prefix
  sanitisation.
- `infrastructure/test/platform-stack.test.ts` — asserts the CloudFront Function stamps the
  header, so the half of the fix that lives in infra cannot be silently dropped.
- Exercised against the **real** `apis.app_api.main:app`, not just a fixture app:
  `/agents/` → `/api/agents`, `/models/` → `/api/models`, `/agents/pins/` → `/api/agents/pins`,
  and `/agents/` → `/agents` with no prefix header.
- `pytest tests/apis tests/routes tests/security` — 2590 passed.
- `npx jest test/platform-stack.test.ts` — 43 passed.

Post-merge verification on dev: `fetch('/api/agents/')` from a `/s/<id>` page should follow to
`/api/agents` and return 200 with no mixed-content error in the console.

Found while validating #1072; unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)