### PR TITLE
feat(customize): add a tool detail view

### DIFF
--- a/docs/specs/customize-surface.md
+++ b/docs/specs/customize-surface.md
@@ -298,6 +298,53 @@ exactly as they were: both carry load-bearing contrast reasoning in their commen
 `loadChildren` would otherwise swallow it and land the user on the settings shell with no
 matching child. A test asserts that ordering, because the failure is silent.
 
+## Tool detail
+
+`/customize/tools/:toolId` — the drill-in the browse grid's cards link to. It carries what
+a card cannot: the full description (summary, with the docstring's reference material behind
+*Show reference*), an MCP server's tools one by one with their own switches, the prompts and
+resources the server exposes, and the catalog facts (protocol, status, granting roles).
+
+⚠️ **Step 5 deleted the drawer, so this is now the only per-sub-tool surface in the app.**
+Between #1079 and this page there is nowhere to say "3 of Canvas's 48 tools"; the gap is worth
+closing promptly rather than queueing.
+
+It is a **new component, not a port of the drawer's `ToolDetailComponent`**, for the same
+reason the list page is not a port of the drawer's list: the drawer was conversation-scoped
+(`isToolShownEnabled()`, writes through the Agent lock) and this surface is global
+(`tool.isEnabled` / `sub.enabled`, `respectAgentLock: false`). See §"The agent-lock seam".
+
+The drawer's **tab strip did not come with it.** Tabs existed there because the pane was 320px;
+on a page, Tools / Prompts / Resources / About are stacked sections, so find-in-page reaches
+all of them and nothing hides behind a tab the user has to guess at. The real problem tabs
+were solving — a 48-tool server — is solved directly: above eight sub-tools the list grows
+its own filter box.
+
+Prompts and resources stay **read-only**, and stay a read of the stored capability snapshot
+rather than a live probe, for the reasons the drawer recorded: probing opens an MCP session
+per server, a 3LO server cannot be reached without a consent token the browser does not hold,
+and acting on an entry needs `prompts/get` / `resources/read`, which this surface has no
+endpoint for. The snapshot is only fetched for `mcp_external` tools — nothing else has a
+server that could have been asked.
+
+⚠️ The card's name is a link whose `after:absolute inset-0` makes the whole card the
+navigation target; the switch is raised out of it with `z-10` rather than nested inside it.
+A switch inside the link is a control the user cannot reach by keyboard without also
+following the link. A test asserts the switch has no `<a>` ancestor.
+
+⚠️ Colored text uses `text-primary-accessible dark:text-primary-accessible-dark`, never the
+numbered ramp. With the brand primary at `#0033a0`, `dark:text-primary-400` measures **2.59:1**
+against the dark page background (`gray-900`, `#101828`) — a WCAG AA failure at the small text
+sizes involved. The accessible alias is generated to clear 4.5:1 against the resolved dark
+surface and measures 4.52:1. See `src/branding/README.md` §7.
+
+**Known gap, not fixed here:** 16% of catalog sub-tools (19 of 116) have docstrings whose first
+paragraph runs past 400 characters — `canvas_faculty/import_course_package` reaches 2,058 —
+because the prose precedes any `Args:` heading, so `splitToolDescription` returns all of it as
+`summary` and the row renders it unclamped. The *detail* behind "Show details" is by comparison
+modest (median 344 chars). Clamping the summary is the fix; moving the detail behind a modal
+would not touch it.
+
 The `settings/connectors/` **services** deliberately did not move. `UserConnectorsService` and
 `ConnectorStatusService` have nine importers across the app (oauth-consent, export-dialog,
 knowledge-base, the drawer's tool-detail, the Customize Tools tab…), so relocating them is a

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -173,6 +173,16 @@ export const routes: Routes = [
             import('./customize/tools/customize-tools.page').then(m => m.CustomizeToolsPage),
         canActivate: [authGuard],
     },
+    // One tool: its sub-tools, prompts, resources and catalog facts. The id is
+    // bound straight to the page's `toolId` input by `withComponentInputBinding()`.
+    {
+        path: 'customize/tools/:toolId',
+        loadComponent: () =>
+            import('./customize/tools/customize-tool-detail.page').then(
+                m => m.CustomizeToolDetailPage,
+            ),
+        canActivate: [authGuard],
+    },
     {
         path: 'customize/skills',
         loadComponent: () =>

--- a/frontend/ai.client/src/app/customize/components/customize-card.component.ts
+++ b/frontend/ai.client/src/app/customize/components/customize-card.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 /** Connection chip shown beside a card's name, or null to draw none. */
 export type CustomizeCardBadge = 'connected' | 'connect' | null;
@@ -12,19 +13,22 @@ export type CustomizeCardBadge = 'connected' | 'connect' | null;
  * enable semantics stay opposite (tools default ON, skills default OFF —
  * Skills v2 D6).
  *
- * The whole card is NOT a button. The switch is the only control, so the card
- * carries no competing click target and the accessible name of the toggle is
- * the thing being toggled. Detail views arrive in a later step; when they do,
- * the body becomes a link and the switch stays a sibling, never a nested
- * button-in-button (see the drawer's own note at `model-settings.html:667`).
+ * The whole card is NOT a button. Given a `detailLink` the card's *body* becomes
+ * a link and the switch stays its sibling — never a nested control-in-control: a
+ * switch inside the link is a control you cannot reach by keyboard without also
+ * following the link. The link's `after:absolute inset-0` makes the whole card a
+ * click target for the navigation while the switch, raised on its own stacking
+ * context, keeps its own hit area. Without a `detailLink` the body renders as
+ * plain text, so Skills — which have no detail page — are unchanged.
  */
 @Component({
   selector: 'app-customize-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink],
   host: { class: 'block h-full' },
   template: `
     <div
-      class="flex h-full items-start gap-3 rounded-2xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
+      class="relative flex h-full items-start gap-3 rounded-2xl border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
     >
       <span
         aria-hidden="true"
@@ -35,7 +39,15 @@ export type CustomizeCardBadge = 'connected' | 'connect' | null;
       <div class="min-w-0 flex-1">
         <div class="flex min-w-0 items-center gap-1.5">
           <h3 class="min-w-0 truncate text-sm/6 font-semibold text-gray-900 dark:text-white">
-            {{ name() }}
+            @if (detailLink(); as link) {
+              <a
+                [routerLink]="link"
+                class="after:absolute after:inset-0 after:rounded-2xl hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+                >{{ name() }}</a
+              >
+            } @else {
+              {{ name() }}
+            }
           </h3>
           @switch (badge()) {
             @case ('connected') {
@@ -64,7 +76,7 @@ export type CustomizeCardBadge = 'connected' | 'connect' | null;
         [attr.aria-label]="(enabled() ? 'Disable ' : 'Enable ') + name()"
         [disabled]="pending()"
         (click)="toggled.emit()"
-        class="relative mt-0.5 inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+        class="relative z-10 mt-0.5 inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
         [class]="enabled() ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'"
       >
         <span
@@ -85,6 +97,11 @@ export class CustomizeCardComponent {
   /** In-flight save: the switch stays visually settled but refuses a second click. */
   readonly pending = input<boolean>(false);
   readonly badge = input<CustomizeCardBadge>(null);
+  /**
+   * Where the card's name links to, or null to render it as plain text. Given a
+   * link, the whole card becomes the navigation target except for the switch.
+   */
+  readonly detailLink = input<string | null>(null);
 
   readonly toggled = output<void>();
 }

--- a/frontend/ai.client/src/app/customize/tools/customize-tool-detail.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tool-detail.page.spec.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { CustomizeToolDetailPage } from './customize-tool-detail.page';
+import { Tool, ToolService, ToolsResponse } from '../../services/tool/tool.service';
+import { ConfigService } from '../../services/config.service';
+import {
+  ConnectionState,
+  ConnectorStatusService,
+} from '../../settings/connectors/services/connector-status.service';
+import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
+
+/** See the twin in `customize-tools.page.spec.ts`: the real one owns a BroadcastChannel. */
+class FakeConnectorStatus {
+  states: Record<string, ConnectionState> = {};
+  ensured: string[] = [];
+
+  stateFor(providerId: string | null | undefined): ConnectionState {
+    return providerId ? (this.states[providerId] ?? 'unknown') : 'unknown';
+  }
+
+  async ensure(providerIds: readonly (string | null | undefined)[]): Promise<void> {
+    this.ensured.push(...providerIds.filter((p): p is string => !!p));
+  }
+}
+
+/**
+ * Stands in for the real consent service, which reaches `UserConnectorsService`
+ * and `SessionService` — both of which fetch in their constructors. Left real,
+ * those requests are never flushed, the app never reaches stability, and every
+ * `whenStable()` in this file times out. The page asks it three things.
+ */
+class FakeConsent {
+  readonly opened: string[] = [];
+  private readonly inFlight = signal<ReadonlySet<string>>(new Set());
+  readonly inFlightProviders = this.inFlight.asReadonly();
+
+  requestConsent(): void {}
+
+  async openConsentPopup(providerId: string): Promise<boolean> {
+    this.opened.push(providerId);
+    return true;
+  }
+}
+
+/** A failed save lands a microtask after `whenStable()`; one macrotask makes it observable. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const tool = (overrides: Partial<Tool> & Pick<Tool, 'toolId' | 'displayName'>): Tool => ({
+  description: 'Does a thing.',
+  category: 'utility',
+  icon: null,
+  protocol: 'local',
+  status: 'active',
+  grantedBy: [],
+  enabledByDefault: true,
+  userEnabled: null,
+  isEnabled: true,
+  ...overrides,
+});
+
+const CATALOG: Tool[] = [
+  tool({ toolId: 'web_search', displayName: 'Web Search', category: 'search' }),
+  tool({
+    toolId: 'canvas_faculty',
+    displayName: 'Canvas Faculty',
+    category: 'data',
+    protocol: 'mcp_external',
+    description: 'Canvas LMS access.\n\nArgs:\n  course_id: the course',
+    requiresOauthProvider: 'canvas',
+    serverTools: [
+      { name: 'list_courses', description: 'List your courses.', enabled: true },
+      { name: 'list_assignments', description: 'List assignments.', enabled: false },
+    ],
+  }),
+];
+
+const SNAPSHOT = {
+  toolId: 'canvas_faculty',
+  prompts: [
+    { name: 'grade_summary', title: 'Grade summary', description: 'Summarize grades.', arguments: ['course_id'] },
+  ],
+  resources: [
+    {
+      uri: 'canvas://courses/{course_id}/syllabus',
+      name: 'Syllabus',
+      description: null,
+      mimeType: 'text/html',
+      uriTemplate: true,
+    },
+  ],
+  supportsPrompts: true,
+  supportsResources: true,
+  discoveredAt: '2026-09-01T00:00:00Z',
+  discoveredBy: 'admin',
+  error: null,
+  truncated: false,
+};
+
+describe('CustomizeToolDetailPage', () => {
+  let http: HttpTestingController;
+  let tools: ToolService;
+  let connectors: FakeConnectorStatus;
+  let consent: FakeConsent;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    connectors = new FakeConnectorStatus();
+    consent = new FakeConsent();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: ConnectorStatusService, useValue: connectors },
+        { provide: OAuthConsentService, useValue: consent },
+      ],
+    });
+    TestBed.inject(ConfigService).appApiUrl.set('/api');
+    http = TestBed.inject(HttpTestingController);
+
+    tools = TestBed.inject(ToolService);
+    const response: ToolsResponse = {
+      tools: CATALOG.map(t => ({ ...t, serverTools: t.serverTools?.map(s => ({ ...s })) })),
+      categories: ['search', 'data'],
+      appRolesApplied: [],
+    };
+    http.match(req => req.url.startsWith('/api/tools')).forEach(req => req.flush(response));
+  });
+
+  afterEach(() => {
+    http.verify();
+    TestBed.resetTestingModule();
+  });
+
+  async function create(toolId: string): Promise<ComponentFixture<CustomizeToolDetailPage>> {
+    const fixture = TestBed.createComponent(CustomizeToolDetailPage);
+    fixture.componentRef.setInput('toolId', toolId);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = (fixture: ComponentFixture<CustomizeToolDetailPage>) =>
+    (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  it('shows the tool it was routed to', async () => {
+    const fixture = await create('web_search');
+    expect(text(fixture)).toContain('Web Search');
+    expect(text(fixture)).toContain('web_search');
+  });
+
+  it('says so when the id is not in the catalog', async () => {
+    const fixture = await create('not_a_tool');
+    expect(text(fixture)).toContain('Tool not found');
+  });
+
+  it('lists an MCP server’s tools with their own switches', async () => {
+    const fixture = await create('canvas_faculty');
+    http.expectOne('/api/tools/canvas_faculty/capabilities').flush(SNAPSHOT);
+    expect(text(fixture)).toContain('list_courses');
+    expect(text(fixture)).toContain('list_assignments');
+    // Master switch + one per sub-tool.
+    expect(fixture.nativeElement.querySelectorAll('button[role="switch"]')).toHaveLength(3);
+  });
+
+  it('keeps the docstring reference material out of the prose', async () => {
+    const fixture = await create('canvas_faculty');
+    http.expectOne('/api/tools/canvas_faculty/capabilities').flush(SNAPSHOT);
+    expect(text(fixture)).toContain('Canvas LMS access.');
+    expect(text(fixture)).not.toContain('course_id: the course');
+
+    fixture.componentInstance['showDescriptionDetail'].set(true);
+    fixture.detectChanges();
+    expect(text(fixture)).toContain('course_id: the course');
+  });
+
+  it('reads prompts and resources from the stored snapshot', async () => {
+    const fixture = await create('canvas_faculty');
+    http.expectOne('/api/tools/canvas_faculty/capabilities').flush(SNAPSHOT);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain('Grade summary');
+    expect(text(fixture)).toContain('arguments: course_id');
+    expect(text(fixture)).toContain('canvas://courses/{course_id}/syllabus');
+    expect(text(fixture)).toContain('template');
+  });
+
+  it('asks for no capability snapshot for a tool that is not an external MCP server', async () => {
+    // A local tool has no server to have been asked; the request would 404 or,
+    // worse, succeed with an empty snapshot and read as "offers nothing".
+    await create('web_search');
+    http.expectNone('/api/tools/web_search/capabilities');
+  });
+
+  it('writes a sub-tool toggle through to the preferences endpoint', async () => {
+    const fixture = await create('canvas_faculty');
+    http.expectOne('/api/tools/canvas_faculty/capabilities').flush(SNAPSHOT);
+    fixture.detectChanges();
+
+    const switches = fixture.nativeElement.querySelectorAll(
+      'button[role="switch"]',
+    ) as NodeListOf<HTMLButtonElement>;
+    switches[2].click(); // list_assignments, currently off
+    await fixture.whenStable();
+
+    const req = http.expectOne('/api/tools/preferences');
+    expect(req.request.body.preferences).toEqual({ 'canvas_faculty::list_assignments': true });
+    req.flush({});
+  });
+
+  it('surfaces a failed save instead of letting the switch snap back silently', async () => {
+    const fixture = await create('web_search');
+    const toggle = fixture.nativeElement.querySelector(
+      'button[role="switch"]',
+    ) as HTMLButtonElement;
+    toggle.click();
+    await fixture.whenStable();
+
+    http.expectOne('/api/tools/preferences').flush('nope', { status: 500, statusText: 'Error' });
+    await settle();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain("Couldn't save the change to Web Search");
+    expect(tools.getTool('web_search')?.isEnabled).toBe(true);
+  });
+
+  describe('the agent-lock seam', () => {
+    // Same reasoning as the list page: the lock is conversation-scoped state on
+    // a root singleton, and a global preference page must ignore it entirely.
+    // See docs/specs/customize-surface.md §"The agent-lock seam".
+
+    it('still saves a toggle while a lock is held', async () => {
+      tools.lockToAgentTools(['canvas_faculty']);
+      const fixture = await create('web_search');
+
+      const toggle = fixture.nativeElement.querySelector(
+        'button[role="switch"]',
+      ) as HTMLButtonElement;
+      toggle.click();
+      await fixture.whenStable();
+
+      const req = http.expectOne('/api/tools/preferences');
+      expect(req.request.body.preferences).toEqual({ web_search: false });
+      req.flush({});
+    });
+
+    it('shows the user’s own enabled state, not membership of the bound set', async () => {
+      tools['_tools'].update(list =>
+        list.map(t => (t.toolId === 'web_search' ? { ...t, isEnabled: false } : t)),
+      );
+      tools.lockToAgentTools(['web_search']);
+      const fixture = await create('web_search');
+
+      expect(tools.isToolShownEnabled(tools.getTool('web_search')!)).toBe(true); // drawer shim
+      expect(text(fixture)).toContain('Off');
+    });
+  });
+});

--- a/frontend/ai.client/src/app/customize/tools/customize-tool-detail.page.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tool-detail.page.ts
@@ -1,0 +1,728 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroArrowPath,
+  heroCheckCircle,
+  heroMagnifyingGlass,
+} from '@ng-icons/heroicons/outline';
+import { ServerTool, Tool, ToolService } from '../../services/tool/tool.service';
+import { ToolCapabilityService } from '../../services/tool-capability/tool-capability.service';
+import { ConnectorStatusService } from '../../settings/connectors/services/connector-status.service';
+import { OAuthConsentService } from '../../services/oauth-consent/oauth-consent.service';
+import { splitToolDescription } from '../../shared/utils/tool-description';
+import { monogramFor } from '../../shared/utils/monogram';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+
+/** A server's tool with its docstring already split for display. */
+interface SubToolRow extends ServerTool {
+  summary: string;
+  detail: string;
+}
+
+/** Above this many sub-tools the list gets its own filter box. */
+const FILTER_THRESHOLD = 8;
+
+/**
+ * Customize → Tools → one tool. Everything the browse card had no room for:
+ * what the tool is, what an MCP server exposes tool-by-tool, and the prompts
+ * and resources it offers besides tools.
+ *
+ * ⚠️ Since step 5 deleted the composer drawer (#1079) this is the **only**
+ * per-sub-tool surface in the app. A user who wants 3 of Canvas's 48 tools has
+ * nowhere else to say so.
+ *
+ * It descends from the drawer's `ToolDetailComponent` but deliberately did not
+ * inherit two of its traits:
+ *
+ * - The drawer was **conversation-scoped** — it read `isToolShownEnabled()` and
+ *   wrote through the Agent lock. Customize is **global**, so this page reads
+ *   `tool.isEnabled` / `sub.enabled` and writes with `respectAgentLock: false`,
+ *   exactly like the list it drills in from. See
+ *   `docs/specs/customize-surface.md` §"The agent-lock seam".
+ * - The drawer was 320px wide, which is why it had a tab strip. A page does not
+ *   need one: tools, prompts and resources are stacked sections, so browser
+ *   find-in-page works across all of them and nothing is hidden behind a tab a
+ *   user has to guess at. A server with dozens of tools gets a filter box
+ *   instead, which is the real fix for that list's length.
+ *
+ * Prompts and resources come from the stored capability snapshot, never a live
+ * probe: probing opens an MCP session per server, and a 3LO server cannot be
+ * reached without a consent token the browser does not hold. An admin refreshes
+ * the snapshot; this page reads it. They stay read-only because acting on one
+ * needs `prompts/get` / `resources/read`, which the backend does not expose to
+ * this surface yet.
+ */
+@Component({
+  selector: 'app-customize-tool-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, RouterLink, SpinnerComponent],
+  providers: [
+    provideIcons({ heroArrowLeft, heroArrowPath, heroCheckCircle, heroMagnifyingGlass }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <a
+          routerLink="/customize/tools"
+          class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-500 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Tools
+        </a>
+
+        @if (tool(); as t) {
+          <!-- Identity -->
+          <div class="mt-6 flex items-start gap-4">
+            <span
+              aria-hidden="true"
+              class="grid size-12 shrink-0 place-items-center rounded-2xl border border-gray-200 bg-gray-50 font-mono text-base font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+              >{{ monogram() }}</span
+            >
+            <div class="min-w-0 flex-1">
+              <h1 class="text-2xl/8 font-bold break-words text-gray-900 dark:text-white">
+                {{ t.displayName }}
+              </h1>
+              <p class="mt-0.5 font-mono text-xs/5 break-all text-gray-500 dark:text-gray-400">
+                {{ t.toolId }}
+              </p>
+              <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                @for (chip of chips(); track chip) {
+                  <span
+                    class="rounded-sm bg-gray-100 px-1.5 font-mono text-[10px]/5 font-medium text-gray-600 dark:bg-white/10 dark:text-gray-300"
+                    >{{ chip }}</span
+                  >
+                }
+              </div>
+            </div>
+          </div>
+
+          @if (summary()) {
+            <p class="mt-4 text-sm/6 text-gray-600 dark:text-gray-300">{{ summary() }}</p>
+          }
+          @if (detail()) {
+            <button
+              type="button"
+              (click)="showDescriptionDetail.set(!showDescriptionDetail())"
+              [attr.aria-expanded]="showDescriptionDetail()"
+              aria-controls="tool-description-detail"
+              class="mt-2 text-sm/6 font-medium text-primary-accessible hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-accessible-dark"
+            >
+              {{ showDescriptionDetail() ? 'Hide reference' : 'Show reference' }}
+            </button>
+            @if (showDescriptionDetail()) {
+              <!-- Keeps its line structure: an Args: block is a list, and
+                   unwrapping it into a paragraph would read worse. -->
+              <pre
+                id="tool-description-detail"
+                class="mt-2 overflow-x-auto rounded-2xl bg-gray-50 p-3 font-mono text-xs/5 whitespace-pre text-gray-600 dark:bg-white/5 dark:text-gray-300"
+                >{{ detail() }}</pre
+              >
+            }
+          }
+
+          <!--
+            Connection. Only drawn for a tool that actually needs consent, and
+            only once we know the answer — an unknown state means the probe failed, and
+            telling someone to reconnect on that basis sends them through a flow
+            they may not need. Turning the tool on without connecting is still
+            allowed: the agent surfaces its own consent prompt mid-turn, and
+            blocking the switch here would be a second, contradictory gate.
+          -->
+          @switch (connection()) {
+            @case ('disconnected') {
+              <div
+                class="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-state-warning-200 bg-state-warning-50 px-4 py-3 dark:border-state-warning-800 dark:bg-state-warning-900/20"
+              >
+                <span class="min-w-0 text-sm/6 text-state-warning-800 dark:text-state-warning-200">
+                  Needs your {{ t.requiresOauthProvider }} account before it can run.
+                </span>
+                <button
+                  type="button"
+                  (click)="connect()"
+                  [disabled]="connecting()"
+                  class="shrink-0 rounded-2xl bg-primary-accessible px-3.5 py-1.5 text-sm/6 font-semibold text-white transition-[filter] hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {{ connecting() ? 'Waiting…' : 'Connect' }}
+                </button>
+              </div>
+            }
+            @case ('connected') {
+              <p
+                class="mt-4 flex items-center gap-1.5 text-sm/6 text-state-success-700 dark:text-state-success-300"
+              >
+                <ng-icon name="heroCheckCircle" class="size-4 shrink-0" aria-hidden="true" />
+                Connected as you
+              </p>
+            }
+          }
+
+          <!-- Master switch -->
+          <div
+            class="mt-4 flex items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-white/10 dark:bg-white/5"
+          >
+            <div class="min-w-0">
+              <span
+                id="tool-detail-state"
+                class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                >{{ t.isEnabled ? 'On' : 'Off' }}</span
+              >
+              <span class="block text-xs/5 text-gray-500 dark:text-gray-400">
+                Applies to every conversation, including ones already open.
+              </span>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              [attr.aria-checked]="t.isEnabled"
+              aria-labelledby="tool-detail-state"
+              [disabled]="pending().has(t.toolId)"
+              (click)="onToggle(t)"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+              [class]="t.isEnabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'"
+            >
+              <span
+                aria-hidden="true"
+                class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                [class.translate-x-5]="t.isEnabled"
+                [class.translate-x-0]="!t.isEnabled"
+              ></span>
+            </button>
+          </div>
+
+          @if (saveError()) {
+            <div
+              role="alert"
+              class="mt-4 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+            >
+              {{ saveError() }}
+            </div>
+          }
+
+          <!-- Tools -->
+          @if (isMcpServer()) {
+            <section class="mt-8">
+              <h2 class="flex items-baseline gap-2 text-base/7 font-semibold text-gray-900 dark:text-white">
+                Tools
+                <span class="font-mono text-xs/5 font-normal text-gray-500 tabular-nums dark:text-gray-400">
+                  {{ subToolsLabel() }}
+                </span>
+              </h2>
+
+              @if (subTools().length > 0) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  Turn off the ones you don’t need — only the tools left on are sent to the
+                  model.
+                </p>
+
+                <!-- Dozens of tools is the normal case for a real MCP server, and
+                     scrolling is not a way to find one by name. -->
+                @if (subTools().length > FILTER_THRESHOLD) {
+                  <div class="relative mt-3 max-w-sm">
+                    <ng-icon
+                      name="heroMagnifyingGlass"
+                      class="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                      aria-hidden="true"
+                    />
+                    <label for="sub-tool-filter" class="sr-only">Filter this server’s tools</label>
+                    <input
+                      type="search"
+                      id="sub-tool-filter"
+                      [value]="subToolQuery()"
+                      (input)="onSubToolFilter($event)"
+                      placeholder="Filter tools…"
+                      class="block w-full rounded-full border border-gray-300 bg-white py-2 pl-10 pr-4 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+                    />
+                  </div>
+                }
+
+                @if (visibleSubTools().length === 0) {
+                  <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">
+                    No tools match “{{ subToolQuery() }}”.
+                  </p>
+                } @else {
+                  <ul class="mt-3 flex flex-col gap-2">
+                    @for (sub of visibleSubTools(); track sub.name) {
+                      <li
+                        class="flex items-start justify-between gap-4 rounded-2xl border border-gray-200 px-4 py-3 dark:border-white/10"
+                      >
+                        <div class="min-w-0 flex-1">
+                          <span
+                            [id]="'subtool-' + sub.name"
+                            class="block font-mono text-sm/6 font-medium text-gray-900 dark:text-white"
+                            >{{ sub.name }}</span
+                          >
+                          @if (sub.summary) {
+                            <span class="mt-0.5 block text-sm/6 text-gray-500 dark:text-gray-400">{{
+                              sub.summary
+                            }}</span>
+                          }
+                          @if (sub.detail) {
+                            <button
+                              type="button"
+                              (click)="toggleDetail(sub.name)"
+                              [attr.aria-expanded]="isDetailExpanded(sub.name)"
+                              [attr.aria-controls]="'subtool-detail-' + sub.name"
+                              class="mt-1 text-xs/5 font-medium text-primary-accessible hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-accessible-dark"
+                            >
+                              {{ isDetailExpanded(sub.name) ? 'Hide details' : 'Show details' }}
+                            </button>
+                            @if (isDetailExpanded(sub.name)) {
+                              <pre
+                                [id]="'subtool-detail-' + sub.name"
+                                class="mt-1.5 overflow-x-auto rounded-lg bg-gray-50 p-2 font-mono text-[11px]/5 whitespace-pre text-gray-600 dark:bg-white/5 dark:text-gray-300"
+                                >{{ sub.detail }}</pre
+                              >
+                            }
+                          }
+                        </div>
+                        <button
+                          type="button"
+                          role="switch"
+                          [attr.aria-checked]="sub.enabled"
+                          [attr.aria-labelledby]="'subtool-' + sub.name"
+                          [disabled]="pending().has(sub.name)"
+                          (click)="onToggleSubTool(t, sub)"
+                          class="relative mt-0.5 inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+                          [class]="sub.enabled ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'"
+                        >
+                          <span
+                            aria-hidden="true"
+                            class="pointer-events-none inline-block size-4 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                            [class.translate-x-4]="sub.enabled"
+                            [class.translate-x-0]="!sub.enabled"
+                          ></span>
+                        </button>
+                      </li>
+                    }
+                  </ul>
+                }
+              } @else {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  This server hasn’t been asked what it offers yet.
+                </p>
+                <button
+                  type="button"
+                  (click)="discover()"
+                  [disabled]="discovering()"
+                  class="mt-3 inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 px-3.5 py-1.5 text-sm/6 font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <ng-icon
+                    name="heroArrowPath"
+                    class="size-4"
+                    [class.animate-spin]="discovering()"
+                    aria-hidden="true"
+                  />
+                  {{ discovering() ? 'Listing tools…' : 'List this server’s tools' }}
+                </button>
+                @if (discoverError(); as message) {
+                  <p class="mt-2 text-sm/6 text-state-danger-600 dark:text-state-danger-400" role="alert">
+                    {{ message }}
+                  </p>
+                }
+              }
+            </section>
+          }
+
+          <!-- Prompts and resources: external MCP servers only. A local tool has
+               no server to ask, and a Gateway target exposes tools only. -->
+          @if (offersCapabilities()) {
+            <section class="mt-8">
+              <h2 class="flex items-baseline gap-2 text-base/7 font-semibold text-gray-900 dark:text-white">
+                Prompts
+                @if (prompts().length > 0) {
+                  <span class="font-mono text-xs/5 font-normal text-gray-500 tabular-nums dark:text-gray-400">
+                    {{ prompts().length }}
+                  </span>
+                }
+              </h2>
+              @if (capabilitiesLoading()) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">Loading…</p>
+              } @else if (neverDiscovered()) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  Nobody has asked this server what prompts it offers yet. An administrator can
+                  refresh it.
+                </p>
+              } @else if (!capabilities()?.supportsPrompts) {
+                <!-- Distinct from "has none": this server answered prompts/list with
+                     "method not found", so prompts are not part of what it does. -->
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  This server doesn’t offer prompts.
+                </p>
+              } @else if (prompts().length === 0) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  This server offers prompts, but none right now.
+                </p>
+              } @else {
+                <ul class="mt-3 flex flex-col gap-2">
+                  @for (prompt of prompts(); track prompt.name) {
+                    <li class="rounded-2xl border border-gray-200 px-4 py-3 dark:border-white/10">
+                      <span class="block font-mono text-sm/6 font-medium text-gray-900 dark:text-white">{{
+                        prompt.title || prompt.name
+                      }}</span>
+                      @if (prompt.description) {
+                        <span class="mt-0.5 block text-sm/6 text-gray-500 dark:text-gray-400">{{
+                          prompt.description
+                        }}</span>
+                      }
+                      @if (prompt.arguments.length > 0) {
+                        <span class="mt-1 block font-mono text-xs/5 text-gray-400 dark:text-gray-500"
+                          >arguments: {{ prompt.arguments.join(', ') }}</span
+                        >
+                      }
+                    </li>
+                  }
+                </ul>
+              }
+            </section>
+
+            <section class="mt-8">
+              <h2 class="flex items-baseline gap-2 text-base/7 font-semibold text-gray-900 dark:text-white">
+                Resources
+                @if (resources().length > 0) {
+                  <span class="font-mono text-xs/5 font-normal text-gray-500 tabular-nums dark:text-gray-400">
+                    {{ resources().length }}
+                  </span>
+                }
+              </h2>
+              @if (capabilitiesLoading()) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">Loading…</p>
+              } @else if (neverDiscovered()) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  Nobody has asked this server what resources it offers yet. An administrator can
+                  refresh it.
+                </p>
+              } @else if (!capabilities()?.supportsResources) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  This server doesn’t offer resources.
+                </p>
+              } @else if (resources().length === 0) {
+                <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                  This server offers resources, but none right now.
+                </p>
+              } @else {
+                <ul class="mt-3 flex flex-col gap-2">
+                  @for (resource of resources(); track resource.uri) {
+                    <li class="rounded-2xl border border-gray-200 px-4 py-3 dark:border-white/10">
+                      <span class="flex items-start gap-1.5">
+                        <span
+                          class="min-w-0 flex-1 font-mono text-sm/6 font-medium break-all text-gray-900 dark:text-white"
+                          >{{ resource.uri }}</span
+                        >
+                        @if (resource.uriTemplate) {
+                          <!-- A template is a pattern, not a readable URI — the
+                               placeholders have to be filled before anything can
+                               read it. -->
+                          <span
+                            class="shrink-0 rounded-sm bg-gray-100 px-1.5 font-mono text-[10px]/5 text-gray-600 dark:bg-white/10 dark:text-gray-300"
+                            >template</span
+                          >
+                        }
+                      </span>
+                      @if (resource.name || resource.description) {
+                        <span class="mt-0.5 block text-sm/6 text-gray-500 dark:text-gray-400">{{
+                          resource.description || resource.name
+                        }}</span>
+                      }
+                      @if (resource.mimeType) {
+                        <span class="mt-1 block font-mono text-xs/5 text-gray-400 dark:text-gray-500">{{
+                          resource.mimeType
+                        }}</span>
+                      }
+                    </li>
+                  }
+                </ul>
+              }
+              @if (capabilities()?.truncated) {
+                <p class="mt-3 text-xs/5 text-gray-400 dark:text-gray-500">
+                  This server exposes more than we store; the list above is capped.
+                </p>
+              }
+            </section>
+          }
+
+          <!-- About -->
+          <section class="mt-8">
+            <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">About</h2>
+            <dl class="mt-3 flex flex-col gap-2.5">
+              @for (fact of facts(); track fact.label) {
+                <div
+                  class="flex items-baseline justify-between gap-4 border-b border-gray-100 pb-2.5 last:border-0 dark:border-white/5"
+                >
+                  <dt class="text-sm/6 text-gray-500 dark:text-gray-400">{{ fact.label }}</dt>
+                  <dd
+                    class="min-w-0 text-right font-mono text-sm/6 break-words text-gray-700 dark:text-gray-200"
+                  >
+                    {{ fact.value }}
+                  </dd>
+                </div>
+              }
+            </dl>
+          </section>
+        } @else if (toolService.loading() || !toolService.initialized()) {
+          <div class="mt-8 flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
+            <app-spinner size="sm" label="Loading tool" />
+            Loading…
+          </div>
+        } @else {
+          <!-- Loaded, and this id is not in the catalog: either it was retired or
+               the user's roles no longer grant it. Both read the same to them. -->
+          <div
+            class="mt-8 rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700"
+          >
+            <p class="text-sm/6 font-medium text-gray-900 dark:text-white">Tool not found</p>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              This tool no longer exists, or your roles don’t grant it.
+            </p>
+            <a
+              routerLink="/customize/tools"
+              class="mt-4 inline-block text-sm/6 font-semibold text-primary-accessible hover:underline dark:text-primary-accessible-dark"
+              >Back to Tools</a
+            >
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class CustomizeToolDetailPage {
+  protected readonly toolService = inject(ToolService);
+  private readonly capabilityService = inject(ToolCapabilityService);
+  private readonly connectorStatus = inject(ConnectorStatusService);
+  private readonly consent = inject(OAuthConsentService);
+
+  /** Bound from the `:toolId` route param by `withComponentInputBinding()`. */
+  readonly toolId = input.required<string>();
+
+  protected readonly FILTER_THRESHOLD = FILTER_THRESHOLD;
+
+  protected readonly saveError = signal<string | null>(null);
+  protected readonly discovering = signal(false);
+  protected readonly discoverError = signal<string | null>(null);
+  protected readonly showDescriptionDetail = signal(false);
+  protected readonly subToolQuery = signal('');
+  /** Keyed by tool id for the master switch, by sub-tool name for the rest. */
+  protected readonly pending = signal<ReadonlySet<string>>(new Set());
+
+  private readonly expandedDetails = signal<ReadonlySet<string>>(new Set());
+
+  constructor() {
+    // A deep link to this page is a legitimate first paint; the catalog is
+    // usually already in flight from ToolService's own constructor.
+    if (!this.toolService.initialized() && !this.toolService.loading()) {
+      void this.toolService.loadTools();
+    }
+
+    effect(() => {
+      const provider = this.tool()?.requiresOauthProvider;
+      if (provider) void this.connectorStatus.ensure([provider]);
+    });
+
+    // Only external MCP servers have prompts and resources to show, so only
+    // they are worth a request. `ensure` is a no-op for an id already cached.
+    effect(() => {
+      if (this.offersCapabilities()) void this.capabilityService.ensure(this.toolId());
+    });
+  }
+
+  protected readonly tool = computed<Tool | null>(
+    () => this.toolService.tools().find(t => t.toolId === this.toolId()) ?? null,
+  );
+
+  protected readonly monogram = computed(() => monogramFor(this.tool()?.displayName ?? ''));
+
+  private readonly description = computed(() =>
+    splitToolDescription(this.tool()?.description),
+  );
+  protected readonly summary = computed(() => this.description().summary);
+  protected readonly detail = computed(() => this.description().detail);
+
+  /** Category, protocol, and status only when it is worth saying out loud. */
+  protected readonly chips = computed(() => {
+    const t = this.tool();
+    if (!t) return [];
+    const chips: string[] = [t.category, t.protocol];
+    if (t.status !== 'active') chips.push(t.status);
+    return chips;
+  });
+
+  protected readonly isMcpServer = computed(() => {
+    const protocol = this.tool()?.protocol;
+    return protocol === 'mcp' || protocol === 'mcp_external';
+  });
+
+  protected readonly offersCapabilities = computed(
+    () => this.tool()?.protocol === 'mcp_external',
+  );
+
+  /**
+   * The server's tools with their docstrings split into a readable summary and
+   * the reference detail below it.
+   */
+  protected readonly subTools = computed<SubToolRow[]>(() =>
+    (this.tool()?.serverTools ?? []).map(sub => ({
+      ...sub,
+      ...splitToolDescription(sub.description),
+    })),
+  );
+
+  protected readonly visibleSubTools = computed(() => {
+    const q = this.subToolQuery().trim().toLowerCase();
+    if (!q) return this.subTools();
+    return this.subTools().filter(sub =>
+      [sub.name, sub.summary].some(field => field.toLowerCase().includes(q)),
+    );
+  });
+
+  /** "3 of 17 on" while partly selected, so the heading carries the real state. */
+  protected readonly subToolsLabel = computed(() => {
+    const subs = this.subTools();
+    if (subs.length === 0) return '';
+    const on = subs.filter(s => s.enabled).length;
+    return on === subs.length ? `${subs.length}` : `${on} of ${subs.length} on`;
+  });
+
+  protected readonly capabilities = computed(() =>
+    this.capabilityService.capabilitiesFor(this.toolId()),
+  );
+
+  protected readonly capabilitiesLoading = computed(() =>
+    this.capabilityService.isLoading(this.toolId()),
+  );
+
+  protected readonly prompts = computed(() => this.capabilities()?.prompts ?? []);
+  protected readonly resources = computed(() => this.capabilities()?.resources ?? []);
+
+  /** Never discovered — distinct from "discovered and offers nothing". */
+  protected readonly neverDiscovered = computed(() => {
+    const snapshot = this.capabilities();
+    return !!snapshot && !snapshot.discoveredAt;
+  });
+
+  /** The OAuth provider this tool needs, or null when it needs none. */
+  private readonly providerId = computed(() => this.tool()?.requiresOauthProvider ?? null);
+
+  /** Connection state for that provider; 'none' when the tool needs no consent. */
+  protected readonly connection = computed(() => {
+    const provider = this.providerId();
+    return provider ? this.connectorStatus.stateFor(provider) : 'none';
+  });
+
+  protected readonly connecting = computed(() => {
+    const provider = this.providerId();
+    return provider ? this.consent.inFlightProviders().has(provider) : false;
+  });
+
+  /** Catalog facts the card has no room for. */
+  protected readonly facts = computed(() => {
+    const t = this.tool();
+    if (!t) return [];
+    const rows: { label: string; value: string }[] = [
+      { label: 'Tool ID', value: t.toolId },
+      { label: 'Protocol', value: t.protocol },
+      { label: 'Category', value: t.category },
+      { label: 'Status', value: t.status },
+      { label: 'On by default', value: t.enabledByDefault ? 'yes' : 'no' },
+    ];
+    if (t.requiresOauthProvider) {
+      rows.push({ label: 'Requires account', value: t.requiresOauthProvider });
+    }
+    if (t.grantedBy.length > 0) {
+      rows.push({ label: 'Granted by', value: t.grantedBy.join(', ') });
+    }
+    return rows;
+  });
+
+  protected isDetailExpanded(name: string): boolean {
+    return this.expandedDetails().has(name);
+  }
+
+  protected toggleDetail(name: string): void {
+    this.expandedDetails.update(set => {
+      const next = new Set(set);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }
+
+  protected onSubToolFilter(event: Event): void {
+    this.subToolQuery.set((event.target as HTMLInputElement).value);
+  }
+
+  /**
+   * Open the provider's consent popup. Reuses the same service the chat layer
+   * and the connectors page use, so popup blocking, COOP-severed openers and
+   * the completion broadcast are all already handled — and
+   * `ConnectorStatusService` flips the state when that broadcast lands.
+   *
+   * `requestConsent` is called with no authorization URL on purpose: the
+   * service then fetches a fresh one, because AgentCore's URLs expire quickly.
+   */
+  protected connect(): void {
+    const provider = this.providerId();
+    if (!provider) return;
+    this.consent.requestConsent(provider, undefined);
+    void this.consent.openConsentPopup(provider);
+  }
+
+  protected async onToggle(tool: Tool): Promise<void> {
+    await this.withPending(tool.toolId, tool.displayName, () =>
+      // `respectAgentLock: false` — see the class comment.
+      this.toolService.toggleTool(tool.toolId, { respectAgentLock: false }),
+    );
+  }
+
+  protected async onToggleSubTool(tool: Tool, sub: SubToolRow): Promise<void> {
+    await this.withPending(sub.name, sub.name, () =>
+      this.toolService.toggleServerTool(tool.toolId, sub.name, { respectAgentLock: false }),
+    );
+  }
+
+  /**
+   * A switch that snaps back on its own looks like a bug in the switch, so a
+   * failed save says so. The service has already reverted its optimistic
+   * update by the time this runs.
+   */
+  private async withPending(
+    key: string,
+    label: string,
+    save: () => Promise<void>,
+  ): Promise<void> {
+    if (this.pending().has(key)) return;
+    this.saveError.set(null);
+    this.pending.update(set => new Set(set).add(key));
+    try {
+      await save();
+    } catch {
+      this.saveError.set(`Couldn't save the change to ${label}. Please try again.`);
+    } finally {
+      this.pending.update(set => {
+        const next = new Set(set);
+        next.delete(key);
+        return next;
+      });
+    }
+  }
+
+  protected async discover(): Promise<void> {
+    this.discovering.set(true);
+    this.discoverError.set(null);
+    try {
+      await this.toolService.discoverServerTools(this.toolId());
+    } catch {
+      this.discoverError.set('Could not list this server’s tools.');
+    } finally {
+      this.discovering.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/customize/tools/customize-tools.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tools.page.spec.ts
@@ -117,6 +117,26 @@ describe('CustomizeToolsPage', () => {
     expect(text(fixture)).toContain('Canvas Faculty');
   });
 
+  it('links each card to its detail page', async () => {
+    const fixture = await create();
+    const links = [...fixture.nativeElement.querySelectorAll('app-customize-card a')].map(
+      (a: Element) => a.getAttribute('href'),
+    );
+    expect(links).toEqual([
+      '/customize/tools/web_search',
+      '/customize/tools/calculator',
+      '/customize/tools/canvas_faculty',
+    ]);
+  });
+
+  it('keeps the switch out of the card link', async () => {
+    // A control nested inside a link is a control the user cannot operate with
+    // the keyboard without also following the link.
+    const fixture = await create();
+    const toggle = fixture.nativeElement.querySelector('app-customize-card button[role="switch"]');
+    expect(toggle.closest('a')).toBeNull();
+  });
+
   it('counts what is on, not what exists', async () => {
     const fixture = await create();
     expect(text(fixture)).toContain('2 of 3 tools on');

--- a/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
@@ -20,6 +20,8 @@ interface ToolCard {
   monogram: string;
   enabled: boolean;
   badge: CustomizeCardBadge;
+  /** Where the card's name drills in to. Encoded: ids are opaque catalog keys. */
+  detailLink: string;
 }
 
 /**
@@ -150,6 +152,7 @@ interface ToolCard {
                   [monogram]="card.monogram"
                   [enabled]="card.enabled"
                   [badge]="card.badge"
+                  [detailLink]="card.detailLink"
                   [pending]="pending().has(card.tool.toolId)"
                   (toggled)="onToggle(card.tool)"
                 />
@@ -224,6 +227,7 @@ export class CustomizeToolsPage {
       // `isEnabled`, never `isToolShownEnabled()` — see the class comment.
       enabled: tool.isEnabled,
       badge: this.badgeFor(tool),
+      detailLink: `/customize/tools/${encodeURIComponent(tool.toolId)}`,
     }));
   });
 


### PR DESCRIPTION
Clicking a tool in **Customize → Tools** now drills into `/customize/tools/:toolId`.

⚠️ **This closes a gap that opened yesterday.** Step 5 (#1079) deleted the composer drawer, and the drawer's `ToolDetailComponent` was the only per-sub-tool enablement UI in the app. On `develop` as it stands, a user who wants 3 of Canvas for Faculty's 48 tools has nowhere to say so. This restores that, on the surface the spec says owns it.

## What the page carries

- Identity — monogram, display name, tool id, category/protocol chips
- Description — the summary, with the docstring's `Args:`/`Returns:` reference block behind *Show reference*
- Connection state + **Connect** for tools that need OAuth consent
- The master on/off switch
- **Tools** — an MCP server's tools one by one, each with its own switch, summary, and *Show details*; above eight the list grows a filter box
- **Prompts** and **Resources** — what the server exposes besides tools
- **About** — protocol, status, granting roles, on-by-default

## Decisions worth reviewing

**A new component, not a port of `ToolDetailComponent`.** Same reason the Customize list is not a port of the drawer's list: the drawer was conversation-scoped (`isToolShownEnabled()`, writes through the Agent lock) and this surface is global (`tool.isEnabled` / `sub.enabled`, `respectAgentLock: false`). Porting it would reopen the agent-lock seam the spec exists to close.

**The tab strip did not come along.** Tabs existed because the drawer pane was 320px. On a page, Tools / Prompts / Resources / About are stacked sections, so browser find-in-page reaches all of them and nothing hides behind a tab you have to guess at. The problem tabs were actually solving — a 48-tool server — is solved directly with the filter box.

**Prompts and resources stay a read of the stored capability snapshot**, never a live probe: probing opens an MCP session per server, and a 3LO server can't be reached without a consent token the browser doesn't hold. They stay read-only because acting on one needs `prompts/get` / `resources/read`, which this surface has no endpoint for. The snapshot is fetched only for `mcp_external` tools — nothing else has a server that could have been asked.

**Card link accessibility.** The card's name is a link whose `after:absolute inset-0` makes the whole card the navigation target; the switch is raised out with `z-10` rather than nested inside it — a switch inside the link is a control you can't reach by keyboard without also following the link. A test asserts the switch has no `<a>` ancestor. Skills pass no `detailLink` and are unchanged.

**Contrast.** Colored text uses `text-primary-accessible dark:text-primary-accessible-dark`, not the numbered ramp. With the brand primary at `#0033a0`, `dark:text-primary-400` measures **2.59:1** against the dark page background (`gray-900`, `#101828`) — a WCAG AA failure at these text sizes. The accessible alias is generated to clear 4.5:1 against the resolved dark surface and measures **4.52:1**. Per `src/branding/README.md` §7.

## Known gap, deliberately not fixed here

16% of catalog sub-tools (19 of 116 on dev) have docstrings whose first paragraph runs past 400 characters — `canvas_faculty/import_course_package` reaches 2,058 — because the prose precedes any `Args:` heading, so `splitToolDescription` returns all of it as `summary` and the row renders it unclamped. The *detail* behind *Show details* is modest by comparison (median 344 chars). Clamping the summary is the fix; it's noted in the spec and is a separate change.

## Cost

None against the model. Everything here reads catalog and snapshot data the app already loads; nothing reaches the system prompt or `toolConfig`, so the cacheable prefix is untouched. The one added request is `GET /tools/{id}/capabilities`, fetched once per external MCP tool and cached for the life of the page.

## Testing

- 2836/2836 frontend tests pass. 10 new on the detail page (routing, not-found, sub-tool listing, docstring split, snapshot read, no-request-for-local-tools, sub-tool save, failed-save banner, and two on the agent-lock seam), 2 new on the card link.
- Browser-verified against dev data: Student MyBoiseState (17 sub-tools, filter, detail expansion), Canvas for Faculty (48 tools, "Connected as you", deep link with no prior list load), Calculator (local — About only, no capabilities request), and the not-found state. Light and dark both confirmed with computed styles, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
