### PR TITLE
feat(agents): surface what an Agent fixes on the assistant indicator

### DIFF
--- a/docs/specs/customize-surface.md
+++ b/docs/specs/customize-surface.md
@@ -1,7 +1,8 @@
 # Customize — a browse surface for tools, skills and connectors
 
 **Status:** Step 1 (Customize shell: Tools + Skills) SHIPPED — PR #1072, validated on dev.
-Step 3 (drop model + params from the drawer) in flight. Steps 2, 4–7 queued.
+Step 3 (drop model + params from the drawer) SHIPPED — PR #1073, validated on dev.
+Step 4 (agent-lock surfacing) in flight. Steps 2, 5–7 queued.
 **Supersedes:** the composer settings drawer (`components/model-settings/`) as the home for
 tool and skill enablement.
 **Related:** `docs/specs/skills-as-agent-primitive.md` (D6 opt-in), `docs/specs/agent-marketplace.md` (D1 one noun),
@@ -172,9 +173,20 @@ destroy-time clear would drop and re-apply the lock mid-flow.
 The proper resolution is step 4 — the lock is a fact about the *conversation*, so it belongs
 on the assistant indicator pill
 (`session/components/assistant-indicator/assistant-indicator.component.ts`), which is already
-in the conversation and already has an actions menu, but says nothing about bindings today.
-Until then, a user toggling a skill in Customize has no way to know their agent-bound
-conversation will ignore it.
+in the conversation and already has an actions menu.
+
+**Step 4's shape.** The indicator takes an `AgentGovernance` input (`modelName`, `toolCount`,
+`skillCount`; `null` on a field means "the user's own setting applies"), renders a lock glyph
+on the chip, and lists what is fixed in its menu — ending with the line that closes the loop:
+*"Your own choices in Customize don't apply in this conversation."*
+
+⚠️ It is derived from the **Agent record** (`chat-container`'s `agent()` input), NOT from
+`ToolService.agentLocked()` & friends. Those are the leaking singletons this section is about;
+reading them here would reintroduce the same staleness on the surface whose whole job is to
+tell the truth about the current conversation. Deriving from the record also makes the preview
+surfaces correct for free: the Designer preview and the marketplace test-drive render the
+indicator without passing `[agent]`, so they get `null` and say nothing — right, because a
+draft being previewed is not a conversation anyone's saved settings apply to.
 
 ## Cost consequence
 
@@ -201,8 +213,8 @@ Each step is independently shippable. 3 and 6 do not depend on Customize at all.
 |---|------|-----------|
 | 1 | **Customize shell** — `/customize`, Tools + Skills tabs, nav entry. Drawer stays; both live — **shipped (#1072)** | — |
 | 2 | Fold `Settings → Connectors` in as the Connectors tab | 1 |
-| 3 | Drop model + Advanced params from the drawer (pure dedup + param removal) — **in flight** | — |
-| 4 | Agent-lock surfacing moves to the assistant indicator | — |
+| 3 | Drop model + Advanced params from the drawer (pure dedup + param removal) — **shipped (#1073)** | — |
+| 4 | Agent-lock surfacing moves to the assistant indicator — **in flight** | — |
 | 5 | Delete the drawer and the settings icon | 1, 2, 3, 4 |
 | 6 | Conversation Modes retired as an Agent migration | prod-usage check |
 | 7 | `/agents` lands on Discover for users with no agents | — |

--- a/frontend/ai.client/src/app/components/topnav/topnav.html
+++ b/frontend/ai.client/src/app/components/topnav/topnav.html
@@ -145,6 +145,7 @@
           [emoji]="assistant()!.emoji ?? ''"
           [ownerName]="assistant()!.ownerName"
           [isOwner]="isAssistantOwner()"
+          [governance]="agentGovernance()"
           menuPlacement="down"
           (newSessionClicked)="assistantNewSession.emit()"
           (editClicked)="assistantEdit.emit()"

--- a/frontend/ai.client/src/app/components/topnav/topnav.ts
+++ b/frontend/ai.client/src/app/components/topnav/topnav.ts
@@ -15,7 +15,10 @@ import { SidenavService } from '../../services/sidenav/sidenav.service';
 import { ToastService } from '../../services/toast/toast.service';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '../confirmation-dialog';
 import { Assistant } from '../../assistants/models/assistant.model';
-import { AssistantIndicatorComponent } from '../../session/components/assistant-indicator/assistant-indicator.component';
+import {
+  AgentGovernance,
+  AssistantIndicatorComponent,
+} from '../../session/components/assistant-indicator/assistant-indicator.component';
 
 @Component({
   selector: 'app-topnav',
@@ -43,6 +46,11 @@ export class Topnav {
    * Owned by the session page and threaded through the chat container.
    */
   readonly assistant = input<Assistant | null>(null);
+  /**
+   * What the attached Agent fixes for this conversation. Passed straight through
+   * to the indicator; null when unknown or unbound. See `AgentGovernance`.
+   */
+  readonly agentGovernance = input<AgentGovernance | null>(null);
   /** Whether the current user owns the assistant (gates Edit/Share actions). */
   readonly isAssistantOwner = input<boolean>(false);
   /** True while the attached assistant is still being fetched. */

--- a/frontend/ai.client/src/app/session/components/assistant-indicator/assistant-indicator.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/assistant-indicator/assistant-indicator.component.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import {
+  AgentGovernance,
+  AssistantIndicatorComponent,
+} from './assistant-indicator.component';
+
+describe('AssistantIndicatorComponent', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  function create(governance: AgentGovernance | null = null, variant: 'card' | 'compact' = 'card') {
+    const fixture = TestBed.createComponent(AssistantIndicatorComponent);
+    fixture.componentRef.setInput('name', 'Rubric Builder');
+    fixture.componentRef.setInput('variant', variant);
+    fixture.componentRef.setInput('governance', governance);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = (fixture: { nativeElement: HTMLElement }) => fixture.nativeElement.textContent ?? '';
+
+  describe('governance', () => {
+    it('says nothing when the caller does not know', () => {
+      // The Designer preview and the marketplace test-drive both render this
+      // component without applying the picker locks, so null must be silent
+      // rather than a guess. See docs/specs/customize-surface.md step 4.
+      const fixture = create(null);
+      expect(fixture.componentInstance.isGoverned()).toBe(false);
+      expect(fixture.nativeElement.querySelector('.pill-lock')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.indicator-lock')).toBeNull();
+    });
+
+    it('says nothing when an agent binds nothing', () => {
+      const fixture = create({ modelName: null, toolCount: null, skillCount: null });
+      expect(fixture.componentInstance.isGoverned()).toBe(false);
+    });
+
+    it('shows a lock on the chip once anything is fixed', () => {
+      const fixture = create({ modelName: null, toolCount: 4, skillCount: null });
+      expect(fixture.componentInstance.isGoverned()).toBe(true);
+      expect(fixture.nativeElement.querySelector('.indicator-lock')).toBeTruthy();
+    });
+
+    it('shows the lock on the compact pill too', () => {
+      const fixture = create({ modelName: 'Claude Sonnet 5', toolCount: null, skillCount: null }, 'compact');
+      expect(fixture.nativeElement.querySelector('.pill-lock')).toBeTruthy();
+    });
+
+    it('lists what is fixed in the menu, and only what is fixed', () => {
+      const fixture = create({ modelName: 'Claude Sonnet 5', toolCount: 4, skillCount: null });
+      fixture.componentInstance.menuOpen.set(true);
+      fixture.detectChanges();
+
+      const menu = fixture.nativeElement.querySelector('.menu-governance') as HTMLElement;
+      expect(menu).toBeTruthy();
+      expect(menu.textContent).toContain('Claude Sonnet 5');
+      expect(menu.textContent).toContain('4 tools');
+      expect(menu.textContent).not.toContain('Skills');
+    });
+
+    it('tells the user why their Customize choices are being ignored', () => {
+      // The whole point of step 4: with the settings drawer gone, this is the
+      // only place that explains why a skill they enabled does nothing here.
+      const fixture = create({ modelName: null, toolCount: null, skillCount: 2 });
+      fixture.componentInstance.menuOpen.set(true);
+      fixture.detectChanges();
+      expect(text(fixture)).toContain("Customize don't apply in this conversation");
+    });
+
+    it('renders no governance block when nothing is fixed', () => {
+      const fixture = create(null);
+      fixture.componentInstance.menuOpen.set(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.menu-governance')).toBeNull();
+    });
+
+    it('counts in the singular when there is one', () => {
+      const fixture = create({ modelName: null, toolCount: 1, skillCount: 1 });
+      expect(fixture.componentInstance.toolLabel()).toBe('1 tool');
+      expect(fixture.componentInstance.skillLabel()).toBe('1 skill');
+    });
+
+    it('treats a zero count as not governed rather than as "0 tools"', () => {
+      const fixture = create({ modelName: 'Claude Haiku 4.5', toolCount: 0, skillCount: 0 });
+      expect(fixture.componentInstance.toolLabel()).toBeNull();
+      expect(fixture.componentInstance.skillLabel()).toBeNull();
+      // …but the pinned model still counts as governance.
+      expect(fixture.componentInstance.isGoverned()).toBe(true);
+    });
+
+    it('names what is fixed in the lock’s accessible label', () => {
+      // The glyph is the only cue on a collapsed chip; a screen-reader user
+      // should not have to open the menu to learn what this overrides.
+      const fixture = create({ modelName: 'Claude Sonnet 5', toolCount: 4, skillCount: 2 });
+      expect(fixture.componentInstance.governanceLabel()).toBe(
+        'This agent fixes model Claude Sonnet 5, 4 tools and 2 skills for this conversation.',
+      );
+    });
+
+    it('reads naturally with a single fixed thing', () => {
+      const fixture = create({ modelName: null, toolCount: 3, skillCount: null });
+      expect(fixture.componentInstance.governanceLabel()).toBe(
+        'This agent fixes 3 tools for this conversation.',
+      );
+    });
+  });
+});

--- a/frontend/ai.client/src/app/session/components/assistant-indicator/assistant-indicator.component.ts
+++ b/frontend/ai.client/src/app/session/components/assistant-indicator/assistant-indicator.component.ts
@@ -14,7 +14,34 @@ import {
   heroPlusCircle,
   heroChevronDown,
   heroUserGroup,
+  heroLockClosed,
 } from '@ng-icons/heroicons/outline';
+
+/**
+ * What an Agent fixes for the conversation it is bound to.
+ *
+ * A bound Agent governs its own model, tools and skills: the backend applies
+ * them at invocation regardless of what the client sends, so the user's own
+ * preferences — the ones they set in Customize — do not apply here. Before this
+ * existed, that fact was only legible inside the composer's settings drawer, as
+ * greyed switches. With the drawer gone (step 5 of
+ * `docs/specs/customize-surface.md`) a user could toggle a skill in Customize,
+ * return to an agent conversation and watch it be ignored, with nothing
+ * anywhere saying why.
+ *
+ * `null` on any field means "not governed — the user's own setting applies".
+ * The whole input defaults to null, so a surface that does not know the answer
+ * (the Designer preview and the marketplace test-drive both render this
+ * component without ever applying the locks) says nothing rather than guessing.
+ */
+export interface AgentGovernance {
+  /** Display name of the model the Agent pins, or null when it pins none. */
+  modelName: string | null;
+  /** How many tools the Agent binds, or null when it binds none. */
+  toolCount: number | null;
+  /** How many skills the Agent binds, or null when it binds none. */
+  skillCount: number | null;
+}
 
 /**
  * A prominent assistant indicator chip with gradient accent and
@@ -29,6 +56,7 @@ import {
       heroPlusCircle,
       heroChevronDown,
       heroUserGroup,
+      heroLockClosed,
     }),
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -53,6 +81,13 @@ import {
             <span class="pill-emoji leading-none">{{ emoji() }}</span>
           }
           <span class="pill-name">{{ name() }}</span>
+          @if (isGoverned()) {
+            <ng-icon
+              name="heroLockClosed"
+              class="pill-lock"
+              [attr.aria-label]="governanceLabel()"
+            />
+          }
         </button>
       } @else {
         <button
@@ -74,7 +109,16 @@ import {
 
           <!-- Name + owner -->
           <div class="indicator-text">
-            <span class="indicator-name">{{ name() }}</span>
+            <span class="indicator-name">
+              {{ name() }}
+              @if (isGoverned()) {
+                <ng-icon
+                  name="heroLockClosed"
+                  class="indicator-lock"
+                  [attr.aria-label]="governanceLabel()"
+                />
+              }
+            </span>
             @if (ownerName()) {
               <span class="indicator-owner">by {{ ownerName() }}</span>
             }
@@ -98,6 +142,29 @@ import {
           role="menu"
           aria-label="Agent actions"
         >
+          @if (isGoverned()) {
+            <div class="menu-governance">
+              <p class="governance-title">
+                <ng-icon name="heroLockClosed" class="governance-icon" aria-hidden="true" />
+                <span>Fixed by this agent</span>
+              </p>
+              <ul class="governance-list">
+                @if (governance()?.modelName; as modelName) {
+                  <li><span class="governance-key">Model</span><span>{{ modelName }}</span></li>
+                }
+                @if (toolLabel(); as tools) {
+                  <li><span class="governance-key">Tools</span><span>{{ tools }}</span></li>
+                }
+                @if (skillLabel(); as skills) {
+                  <li><span class="governance-key">Skills</span><span>{{ skills }}</span></li>
+                }
+              </ul>
+              <p class="governance-note">
+                Your own choices in Customize don't apply in this conversation.
+              </p>
+            </div>
+          }
+
           <button
             type="button"
             class="menu-item"
@@ -318,12 +385,111 @@ import {
     }
 
     /* ── Dropdown menu ── */
+    .pill-lock,
+    .indicator-lock {
+      width: 0.75rem;
+      height: 0.75rem;
+      flex-shrink: 0;
+      color: var(--color-gray-400);
+    }
+
+    .indicator-lock {
+      display: inline-block;
+      vertical-align: -0.0625rem;
+      margin-left: 0.25rem;
+    }
+
+    :host-context(html.dark) .pill-lock,
+    :host-context(html.dark) .indicator-lock {
+      color: var(--color-gray-500);
+    }
+
+    .menu-governance {
+      padding: 0.5rem 0.625rem 0.625rem;
+      border-bottom: 1px solid var(--color-gray-200);
+      margin-bottom: 0.25rem;
+    }
+
+    :host-context(html.dark) .menu-governance {
+      border-bottom-color: rgba(255, 255, 255, 0.1);
+    }
+
+    .governance-title {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      color: var(--color-gray-500);
+    }
+
+    .governance-icon {
+      width: 0.75rem;
+      height: 0.75rem;
+      flex-shrink: 0;
+    }
+
+    .governance-list {
+      margin: 0.375rem 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 0.125rem;
+      font-size: 0.75rem;
+      line-height: 1.25rem;
+      color: var(--color-gray-700);
+    }
+
+    .governance-list li {
+      display: flex;
+      gap: 0.5rem;
+      /* The value is the interesting half: let a long model name truncate
+         rather than wrap the label away from it. */
+      min-width: 0;
+    }
+
+    .governance-list li > :not(.governance-key) {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .governance-key {
+      flex-shrink: 0;
+      min-width: 2.75rem;
+      color: var(--color-gray-500);
+    }
+
+    .governance-note {
+      margin-top: 0.375rem;
+      font-size: 0.6875rem;
+      line-height: 1rem;
+      color: var(--color-gray-500);
+    }
+
+    :host-context(html.dark) .governance-list {
+      color: var(--color-gray-300);
+    }
+
+    :host-context(html.dark) .governance-title,
+    :host-context(html.dark) .governance-key,
+    :host-context(html.dark) .governance-note {
+      color: var(--color-gray-400);
+    }
+
     .indicator-menu {
       position: absolute;
       bottom: calc(100% + 0.375rem);
       left: 50%;
       transform: translateX(-50%);
+      /* Sizes to content so a governance row like "Model  Claude Sonnet 5"
+         reads on one line, but never wider than the viewport allows. */
+      width: max-content;
       min-width: 11rem;
+      max-width: min(20rem, 90vw);
       padding: 0.25rem;
       border-radius: 0.75rem;
       background: var(--color-white);
@@ -447,6 +613,11 @@ export class AssistantIndicatorComponent {
    * subtle name-only pill for dense contexts like the top nav.
    */
   readonly variant = input<'card' | 'compact'>('card');
+  /**
+   * What this Agent fixes for the conversation. Null (the default) means the
+   * caller does not know — say nothing rather than guess. See `AgentGovernance`.
+   */
+  readonly governance = input<AgentGovernance | null>(null);
 
   // Outputs
   readonly newSessionClicked = output<void>();
@@ -455,6 +626,38 @@ export class AssistantIndicatorComponent {
 
   // Menu state
   readonly menuOpen = signal(false);
+
+  /** True when the Agent fixes at least one of model / tools / skills. */
+  readonly isGoverned = computed(() => {
+    const g = this.governance();
+    if (!g) return false;
+    return !!g.modelName || !!g.toolCount || !!g.skillCount;
+  });
+
+  /** "4 tools", or null when tools are the user's own to choose. */
+  readonly toolLabel = computed(() => countLabel(this.governance()?.toolCount ?? null, 'tool'));
+
+  /** "2 skills", or null when skills are the user's own to choose. */
+  readonly skillLabel = computed(() => countLabel(this.governance()?.skillCount ?? null, 'skill'));
+
+  /**
+   * Accessible name for the lock glyph. The glyph is the only governance cue on
+   * the collapsed chip, so it names what is fixed rather than just saying
+   * "locked" — a screen-reader user should not have to open the menu to learn
+   * which of their settings this conversation overrides.
+   */
+  readonly governanceLabel = computed(() => {
+    const g = this.governance();
+    if (!g) return '';
+    const parts: string[] = [];
+    if (g.modelName) parts.push(`model ${g.modelName}`);
+    const tools = this.toolLabel();
+    if (tools) parts.push(tools);
+    const skills = this.skillLabel();
+    if (skills) parts.push(skills);
+    if (parts.length === 0) return '';
+    return `This agent fixes ${joinList(parts)} for this conversation.`;
+  });
 
   // Computed: first letter for avatar fallback
   readonly firstLetter = computed(() => {
@@ -524,4 +727,16 @@ export class AssistantIndicatorComponent {
     this.menuOpen.set(false);
     this.shareClicked.emit();
   }
+}
+
+/** `3` + `'tool'` -> `'3 tools'`; 0 and null both mean "not governed". */
+function countLabel(count: number | null, noun: string): string | null {
+  if (!count) return null;
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/** `['a','b','c']` -> `'a, b and c'`. */
+function joinList(parts: string[]): string {
+  if (parts.length === 1) return parts[0];
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
 }

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.html
@@ -8,6 +8,7 @@
     [class.artifact-pane-open]="artifactPanelOpen()">
     <app-topnav
       [assistant]="assistant()"
+      [agentGovernance]="agentGovernance()"
       [isAssistantOwner]="isAssistantOwner()"
       [isLoadingAssistant]="isLoadingAssistant()"
       (assistantNewSession)="onAssistantNewSession()"
@@ -296,6 +297,7 @@
               [emoji]="assistant()!.emoji ?? ''"
               [ownerName]="assistant()!.ownerName"
               [isOwner]="isAssistantOwner()"
+              [governance]="agentGovernance()"
               (newSessionClicked)="onAssistantNewSession()"
               (editClicked)="onAssistantEdit()"
               (shareClicked)="onAssistantShare()" />

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.spec.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.spec.ts
@@ -76,3 +76,82 @@ describe('ChatContainerComponent — the feedback link gate', () => {
     expect(feedbackAgentFor(null)).toBeNull();
   });
 });
+
+/**
+ * Step 4 of `docs/specs/customize-surface.md`: with the composer's settings
+ * drawer gone, the assistant indicator becomes the only place a user can learn
+ * that this conversation's model, tools and skills are fixed by the Agent — and
+ * therefore why the preferences they set in Customize are being ignored here.
+ *
+ * Derived from the Agent record rather than from `ToolService.agentLocked()` &
+ * friends, which live on root singletons and outlive the view that set them.
+ */
+describe('ChatContainerComponent — agent governance for the indicator', () => {
+  function agentWith(overrides: Partial<Agent>): Agent {
+    return {
+      agentId: 'ast-001',
+      ownerName: 'Ada Author',
+      name: 'Rubric Builder',
+      description: 'Build a rubric',
+      bindings: [],
+      visibility: 'PRIVATE',
+      tags: [],
+      starters: [],
+      usageCount: 0,
+      status: 'COMPLETE',
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+      ...overrides,
+    } as Agent;
+  }
+
+  function governanceFor(value: Agent | null) {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
+    });
+    const fixture = TestBed.createComponent(ChatContainerComponent);
+    fixture.componentRef.setInput('messages', []);
+    fixture.componentRef.setInput('agent', value);
+    return fixture.componentInstance['agentGovernance']();
+  }
+
+  it('claims nothing without an agent — which is what the previews get', () => {
+    // The Designer preview and the marketplace test-drive render this component
+    // without passing `[agent]`, and neither applies the picker locks. Silence
+    // is the correct answer there, and it falls out of the derivation for free.
+    expect(governanceFor(null)).toBeNull();
+  });
+
+  it('claims nothing for an agent that binds nothing', () => {
+    expect(governanceFor(agentWith({ bindings: [] }))).toBeNull();
+  });
+
+  it('counts tool and skill bindings separately', () => {
+    const value = governanceFor(
+      agentWith({
+        bindings: [
+          { kind: 'tool', ref: 'web_search' },
+          { kind: 'tool', ref: 'calculator' },
+          { kind: 'skill', ref: 'sk_apa' },
+        ],
+      } as Partial<Agent>),
+    );
+    expect(value).toEqual({ modelName: null, toolCount: 2, skillCount: 1 });
+  });
+
+  it('falls back to the raw model id when the catalog has not loaded', () => {
+    // Naming the model badly beats dropping the row that says one is pinned.
+    const value = governanceFor(
+      agentWith({ modelConfig: { modelId: 'us.anthropic.claude-sonnet-5' } } as Partial<Agent>),
+    );
+    expect(value?.modelName).toBe('us.anthropic.claude-sonnet-5');
+  });
+
+  it('reports a pinned model even when no tools or skills are bound', () => {
+    const value = governanceFor(
+      agentWith({ modelConfig: { modelId: 'm-1' }, bindings: [] } as Partial<Agent>),
+    );
+    expect(value).toEqual({ modelName: 'm-1', toolCount: null, skillCount: null });
+  });
+});

--- a/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-container/chat-container.component.ts
@@ -25,7 +25,11 @@ import {
   AgentLaunchCardView,
   agentLaunchCardView,
 } from '../../../agents/components/agent-launch-card.component';
-import { AssistantIndicatorComponent } from '../assistant-indicator/assistant-indicator.component';
+import {
+  AgentGovernance,
+  AssistantIndicatorComponent,
+} from '../assistant-indicator/assistant-indicator.component';
+import { ModelService } from '../../services/model/model.service';
 import { SessionCostBadgeComponent } from '../session-cost-badge/session-cost-badge.component';
 import { VoiceOverlayComponent } from '../voice-overlay';
 import { VoiceChatService } from '../../services/voice';
@@ -94,6 +98,40 @@ export class ChatContainerComponent {
   private messageListComponent = viewChild(MessageListComponent);
 
   private readonly chatState = inject(ChatStateService);
+  private readonly modelService = inject(ModelService);
+
+  /**
+   * What the bound Agent fixes for this conversation, for the indicator.
+   *
+   * Derived from the Agent record itself rather than from the picker locks,
+   * which live on root singletons and outlive the view that set them. It also
+   * makes the preview surfaces correct for free: the Designer preview and the
+   * marketplace test-drive render this component without passing `[agent]`, so
+   * they get null and the indicator says nothing — which is right, because a
+   * draft being previewed is not a conversation anyone's saved settings apply to.
+   */
+  protected readonly agentGovernance = computed<AgentGovernance | null>(() => {
+    const agent = this.agent();
+    if (!agent) return null;
+
+    const bindings = agent.bindings ?? [];
+    const toolCount = bindings.filter(b => b.kind === 'tool').length;
+    const skillCount = bindings.filter(b => b.kind === 'skill').length;
+
+    const modelId = agent.modelConfig?.modelId ?? null;
+    // Fall back to the raw id: the catalog may not have loaded yet, and naming
+    // the model badly beats dropping the row that says one is pinned at all.
+    const modelName = modelId
+      ? (this.modelService.availableModels().find(m => m.modelId === modelId)?.modelName ?? modelId)
+      : null;
+
+    if (!modelName && toolCount === 0 && skillCount === 0) return null;
+    return {
+      modelName,
+      toolCount: toolCount || null,
+      skillCount: skillCount || null,
+    };
+  });
 
   // Non-composer submit paths (e.g. an MCP App widget's ui/message) bump
   // ChatStateService.scrollToLastUserTick to get the same "scroll the new
@@ -114,6 +152,7 @@ export class ChatContainerComponent {
 
   // Optional inputs
   assistant = input<Assistant | null>(null);
+
   /**
    * The governed Agent behind this conversation, when it resolves (`agentId ==
    * assistantId`). The launch card reads from this rather than `assistant` because


### PR DESCRIPTION
Step 4 of [`docs/specs/customize-surface.md`](docs/specs/customize-surface.md). Independent of the other steps, but it's what makes step 5 safe to ship.

## Why

A bound Agent governs its own model, tools and skills — the backend applies them at invocation regardless of what the client sends. So the preferences a user sets in Customize **do not apply** in that conversation.

Until now that was only legible inside the composer's settings drawer, as greyed switches. The drawer is on its way out. Without this, a user could enable a skill in Customize, return to an agent conversation, watch it be ignored, and find nothing anywhere saying why.

## What it looks like

A lock glyph on the chip, and in the menu:

```
🔒 FIXED BY THIS AGENT
   Model    Claude Sonnet 5
   Tools    7 tools
   Skills   2 skills
   Your own choices in Customize don't apply in this conversation.
```

Only fixed things are listed — an agent that binds no skills shows no Skills row. The glyph's accessible label carries the same facts ("This agent fixes model Claude Sonnet 5, 7 tools and 2 skills for this conversation."), so a screen-reader user doesn't have to open the menu to learn what this conversation overrides.

## ⚠️ Derived from the Agent record, not from the locks

The obvious implementation reads `ToolService.agentLocked()` / `SkillService.agentLocked()` / `agentModelLocked()`. It would be wrong.

Those are conversation-scoped locks living on **root singletons that the session view never releases on teardown** — the same seam the Customize pages already had to defend against (spec §"The agent-lock seam"). Reading them on the one surface whose entire job is to describe the *current* conversation would reintroduce exactly that staleness, on the surface least able to afford it.

So governance is computed in `chat-container` from its `agent()` input. That also makes the preview surfaces correct for free: the Designer preview and the marketplace test-drive render this component **without** passing `[agent]`, so they get `null` and say nothing — which is right, because a draft being previewed isn't a conversation anyone's saved settings apply to. Safe by default rather than opt-out.

## Verification

- `ng test` — **2819 passed** (237 files); 16 new across a new indicator spec and a new chat-container block, covering the null/zero/singular cases, the preview-silence guarantee, and the accessible label.
- `tsc --noEmit` clean.
- Browser-verified against a real agent-bound conversation (Rubric Builder, dev data): lock renders on the chip; menu reads Model / Claude Sonnet 5, Tools / 7 tools, Skills / 2 skills; accessible label correct.
- Caught and fixed in the browser: the menu's `min-width: 11rem` wrapped "Claude Sonnet 5" across three lines. Now `width: max-content` with a `max-width` cap and flex rows that truncate a long model name rather than wrapping the label off it — measured 320px, every row one line.

Dark mode follows this file's existing `:host-context(html.dark)` token idiom; I'll confirm it on dev after deploy, as with the previous two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)