### PR TITLE
refactor(agents): drop Max tokens from the Designer's param form

### DIFF
--- a/frontend/ai.client/src/app/agents/agent-form/agent-form-params.spec.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form-params.spec.ts
@@ -1,0 +1,220 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { provideRouter, ActivatedRoute } from '@angular/router';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Component, input, output } from '@angular/core';
+import { AgentFormPage } from './agent-form.page';
+import { AgentPreviewComponent } from './components/agent-preview.component';
+import { KnowledgeBaseSectionComponent } from '../../knowledge-base/knowledge-base-section.component';
+import { AgentService } from '../services/agent.service';
+import { SidenavService } from '../../services/sidenav/sidenav.service';
+import { ThemeService } from '../../components/topnav/components/theme-toggle/theme.service';
+import { ToastService } from '../../services/toast/toast.service';
+
+/**
+ * `max_tokens` is deliberately not an author-facing knob — see the
+ * `AUTHOR_HIDDEN_PARAMS` block comment in `agent-form.page.ts`. These tests pin
+ * both halves of that: the model catalog can declare it and the Designer still
+ * won't render it, and an agent saved with one before the filter existed drops
+ * it on hydrate rather than carrying an invisible override.
+ */
+
+@Component({ selector: 'app-agent-preview', template: '' })
+class StubPreviewComponent {
+  agentId = input<string | null>(null);
+  name = input('');
+  description = input('');
+  emoji = input('');
+  starters = input<string[]>([]);
+  modelId = input<string | null>(null);
+  isDirty = input(false);
+  saving = input(false);
+  canSave = input(false);
+  save = output<void>();
+  openFull = output<void>();
+}
+
+@Component({ selector: 'app-knowledge-base-section', template: '' })
+class StubKnowledgeBaseComponent {
+  entityId = input<string | null>(null);
+  userPermission = input('owner');
+  permissionResolved = input(false);
+  createDraft = input<unknown>(null);
+}
+
+async function settle(fixture: ComponentFixture<AgentFormPage>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  fixture.detectChanges();
+}
+
+/** Mirrors the live dev record for Claude Sonnet 5: max_tokens + effort. */
+const MODEL_WITH_MAX_TOKENS = {
+  kind: 'model',
+  ref: 'us.anthropic.claude-sonnet-5',
+  label: 'Claude Sonnet 5',
+  description: 'Anthropic',
+  meta: {
+    provider: 'bedrock',
+    supportedParams: {
+      params: {
+        max_tokens: { supported: true, locked: false, min: 1, max: 128_000, default: 128_000 },
+        effort: {
+          supported: true,
+          locked: false,
+          allowed: ['low', 'medium', 'high', 'xhigh'],
+          default: 'medium',
+        },
+      },
+    },
+  },
+};
+
+/** A model whose only editable param is the one we hide — section must collapse. */
+const MODEL_WITH_ONLY_MAX_TOKENS = {
+  ...MODEL_WITH_MAX_TOKENS,
+  ref: 'us.anthropic.claude-maxtokens-only',
+  label: 'Max Tokens Only',
+  meta: {
+    provider: 'bedrock',
+    supportedParams: {
+      params: {
+        max_tokens: { supported: true, locked: false, min: 1, max: 8_192, default: 4_096 },
+      },
+    },
+  },
+};
+
+/** An admin-locked max_tokens must not surface in the read-only list either. */
+const MODEL_WITH_LOCKED_MAX_TOKENS = {
+  ...MODEL_WITH_MAX_TOKENS,
+  ref: 'us.anthropic.claude-locked',
+  label: 'Locked Max Tokens',
+  meta: {
+    provider: 'bedrock',
+    supportedParams: {
+      params: {
+        max_tokens: { supported: true, locked: true, min: 1, max: 4_096, default: 4_096 },
+      },
+    },
+  },
+};
+
+function setup(options: { agent?: unknown } = {}) {
+  const mockAgentService = {
+    loadBindable: vi.fn(async (kind: string) =>
+      kind === 'model'
+        ? [MODEL_WITH_MAX_TOKENS, MODEL_WITH_ONLY_MAX_TOKENS, MODEL_WITH_LOCKED_MAX_TOKENS]
+        : [],
+    ),
+    createAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+    updateAgent: vi.fn().mockResolvedValue({ agentId: 'agt-1' }),
+    getAgent: vi.fn().mockResolvedValue(options.agent),
+  };
+  const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() };
+
+  TestBed.resetTestingModule();
+  vi.clearAllMocks();
+  Element.prototype.scrollIntoView = vi.fn();
+
+  TestBed.configureTestingModule({
+    imports: [ReactiveFormsModule],
+    providers: [
+      provideRouter([{ path: 'agents', children: [] }]),
+      { provide: AgentService, useValue: mockAgentService },
+      { provide: ToastService, useValue: mockToast },
+      { provide: SidenavService, useValue: { hide: vi.fn(), show: vi.fn() } },
+      { provide: ThemeService, useValue: { isDark: () => false } },
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          snapshot: { paramMap: { get: () => (options.agent ? 'agt-1' : null) } },
+        },
+      },
+    ],
+  });
+
+  TestBed.overrideComponent(AgentFormPage, {
+    remove: { imports: [AgentPreviewComponent, KnowledgeBaseSectionComponent] },
+    add: { imports: [StubPreviewComponent, StubKnowledgeBaseComponent] },
+  });
+
+  return { mockAgentService, mockToast };
+}
+
+describe('AgentFormPage — max_tokens is not author-facing', () => {
+  let component: AgentFormPage;
+  let fixture: ComponentFixture<AgentFormPage>;
+
+  async function render(options: { agent?: unknown } = {}) {
+    const mocks = setup(options);
+    fixture = TestBed.createComponent(AgentFormPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await settle(fixture);
+    return mocks;
+  }
+
+  beforeEach(async () => {
+    await render();
+  });
+
+  it('omits max_tokens from the editable params even when the model declares it', () => {
+    component.selectModel('us.anthropic.claude-sonnet-5');
+    fixture.detectChanges();
+
+    const keys = component.numberParams().map((p) => p.key);
+    expect(keys).not.toContain('max_tokens');
+  });
+
+  it('still renders the other params the model declares', () => {
+    component.selectModel('us.anthropic.claude-sonnet-5');
+    fixture.detectChanges();
+
+    expect(component.enumParams().map((p) => p.key)).toContain('effort');
+    expect(component.hasParamControls()).toBe(true);
+  });
+
+  it('omits an admin-locked max_tokens from the read-only list too', () => {
+    component.selectModel('us.anthropic.claude-locked');
+    fixture.detectChanges();
+
+    expect(component.lockedParams().map((p) => p.key)).not.toContain('max_tokens');
+  });
+
+  it('hides the whole Parameters section when max_tokens was the only param', () => {
+    component.selectModel('us.anthropic.claude-maxtokens-only');
+    fixture.detectChanges();
+
+    expect(component.hasParamControls()).toBe(false);
+    expect(fixture.nativeElement.textContent).not.toContain('Max tokens');
+  });
+
+  it('never renders a "Max tokens" control for a model that declares one', () => {
+    component.selectModel('us.anthropic.claude-sonnet-5');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#param-max_tokens')).toBeNull();
+    expect(fixture.nativeElement.textContent).not.toContain('Max tokens');
+  });
+
+  it('drops a previously-saved max_tokens on hydrate, keeping the rest', async () => {
+    await render({
+      agent: {
+        agentId: 'agt-1',
+        name: 'Legacy Agent',
+        description: 'Saved before max_tokens was hidden',
+        instructions: 'You are helpful.',
+        visibility: 'private',
+        tags: [],
+        modelConfig: {
+          modelId: 'us.anthropic.claude-sonnet-5',
+          params: { max_tokens: 2000, effort: 'high' },
+        },
+        bindings: [],
+      },
+    });
+
+    expect(component.modelParams()).toEqual({ effort: 'high' });
+  });
+});

--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.ts
@@ -75,12 +75,31 @@ interface ParamView {
 /** Friendly labels for the canonical param keys the Designer commonly exposes. */
 const PARAM_LABELS: Record<string, string> = {
   temperature: 'Temperature',
-  max_tokens: 'Max tokens',
   top_p: 'Top P',
   top_k: 'Top K',
   reasoning_effort: 'Reasoning effort',
   effort: 'Reasoning effort',
 };
+
+/**
+ * Params the Designer never exposes to an agent author, whatever the admin
+ * record declares. Filtered out of `paramSpecs` — the single choke point
+ * feeding the editable *and* the locked lists — and stripped on hydrate so a
+ * value saved before this filter can't survive invisibly.
+ *
+ * `max_tokens` is here because it is a hard truncation, not a length
+ * preference: an author who sets it low to "keep answers short" gets replies
+ * severed mid-sentence, or a tool loop cut mid-`toolUse` block. Response
+ * length belongs in the instructions. It also re-opens the `max_tokens` <->
+ * thinking coupling (`thinking budget < max_tokens default`, enforced in
+ * `shared/models/models.py`) that the drawer's param form was carrying 700+
+ * lines of clamp/conflict machinery to serve before `dae2b20e` retired it.
+ *
+ * The admin ceiling is unaffected: `maxOutputTokens` and a locked `max_tokens`
+ * spec still govern the request at the runtime. This removes the author's
+ * knob, not the governance.
+ */
+const AUTHOR_HIDDEN_PARAMS: ReadonlySet<string> = new Set(['max_tokens']);
 
 /** One of a server's tools with its docstring split for display, as the chat picker does. */
 interface DisplayServerTool {
@@ -216,7 +235,9 @@ export class AgentFormPage implements OnInit, OnDestroy {
   private readonly paramSpecs = computed<[string, ModelParamSpec][]>(() => {
     const supported = this.selectedModel()?.meta?.['supportedParams'] as SupportedParams | undefined;
     const params = supported?.params ?? {};
-    return Object.entries(params).filter(([, spec]) => spec.supported);
+    return Object.entries(params).filter(
+      ([key, spec]) => spec.supported && !AUTHOR_HIDDEN_PARAMS.has(key),
+    );
   });
   /** Editable enum params (a fixed `allowed` domain) → rendered as a select. */
   readonly enumParams = computed<ParamView[]>(() =>
@@ -354,7 +375,9 @@ export class AgentFormPage implements OnInit, OnDestroy {
 
       this.selectedModelId.set(agent.modelConfig?.modelId ?? null);
       this.modelParams.set(
-        (agent.modelConfig?.params ?? {}) as Record<string, number | string>,
+        stripHiddenParams(
+          (agent.modelConfig?.params ?? {}) as Record<string, number | string>,
+        ),
       );
 
       const toolRefs = new Set<string>();
@@ -859,6 +882,21 @@ function toggle(set: Set<string>, ref: string): Set<string> {
 
 function paramLabel(key: string): string {
   return PARAM_LABELS[key] ?? key.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
+}
+
+/**
+ * Drop author params the Designer no longer exposes, so a value saved before
+ * the key was hidden is cleared on the next save rather than lingering as an
+ * invisible override the author can neither see nor edit.
+ */
+function stripHiddenParams(
+  params: Record<string, number | string>,
+): Record<string, number | string> {
+  const next: Record<string, number | string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (!AUTHOR_HIDDEN_PARAMS.has(key)) next[key] = value;
+  }
+  return next;
 }
 
 /** Token counts step by 1; everything else (temperature, top_p, …) by 0.1. */


### PR DESCRIPTION
Follows `dae2b20e`, which retired the same form from the drawer. The argument carries over — and the live data turned out to make it stronger.

## What prompted this

The Designer showed **"Range 1 to 4096"** for Claude Sonnet 5, which looked far too low. It was: the range isn't hardcoded, it's read verbatim off the model's admin record, and the dev record was stale.

That turned out not to be cosmetic. `_merge_inference_params` applies `spec.default` to any request that doesn't set one, so the dev row's `max_tokens.default: 4096` was **capping every Sonnet 5 response on dev at 4096 output tokens — plain chat included, not just agents**, against a real ceiling of 128,000.

**The dev record is already fixed** (`4096` → `128000` on `maxOutputTokens`, `max_tokens.max` and `max_tokens.default`, matching `curated-models.ts`), verified live in the dev UI. **Prod was already correct** — this was dev-only. No code in this PR touches that; it's noted here so the two halves stay connected.

## Why drop the field

- **It's a hard truncation, not a length preference.** An author who sets it low to "keep answers short" gets replies severed mid-sentence, or a tool loop cut mid-`toolUse` block. Response length belongs in the instructions.
- **It re-opens the `max_tokens` ↔ thinking coupling** (`thinking budget < max_tokens default`, enforced in `shared/models/models.py`) that the drawer's form was carrying 700+ lines of clamp/conflict machinery to serve.
- **It misrepresents part of the catalog.** The three GPT-5.6 rows declare `{supported: true, min: 1}` with no max and no default, so the Designer rendered an unbounded box with a meaningless range hint — the same reason `temperature`/`top_p` were dropped from the drawer.
- **Nobody is using it.** Of **369 agents on dev, zero have any `modelConfig.params` set at all.** This is a removal with no migration surface, not a capability being taken away.

`reasoning_effort` stays — it's the lever that actually changes agent behaviour, and unlike in the drawer it isn't duplicated three inches from a picker that already shows it.

## Implementation

The filter sits on `paramSpecs`, the single choke point feeding the editable **and** locked lists, so an admin-locked `max_tokens` stops rendering too. Hydrate strips a previously-saved value so it can't linger as an invisible override the author can neither see nor edit.

**Governance is unaffected.** `maxOutputTokens` and the admin `max_tokens` spec still bound the request at the runtime. This removes the author's knob, not the guardrail.

## Effect on the live catalog

Measured against the nine enabled dev models:

| Model | Parameters section after this change |
|---|---|
| Claude Sonnet 5, Opus 4.7 | Reasoning effort |
| Claude Sonnet 4.6 | Temperature, Top P, Reasoning effort |
| Claude Haiku 4.5 | Temperature, Top P |
| GPT-5.6 Luna / Sol / Terra | Reasoning effort |
| GPT-5.4, Gemma 4 31B | *(section collapses entirely)* |

## Testing

- 6 new specs in `agent-form-params.spec.ts` covering the editable filter, the locked-list filter, section collapse, and the hydrate strip.
- **Verified the tests bite**: neutering `AUTHOR_HIDDEN_PARAMS` to an empty set fails 5 of 6 (the 6th is the positive control asserting the *other* params still render).
- Full SPA suite: **238 files, 2825 tests, all passing**.

## Relationship to #1073

This is the second half of the pair. #1073 dropped the same form from the **drawer** (chat) and is already merged into `develop`; this branch is based on that, so the two do not overlap — different files, no conflict. Together they leave exactly one place a user picks reasoning effort and no place either a user or an author sets `max_tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
