### PR TITLE
feat(customize): fold Connectors in from Settings

### DIFF
--- a/docs/specs/customize-surface.md
+++ b/docs/specs/customize-surface.md
@@ -2,7 +2,8 @@
 
 **Status:** Step 1 (Customize shell: Tools + Skills) SHIPPED — PR #1072, validated on dev.
 Step 3 (drop model + params from the drawer) SHIPPED — PR #1073, validated on dev.
-Step 4 (agent-lock surfacing) in flight. Steps 2, 5–7 queued.
+Step 4 (agent-lock surfacing) SHIPPED — PR #1075, validated on dev.
+Step 2 (Connectors tab) in flight. Steps 5–7 queued.
 **Supersedes:** the composer settings drawer (`components/model-settings/`) as the home for
 tool and skill enablement.
 **Related:** `docs/specs/skills-as-agent-primitive.md` (D6 opt-in), `docs/specs/agent-marketplace.md` (D1 one noun),
@@ -33,7 +34,7 @@ A full page at `/customize` that owns the things a user *adds to* their assistan
 |-----|----------|--------------|
 | **Tools** | The RBAC-granted tool catalog, per-tool and per-server enablement | Drawer § Tools |
 | **Skills** | Accessible skills (catalog-granted ∪ authored), opt-in toggles | Drawer § Skills |
-| **Connectors** | OAuth connection state for external MCP servers | `Settings → Connectors` |
+| **Connectors** | OAuth connection state for external MCP servers | `Settings → Connectors` (folded in, step 2) |
 
 It is deliberately **capabilities only**. See §"What Customize is not".
 
@@ -212,9 +213,9 @@ Each step is independently shippable. 3 and 6 do not depend on Customize at all.
 | # | Step | Depends on |
 |---|------|-----------|
 | 1 | **Customize shell** — `/customize`, Tools + Skills tabs, nav entry. Drawer stays; both live — **shipped (#1072)** | — |
-| 2 | Fold `Settings → Connectors` in as the Connectors tab | 1 |
+| 2 | Fold `Settings → Connectors` in as the Connectors tab — **in flight** | 1 |
 | 3 | Drop model + Advanced params from the drawer (pure dedup + param removal) — **shipped (#1073)** | — |
-| 4 | Agent-lock surfacing moves to the assistant indicator — **in flight** | — |
+| 4 | Agent-lock surfacing moves to the assistant indicator — **shipped (#1075)** | — |
 | 5 | Delete the drawer and the settings icon | 1, 2, 3, 4 |
 | 6 | Conversation Modes retired as an Agent migration | prod-usage check |
 | 7 | `/agents` lands on Discover for users with no agents | — |
@@ -250,3 +251,20 @@ discovered. Resolve before step 5.
 
 **Out:** connectors tab (step 2), tool detail pane / per-sub-tool expansion, any drawer
 deletion, prompt-weight display, marketplace changes.
+
+## Step 2 notes
+
+The page moved wholesale (`git mv`, so history follows it); only the shell changed — tabs
+plus an `h1`, and the row/empty/error containers went to `rounded-2xl` so the three tabs read
+as one surface. The Connect/Disconnect buttons and the `vendor-*` icon tokens were left
+exactly as they were: both carry load-bearing contrast reasoning in their comments.
+
+⚠️ `/settings/connectors` stays as a **redirect**, declared BEFORE the `settings` route whose
+`loadChildren` would otherwise swallow it and land the user on the settings shell with no
+matching child. A test asserts that ordering, because the failure is silent.
+
+The `settings/connectors/` **services** deliberately did not move. `UserConnectorsService` and
+`ConnectorStatusService` have nine importers across the app (oauth-consent, export-dialog,
+knowledge-base, the drawer's tool-detail, the Customize Tools tab…), so relocating them is a
+wide, purely-mechanical diff that belongs on its own. Their real home is probably
+`services/connectors/` — noted, not done here.

--- a/frontend/ai.client/src/app/app.routes.spec.ts
+++ b/frontend/ai.client/src/app/app.routes.spec.ts
@@ -114,3 +114,77 @@ describe('app routes — shell chrome', () => {
     expect(minimal).toEqual(['shared-artifact/:shareId', 'artifacts/:artifactId']);
   });
 });
+
+/**
+ * Connectors moved out of Settings and into Customize (step 2 of
+ * `docs/specs/customize-surface.md`): connecting an account and enabling the tools
+ * that need it are one user intent, and keeping them on separate pages only got
+ * worse once Tools moved to Customize.
+ *
+ * `/settings/connectors` stays as a redirect rather than a deletion. It is in
+ * bookmarks, and the schedules page linked users straight to it for a long time —
+ * deleting it would turn every one of those into the catch-all 404.
+ *
+ * ⚠️ Order-sensitive: `settings/connectors` must be declared BEFORE the `settings`
+ * route, whose `loadChildren` would otherwise swallow the path and land the user on
+ * the settings shell with no matching child.
+ */
+describe('app routes — connectors moved into Customize', () => {
+  @Component({ template: '' })
+  class BlankComponent {}
+
+  function stubbedRoutes(source: Routes): Routes {
+    return source.map((route) => {
+      const { loadComponent, loadChildren, children, canActivate, ...rest } = route;
+      const stubbed: Routes[number] = { ...rest };
+      if (children) stubbed.children = stubbedRoutes(children);
+      if ((loadComponent || loadChildren) && !rest.redirectTo) stubbed.component = BlankComponent;
+      return stubbed;
+    });
+  }
+
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideRouter(stubbedRoutes(routes)), provideLocationMocks()],
+    });
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('sends the old settings deep link to the Customize tab', async () => {
+    await router.navigateByUrl('/settings/connectors');
+    expect(router.url).toBe('/customize/connectors');
+  });
+
+  it('declares the redirect before the settings shell that would swallow it', () => {
+    const paths = routes.map(r => r.path);
+    expect(paths.indexOf('settings/connectors')).toBeGreaterThan(-1);
+    expect(paths.indexOf('settings/connectors')).toBeLessThan(paths.indexOf('settings'));
+  });
+
+  it('serves the connectors tab in its own right', async () => {
+    await router.navigateByUrl('/customize/connectors');
+    expect(router.url).toBe('/customize/connectors');
+  });
+
+  it('keeps the other Customize tabs reachable', async () => {
+    await router.navigateByUrl('/customize');
+    expect(router.url).toBe('/customize/tools');
+    await router.navigateByUrl('/customize/skills');
+    expect(router.url).toBe('/customize/skills');
+  });
+
+  it('leaves the rest of Settings alone', async () => {
+    await router.navigateByUrl('/settings/profile');
+    expect(router.url).toBe('/settings/profile');
+  });
+
+  it('no longer offers connectors as a Settings child route', async () => {
+    const { settingsRoutes } = await import('./settings/settings.routes');
+    expect(settingsRoutes.map(r => r.path)).not.toContain('connectors');
+  });
+});

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -180,8 +180,25 @@ export const routes: Routes = [
         canActivate: [authGuard],
     },
     {
+        path: 'customize/connectors',
+        loadComponent: () =>
+            import('./customize/connectors/customize-connectors.page').then(
+                m => m.CustomizeConnectorsPage,
+            ),
+        canActivate: [authGuard],
+    },
+    {
         path: 'customize',
         redirectTo: 'customize/tools',
+        pathMatch: 'full',
+    },
+    // Connectors moved out of Settings and into Customize (spec step 2):
+    // connecting an account and enabling the tools that need it are one intent.
+    // The old deep link stays as a redirect rather than a deletion — it is in
+    // bookmarks, and `schedules` linked users straight to it for years.
+    {
+        path: 'settings/connectors',
+        redirectTo: 'customize/connectors',
         pathMatch: 'full',
     },
     {

--- a/frontend/ai.client/src/app/customize/components/customize-tabs.component.ts
+++ b/frontend/ai.client/src/app/customize/components/customize-tabs.component.ts
@@ -4,10 +4,10 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
 /**
  * The `/customize` hub tab strip.
  *
- * Two tabs in PR-1: **Tools** and **Skills**. **Connectors** joins them in step 2
- * when `Settings → Connectors` folds in — connecting an external MCP server and
- * enabling its tools are one user intent split across two pages today, and that
- * split gets worse, not better, once Tools lives here.
+ * **Tools**, **Skills** and **Connectors**. Connectors folded in from
+ * `Settings → Connectors` in step 2: connecting an account and enabling the tools
+ * that need it are one user intent, and splitting them across two pages only got
+ * worse once Tools moved here.
  *
  * Mirrors `AgentsTabsComponent` deliberately: `/agents` and `/customize` are
  * sibling hubs, and a second tab idiom would make them read as unrelated
@@ -35,6 +35,13 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
         class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
       >
         Skills
+      </a>
+      <a
+        routerLink="/customize/connectors"
+        routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white"
+        class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+      >
+        Connectors
       </a>
     </nav>
   `,

--- a/frontend/ai.client/src/app/customize/connectors/customize-connectors.page.ts
+++ b/frontend/ai.client/src/app/customize/connectors/customize-connectors.page.ts
@@ -18,15 +18,16 @@ import {
   heroArrowPath,
   heroExclamationTriangle,
 } from '@ng-icons/heroicons/outline';
-import { UserConnectorsService } from '../../connectors/services/user-connectors.service';
-import { OAuthConsentService } from '../../../services/oauth-consent/oauth-consent.service';
-import { UserConnector } from '../../connectors/models/user-connector.model';
-import { ToastService } from '../../../services/toast/toast.service';
+import { UserConnectorsService } from '../../settings/connectors/services/user-connectors.service';
+import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
+import { UserConnector } from '../../settings/connectors/models/user-connector.model';
+import { ToastService } from '../../services/toast/toast.service';
 import {
   ConfirmationDialogComponent,
   ConfirmationDialogData,
-} from '../../../components/confirmation-dialog';
-import { SpinnerComponent } from '../../../components/spinner/spinner.component';
+} from '../../components/confirmation-dialog';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+import { CustomizeTabsComponent } from '../components/customize-tabs.component';
 
 type ConnectState =
   | 'probing'
@@ -37,9 +38,9 @@ type ConnectState =
   | 'error';
 
 @Component({
-  selector: 'app-connectors-settings',
+  selector: 'app-customize-connectors',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, SpinnerComponent],
+  imports: [NgIcon, SpinnerComponent, CustomizeTabsComponent],
   providers: [
     provideIcons({
       heroLink,
@@ -51,15 +52,18 @@ type ConnectState =
       heroExclamationTriangle,
     }),
   ],
-  host: { class: 'block' },
   template: `
-    <div class="flex flex-col gap-8">
-      <div>
-        <h2 class="text-lg/7 font-semibold text-gray-900 dark:text-white">Connectors</h2>
-        <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
-          Connect your third-party accounts so agents can call tools on your behalf.
-        </p>
-      </div>
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <app-customize-tabs />
+
+        <div class="mt-6 mb-6">
+          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Connectors</h1>
+          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+            Connect your accounts so tools can act on your behalf. A tool that needs a
+            connection is marked on the Tools tab.
+          </p>
+        </div>
 
       @if (resource.isLoading()) {
         <div class="flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
@@ -67,7 +71,7 @@ type ConnectState =
           Loading connectors...
         </div>
       } @else if (resource.error()) {
-        <div class="flex items-start gap-3 rounded-sm border border-state-danger-200 bg-state-danger-50 p-4 dark:border-state-danger-800 dark:bg-state-danger-900/20">
+        <div class="flex items-start gap-3 rounded-2xl border border-state-danger-200 bg-state-danger-50 p-4 dark:border-state-danger-800 dark:bg-state-danger-900/20">
           <ng-icon name="heroExclamationTriangle" class="size-5 shrink-0 text-state-danger-600 dark:text-state-danger-400" />
           <div>
             <h3 class="text-sm/6 font-medium text-state-danger-800 dark:text-state-danger-200">Couldn't load connectors</h3>
@@ -84,7 +88,7 @@ type ConnectState =
           </div>
         </div>
       } @else if (connectors().length === 0) {
-        <div class="rounded-sm border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
+        <div class="rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
           <ng-icon name="heroLink" class="mx-auto size-8 text-gray-400" />
           <p class="mt-3 text-sm/6 font-medium text-gray-700 dark:text-gray-300">
             No connectors are available to you yet.
@@ -97,7 +101,7 @@ type ConnectState =
         <ul class="flex flex-col gap-3">
           @for (connector of connectors(); track connector.providerId) {
             <li
-              class="flex items-center justify-between gap-4 rounded-sm border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+              class="flex items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
             >
               <div class="flex items-center gap-3">
                 @if (connector.iconData) {
@@ -190,10 +194,11 @@ type ConnectState =
           }
         </ul>
       }
+      </div>
     </div>
   `,
 })
-export class ConnectorsSettingsPage {
+export class CustomizeConnectorsPage {
   private readonly connectorsService = inject(UserConnectorsService);
   private readonly consentService = inject(OAuthConsentService);
   private readonly toast = inject(ToastService);

--- a/frontend/ai.client/src/app/schedules/schedules.page.html
+++ b/frontend/ai.client/src/app/schedules/schedules.page.html
@@ -121,7 +121,7 @@
                         A connected tool needs to be reconnected before this can resume.
                       </span>
                       <a
-                        routerLink="/settings/connectors"
+                        routerLink="/customize/connectors"
                         class="text-xs/5 font-semibold text-state-warning-900 underline hover:no-underline dark:text-state-warning-200"
                       >
                         Reconnect a tool

--- a/frontend/ai.client/src/app/settings/settings.page.ts
+++ b/frontend/ai.client/src/app/settings/settings.page.ts
@@ -10,7 +10,6 @@ import {
   heroUser,
   heroPaintBrush,
   heroChatBubbleLeftRight,
-  heroLink,
   heroKey,
   heroChartBar,
   heroCog6Tooth,
@@ -33,7 +32,6 @@ interface NavItem {
       heroUser,
       heroPaintBrush,
       heroChatBubbleLeftRight,
-      heroLink,
       heroKey,
       heroChartBar,
       heroCog6Tooth,
@@ -114,7 +112,6 @@ export class SettingsPage {
     { label: 'Profile', icon: 'heroUser', route: '/settings/profile', description: 'Your personal information' },
     { label: 'Appearance', icon: 'heroPaintBrush', route: '/settings/appearance', description: 'Theme and display' },
     { label: 'Chat', icon: 'heroChatBubbleLeftRight', route: '/settings/chat', description: 'Chat preferences' },
-    { label: 'Connectors', icon: 'heroLink', route: '/settings/connectors', description: 'Connected accounts' },
     { label: 'API Keys', icon: 'heroKey', route: '/settings/api-keys', description: 'API key management' },
     { label: 'Usage', icon: 'heroChartBar', route: '/settings/usage', description: 'Usage and billing' },
   ];

--- a/frontend/ai.client/src/app/settings/settings.routes.ts
+++ b/frontend/ai.client/src/app/settings/settings.routes.ts
@@ -22,11 +22,6 @@ export const settingsRoutes: Routes = [
       import('./pages/chat-preferences/chat-preferences-settings.page').then(m => m.ChatPreferencesSettingsPage),
   },
   {
-    path: 'connectors',
-    loadComponent: () =>
-      import('./pages/connectors-settings/connectors-settings.page').then(m => m.ConnectorsSettingsPage),
-  },
-  {
     path: 'api-keys',
     loadComponent: () =>
       import('./pages/api-keys/api-keys.page').then(m => m.ApiKeysPage),


### PR DESCRIPTION
Step 2 of [`docs/specs/customize-surface.md`](docs/specs/customize-surface.md). Customize is now Tools · Skills · Connectors.

## Why

Connecting an account and enabling the tools that need it are **one user intent**. They were split across two pages before, and once Tools moved to Customize the split got worse, not better: the Tools tab marks a tool `connect`, and the place to act on that lived under Settings.

## What moved

The page moves wholesale via `git mv`, so history follows it (90% similarity). Only the shell changed — tabs plus an `h1` matching the other two tabs — and the row / empty / error containers went to `rounded-2xl` so the three tabs read as one surface.

**Deliberately untouched:** the Connect/Disconnect buttons and the `vendor-*` icon tokens. Both carry load-bearing contrast reasoning in their comments (the `primary-accessible` brand-fill rationale, and the note that vendor hues must *not* follow `Brand_Config`). This isn't the change to revisit those in.

## ⚠️ Route ordering

`/settings/connectors` stays as a **redirect**, not a deletion — it's in bookmarks, and `schedules.page.html` linked users straight to it (that link now points at the new home).

It must be declared **before** the `settings` route, whose `loadChildren` would otherwise swallow the path and land the user on the settings shell with no matching child. There's a test asserting that ordering specifically, because the failure mode is silent — you'd get a blank settings pane, not an error.

## What didn't move

`settings/connectors/services/` stays put. `UserConnectorsService` and `ConnectorStatusService` have **nine** importers across the app (oauth-consent, export-dialog, knowledge-base, file-source-browser, the drawer's tool-detail, the Customize Tools tab…). Relocating them is a wide, purely mechanical diff that belongs on its own. Their real home is probably `services/connectors/` — noted in the spec, not done here.

## Verification

- `ng test` — **2819 passed** before the new tests; 6 new route tests covering the redirect, the declaration ordering, the tab in its own right, the other tabs still resolving, the rest of Settings unaffected, and `connectors` being gone from the Settings child routes.
- `tsc --noEmit` clean.

**Not browser-verified pre-merge.** My local stack's AWS credentials expired mid-session — app-api can't reach DynamoDB, so the first-boot guard fires and the SPA won't load. Re-auth needs an interactive SSO flow. I'll validate on dev straight after deploy, as with #1072/#1073/#1075. Flagging it rather than implying a check I didn't run; the risk is lower here than the earlier steps (a move plus a shell swap, with routing under test), but it is a real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)