### PR TITLE
style(spa): unify page chrome across Agents, Customize and Artifacts

### DIFF
--- a/.claude/skills/tailwind-ui/references/app-conventions.md
+++ b/.claude/skills/tailwind-ui/references/app-conventions.md
@@ -26,10 +26,78 @@ Every token has a dark-mode pair (`dark:*`). Test both modes.
 ```html
 <div class="min-h-dvh">
   <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
-    <!-- list pages: max-w-5xl · form pages: max-w-3xl -->
+    <!-- admin list pages: max-w-5xl · form pages: max-w-3xl -->
   </div>
 </div>
 ```
+
+## Top-level user-facing pages
+
+The pages a non-admin lands on from the sidenav — `/agents` (all three tabs),
+`/customize` (all three tabs), `/artifacts`, `/my-skills`, `/schedules`,
+`/memory-spaces` — use a **larger header and a wider shell** than the admin
+tables above. These are destinations, not records-management screens, and the
+`text-2xl/8` admin title reads as a section label rather than a page.
+
+```html
+<div class="min-h-dvh">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+    <app-…-tabs />                     <!-- hub tab strip, if the page is in a hub -->
+
+    <div class="mt-6 mb-10">
+      <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">
+        Title
+      </h1>
+      <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+        One sentence on what the page is for.
+      </p>
+    </div>
+  </div>
+</div>
+```
+
+| Element | Token |
+|---------|-------|
+| Shell | `mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8` |
+| Header block | `mt-6 mb-10` (drop `mt-6` when no tab strip sits above it) |
+| `h1` | `text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white` |
+| Subtitle | `mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400` |
+| Card grid | `grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3` (`gap-4` for the denser Customize toggle cards) |
+| Primary button | `inline-flex items-center gap-2 rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500` |
+| Secondary button | same shell, `rounded-xl border border-gray-200 bg-white px-3.5 py-1.5 text-sm/6 font-medium text-gray-700` |
+| Search field | `block w-full rounded-full border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm/6 …` in a `relative max-w-md` wrapper, with the `heroMagnifyingGlass` icon at `left-4` |
+| Filter chip | `rounded-full border px-3.5 py-1 text-sm/6 font-medium`; active `border-gray-900 bg-gray-900 text-white dark:border-white dark:bg-white dark:text-gray-900` |
+
+Use `bg-primary-accessible`, never a raw `bg-primary-500` fill: the two resolve to
+the same hex for the current brand, but only the alias is guaranteed AA against
+white text after a rebrand.
+
+### Pill tabs (hub strips and in-page filters)
+
+One idiom, whether the tabs are routes (`AgentsTabsComponent`,
+`CustomizeTabsComponent`) or an in-page filter (the Artifacts All/Yours/Shared
+strip). A raised white pill on a recessed gray shell — **not** a solid brand fill,
+and **not** an underline: the brand token is a fixed colour with no dark variant,
+so an underline in it all but disappears on the dark surface.
+
+```html
+<nav class="inline-flex gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800">
+  <a class="rounded-xl px-4 py-1.5 text-sm/6 font-medium text-gray-600 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+     routerLinkActive="bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white">Tab</a>
+</nav>
+```
+
+`inline-flex`, never `flex`: a strip stretched to the content width reads as a
+segmented control over the whole page instead of as N choices.
+
+The grid/list view toggle is the same idiom one size down — `rounded-xl` shell,
+`grid size-8 place-items-center rounded-lg` buttons, same raised-active classes —
+and is a `role="radiogroup"` of `role="radio"` buttons, since it is one setting
+with two values rather than two independent toggles. `rounded-lg` is correct
+*there* and nowhere else on these pages: it reads as a segment inside a shell,
+not as a button. Standalone buttons are `rounded-xl`, so they sit between the
+`rounded-2xl` cards and the `rounded-full` chips and search field rather than
+looking squared-off against both.
 
 ## Form pages
 

--- a/frontend/ai.client/src/app/agents/agents.page.html
+++ b/frontend/ai.client/src/app/agents/agents.page.html
@@ -10,7 +10,7 @@
           <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-3xl">
             Agents
           </h1>
-          <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
+          <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Compose an agent from a model, tools, skills and memory — governed by your role.
           </p>
         </div>
@@ -65,7 +65,7 @@
             type="button"
             (click)="onCreateNew()"
             [disabled]="loading()"
-            class="group relative inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm font-semibold text-white shadow-xs transition-all duration-200 hover:bg-primary-600 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] dark:focus-visible:ring-offset-gray-900"
+            class="group inline-flex items-center gap-2 rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition duration-200 hover:brightness-95 hover:shadow-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
           >
             <ng-icon name="heroPlus" class="size-4 transition-transform duration-200 group-hover:rotate-90" aria-hidden="true" />
             {{ loading() ? 'Creating…' : 'New Agent' }}
@@ -112,7 +112,7 @@
           <button
             type="button"
             (click)="onCreateNew()"
-            class="mt-5 inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-xs transition hover:bg-primary-600"
+            class="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           >
             <ng-icon name="heroPlus" class="size-4" aria-hidden="true" />
             New Agent

--- a/frontend/ai.client/src/app/agents/discover/discover.page.ts
+++ b/frontend/ai.client/src/app/agents/discover/discover.page.ts
@@ -65,12 +65,12 @@ const PINNED_STRIP_LIMIT = 8;
   providers: [provideIcons({ heroMagnifyingGlass, heroSparkles })],
   template: `
     <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         <app-agents-tabs />
 
-        <div class="mt-6 mb-6">
-          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Discover agents</h1>
-          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        <div class="mt-6 mb-10">
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">Discover agents</h1>
+          <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Agents published by teams across the university.
           </p>
         </div>

--- a/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
+++ b/frontend/ai.client/src/app/agents/pinned/pinned.page.ts
@@ -43,12 +43,12 @@ import { SpinnerComponent } from '../../components/spinner/spinner.component';
   providers: [provideIcons({ heroBookmark })],
   template: `
     <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         <app-agents-tabs />
 
-        <div class="mt-6 mb-6">
-          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Pinned agents</h1>
-          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        <div class="mt-6 mb-10">
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">Pinned agents</h1>
+          <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             The agents you have added, plus any your role starts you with. Removing one
             here does not affect anyone else.
           </p>
@@ -84,7 +84,7 @@ import { SpinnerComponent } from '../../components/spinner/spinner.component';
             </p>
             <a
               routerLink="/agents/discover"
-              class="mt-4 inline-flex rounded-full bg-primary-accessible px-4 py-2 text-sm/6 font-semibold text-white hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              class="mt-4 inline-flex items-center gap-2 rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
             >
               Browse agents
             </a>

--- a/frontend/ai.client/src/app/artifacts/artifact-library.page.html
+++ b/frontend/ai.client/src/app/artifacts/artifact-library.page.html
@@ -23,7 +23,7 @@
         <div
           role="radiogroup"
           aria-label="Layout"
-          class="inline-flex shrink-0 self-start gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
+          class="inline-flex shrink-0 self-start gap-1 rounded-xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
         >
           <button
             type="button"
@@ -32,7 +32,7 @@
             (click)="setViewMode('list')"
             [appTooltip]="'List view'"
             appTooltipPosition="top"
-            class="grid size-8 place-items-center rounded-xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            class="grid size-8 place-items-center rounded-lg transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
             [class]="
               viewMode() === 'list'
                 ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white'
@@ -49,7 +49,7 @@
             (click)="setViewMode('grid')"
             [appTooltip]="'Grid view'"
             appTooltipPosition="top"
-            class="grid size-8 place-items-center rounded-xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            class="grid size-8 place-items-center rounded-lg transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
             [class]="
               viewMode() === 'grid'
                 ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white'
@@ -85,14 +85,15 @@
          has one list, and a lone "Yours" tab would be chrome around
          nothing. -->
     @if (sharedAvailable() && !loading()) {
-      <!-- A filled pill, not an underline. Matches the model-catalog tabs
-           and the view toggle in this page's own header, and an underline
-           in brand blue is close to invisible on the dark surface — the
-           token is a fixed brand colour with no dark variant. -->
+      <!-- The shared hub pill strip — the same shell and raised-active
+           treatment as `AgentsTabsComponent` / `CustomizeTabsComponent` and as
+           the view toggle in this page's own header. `inline-flex`, not `flex`:
+           a tab strip stretched to the content width reads as a segmented
+           control over the whole page rather than as three choices. -->
       <div
         role="tablist"
         aria-label="Which artifacts to show"
-        class="mt-6 flex flex-wrap items-center gap-1 rounded-2xl border border-gray-200 bg-white p-1 dark:border-gray-700 dark:bg-gray-800"
+        class="mt-6 inline-flex flex-wrap items-center gap-1 rounded-2xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-800"
       >
         @for (option of tabOptions; track option.value) {
           <button
@@ -103,11 +104,11 @@
             aria-controls="artifact-tabpanel"
             [tabindex]="tab() === option.value ? 0 : -1"
             (click)="setTab(option.value)"
-            class="rounded-2xl px-4 py-1.5 text-sm/6 font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            class="rounded-xl px-4 py-1.5 text-sm/6 font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
             [class]="
               tab() === option.value
-                ? 'bg-primary-accessible text-white'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'
+                ? 'bg-white text-gray-900 shadow-xs dark:bg-gray-900 dark:text-white'
+                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
             "
           >
             {{ option.label }}
@@ -119,10 +120,10 @@
     <!-- Filters. Hidden until there is enough to be worth filtering. -->
     @if (totalCount() > 0) {
       <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div class="relative flex-1 sm:max-w-xs">
+        <div class="relative flex-1 sm:max-w-md">
           <ng-icon
             name="heroMagnifyingGlass"
-            class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+            class="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
             aria-hidden="true"
           />
           <label for="artifact-search" class="sr-only">Search artifacts by title</label>
@@ -132,20 +133,26 @@
             [value]="search()"
             (input)="onSearch($event)"
             placeholder="Search by title"
-            class="block w-full rounded-2xl border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
+            class="block w-full rounded-full border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm/6 text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500"
           />
         </div>
 
         @if (typeOptions().length > 1) {
           <!-- appearance-none + overlaid chevron: the native chevron sits at a
-               fixed offset and collides with the rounded-2xl corner. -->
-          <div class="relative inline-flex">
+               fixed offset and collides with the pill corner. -->
+          <!-- `self-start` for the same reason the header toggle needs it: below
+               `sm` this row is a flex column, whose default align-items:stretch
+               pulls the wrapper to full width while the native select stays
+               shrink-to-fit — stranding the absolutely-positioned chevron at the
+               far right, detached from the control. `sm:self-auto` hands
+               alignment back to the row's `sm:items-center`. -->
+          <div class="relative inline-flex self-start sm:self-auto">
             <label for="artifact-type" class="sr-only">Filter by type</label>
             <select
               id="artifact-type"
               [value]="typeFilter()"
               (change)="onTypeFilter($event)"
-              class="appearance-none rounded-2xl border border-gray-300 bg-white py-2 pl-3 pr-9 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              class="appearance-none rounded-full border border-gray-300 bg-white py-2.5 pl-4 pr-9 text-sm/6 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
             >
               <option value="all">All types</option>
               @for (option of typeOptions(); track option.value) {
@@ -214,7 +221,7 @@
         </p>
         <a
           routerLink="/"
-          class="mt-6 inline-flex items-center gap-2 rounded-2xl bg-primary-accessible px-4 py-2 text-sm/6 font-medium text-white hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          class="mt-6 inline-flex items-center gap-2 rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold text-white shadow-xs transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
         >
           Start a conversation
         </a>

--- a/frontend/ai.client/src/app/customize/connectors/customize-connectors.page.ts
+++ b/frontend/ai.client/src/app/customize/connectors/customize-connectors.page.ts
@@ -54,12 +54,12 @@ type ConnectState =
   ],
   template: `
     <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         <app-customize-tabs />
 
-        <div class="mt-6 mb-6">
-          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Connectors</h1>
-          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        <div class="mt-6 mb-10">
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">Connectors</h1>
+          <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             Connect your accounts so tools can act on your behalf. A tool that needs a
             connection is marked on the Tools tab.
           </p>
@@ -175,7 +175,7 @@ type ConnectState =
                       type="button"
                       (click)="connect(connector.providerId)"
                       [disabled]="state === 'initiating' || state === 'awaiting'"
-                      class="inline-flex items-center gap-1.5 rounded-sm bg-primary-accessible px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs transition-[filter] hover:brightness-95 focus:outline-hidden focus:ring-3 focus:ring-primary-accessible/50 disabled:cursor-not-allowed disabled:opacity-50"
+                      class="inline-flex items-center gap-1.5 rounded-xl bg-primary-accessible px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       @if (state === 'initiating') {
                         <app-spinner size="sm" variant="on-solid" label="Starting" />

--- a/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
@@ -42,13 +42,13 @@ interface SkillCard {
   providers: [provideIcons({ heroMagnifyingGlass, heroArrowTopRightOnSquare })],
   template: `
     <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         <app-customize-tabs />
 
-        <div class="mt-6 mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div class="mt-6 mb-10 flex flex-wrap items-start justify-between gap-4">
           <div>
-            <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Skills</h1>
-            <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+            <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">Skills</h1>
+            <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
               Instructions your assistant can pull in on demand. Skills are off until you
               turn them on, and apply to every conversation.
             </p>
@@ -57,7 +57,7 @@ interface SkillCard {
                standing open question in the sidenav (see sidenav.html). -->
           <a
             routerLink="/my-skills"
-            class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl border border-gray-200 bg-white px-3.5 py-1.5 text-sm/6 font-medium text-gray-700 transition-colors hover:border-gray-300 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
+            class="inline-flex shrink-0 items-center gap-1.5 rounded-xl border border-gray-200 bg-white px-3.5 py-1.5 text-sm/6 font-medium text-gray-700 transition-colors hover:border-gray-300 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
           >
             My skills
             <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
@@ -143,7 +143,7 @@ interface SkillCard {
           <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400" aria-live="polite">
             {{ enabledLabel() }}
           </p>
-          <ul class="mt-3 grid gap-3 sm:grid-cols-2">
+          <ul class="mt-3 grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
             @for (card of cards(); track card.skill.skillId) {
               <li>
                 <app-customize-card

--- a/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
+++ b/frontend/ai.client/src/app/customize/tools/customize-tools.page.ts
@@ -45,12 +45,12 @@ interface ToolCard {
   providers: [provideIcons({ heroMagnifyingGlass })],
   template: `
     <div class="min-h-dvh">
-      <div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
         <app-customize-tabs />
 
-        <div class="mt-6 mb-6">
-          <h1 class="text-2xl/8 font-bold text-gray-900 dark:text-white">Tools</h1>
-          <p class="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+        <div class="mt-6 mb-10">
+          <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl dark:text-white">Tools</h1>
+          <p class="mt-1.5 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
             What your assistant can do. Changes apply to every conversation, including
             ones already open.
           </p>
@@ -141,7 +141,7 @@ interface ToolCard {
           <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400" aria-live="polite">
             {{ enabledLabel() }}
           </p>
-          <ul class="mt-3 grid gap-3 sm:grid-cols-2">
+          <ul class="mt-3 grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
             @for (card of cards(); track card.tool.toolId) {
               <li>
                 <app-customize-card


### PR DESCRIPTION
## Why

These three surfaces had drifted into two different design languages. Most visibly, switching tabs inside a single hub changed the title size and the content width: `/agents` used a `max-w-6xl` shell with a `tracking-tight sm:text-3xl` title, while `/agents/discover`, `/agents/pinned` and all three `/customize` tabs used the `max-w-5xl` + `text-2xl/8` idiom that the admin tables use.

The larger header wasn't a one-off — `/my-skills`, `/schedules` and `/memory-spaces` had already adopted it. Discover, Pinned and Customize were simply the pages that hadn't caught up.

## What changed

**Page header** — seven pages now share `max-w-6xl`, an `mt-6 mb-10` header block, `text-2xl font-bold tracking-tight sm:text-3xl`, and a `mt-1.5 max-w-2xl text-sm/6 text-gray-600` subtitle.

**Pill tabs** — the Artifacts All/Yours/Shared strip was the outlier: full-width, white shell, solid brand-fill active pill. It now uses the same recessed `bg-gray-50` shell and raised white active pill as `AgentsTabsComponent` / `CustomizeTabsComponent`, and `inline-flex` so it hugs its content instead of reading as a segmented control over the whole page. Its grid/list toggle was one radius step larger than the Agents one; they now match.

**Buttons** — there were four different primaries across the three views, including a pre-redesign `rounded-sm` + `focus:ring-3` on Connectors. All are now `rounded-xl bg-primary-accessible px-4 py-2.5 text-sm/6 font-semibold`. `rounded-xl` puts them between the `rounded-2xl` cards and the `rounded-full` chips instead of squared-off against both. The `bg-primary-500` → `primary-accessible` swap is a visual no-op today (both `#0033a0`) but is the only fill guaranteed AA against white text after a rebrand.

**Fields** — Artifacts search and type filter adopt the pill field Discover and Customize already use.

**Grid** — Customize cards go 3-up only at `2xl`. At `lg` the denser toggle cards left ~230px for the title and truncated names like "Student MyBoiseState".

## Bug fixed in passing

Below `sm`, the Artifacts type-select wrapper stretched to full width while the native select stayed shrink-to-fit, stranding the overlaid chevron at the far right, visibly detached from the control. Added the `self-start sm:self-auto` guard the header view toggle already carries — the same failure mode its existing comment describes.

## Docs

`.claude/skills/tailwind-ui/references/app-conventions.md` documented only the admin list/form idiom, so the next session restyling one of these pages would have reverted this. Added a "Top-level user-facing pages" section with the token table, the pill-tab idiom, and the one place `rounded-lg` is still correct (segmented-control children inside a `rounded-xl` shell).

## Testing

- `npx ng test --watch=false` → **2844 passed / 239 files**.
- Browser-verified all three views against real dev data in light and dark, at 1280px and 420px. Light mode checked with both levers (`documentElement.className` empty *and* `prefers-color-scheme`), and the button confirmed by computed style rather than by eye: `border-radius: 12px`, `background: rgb(0, 51, 160)`, `font: 14px/24px`.
- The `2xl` grid change came directly out of that browser pass — the truncation was invisible in isolated-token screenshots.

No behavior change; classes and comments only.

## Follow-up

~47 more primary buttons elsewhere in the app are still on `rounded-lg` / `rounded-sm` / `rounded-md` (admin pages, agent-form, session share modal, fine-tuning, knowledge-base). Being handled separately — that sweep has to settle whether admin keeps its documented `rounded-2xl` or the whole app moves to one radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)