### PR TITLE
feat(customize): add a skill detail view

### DIFF
--- a/backend/src/apis/app_api/skills/routes.py
+++ b/backend/src/apis/app_api/skills/routes.py
@@ -54,6 +54,7 @@ from apis.shared.skills.resource_types import (
     safe_download_content_type,
 )
 
+from .service import get_skill_catalog_service
 from .user_service import (
     UserSkillError,
     UserSkillLimitError,
@@ -450,3 +451,153 @@ async def delete_my_skill_resource(
         raise _resource_value_error(e)
 
     return SkillResourcesResponse(skill_id=skill_id, resources=resources)
+
+
+# -----------------------------------------------------------------------------
+# One accessible skill (read-only detail)
+#
+# ⚠️ REGISTRATION ORDER IS LOAD-BEARING. These routes must stay BELOW every
+# ``/mine`` route in this module. Starlette matches in registration order and
+# ``SKILL_ID_PATTERN`` happily matches the literal string ``mine`` — declare
+# ``/{skill_id}`` first and ``GET /skills/mine`` becomes a lookup for a skill
+# called "mine", which 404s for every user in the product.
+# -----------------------------------------------------------------------------
+
+
+class SkillDetailResponse(BaseModel):
+    """One skill the user can reach, with everything the picker line omits.
+
+    The fat sibling of ``UserSkillResponse``. ``GET /skills/`` stays thin on
+    purpose — it is a first-load payload, and putting every granted skill's
+    SKILL.md body on it would buy nothing for the list and cost on every load.
+    This is fetched once, for the one skill the user opened.
+
+    ``instructions`` is served to anyone the skill is granted to. It is not a
+    secret from them: it is the text their own turns load on dispatch, so the
+    page is showing the user what they are already talking to.
+
+    Deliberately absent: ``ownerId`` (``isOwned`` is the only part of it this
+    surface needs, and a raw owner id would leak one user's identity to
+    another) and ``allowedAppRoles`` (an admin-display projection — see the
+    RBAC note in CLAUDE.md — which would expose the role topology to any user
+    holding the skill).
+    """
+
+    skill_id: str = Field(..., alias="skillId")
+    display_name: str = Field(..., alias="displayName")
+    description: str
+    instructions: str = ""
+    compose: List[str] = Field(default_factory=list)
+    allowed_tools: List[str] = Field(default_factory=list, alias="allowedTools")
+    skill_metadata: Dict = Field(default_factory=dict, alias="skillMetadata")
+    resources: List[SkillResourceRef] = Field(default_factory=list)
+    status: str = SkillStatus.ACTIVE.value
+    category: Optional[str] = None
+    user_enabled: Optional[bool] = Field(None, alias="userEnabled")
+    is_enabled: bool = Field(..., alias="isEnabled")
+    #: True when the caller authored this skill — drives the SPA's "Edit in My
+    #: Skills" affordance. Ownership is its own grant (``access.py``), so this
+    #: can be true for a user with no skill-granting role at all.
+    is_owned: bool = Field(..., alias="isOwned")
+    created_at: Optional[str] = Field(None, alias="createdAt")
+    updated_at: Optional[str] = Field(None, alias="updatedAt")
+
+    model_config = {"populate_by_name": True}
+
+
+async def _require_accessible_skill(skill_id: str, user: User) -> SkillDefinition:
+    """Load a skill the user can reach, or raise 404.
+
+    Access is ``resolve_accessible_skill_ids`` — the *same* resolution that
+    builds the picker and that the runtime uses to decide what a turn may
+    activate. A skill the user cannot reach and a skill that does not exist
+    both 404, so this never discloses the existence of a skill someone else
+    was granted.
+
+    Status is checked too: ``GET /skills/`` filters to ACTIVE, so a drilled-in
+    DRAFT or DISABLED catalog skill would otherwise be reachable by id from a
+    surface that never listed it.
+    """
+    accessible = await resolve_accessible_skill_ids(user)
+    if skill_id not in accessible:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    skill = await get_skill_catalog_service().get_skill(skill_id)
+    if skill is None:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    status = skill.status.value if hasattr(skill.status, "value") else skill.status
+    if status != SkillStatus.ACTIVE.value and skill.owner_id != user.user_id:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_id}' not found")
+
+    return skill
+
+
+@router.get("/{skill_id}", response_model=SkillDetailResponse)
+async def get_accessible_skill(
+    skill_id: str,
+    user: User = Depends(get_current_user_from_session),
+) -> SkillDetailResponse:
+    """Read one skill the current user can reach, catalog or self-authored."""
+    logger.info(f"User {user.name} reading skill '{skill_id}'")
+
+    skill = await _require_accessible_skill(skill_id, user)
+
+    repo = get_skill_catalog_repository()
+    preferences = (await repo.get_user_preferences(user.user_id)).skill_preferences
+
+    status = skill.status.value if hasattr(skill.status, "value") else skill.status
+    return SkillDetailResponse(
+        skill_id=skill.skill_id,
+        display_name=skill.display_name,
+        description=skill.description,
+        instructions=skill.instructions,
+        compose=list(skill.compose),
+        allowed_tools=list(skill.allowed_tools),
+        skill_metadata=dict(skill.skill_metadata),
+        resources=list(skill.resources),
+        status=str(status),
+        category=skill.category,
+        user_enabled=preferences.get(skill.skill_id),
+        # Skills v2 D6 opt-in: untouched is OFF. Same default as the picker —
+        # the two must agree or the page would contradict the list it came from.
+        is_enabled=preferences.get(skill.skill_id, False),
+        is_owned=skill.owner_id == user.user_id,
+        created_at=skill.created_at.isoformat() if skill.created_at else None,
+        updated_at=skill.updated_at.isoformat() if skill.updated_at else None,
+    )
+
+
+@router.get("/{skill_id}/resources/{filename}")
+async def read_accessible_skill_resource(
+    skill_id: str,
+    filename: str,
+    user: User = Depends(get_current_user_from_session),
+):
+    """Return the raw bytes of one supporting file on an accessible skill.
+
+    The read counterpart of ``/mine/{id}/resources/{filename}``, scoped by
+    *access* rather than ownership so a user granted a catalog skill can open
+    its reference files — the level-3 half of the same progressive disclosure
+    whose level-2 body this page already renders. Read-only by construction:
+    there is no accessible-scoped upload or delete.
+
+    Hardened identically to the owner and admin read routes: the media type is
+    re-derived from the filename and the body is served ``attachment`` +
+    ``nosniff`` + inert CSP, so a resource can never become a script-bearing
+    document on the SPA's origin (``apis.shared.skills.resource_types``).
+    """
+    await _require_accessible_skill(skill_id, user)
+
+    try:
+        ref, content = await get_skill_catalog_service().read_resource(
+            skill_id, filename
+        )
+    except ValueError as e:
+        raise _resource_value_error(e)
+
+    return Response(
+        content=content,
+        media_type=safe_download_content_type(ref.filename),
+        headers=resource_download_headers(ref.filename),
+    )

--- a/backend/tests/apis/app_api/test_user_skills_routes.py
+++ b/backend/tests/apis/app_api/test_user_skills_routes.py
@@ -1,4 +1,9 @@
-"""Route tests for the user-facing skills API (GET /skills/, PUT /skills/preferences)."""
+"""Route tests for the user-facing skills API.
+
+Covers the picker (GET /skills/, PUT /skills/preferences) and the
+read-only detail surface behind Customize → Skills → one skill
+(GET /skills/{id}, GET /skills/{id}/resources/{filename}).
+"""
 
 from __future__ import annotations
 
@@ -10,7 +15,12 @@ from fastapi.testclient import TestClient
 
 from apis.shared.auth import get_current_user_from_session
 from apis.shared.auth.models import User
-from apis.shared.skills.models import SkillDefinition, SkillStatus, UserSkillPreference
+from apis.shared.skills.models import (
+    SkillDefinition,
+    SkillResourceRef,
+    SkillStatus,
+    UserSkillPreference,
+)
 
 from apis.app_api.skills import routes as skills_routes
 
@@ -151,3 +161,194 @@ class TestUpdateSkillPreferences:
         assert resp.status_code == 400
         assert "forbidden_skill" in resp.json()["detail"]
         assert repo.saved is None
+
+
+class _FakeCatalogService:
+    """Duck-typed stand-in for SkillCatalogService (detail + resource read)."""
+
+    def __init__(self, skills: List[SkillDefinition], blobs: Dict[str, bytes] = None):
+        self._skills = {s.skill_id: s for s in skills}
+        self._blobs = dict(blobs or {})
+
+    async def get_skill(self, skill_id: str):
+        return self._skills.get(skill_id)
+
+    async def read_resource(self, skill_id: str, filename: str):
+        skill = self._skills.get(skill_id)
+        if skill is None:
+            raise ValueError(f"Skill '{skill_id}' not found")
+        ref = next((r for r in skill.resources if r.filename == filename), None)
+        if ref is None:
+            raise ValueError(f"Reference file '{filename}' not found")
+        return ref, self._blobs.get(filename, b"")
+
+
+def _make_detail_client(
+    monkeypatch: pytest.MonkeyPatch,
+    accessible: List[str],
+    repo: _FakeRepo,
+    catalog: _FakeCatalogService,
+) -> TestClient:
+    client = _make_client(monkeypatch, accessible, repo)
+    monkeypatch.setattr(skills_routes, "get_skill_catalog_service", lambda: catalog)
+    return client
+
+
+class TestGetAccessibleSkill:
+    def test_returns_the_instructions_body_and_merged_preference(self, monkeypatch):
+        skill = _skill("web_research", "Web Research")
+        skill.instructions = "# Web Research\n\nSearch broadly, cite everything."
+        skill.category = "research"
+        skill.allowed_tools = ["web_search"]
+        repo = _FakeRepo(skills=[skill], prefs={"web_research": True})
+        client = _make_detail_client(
+            monkeypatch, ["web_research"], repo, _FakeCatalogService([skill])
+        )
+
+        body = client.get("/skills/web_research").json()
+        assert body["skillId"] == "web_research"
+        # The point of the endpoint: GET /skills/ carries none of this.
+        assert body["instructions"] == "# Web Research\n\nSearch broadly, cite everything."
+        assert body["allowedTools"] == ["web_search"]
+        assert body["category"] == "research"
+        assert body["userEnabled"] is True
+        assert body["isEnabled"] is True
+
+    def test_untouched_skill_reads_off_like_the_picker(self, monkeypatch):
+        """D6 opt-in. The detail page must not contradict the list it came from."""
+        skill = _skill("pdf_workflows", "PDF Workflows")
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["pdf_workflows"], repo, _FakeCatalogService([skill])
+        )
+
+        body = client.get("/skills/pdf_workflows").json()
+        assert body["userEnabled"] is None
+        assert body["isEnabled"] is False
+
+    def test_inaccessible_skill_is_404_not_403(self, monkeypatch):
+        """A skill you weren't granted must be indistinguishable from one that
+        does not exist — a 403 would confirm it is out there."""
+        skill = _skill("someone_elses", "Someone Else's")
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["web_research"], repo, _FakeCatalogService([skill])
+        )
+
+        assert client.get("/skills/someone_elses").status_code == 404
+
+    def test_non_active_catalog_skill_is_404(self, monkeypatch):
+        """GET /skills/ filters to ACTIVE, so a drilled-in DRAFT must not be
+        reachable by id from a surface that never listed it."""
+        skill = _skill("draft_one", "Draft One", status=SkillStatus.DRAFT)
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["draft_one"], repo, _FakeCatalogService([skill])
+        )
+
+        assert client.get("/skills/draft_one").status_code == 404
+
+    def test_owner_still_reads_their_own_non_active_skill(self, monkeypatch):
+        """Ownership is its own grant: a user's own draft is theirs to open."""
+        skill = _skill("my_draft", "My Draft", status=SkillStatus.DRAFT)
+        skill.owner_id = "user-1"
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["my_draft"], repo, _FakeCatalogService([skill])
+        )
+
+        body = client.get("/skills/my_draft").json()
+        assert body["isOwned"] is True
+        assert body["status"] == "draft"
+
+    def test_catalog_skill_is_not_owned(self, monkeypatch):
+        skill = _skill("web_research", "Web Research")  # owner_id defaults to "system"
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["web_research"], repo, _FakeCatalogService([skill])
+        )
+
+        assert client.get("/skills/web_research").json()["isOwned"] is False
+
+    def test_does_not_leak_owner_id_or_role_topology(self, monkeypatch):
+        """`ownerId` would name another user; `allowedAppRoles` is an
+        admin-display projection of RBAC (CLAUDE.md) and has no business on a
+        surface any granted user can open."""
+        skill = _skill("web_research", "Web Research")
+        skill.owner_id = "someone-else"
+        skill.allowed_app_roles = ["faculty", "staff"]
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["web_research"], repo, _FakeCatalogService([skill])
+        )
+
+        body = client.get("/skills/web_research").json()
+        assert "ownerId" not in body
+        assert "allowedAppRoles" not in body
+
+    def test_mine_still_routes_to_the_list_not_a_skill_called_mine(self, monkeypatch):
+        """⚠️ Registration-order guard. SKILL_ID_PATTERN matches the literal
+        'mine', so declaring /{skill_id} above the /mine routes would turn
+        GET /skills/mine into a lookup for a skill named "mine"."""
+        repo = _FakeRepo(skills=[], prefs={})
+        client = _make_detail_client(monkeypatch, [], repo, _FakeCatalogService([]))
+
+        async def fake_list(user):
+            return []
+
+        monkeypatch.setattr(
+            skills_routes.get_user_skill_service(), "list_my_skills", fake_list
+        )
+        resp = client.get("/skills/mine")
+        assert resp.status_code == 200
+        assert resp.json() == {"skills": [], "totalCount": 0}
+
+
+class TestReadAccessibleSkillResource:
+    def _skill_with_file(self) -> SkillDefinition:
+        skill = _skill("web_research", "Web Research")
+        skill.resources = [
+            SkillResourceRef(
+                filename="forms.md",
+                content_hash="abc123",
+                size=11,
+                content_type="text/markdown",
+                s3_key="skills/web_research/references/forms.md",
+            )
+        ]
+        return skill
+
+    def test_serves_a_granted_skills_file_the_user_does_not_own(self, monkeypatch):
+        skill = self._skill_with_file()
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch,
+            ["web_research"],
+            repo,
+            _FakeCatalogService([skill], {"forms.md": b"hello world"}),
+        )
+
+        resp = client.get("/skills/web_research/resources/forms.md")
+        assert resp.status_code == 200
+        assert resp.content == b"hello world"
+        # Served inert: never a script-bearing document on the SPA's origin.
+        assert resp.headers["x-content-type-options"] == "nosniff"
+        assert "attachment" in resp.headers["content-disposition"]
+
+    def test_inaccessible_skills_file_is_404(self, monkeypatch):
+        skill = self._skill_with_file()
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, [], repo, _FakeCatalogService([skill], {"forms.md": b"x"})
+        )
+
+        assert client.get("/skills/web_research/resources/forms.md").status_code == 404
+
+    def test_unknown_filename_is_404(self, monkeypatch):
+        skill = self._skill_with_file()
+        repo = _FakeRepo(skills=[skill], prefs={})
+        client = _make_detail_client(
+            monkeypatch, ["web_research"], repo, _FakeCatalogService([skill])
+        )
+
+        assert client.get("/skills/web_research/resources/nope.md").status_code == 404

--- a/docs/specs/customize-surface.md
+++ b/docs/specs/customize-surface.md
@@ -346,6 +346,71 @@ because the prose precedes any `Args:` heading, so `splitToolDescription` return
 modest (median 344 chars). Clamping the summary is the fix; moving the detail behind a modal
 would not touch it.
 
+## Skill detail
+
+`/customize/skills/:skillId` — the sibling drill-in, reached the same way: the card's name is
+a link, the switch stays its sibling. It carries the SKILL.md body the skill actually injects,
+its supporting files, any composed skills, the advisory `allowed-tools` frontmatter, and the
+catalog facts.
+
+⚠️ **Unlike the tool page, this one needed backend work.** `GET /tools/` already returns the
+whole `Tool` including `serverTools`, so `/customize/tools/:toolId` is pure frontend.
+`GET /skills/` returns six thin fields — id, name, description, category, `userEnabled`,
+`isEnabled` — and *everything* worth opening a page for lives on `SkillDefinition` and never
+reaches the SPA. The only per-skill read that existed, `GET /skills/mine/{id}`, is
+**owner-scoped**: a catalog skill granted to you 404s there.
+
+So this adds **`GET /skills/{id}`**, access-checked by `resolve_accessible_skill_ids` — the
+same resolution that builds the picker and that the runtime uses to decide what a turn may
+activate — plus **`GET /skills/{id}/resources/{filename}`**, the access-scoped read
+counterpart of the owner route, so a granted user can open a catalog skill's reference files.
+
+⚠️ **Route registration order is load-bearing.** Both live at the BOTTOM of
+`apis/app_api/skills/routes.py`, below every `/mine` route. Starlette matches in registration
+order and `SKILL_ID_PATTERN` happily matches the literal string `mine` — declare `/{skill_id}`
+first and `GET /skills/mine` becomes a lookup for a skill called "mine", which 404s for every
+user in the product. A test asserts it.
+
+`GET /skills/` was **not** fattened instead. It is a first-load payload covering every granted
+skill; a SKILL.md body per row would be paid on every load to render a list that shows neither
+the body nor the files.
+
+**What the detail response deliberately omits.** `ownerId` — `isOwned` is the only part of
+ownership this surface needs, and a raw owner id would name one user to another. And
+`allowedAppRoles`, which is an admin-display projection of RBAC (see the RBAC §in CLAUDE.md)
+and has no business on a page any granted user can open. A skill the caller cannot reach 404s
+rather than 403s, so the endpoint never confirms the existence of a skill someone else holds;
+a non-ACTIVE catalog skill 404s too, matching the ACTIVE filter `GET /skills/` already applies
+— though an owner still reads their own draft, because ownership is its own grant.
+
+**Instructions render expanded**, not behind a disclosure like the tool page's `Args:` block.
+They are not a secret from a user the skill is granted to: this is the text their own turns
+load on dispatch, so the honest answer to "what does this skill do" is to show it. Rendered
+through `ngx-markdown` **with sanitization on** — do not add `[disableSanitizer]`; a SKILL.md
+body can be authored by a non-admin (Skills v2 PR-3 user tier), and the reasoning recorded on
+`announcement-modal.component.ts` applies unchanged.
+
+**`allowedTools` is rendered with its advisory status stated in the copy**, not as a bare list.
+Skills v2 D4: the platform never grants, mounts or folds a tool because a skill names it. A
+bare list of tool names on a page about a skill you just enabled would read as a grant.
+
+**A skill the user authored links out to `/my-skills/{id}/edit`** rather than growing a second
+editor here. One destination for every card; the read view stays useful for your own skill.
+
+**This page closes no functional gap**, and that is the difference from the tool detail page.
+That one had to exist the moment #1079 deleted the drawer, because per-sub-tool enablement had
+nowhere else to live. A skill has no sub-unit — the only control here is the same on/off the
+card already offers — so this page is informational, and was queued rather than rushed.
+
+⚠️ The switch stays **disabled until the picker list lands**. `SkillService.toggleSkill`
+silently returns on a skill it has never loaded, so on a deep link a click before the list
+arrived would look like a broken switch rather than a dead moment. The page warms
+`loadSkills()` in its constructor and gates the control on `initialized()`.
+
+**Cost:** none against the model. Everything here is catalog data read for display; nothing
+reaches the system prompt or `toolConfig`, so the cacheable prefix is untouched. The added
+traffic is one `GET /skills/{id}` per drill-in, cached for the life of the page.
+
 The `settings/connectors/` **services** deliberately did not move. `UserConnectorsService` and
 `ConnectorStatusService` have nine importers across the app (oauth-consent, export-dialog,
 knowledge-base, the drawer's tool-detail, the Customize Tools tab…), so relocating them is a

--- a/frontend/ai.client/src/app/app.routes.ts
+++ b/frontend/ai.client/src/app/app.routes.ts
@@ -189,6 +189,17 @@ export const routes: Routes = [
             import('./customize/skills/customize-skills.page').then(m => m.CustomizeSkillsPage),
         canActivate: [authGuard],
     },
+    // One skill: its SKILL.md body, supporting files and catalog facts. The id
+    // is bound straight to the page's `skillId` input by
+    // `withComponentInputBinding()`.
+    {
+        path: 'customize/skills/:skillId',
+        loadComponent: () =>
+            import('./customize/skills/customize-skill-detail.page').then(
+                m => m.CustomizeSkillDetailPage,
+            ),
+        canActivate: [authGuard],
+    },
     {
         path: 'customize/connectors',
         loadComponent: () =>

--- a/frontend/ai.client/src/app/customize/components/customize-card.component.ts
+++ b/frontend/ai.client/src/app/customize/components/customize-card.component.ts
@@ -19,7 +19,7 @@ export type CustomizeCardBadge = 'connected' | 'connect' | null;
  * following the link. The link's `after:absolute inset-0` makes the whole card a
  * click target for the navigation while the switch, raised on its own stacking
  * context, keeps its own hit area. Without a `detailLink` the body renders as
- * plain text, so Skills — which have no detail page — are unchanged.
+ * plain text, so a surface with no detail page to drill into is unchanged.
  */
 @Component({
   selector: 'app-customize-card',

--- a/frontend/ai.client/src/app/customize/skills/customize-skill-detail.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skill-detail.page.spec.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideMarkdown } from 'ngx-markdown';
+import { CustomizeSkillDetailPage } from './customize-skill-detail.page';
+import { SkillService, SkillsResponse } from '../../services/skill/skill.service';
+import { SkillDetail } from '../../services/skill-detail/skill-detail.service';
+import { ConfigService } from '../../services/config.service';
+
+/** A failed save lands a microtask after `whenStable()`; one macrotask makes it observable. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const detail = (
+  overrides: Partial<SkillDetail> & Pick<SkillDetail, 'skillId' | 'displayName'>,
+): SkillDetail => ({
+  description: 'Does a thing.',
+  instructions: '',
+  compose: [],
+  allowedTools: [],
+  skillMetadata: {},
+  resources: [],
+  status: 'active',
+  category: null,
+  userEnabled: null,
+  isEnabled: false,
+  isOwned: false,
+  createdAt: null,
+  updatedAt: null,
+  ...overrides,
+});
+
+const PICKER: SkillsResponse = {
+  skills: [
+    {
+      skillId: 'web_research',
+      displayName: 'Web Research',
+      description: 'Does a thing.',
+      category: 'research',
+      userEnabled: null,
+      isEnabled: false,
+    },
+  ],
+  totalCount: 1,
+};
+
+describe('CustomizeSkillDetailPage', () => {
+  let http: HttpTestingController;
+  let skills: SkillService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideMarkdown(),
+      ],
+    });
+    TestBed.inject(ConfigService).appApiUrl.set('/api');
+    http = TestBed.inject(HttpTestingController);
+    skills = TestBed.inject(SkillService);
+  });
+
+  afterEach(() => {
+    http.verify();
+    TestBed.resetTestingModule();
+  });
+
+  /**
+   * Creates the page and flushes both reads it makes: the picker list (warmed
+   * so the toggle has a row to write through) and the detail record.
+   */
+  async function create(
+    skillId: string,
+    record: SkillDetail | null,
+    status = 404,
+  ): Promise<ComponentFixture<CustomizeSkillDetailPage>> {
+    const fixture = TestBed.createComponent(CustomizeSkillDetailPage);
+    fixture.componentRef.setInput('skillId', skillId);
+    fixture.detectChanges();
+
+    http.match(req => req.url === '/api/skills/').forEach(req => req.flush(PICKER));
+
+    const url = `/api/skills/${encodeURIComponent(skillId)}`;
+    http.match(url).forEach(req => {
+      if (record) req.flush(record);
+      else req.flush({ detail: 'nope' }, { status, statusText: 'Not Found' });
+    });
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const text = (fixture: ComponentFixture<CustomizeSkillDetailPage>) =>
+    (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  it('shows the skill it was routed to', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({ skillId: 'web_research', displayName: 'Web Research' }),
+    );
+    expect(text(fixture)).toContain('Web Research');
+    expect(text(fixture)).toContain('web_research');
+  });
+
+  it('renders the SKILL.md body expanded, with no click needed', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({
+        skillId: 'web_research',
+        displayName: 'Web Research',
+        instructions: '# How to research\n\nSearch broadly, cite everything.',
+      }),
+    );
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain('Search broadly, cite everything.');
+    // The heading came through the markdown renderer, not as literal `#`.
+    expect(fixture.nativeElement.querySelector('markdown h1')?.textContent).toContain(
+      'How to research',
+    );
+  });
+
+  it('says so when a skill carries no instructions body', async () => {
+    const fixture = await create(
+      'thin_one',
+      detail({ skillId: 'thin_one', displayName: 'Thin One', instructions: '' }),
+    );
+    expect(text(fixture)).toContain('no instructions body');
+  });
+
+  it('lists supporting files with an access-scoped link, not the owner route', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({
+        skillId: 'web_research',
+        displayName: 'Web Research',
+        resources: [
+          {
+            filename: 'forms.md',
+            contentHash: 'abc',
+            size: 2048,
+            contentType: 'text/markdown',
+            s3Key: 'skills/web_research/references/forms.md',
+            kind: 'reference',
+          },
+        ],
+      }),
+    );
+
+    expect(text(fixture)).toContain('forms.md');
+    expect(text(fixture)).toContain('2 KB');
+    const link = fixture.nativeElement.querySelector('a[href*="forms.md"]') as HTMLAnchorElement;
+    // `/skills/{id}/resources/...`, never `/skills/mine/...` — the owner route
+    // 404s for a catalog skill, which is most of what this page shows.
+    expect(link.getAttribute('href')).toBe('/api/skills/web_research/resources/forms.md');
+    expect(link.getAttribute('href')).not.toContain('/mine/');
+  });
+
+  it('marks frontmatter tool names as advisory, never as a grant', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({
+        skillId: 'web_research',
+        displayName: 'Web Research',
+        allowedTools: ['web_search'],
+      }),
+    );
+    expect(text(fixture)).toContain('web_search');
+    // Skills v2 D4: naming a tool never grants it. A bare list would read as one.
+    expect(text(fixture)).toContain('not a grant');
+  });
+
+  it('offers an edit path only for a skill the user wrote', async () => {
+    const mine = await create(
+      'my_skill',
+      detail({ skillId: 'my_skill', displayName: 'My Skill', isOwned: true }),
+    );
+    expect(text(mine)).toContain('Edit in My Skills');
+    // The route is /my-skills/:skillId/edit — a bare /my-skills/:id does not exist.
+    expect(
+      mine.nativeElement.querySelector('a[href="/my-skills/my_skill/edit"]'),
+    ).toBeTruthy();
+  });
+
+  it('offers no edit path for a catalog skill', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({ skillId: 'web_research', displayName: 'Web Research', isOwned: false }),
+    );
+    expect(text(fixture)).not.toContain('Edit in My Skills');
+  });
+
+  it('distinguishes a missing skill from a failed read', async () => {
+    const missing = await create('gone', null, 404);
+    expect(text(missing)).toContain('Skill not found');
+  });
+
+  it('does not claim a skill is gone when the read merely failed', async () => {
+    const fixture = await create('web_research', null, 500);
+    expect(text(fixture)).toContain("Couldn't load this skill");
+    // A 500 says nothing about whether the skill exists; saying it is gone
+    // would be a lie the user cannot check.
+    expect(text(fixture)).not.toContain('Skill not found');
+  });
+
+  it('writes the toggle globally, never through the agent lock', async () => {
+    skills.lockToAgentSkills([]);
+    const fixture = await create(
+      'web_research',
+      detail({ skillId: 'web_research', displayName: 'Web Research' }),
+    );
+
+    (fixture.nativeElement.querySelector('button[role="switch"]') as HTMLButtonElement).click();
+    await settle();
+
+    // An agent-locked page must still save: this surface is global state, and
+    // `respectAgentLock: false` is what makes that true (spec §agent-lock seam).
+    http.expectOne('/api/skills/preferences').flush({});
+    expect(skills.skills()[0].isEnabled).toBe(true);
+  });
+
+  it('says so when a save fails instead of letting the switch snap back', async () => {
+    const fixture = await create(
+      'web_research',
+      detail({ skillId: 'web_research', displayName: 'Web Research' }),
+    );
+
+    (fixture.nativeElement.querySelector('button[role="switch"]') as HTMLButtonElement).click();
+    http
+      .expectOne('/api/skills/preferences')
+      .flush({ detail: 'boom' }, { status: 500, statusText: 'Server Error' });
+    await settle();
+    fixture.detectChanges();
+
+    expect(text(fixture)).toContain("Couldn't save the change to Web Research");
+    expect(skills.skills()[0].isEnabled).toBe(false);
+  });
+
+  it('keeps the switch inert until the picker list has landed', async () => {
+    // `SkillService.toggleSkill` silently no-ops on a skill it never loaded, so
+    // a deep link that clicked before the list arrived would look like a broken
+    // switch. The guard makes the dead moment visible instead.
+    const fixture = TestBed.createComponent(CustomizeSkillDetailPage);
+    fixture.componentRef.setInput('skillId', 'web_research');
+    fixture.detectChanges();
+
+    http
+      .match('/api/skills/web_research')
+      .forEach(req =>
+        req.flush(detail({ skillId: 'web_research', displayName: 'Web Research' })),
+      );
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const toggle = fixture.nativeElement.querySelector(
+      'button[role="switch"]',
+    ) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+
+    http.match(req => req.url === '/api/skills/').forEach(req => req.flush(PICKER));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(
+      (fixture.nativeElement.querySelector('button[role="switch"]') as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+});

--- a/frontend/ai.client/src/app/customize/skills/customize-skill-detail.page.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skill-detail.page.ts
@@ -1,0 +1,463 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroArrowLeft,
+  heroArrowTopRightOnSquare,
+  heroDocumentText,
+} from '@ng-icons/heroicons/outline';
+import { MarkdownComponent } from 'ngx-markdown';
+import { SkillService } from '../../services/skill/skill.service';
+import {
+  SkillDetail,
+  SkillDetailResource,
+  SkillDetailService,
+} from '../../services/skill-detail/skill-detail.service';
+import { monogramFor } from '../../shared/utils/monogram';
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+
+/** Bundle-directory labels, in the order agentskills.io lists them. */
+const KIND_ORDER: Record<string, number> = { reference: 0, script: 1, asset: 2 };
+
+/**
+ * Customize → Skills → one skill. What the browse card has no room for: the
+ * SKILL.md body the skill actually injects, the supporting files behind it,
+ * and the catalog facts.
+ *
+ * The sibling of `CustomizeToolDetailPage`, with one structural difference
+ * worth knowing before reading it: **the tool page needed no backend work.**
+ * `GET /tools/` already returns the whole `Tool` including `serverTools`. The
+ * skills picker returns six thin fields, so everything below the switch here
+ * comes from `GET /skills/{id}` — an access-checked read added alongside this
+ * page (`apis/app_api/skills/routes.py`).
+ *
+ * ⚠️ Reads and writes **global** state, like the list it drills in from:
+ * `skill.isEnabled`, never `isSkillShownEnabled()`, and
+ * `toggleSkill(..., { respectAgentLock: false })`. See
+ * `docs/specs/customize-surface.md` §"The agent-lock seam".
+ *
+ * Two deliberate differences from the tool page:
+ *
+ * - **This page closes no functional gap.** The tool page had to exist the
+ *   moment #1079 deleted the drawer, because per-sub-tool enablement had
+ *   nowhere else to live. A skill has no sub-unit; the only control here is
+ *   the same on/off the card already offers. Its value is informational —
+ *   answering "what will this actually put in my prompt?" — so the
+ *   instructions body is the page's centre of gravity, not a disclosure.
+ * - **Instructions render expanded.** They are not a secret from a user the
+ *   skill is granted to: this is the text their own turns load on dispatch.
+ *   Rendered through `ngx-markdown` **with sanitization on** — do not add
+ *   `[disableSanitizer]`; a SKILL.md body can be authored by a non-admin
+ *   (Skills v2 PR-3 user tier), and the same reasoning as
+ *   `announcement-modal.component.ts` applies.
+ *
+ * Costs nothing against the model: everything here is catalog data read for
+ * display. Nothing reaches the system prompt or `toolConfig`.
+ */
+@Component({
+  selector: 'app-customize-skill-detail',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIcon, RouterLink, SpinnerComponent, MarkdownComponent],
+  providers: [
+    provideIcons({ heroArrowLeft, heroArrowTopRightOnSquare, heroDocumentText }),
+  ],
+  template: `
+    <div class="min-h-dvh">
+      <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <a
+          routerLink="/customize/skills"
+          class="inline-flex items-center gap-1.5 text-sm/6 font-medium text-gray-500 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-gray-400 dark:hover:text-white"
+        >
+          <ng-icon name="heroArrowLeft" class="size-4" aria-hidden="true" />
+          Skills
+        </a>
+
+        @if (skill(); as s) {
+          <!-- Identity -->
+          <div class="mt-6 flex items-start gap-4">
+            <span
+              aria-hidden="true"
+              class="grid size-12 shrink-0 place-items-center rounded-2xl border border-gray-200 bg-gray-50 font-mono text-base font-semibold text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300"
+              >{{ monogram() }}</span
+            >
+            <div class="min-w-0 flex-1">
+              <h1 class="text-2xl/8 font-bold break-words text-gray-900 dark:text-white">
+                {{ s.displayName }}
+              </h1>
+              <p class="mt-0.5 font-mono text-xs/5 break-all text-gray-500 dark:text-gray-400">
+                {{ s.skillId }}
+              </p>
+              <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                @for (chip of chips(); track chip) {
+                  <span
+                    class="rounded-sm bg-gray-100 px-1.5 font-mono text-[10px]/5 font-medium text-gray-600 dark:bg-white/10 dark:text-gray-300"
+                    >{{ chip }}</span
+                  >
+                }
+              </div>
+            </div>
+            <!-- Editing lives on /my-skills, which owns the authoring form and
+                 the upload path. This is a read surface; it links there rather
+                 than growing a second editor. -->
+            @if (s.isOwned) {
+              <a
+                [routerLink]="['/my-skills', s.skillId, 'edit']"
+                class="inline-flex shrink-0 items-center gap-1.5 rounded-2xl border border-gray-200 bg-white px-3.5 py-1.5 text-sm/6 font-medium text-gray-700 transition-colors hover:border-gray-300 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
+              >
+                Edit in My Skills
+                <ng-icon name="heroArrowTopRightOnSquare" class="size-4" aria-hidden="true" />
+              </a>
+            }
+          </div>
+
+          @if (s.description) {
+            <p class="mt-4 text-sm/6 text-gray-600 dark:text-gray-300">{{ s.description }}</p>
+          }
+
+          <!-- Master switch -->
+          <div
+            class="mt-4 flex items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-white/10 dark:bg-white/5"
+          >
+            <div class="min-w-0">
+              <span
+                id="skill-detail-state"
+                class="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                >{{ enabled() ? 'On' : 'Off' }}</span
+              >
+              <span class="block text-xs/5 text-gray-500 dark:text-gray-400">
+                Applies to every conversation, including ones already open.
+              </span>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              [attr.aria-checked]="enabled()"
+              aria-labelledby="skill-detail-state"
+              [disabled]="saving() || !skillService.initialized()"
+              (click)="onToggle()"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+              [class]="enabled() ? 'bg-primary-600 dark:bg-primary-500' : 'bg-gray-200 dark:bg-gray-700'"
+            >
+              <span
+                aria-hidden="true"
+                class="pointer-events-none inline-block size-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out"
+                [class.translate-x-5]="enabled()"
+                [class.translate-x-0]="!enabled()"
+              ></span>
+            </button>
+          </div>
+
+          @if (saveError()) {
+            <div
+              role="alert"
+              class="mt-4 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+            >
+              {{ saveError() }}
+            </div>
+          }
+
+          <!-- Instructions: the reason to open this page at all. -->
+          <section class="mt-8">
+            <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Instructions</h2>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              What the assistant reads when it picks this skill up.
+            </p>
+            @if (s.instructions) {
+              <div
+                class="message-block mt-3 overflow-x-auto rounded-2xl border border-gray-200 px-4 py-3 text-sm/6 text-gray-700 dark:border-white/10 dark:text-gray-200"
+              >
+                <markdown [data]="s.instructions" />
+              </div>
+            } @else {
+              <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">
+                This skill has no instructions body — only the one-line description above
+                reaches the model.
+              </p>
+            }
+          </section>
+
+          <!-- Supporting files -->
+          @if (s.resources.length > 0) {
+            <section class="mt-8">
+              <h2
+                class="flex items-baseline gap-2 text-base/7 font-semibold text-gray-900 dark:text-white"
+              >
+                Files
+                <span
+                  class="font-mono text-xs/5 font-normal text-gray-500 tabular-nums dark:text-gray-400"
+                  >{{ s.resources.length }}</span
+                >
+              </h2>
+              <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                Reference material the assistant can open on demand — not loaded up front.
+              </p>
+              <ul class="mt-3 flex flex-col gap-2">
+                @for (file of files(); track file.filename) {
+                  <li
+                    class="flex items-center justify-between gap-4 rounded-2xl border border-gray-200 px-4 py-3 dark:border-white/10"
+                  >
+                    <span class="flex min-w-0 items-center gap-2">
+                      <ng-icon
+                        name="heroDocumentText"
+                        class="size-4 shrink-0 text-gray-400 dark:text-gray-500"
+                        aria-hidden="true"
+                      />
+                      <span class="min-w-0">
+                        <span
+                          class="block truncate font-mono text-sm/6 font-medium text-gray-900 dark:text-white"
+                          >{{ file.filename }}</span
+                        >
+                        <span class="block text-xs/5 text-gray-500 capitalize dark:text-gray-400">
+                          {{ file.kind }} · {{ sizeLabel(file.size) }}
+                        </span>
+                      </span>
+                    </span>
+                    <!-- A plain link, not a fetch: the backend serves these
+                         attachment + nosniff with an inert CSP, so letting the
+                         browser handle it is both simpler and the safe path.
+                         Opened in a new tab with rel=noopener so a download
+                         never navigates the SPA away from this page. -->
+                    <a
+                      [href]="resourceUrl(s.skillId, file.filename)"
+                      target="_blank"
+                      rel="noopener"
+                      class="shrink-0 text-sm/6 font-medium text-primary-accessible hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 dark:text-primary-accessible-dark"
+                      >Open</a
+                    >
+                  </li>
+                }
+              </ul>
+            </section>
+          }
+
+          <!-- Composed skills -->
+          @if (s.compose.length > 0) {
+            <section class="mt-8">
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">Builds on</h2>
+              <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                Turning this on brings these in too.
+              </p>
+              <div class="mt-3 flex flex-wrap gap-2">
+                @for (id of s.compose; track id) {
+                  <span
+                    class="rounded-full bg-gray-100 px-3 py-1 font-mono text-xs/5 text-gray-700 dark:bg-white/10 dark:text-gray-200"
+                    >{{ id }}</span
+                  >
+                }
+              </div>
+            </section>
+          }
+
+          <!-- Advisory tool names -->
+          @if (s.allowedTools.length > 0) {
+            <section class="mt-8">
+              <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                Tools it mentions
+              </h2>
+              <!-- Skills v2 D4: the allowed-tools frontmatter is ADVISORY. The
+                   platform never grants, mounts or folds a tool because a skill
+                   names it. Saying so is the whole point of rendering it — a bare
+                   list here would read as a grant. -->
+              <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+                Named in the skill's own frontmatter as useful to it. This is a note from
+                its author, not a grant — your tools are whatever Customize → Tools says
+                they are.
+              </p>
+              <div class="mt-3 flex flex-wrap gap-2">
+                @for (name of s.allowedTools; track name) {
+                  <span
+                    class="rounded-full bg-gray-100 px-3 py-1 font-mono text-xs/5 text-gray-700 dark:bg-white/10 dark:text-gray-200"
+                    >{{ name }}</span
+                  >
+                }
+              </div>
+            </section>
+          }
+
+          <!-- About -->
+          <section class="mt-8">
+            <h2 class="text-base/7 font-semibold text-gray-900 dark:text-white">About</h2>
+            <dl class="mt-3 flex flex-col gap-2.5">
+              @for (fact of facts(); track fact.label) {
+                <div
+                  class="flex items-baseline justify-between gap-4 border-b border-gray-100 pb-2.5 last:border-0 dark:border-white/5"
+                >
+                  <dt class="text-sm/6 text-gray-500 dark:text-gray-400">{{ fact.label }}</dt>
+                  <dd
+                    class="min-w-0 text-right font-mono text-sm/6 break-words text-gray-700 dark:text-gray-200"
+                  >
+                    {{ fact.value }}
+                  </dd>
+                </div>
+              }
+            </dl>
+          </section>
+        } @else if (detailService.isLoading(skillId()) || !resolved()) {
+          <div class="mt-8 flex items-center gap-3 text-sm/6 text-gray-500 dark:text-gray-400">
+            <app-spinner size="sm" label="Loading skill" />
+            Loading…
+          </div>
+        } @else if (detailService.hasFailed(skillId())) {
+          <!-- Distinct from not-found: the skill may well exist and we simply
+               could not read it. Telling the user it is gone would be a lie. -->
+          <div
+            role="alert"
+            class="mt-8 rounded-2xl border border-state-danger-200 bg-state-danger-50 px-4 py-3 text-sm/6 text-state-danger-800 dark:border-state-danger-900 dark:bg-state-danger-900/20 dark:text-state-danger-300"
+          >
+            Couldn't load this skill. Please try again.
+          </div>
+        } @else {
+          <!-- Resolved 404: retired, or the user's roles no longer grant it.
+               Both read the same to them, and deliberately so — a message that
+               distinguished them would confirm a skill someone else holds. -->
+          <div
+            class="mt-8 rounded-2xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700"
+          >
+            <p class="text-sm/6 font-medium text-gray-900 dark:text-white">Skill not found</p>
+            <p class="mt-1 text-sm/6 text-gray-500 dark:text-gray-400">
+              This skill no longer exists, or your roles don't grant it.
+            </p>
+            <a
+              routerLink="/customize/skills"
+              class="mt-4 inline-block text-sm/6 font-semibold text-primary-accessible hover:underline dark:text-primary-accessible-dark"
+              >Back to Skills</a
+            >
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class CustomizeSkillDetailPage {
+  protected readonly skillService = inject(SkillService);
+  protected readonly detailService = inject(SkillDetailService);
+
+  /** Bound from the `:skillId` route param by `withComponentInputBinding()`. */
+  readonly skillId = input.required<string>();
+
+  protected readonly saving = signal(false);
+  protected readonly saveError = signal<string | null>(null);
+
+  constructor() {
+    // The toggle writes through SkillService, which silently no-ops on a skill
+    // it has never loaded — so a deep link to this page has to warm the list,
+    // not just the detail record. The switch stays disabled until it lands.
+    if (!this.skillService.initialized() && !this.skillService.loading()) {
+      void this.skillService.loadSkills();
+    }
+
+    effect(() => void this.detailService.ensure(this.skillId()));
+  }
+
+  protected readonly skill = computed<SkillDetail | null>(() =>
+    this.detailService.detailFor(this.skillId()),
+  );
+
+  /** The detail read has settled, whatever the answer. */
+  protected readonly resolved = computed(
+    () =>
+      !!this.skill() ||
+      this.detailService.isMissing(this.skillId()) ||
+      this.detailService.hasFailed(this.skillId()),
+  );
+
+  protected readonly monogram = computed(() =>
+    monogramFor(this.skill()?.displayName ?? ''),
+  );
+
+  /**
+   * The switch reads SkillService once it has loaded, so this page and the
+   * list it came from can never disagree about a toggle made on either. The
+   * detail record covers the gap before that load lands.
+   */
+  protected readonly enabled = computed(() => {
+    const row = this.skillService.skills().find(s => s.skillId === this.skillId());
+    return row ? row.isEnabled : (this.skill()?.isEnabled ?? false);
+  });
+
+  /** Category, ownership, and status only when it is worth saying out loud. */
+  protected readonly chips = computed(() => {
+    const s = this.skill();
+    if (!s) return [];
+    const chips: string[] = [];
+    if (s.category) chips.push(s.category);
+    if (s.isOwned) chips.push('yours');
+    if (s.status !== 'active') chips.push(s.status);
+    return chips;
+  });
+
+  /** Reference files first, then scripts, then assets; alphabetical within. */
+  protected readonly files = computed<SkillDetailResource[]>(() =>
+    [...(this.skill()?.resources ?? [])].sort(
+      (a, b) =>
+        (KIND_ORDER[a.kind] ?? 9) - (KIND_ORDER[b.kind] ?? 9) ||
+        a.filename.localeCompare(b.filename),
+    ),
+  );
+
+  /** Catalog facts the card has no room for. */
+  protected readonly facts = computed(() => {
+    const s = this.skill();
+    if (!s) return [];
+    const rows: { label: string; value: string }[] = [
+      { label: 'Skill ID', value: s.skillId },
+      { label: 'Source', value: s.isOwned ? 'you wrote this' : 'catalog' },
+      { label: 'Status', value: s.status },
+    ];
+    if (s.category) rows.push({ label: 'Category', value: s.category });
+    if (s.resources.length > 0) {
+      rows.push({ label: 'Files', value: `${s.resources.length}` });
+    }
+    const updated = this.dateLabel(s.updatedAt);
+    if (updated) rows.push({ label: 'Updated', value: updated });
+    return rows;
+  });
+
+  protected resourceUrl(skillId: string, filename: string): string {
+    return this.detailService.resourceUrl(skillId, filename);
+  }
+
+  protected sizeLabel(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  /** An unparseable timestamp is dropped rather than rendered as "Invalid Date". */
+  private dateLabel(iso: string | null): string | null {
+    if (!iso) return null;
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? null : date.toLocaleDateString();
+  }
+
+  /**
+   * A switch that snaps back on its own looks like a bug in the switch, so a
+   * failed save says so. `SkillService` has already reverted its optimistic
+   * update by the time this runs.
+   */
+  protected async onToggle(): Promise<void> {
+    const s = this.skill();
+    if (!s || this.saving()) return;
+
+    this.saving.set(true);
+    this.saveError.set(null);
+    try {
+      // `respectAgentLock: false` — see the class comment.
+      await this.skillService.toggleSkill(s.skillId, { respectAgentLock: false });
+    } catch {
+      this.saveError.set(
+        `Couldn't save the change to ${s.displayName}. Please try again.`,
+      );
+    } finally {
+      this.saving.set(false);
+    }
+  }
+}

--- a/frontend/ai.client/src/app/customize/skills/customize-skills.page.spec.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skills.page.spec.ts
@@ -67,6 +67,26 @@ describe('CustomizeSkillsPage', () => {
     expect(fixture.nativeElement.querySelectorAll('app-customize-card')).toHaveLength(3);
   });
 
+  it('links each card to its detail page', async () => {
+    const fixture = await create();
+    const links = [...fixture.nativeElement.querySelectorAll('app-customize-card a')].map(
+      (a: Element) => a.getAttribute('href'),
+    );
+    expect(links).toEqual([
+      '/customize/skills/sk_apa',
+      '/customize/skills/sk_syllabus',
+      '/customize/skills/sk_rubric',
+    ]);
+  });
+
+  it('keeps the switch out of the card link', async () => {
+    // A control nested inside a link is a control the user cannot operate with
+    // the keyboard without also following the link.
+    const fixture = await create();
+    const toggle = fixture.nativeElement.querySelector('app-customize-card button[role="switch"]');
+    expect(toggle.closest('a')).toBeNull();
+  });
+
   it('counts what is on — skills default off, so most of the catalog is', async () => {
     const fixture = await create();
     expect(text(fixture)).toContain('1 of 3 skills on');

--- a/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
+++ b/frontend/ai.client/src/app/customize/skills/customize-skills.page.ts
@@ -15,6 +15,8 @@ interface SkillCard {
   description: string;
   monogram: string;
   enabled: boolean;
+  /** Where the card's name drills in to. Encoded: ids are opaque catalog keys. */
+  detailLink: string;
 }
 
 /**
@@ -151,6 +153,7 @@ interface SkillCard {
                   [description]="card.description"
                   [monogram]="card.monogram"
                   [enabled]="card.enabled"
+                  [detailLink]="card.detailLink"
                   [pending]="pending().has(card.skill.skillId)"
                   (toggled)="onToggle(card.skill)"
                 />
@@ -218,6 +221,7 @@ export class CustomizeSkillsPage {
       monogram: monogramFor(skill.displayName),
       // `isEnabled`, never `isSkillShownEnabled()` — see the class comment.
       enabled: skill.isEnabled,
+      detailLink: `/customize/skills/${encodeURIComponent(skill.skillId)}`,
     }));
   });
 

--- a/frontend/ai.client/src/app/services/skill-detail/skill-detail.service.ts
+++ b/frontend/ai.client/src/app/services/skill-detail/skill-detail.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '../config.service';
+import { SkillResourceKind } from '../../my-skills/models/my-skill.model';
+
+/**
+ * One supporting file on a skill's agentskills.io bundle. Bytes live in S3;
+ * this is the manifest entry the skill row carries.
+ */
+export interface SkillDetailResource {
+  filename: string;
+  contentHash: string;
+  size: number;
+  contentType: string;
+  s3Key: string;
+  kind: SkillResourceKind;
+}
+
+/**
+ * One skill the user can reach, with everything `GET /skills/` leaves out.
+ * Mirrors the backend `SkillDetailResponse` in
+ * `apis/app_api/skills/routes.py` (CLAUDE.md cross-package contract).
+ *
+ * ⚠️ There is deliberately no `ownerId` and no `allowedAppRoles`: the first
+ * would name another user, and the second is an admin-display projection of
+ * RBAC. `isOwned` is the only part of ownership this surface needs.
+ */
+export interface SkillDetail {
+  skillId: string;
+  displayName: string;
+  description: string;
+  /** The SKILL.md body — level 2 of the progressive disclosure. */
+  instructions: string;
+  /** skill_ids folded into this one (composite skills). */
+  compose: string[];
+  /** Advisory only: parsed from frontmatter, never enforced (Skills v2 D4). */
+  allowedTools: string[];
+  /** Frontmatter passthrough (license, compatibility, arbitrary keys). */
+  skillMetadata: Record<string, unknown>;
+  resources: SkillDetailResource[];
+  status: string;
+  category: string | null;
+  userEnabled: boolean | null;
+  isEnabled: boolean;
+  /** True when the caller authored it — drives the "Edit in My Skills" link. */
+  isOwned: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+type Entry =
+  | { state: 'loading' }
+  | { state: 'loaded'; value: SkillDetail }
+  | { state: 'missing' }
+  | { state: 'failed' };
+
+/**
+ * Reads one accessible skill's full record.
+ *
+ * Its own endpoint rather than a fatter `GET /skills/`: that call is a
+ * first-load payload for every granted skill, and a SKILL.md body per row
+ * would be paid on every load to render a list that shows neither. This is
+ * fetched once, for the one skill a user opened.
+ *
+ * Cached per skill for the life of the page. `missing` is kept distinct from
+ * `failed` because a 404 here means "retired, or your roles no longer grant
+ * it" — a real answer the page renders — while `failed` is a transport fault,
+ * and both are remembered rather than retried, so a dead endpoint cannot turn
+ * a re-render into a request loop.
+ */
+@Injectable({ providedIn: 'root' })
+export class SkillDetailService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  private readonly entries = signal<Record<string, Entry>>({});
+
+  private readonly baseUrl = computed(() => `${this.config.appApiUrl()}/skills`);
+
+  /** The detail for a skill, or null while loading / missing / failed. */
+  detailFor(skillId: string): SkillDetail | null {
+    const entry = this.entries()[skillId];
+    return entry?.state === 'loaded' ? entry.value : null;
+  }
+
+  isLoading(skillId: string): boolean {
+    return this.entries()[skillId]?.state === 'loading';
+  }
+
+  /** Resolved, and the skill is not reachable by this user. */
+  isMissing(skillId: string): boolean {
+    return this.entries()[skillId]?.state === 'missing';
+  }
+
+  hasFailed(skillId: string): boolean {
+    return this.entries()[skillId]?.state === 'failed';
+  }
+
+  /** Fetch once per skill. A resolved entry of any kind is never re-fetched. */
+  async ensure(skillId: string): Promise<void> {
+    if (!skillId || this.entries()[skillId]) return;
+    this.entries.update(current => ({ ...current, [skillId]: { state: 'loading' } }));
+    try {
+      const value = await firstValueFrom(
+        this.http.get<SkillDetail>(
+          `${this.baseUrl()}/${encodeURIComponent(skillId)}`,
+          { withCredentials: true },
+        ),
+      );
+      this.entries.update(current => ({
+        ...current,
+        [skillId]: { state: 'loaded', value },
+      }));
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      this.entries.update(current => ({
+        ...current,
+        [skillId]: { state: status === 404 ? 'missing' : 'failed' },
+      }));
+    }
+  }
+
+  /**
+   * Where a supporting file's bytes are served from. Access-scoped, not
+   * owner-scoped, so a catalog skill's reference files open for anyone the
+   * skill is granted to. Served `attachment` + `nosniff` by the backend.
+   */
+  resourceUrl(skillId: string, filename: string): string {
+    return `${this.baseUrl()}/${encodeURIComponent(skillId)}/resources/${encodeURIComponent(filename)}`;
+  }
+
+  /** Drop a cached record so the next `ensure` re-reads it. */
+  invalidate(skillId: string): void {
+    this.entries.update(current => {
+      if (!(skillId in current)) return current;
+      const next = { ...current };
+      delete next[skillId];
+      return next;
+    });
+  }
+}


### PR DESCRIPTION
Clicking a skill in **Customize → Skills** now drills into `/customize/skills/:skillId`. The sibling of the tool detail view (#1081), reusing the `detailLink` input that PR added to the shared `CustomizeCardComponent`. Rebased onto `develop` after #1081 and #1082 merged.

## ⚠️ Unlike the tool page, this one needed backend work

The tool detail view is pure frontend: `GET /tools/` already returns the whole `Tool`, `serverTools` and all. The skills picker returns **six thin fields** — id, name, description, category, `userEnabled`, `isEnabled` — and everything worth opening a page for (the SKILL.md `instructions`, the `resources` manifest, `allowedTools`, `compose`, status, timestamps) lives on `SkillDefinition` and never reaches the SPA. The only per-skill read that existed, `GET /skills/mine/{id}`, is **owner-scoped**: a catalog skill granted to you 404s there.

So this adds two access-scoped reads to `apis/app_api/skills/routes.py`:

- **`GET /skills/{id}`** — gated by `resolve_accessible_skill_ids`, the same resolution that builds the picker and that the runtime uses to decide what a turn may activate.
- **`GET /skills/{id}/resources/{filename}`** — the access-scoped counterpart of the owner route, so a granted user can open a **catalog** skill's reference files. Hardened identically (media type re-derived from the filename, `attachment` + `nosniff` + inert CSP). Read-only by construction: there is no access-scoped upload or delete.

**`GET /skills/` was NOT fattened instead.** It is a first-load payload covering every granted skill; a SKILL.md body per row would be paid on every load to render a list that shows neither the body nor the files.

## ⚠️ Route registration order is load-bearing

Both new routes sit at the **bottom** of the module, below every `/mine` route. Starlette matches in registration order and `SKILL_ID_PATTERN` (`^[a-z][a-z0-9_]{2,49}$`) happily matches the literal string `mine` — declare `/{skill_id}` first and `GET /skills/mine` becomes a lookup for a skill called "mine", which 404s for every user in the product. A test asserts it.

## What the page carries

- Identity — monogram, display name, skill id, category / `yours` / non-active chips
- Description, then the master on/off switch
- **Instructions** — the SKILL.md body, rendered **expanded**
- **Files** — the bundle manifest, each with an Open link to the new access-scoped route
- **Builds on** — composed skill ids
- **Tools it mentions** — the advisory `allowed-tools` frontmatter
- **About** — skill id, source, status, category, file count, updated
- **Edit in My Skills** for a skill the user authored

## Decisions worth reviewing

**Instructions render expanded, not behind a disclosure.** They are not a secret from a user the skill is granted to — this is the text their own turns load on dispatch, so the honest answer to "what does this skill do" is to show it. Rendered through `ngx-markdown` **with sanitization on**; do not add `[disableSanitizer]`, since a SKILL.md body can be authored by a non-admin (Skills v2 PR-3 user tier). Same reasoning already recorded on `announcement-modal.component.ts`.

**The detail response omits `ownerId` and `allowedAppRoles`.** The first would name one user to another; `isOwned` is the only part of ownership this surface needs. The second is an admin-display projection of RBAC (CLAUDE.md §RBAC) and has no business on a page any granted user can open.

**404, never 403.** A skill the caller cannot reach is indistinguishable from one that does not exist, so the endpoint never confirms a skill someone else holds. A non-ACTIVE *catalog* skill 404s too, matching the ACTIVE filter `GET /skills/` already applies — but an owner still reads their own draft, because ownership is its own grant.

**`allowedTools` is rendered with its advisory status in the copy**, not as a bare list. Skills v2 D4: the platform never grants, mounts or folds a tool because a skill names it. A bare list of tool names on a page about a skill you just enabled would read as a grant.

**Owned skills link out to `/my-skills/{id}/edit`** rather than growing a second editor. One destination for every card, and the read view stays useful for your own skill.

**⚠️ The switch is disabled until the picker list lands.** `SkillService.toggleSkill` silently returns on a skill it has never loaded, so on a deep link a click before the list arrived would look like a broken switch rather than a dead moment. The page warms `loadSkills()` in its constructor and gates the control on `initialized()`.

**This page closes no functional gap** — and that is the difference from #1081. The tool page *had* to exist the moment #1079 deleted the drawer, because per-sub-tool enablement had nowhere else to live. A skill has no sub-unit; the only control here is the same on/off the card already offers. Its value is informational.

## Cost

None against the model. Everything here is catalog data read for display; nothing reaches the system prompt or `toolConfig`, so the cacheable prefix is untouched. Added traffic is one `GET /skills/{id}` per drill-in, cached for the life of the page. Verified on a cold deep link: exactly one list read plus one detail read, no duplicates.

## Testing

- **Frontend 2850/2850 pass** (2836 before + 14 new: 12 on the detail page, 2 on the card link). Re-run green after the rebase onto `develop`.
- **Backend 8369 passed / 3 skipped**, 12 new in `test_user_skills_routes.py` — including the registration-order guard and one asserting the response leaks neither `ownerId` nor `allowedAppRoles`.
- **Browser-verified against dev data** (local branch + `/api` proxy to the running app-api, since neither route is deployed):
  - `web_research` — catalog skill with a file. The new route serves `extraction_tips.md` **200, 824 B, `attachment` + `nosniff`, `text/markdown`**, while the pre-existing owner route returns **404** for the same file. That pair is the proof the endpoint was necessary.
  - `docx` — owned: `yours` chip, `Source: you wrote this`, edit link resolving to `/my-skills/docx/edit`. Toggle round-tripped to the server (`isEnabled` true) and was restored to its original state.
  - `canvas_rubric_publishing` — 3.9k-char body with a markdown table: renders as a real table, no script nodes injected. At 375px the table scrolls inside its own `overflow-x:auto` container and the page body does **not** scroll horizontally.
  - Not-found state, and a 500 distinguished from a 404 (a failed read must not claim the skill is gone).
  - Light and dark confirmed with computed styles. Dark contrast against `#101828`: file link (`primary-accessible-dark`) **4.53:1**, h1 17.75:1, markdown body 14.33:1, section subtext 6.82:1 — all clear AA. Already on the accessible pairing #1082 standardized; no legacy `dark:text-primary-400` in the new files. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)