### PR TITLE
fix(a11y): use the accessible dark token for colored text and icons

### DIFF
--- a/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
+++ b/frontend/ai.client/src/app/agents/agent-form/agent-form.page.html
@@ -208,7 +208,7 @@
       <div class="mt-4" formArrayName="starters">
         <div class="flex items-center justify-between">
           <label class="block text-sm/6 font-medium text-gray-700 dark:text-gray-300">Conversation starters</label>
-          <button type="button" (click)="addStarter()" class="inline-flex items-center gap-1 text-xs/5 font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400">
+          <button type="button" (click)="addStarter()" class="inline-flex items-center gap-1 text-xs/5 font-medium text-primary-accessible hover:text-primary-700 dark:text-primary-accessible-dark">
             <ng-icon name="heroPlus" class="size-3.5" /> Add
           </button>
         </div>
@@ -413,7 +413,7 @@
                         <span class="mt-0.5 block text-xs/5 text-gray-500 dark:text-gray-400">{{ sub.summary }}</span>
                       }
                       @if (sub.detail) {
-                        <button type="button" (click)="toggleToolDetail(t.ref + '::' + sub.name)" [attr.aria-expanded]="isToolDetailExpanded(t.ref + '::' + sub.name)" [attr.aria-controls]="'agent-subtool-detail-' + t.ref + '-' + sub.name" class="mt-1 text-xs/5 font-medium text-primary-600 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-400">
+                        <button type="button" (click)="toggleToolDetail(t.ref + '::' + sub.name)" [attr.aria-expanded]="isToolDetailExpanded(t.ref + '::' + sub.name)" [attr.aria-controls]="'agent-subtool-detail-' + t.ref + '-' + sub.name" class="mt-1 text-xs/5 font-medium text-primary-accessible hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-accessible-dark">
                           {{ isToolDetailExpanded(t.ref + '::' + sub.name) ? 'Hide details' : 'Show details' }}
                         </button>
                         @if (isToolDetailExpanded(t.ref + '::' + sub.name)) {

--- a/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
+++ b/frontend/ai.client/src/app/fine-tuning/pages/create-training-job/create-training-job.page.html
@@ -48,7 +48,7 @@
             <div class="flex items-start justify-between gap-2">
               <span class="text-sm/6 font-medium text-gray-900 dark:text-white">{{ task.display_name }}</span>
               @if (selectedTaskType() === task.task_type) {
-                <ng-icon name="heroCheck" class="size-5 shrink-0 text-primary-600 dark:text-primary-400" />
+                <ng-icon name="heroCheck" class="size-5 shrink-0 text-primary-accessible dark:text-primary-accessible-dark" />
               }
             </div>
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ task.description }}</p>

--- a/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
+++ b/frontend/ai.client/src/app/knowledge-base/knowledge-base-section.component.html
@@ -27,7 +27,7 @@
       <div class="flex items-start gap-3">
         <ng-icon
           name="heroSparkles"
-          class="mt-0.5 size-5 shrink-0 text-primary-600 dark:text-primary-400"
+          class="mt-0.5 size-5 shrink-0 text-primary-accessible dark:text-primary-accessible-dark"
           aria-hidden="true"
         />
         <div class="min-w-0 flex-1">

--- a/frontend/ai.client/src/app/session/components/chat-input/conversation-mode-picker.component.ts
+++ b/frontend/ai.client/src/app/session/components/chat-input/conversation-mode-picker.component.ts
@@ -67,7 +67,7 @@ import { SystemPromptsService } from '../../../services/system-prompts/system-pr
               @if (activePromptId() === null) {
                 <ng-icon
                   name="heroCheck"
-                  class="mt-0.5 size-4 shrink-0 text-primary-600 dark:text-primary-400"
+                  class="mt-0.5 size-4 shrink-0 text-primary-accessible dark:text-primary-accessible-dark"
                   aria-hidden="true"
                 />
               }
@@ -91,7 +91,7 @@ import { SystemPromptsService } from '../../../services/system-prompts/system-pr
                 @if (activePromptId() === prompt.prompt_id) {
                   <ng-icon
                     name="heroCheck"
-                    class="mt-0.5 size-4 shrink-0 text-primary-600 dark:text-primary-400"
+                    class="mt-0.5 size-4 shrink-0 text-primary-accessible dark:text-primary-accessible-dark"
                     aria-hidden="true"
                   />
                 }


### PR DESCRIPTION
## What

`dark:text-primary-400` resolves to `#1e53c1` and fails WCAG AA in dark mode. The repo already generates `--color-primary-accessible-dark` (`#437cee`) for exactly this case, via `findAccessibleLightnessDelta(..., darkSurface, 'lighten')`, and `src/branding/README.md` §7 documents the pairing:

> Colored text or icon on a dark surface → `dark:text-primary-accessible-dark`

This swaps the remaining legacy occurrences to `text-primary-accessible dark:text-primary-accessible-dark`. Six lines, four files.

## Scope was smaller than the original sweep

The sweep found 11 occurrences across 6 files. **Five are already gone** — `71a8901d` (#1079, "move Conversation Mode to the composer, delete the drawer") landed at the tip of `develop` and deleted both `components/model-settings/` files along with the `chat-input.component.html` attachment button. The two `conversation-mode-picker.component.ts` sites are that commit's replacement picker, which carried the legacy token forward.

## Measurements

Contrast measured with `getComputedStyle` on each site's real composited backdrop chain, in both themes, with both dark-mode levers set (`documentElement.classList` + browser `colorScheme` emulation). The harness calibrates to the known figures: `gray-900` → 4.53:1, `gray-800` → 3.74:1.

| site | kind | backdrop | before | after | bar | |
|---|---|---|---|---|---|---|
| `agent-form:211` `+ Add` | **text** `xs/5` | `gray-800/80` | 2.23 | **3.90** | 4.5 | ⚠ |
| `agent-form:416` `Show details` | **text** `xs/5` | `gray-800/80` | 2.23 | **3.90** | 4.5 | ⚠ |
| `create-training-job:51` | icon | `gray-900` | 2.59 | 4.53 | 3.0 | ok |
| `knowledge-base:30` | icon | `primary-950/30` on `gray-800/80` | 2.48 | 4.31 | 3.0 | ok |
| `mode-picker:70/94` | icon | `gray-800` | 2.14 | 3.74 | 3.0 | ok |

Light mode is unaffected — all six at 10.6:1 on white, except the KB tint at 6.7:1.

## ⚠️ Flagged: the two text sites are still short of AA

The two `agent-form` buttons are the only real *text* of the six, and both sit on a `dark:bg-gray-800/80` card rather than the page background. They land at **3.90:1** — past AA-large, a large improvement on the 2.23:1 they replace, but short of the 4.5:1 AA minimum for `text-xs/5`.

This is not specific to these two sites. `findAccessibleLightnessDelta` targets the resolved dark **surface** (`gray-900`, `#101828`), where the token clears AA at 4.53:1. Every `accessible-dark` **text** sitting on a `gray-800` card carries the same ~0.6 shortfall. I left the documented token in place rather than adding a one-off override, since the fix belongs in `scripts/branding/generate-brand-theme.ts` as a card-surface variant. `primary-200` (`#5892ff`, 5.08:1 on the card) would work as a stopgap but contradicts README §7.

The four icon sites all clear the 3:1 non-text bar; three are `aria-hidden` decorative anyway, with state carried by `aria-checked`.

## Two adjacent issues, not fixed here

- **`hover:text-primary-700` at `agent-form:211`** has no `dark:` variant, so hovering in dark mode drops to **1.12:1**. Pre-existing, and `citation-display.component.ts:93` uses the identical combination — worth fixing together rather than one-off.
- **The mode-picker's hovered row** (`dark:hover:bg-gray-700`) drops its check icon to **2.63:1**, under even the 3:1 non-text bar. `aria-hidden` with state on `aria-checked`, so not a strict violation.

## Verification

- `npx ng test --no-watch` → **239 files, 2824 tests passed**.
  - ⚠️ Note for reviewers: the first run exited **0 while actually failing** (`node_modules` not installed in the worktree → "Could not find the '@angular/build:unit-test' builder"). Ran `npm ci` and re-ran for a real pass.
- Dark-mode browser check with computed styles, both levers, per the table above.
- Caveat: the local app-api redirected to `/auth/first-boot`, so the authenticated pages were unreachable. Measurements were taken against markup copied verbatim from the templates with their exact source-derived ancestor chains, on the app's real compiled stylesheet — real token resolution and real backdrop blending, but not the live pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)